### PR TITLE
docs: add Babylon.js → Babylon Lite porting guide

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -1,0 +1,243 @@
+# Porting from Babylon.js to Babylon Lite
+
+This guide shows how to translate a Babylon.js (BJS) scene to Babylon Lite, side by side. Babylon Lite uses **factory functions** instead of constructors, **plain data** instead of class instances, and explicit `scene.add()` instead of auto-registration.
+
+---
+
+## Quick Reference
+
+| Babylon.js | Babylon Lite |
+|---|---|
+| `new WebGPUEngine(canvas); await engine.initAsync()` | `const engine = await createEngine(canvas)` |
+| `new Scene(engine)` | `createSceneContext(engine)` |
+| `engine.runRenderLoop(() => scene.render())` | `await engine.start(scene)` |
+| `new ArcRotateCamera("cam", α, β, r, target, scene)` | `createArcRotateCamera(α, β, r, target)` |
+| `scene.createDefaultCamera(true, true, true)` | `createDefaultCamera(scene)` |
+| `camera.attachControl(canvas, true)` | `attachControl(camera, canvas, scene)` |
+| `new HemisphericLight("h", new Vector3(0,1,0), scene)` | `createHemisphericLight([0,1,0], 1.0)` |
+| `new DirectionalLight("d", new Vector3(0,-1,0), scene)` | `createDirectionalLight([0,-1,0])` |
+| `new SpotLight("s", pos, dir, angle, exp, scene)` | `createSpotLight(pos, dir, angle, exp)` |
+| `MeshBuilder.CreateSphere("s", {}, scene)` | `createSphere(engine)` |
+| `MeshBuilder.CreateBox("b", {}, scene)` | `createBox(engine)` |
+| `MeshBuilder.CreateGround("g", {}, scene)` | `createGround(engine, opts)` |
+| `new StandardMaterial("mat", scene)` | `createStandardMaterial()` |
+| `new PBRMaterial("pbr", scene)` | `createPbrMaterial()` |
+| `SceneLoader.ImportMeshAsync("", url, file, scene)` | `await loadGltf(scene, url)` |
+| `new CubeTexture(url, scene)` + `createDefaultEnvironment()` | `await loadEnvironment(scene, url, opts)` |
+| `new Texture(url, scene)` | `await loadTexture2D(engine, url)` |
+| `new ShadowGenerator(size, light)` | `createShadowGenerator(engine, light, casters, opts)` |
+| `sg.usePercentageCloserFiltering = true` | `createPcfShadowGenerator(engine, light, casters, opts)` |
+| `mesh.thinInstanceSetBuffer("matrix", data, 16)` | `setThinInstances(mesh, data, count)` |
+| `mesh.thinInstanceSetBuffer("color", data, 4)` | `setThinInstanceColors(mesh, data)` |
+| `new Vector3(x, y, z)` | `{ x, y, z }` or `[x, y, z]` |
+| `new Color3(r, g, b)` | `[r, g, b]` |
+| `Matrix.Identity()` | `mat4Identity()` |
+| `scene.onBeforeRenderObservable.add(fn)` | `scene.onBeforeRender(fn)` |
+
+---
+
+## Key Differences
+
+### 1. No Scene in Constructors
+
+BJS objects take `scene` in their constructor and auto-register. Lite objects are plain data — you create them, then `scene.add()` them explicitly.
+
+```typescript
+// ❌ Babylon.js
+const light = new HemisphericLight("light", new Vector3(0, 1, 0), scene);
+
+// ✅ Babylon Lite
+const light = createHemisphericLight([0, 1, 0], 1.0);
+scene.add(light);
+```
+
+### 2. Engine & Render Loop
+
+BJS uses `runRenderLoop` with a callback. Lite uses a single `engine.start(scene)` that returns a promise resolving after the first frame.
+
+```typescript
+// ❌ Babylon.js
+const engine = new WebGPUEngine(canvas);
+await engine.initAsync();
+const scene = new Scene(engine);
+// ... setup ...
+engine.runRenderLoop(() => scene.render());
+
+// ✅ Babylon Lite
+const engine = await createEngine(canvas);
+const scene = createSceneContext(engine);
+// ... setup ...
+await engine.start(scene);
+```
+
+### 3. Plain Data, Not Classes
+
+Lite uses plain objects, arrays, and `Float32Array` instead of BJS classes like `Vector3`, `Color3`, `Matrix`.
+
+```typescript
+// ❌ Babylon.js
+light.direction = new Vector3(0, -1, 0);
+light.diffuse = new Color3(1, 0, 0);
+
+// ✅ Babylon Lite
+const light = createDirectionalLight([0, -1, 0]);
+light.diffuse = [1, 0, 0];
+```
+
+### 4. Camera Controls Are Separate
+
+BJS cameras have `attachControl` as a method. Lite separates camera data from input handling.
+
+```typescript
+// ❌ Babylon.js
+const camera = new ArcRotateCamera("cam", -Math.PI/2, Math.PI/2, 5, Vector3.Zero(), scene);
+camera.attachControl(canvas, true);
+
+// ✅ Babylon Lite
+const camera = createArcRotateCamera(-Math.PI/2, Math.PI/2, 5, { x: 0, y: 0, z: 0 });
+scene.camera = camera;
+attachControl(camera, canvas, scene);
+```
+
+### 5. Loaders Auto-Add to Scene
+
+`loadGltf()` and `loadEnvironment()` add entities to the scene internally — no need to call `scene.add()` for their results.
+
+```typescript
+// ❌ Babylon.js
+await SceneLoader.ImportMeshAsync("", baseUrl, "model.glb", scene);
+scene.environmentTexture = new CubeTexture(envUrl, scene);
+scene.createDefaultEnvironment({ createSkybox: true, skyboxSize: 1000 });
+
+// ✅ Babylon Lite
+await loadGltf(scene, "model.glb");
+await loadEnvironment(scene, envUrl, {
+    skyboxUrl: "skybox.dds",
+    skyboxSize: 1000,
+    groundTextureUrl: "ground.png",
+    brdfUrl: "/brdf-lut.png",
+});
+```
+
+### 6. Shadows Attach to Lights
+
+BJS creates a `ShadowGenerator` separately. Lite assigns it directly to the light.
+
+```typescript
+// ❌ Babylon.js
+const sg = new ShadowGenerator(1024, light);
+sg.addShadowCaster(mesh);
+sg.useBlurExponentialShadowMap = true;
+ground.receiveShadows = true;
+
+// ✅ Babylon Lite
+light.shadowGenerator = createShadowGenerator(engine, light, [mesh], {
+    mapSize: 1024,
+    depthScale: 50,
+    blurScale: 2,
+});
+ground.receiveShadows = true;
+```
+
+For PCF shadows:
+```typescript
+// ❌ Babylon.js
+const sg = new ShadowGenerator(1024, spotLight);
+sg.usePercentageCloserFiltering = true;
+
+// ✅ Babylon Lite
+spotLight.shadowGenerator = createPcfShadowGenerator(engine, spotLight, [mesh], {
+    mapSize: 1024,
+});
+```
+
+### 7. Thin Instances Use Raw Arrays
+
+No `Matrix` class needed. Pass raw `Float32Array` with 16 floats per instance.
+
+```typescript
+// ❌ Babylon.js
+const matrices = new Float32Array(count * 16);
+// ... fill with Matrix values ...
+mesh.thinInstanceSetBuffer("matrix", matrices, 16);
+mesh.thinInstanceSetBuffer("color", colors, 4);
+
+// ✅ Babylon Lite
+const matrices = new Float32Array(count * 16);
+// ... fill directly (column-major 4x4) ...
+setThinInstances(mesh, matrices, count);
+setThinInstanceColors(mesh, colors);
+scene.add(mesh);
+```
+
+### 8. Mesh Factories Take Engine, Not Scene
+
+BJS mesh builders take `scene`. Lite mesh factories take `engine` (for GPU buffer creation) and return plain mesh data.
+
+```typescript
+// ❌ Babylon.js
+const sphere = MeshBuilder.CreateSphere("sphere", { diameter: 2 }, scene);
+sphere.material = new StandardMaterial("mat", scene);
+
+// ✅ Babylon Lite
+const sphere = createSphere(engine);
+sphere.material = createStandardMaterial();
+scene.add(sphere);
+```
+
+---
+
+## Full Example: Porting a PBR Scene
+
+### Babylon.js
+```typescript
+const engine = new WebGPUEngine(canvas);
+await engine.initAsync();
+const scene = new Scene(engine);
+scene.clearColor = new Color4(0.2, 0.2, 0.3, 1);
+
+const light = new HemisphericLight("h", new Vector3(0, 1, 0), scene);
+light.intensity = 1.0;
+
+await SceneLoader.ImportMeshAsync("", baseUrl, "BoomBox.glb", scene);
+const envTex = new CubeTexture(envUrl, scene);
+scene.environmentTexture = envTex;
+scene.createDefaultCamera(true, true, true);
+scene.createDefaultEnvironment({ skyboxSize: 1000 });
+
+engine.runRenderLoop(() => scene.render());
+```
+
+### Babylon Lite
+```typescript
+const engine = await createEngine(canvas);
+const scene = createSceneContext(engine);
+
+await loadGltf(scene, "BoomBox.glb");
+await loadEnvironment(scene, envUrl, {
+    skyboxUrl: "skybox.dds",
+    skyboxSize: 1000,
+    groundTextureUrl: "ground.png",
+    brdfUrl: "/brdf-lut.png",
+});
+
+const cam = createDefaultCamera(scene);
+attachControl(cam, canvas, scene);
+scene.add(createHemisphericLight([0, 1, 0], 1.0));
+
+await engine.start(scene);
+```
+
+---
+
+## Gotchas
+
+| Gotcha | Details |
+|---|---|
+| **No auto-add** | Meshes, lights, and transform nodes must be explicitly added with `scene.add()`. Exception: `loadGltf()` and `loadEnvironment()` add internally. |
+| **No `new` keyword** | Everything is created via factory functions, not constructors. |
+| **Assign camera explicitly** | Either use `createDefaultCamera(scene)` (auto-assigns) or set `scene.camera = myCamera` manually. |
+| **Materials are optional** | `createStandardMaterial()` / `createPbrMaterial()` return props objects. Assign to `mesh.material`. |
+| **WebGPU only** | No WebGL fallback. `createEngine()` throws if WebGPU is unavailable. |
+| **No `dispose()` on meshes** | Call `scene.dispose()` then `engine.dispose()` to clean up everything. |
+| **Tree-shakable imports** | Import only what you use. Unused features are stripped from the bundle. |

--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -32,6 +32,7 @@ This guide shows how to translate a Babylon.js (BJS) scene to Babylon Lite, side
 | `new Vector3(x, y, z)` | `{ x, y, z }` or `[x, y, z]` |
 | `new Color3(r, g, b)` | `[r, g, b]` |
 | `Matrix.Identity()` | `mat4Identity()` |
+| `mesh.dispose()` | `removeFromScene(scene, mesh)` |
 | `scene.onBeforeRenderObservable.add(fn)` | `scene.onBeforeRender(fn)` |
 
 ---
@@ -185,6 +186,25 @@ sphere.material = createStandardMaterial();
 scene.add(sphere);
 ```
 
+### 9. Removing & Disposing Entities
+
+BJS uses `mesh.dispose()` on individual objects. Lite uses `removeFromScene()` which removes the mesh from the scene and destroys all its GPU resources (buffers, textures, skeleton data).
+
+```typescript
+// ❌ Babylon.js
+sphere.dispose();
+
+// ✅ Babylon Lite
+removeFromScene(scene, sphere);
+```
+
+For full teardown:
+```typescript
+// ✅ Babylon Lite — tear down everything
+scene.dispose();   // releases all meshes, renderables, disposables
+engine.dispose();  // destroys GPU device, render targets, swapchain
+```
+
 ---
 
 ## Full Example: Porting a PBR Scene
@@ -239,5 +259,5 @@ await engine.start(scene);
 | **Assign camera explicitly** | Either use `createDefaultCamera(scene)` (auto-assigns) or set `scene.camera = myCamera` manually. |
 | **Materials are optional** | `createStandardMaterial()` / `createPbrMaterial()` return props objects. Assign to `mesh.material`. |
 | **WebGPU only** | No WebGL fallback. `createEngine()` throws if WebGPU is unavailable. |
-| **No `dispose()` on meshes** | Call `scene.dispose()` then `engine.dispose()` to clean up everything. |
+| **No `dispose()` on meshes** | Use `removeFromScene(scene, mesh)` to remove a single mesh and destroy its GPU resources. Use `scene.dispose()` + `engine.dispose()` to tear down everything. |
 | **Tree-shakable imports** | Import only what you use. Unused features are stripped from the bundle. |


### PR DESCRIPTION
Adds \docs/porting-guide.md\ with:

- **Quick reference table** — one-line BJS → Lite API mappings
- **8 key differences** — engine, scene, plain data, cameras, loaders, shadows, thin instances, mesh factories (each with side-by-side code examples)
- **Full porting example** — complete PBR scene ported end-to-end
- **Gotchas table** — common pitfalls when porting