### PR TITLE
test: remove WebGPU skip guards — test SwiftShader in CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,12 +190,9 @@ Plumbing tests validate engine internals (dispose, material-swap, etc.) using Pl
 
 1. Create a test page in `apps/manual-lab/` (HTML + TS)
 2. Create the spec in `tests/plumbing/`
-3. **Always add a WebGPU skip guard** for CI compatibility:
-   ```typescript
-   const hasWebGPU = await page.evaluate(() => !!navigator.gpu);
-   test.skip(!hasWebGPU, "WebGPU not available — requires GPU hardware");
-   ```
-4. Run: `npx playwright test tests/plumbing/my-test.spec.ts`
+3. Run: `npx playwright test tests/plumbing/my-test.spec.ts`
+
+> **Note:** CI uses Chrome's SwiftShader Vulkan backend for WebGPU — no real GPU needed.
 
 ## Adding Unit Tests
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,9 @@ For GPU integration tests (dispose, material-swap, lifecycle):
 1. Create a test page: `apps/manual-lab/my-test.html` + `apps/manual-lab/src/my-test.ts`
 2. Add the HTML entry to `apps/manual-lab/vite.config.ts` (auto-detected if in root)
 3. Create `tests/plumbing/my-test.spec.ts`
-4. **Always add a WebGPU skip guard** at the top of each test:
-   ```typescript
-   const hasWebGPU = await page.evaluate(() => !!navigator.gpu);
-   test.skip(!hasWebGPU, "WebGPU not available — requires GPU hardware");
-   ```
-5. Run locally: `npx playwright test tests/plumbing/my-test.spec.ts`
+4. Run: `npx playwright test tests/plumbing/my-test.spec.ts`
+
+> CI uses Chrome's SwiftShader Vulkan backend — WebGPU works without a real GPU.
 
 ### Scene Parity Tests (Playwright + WebGPU)
 
@@ -108,12 +105,10 @@ For pixel-diff visual regression tests against Babylon.js golden references:
 | Workflow | Trigger | What it runs |
 |---|---|---|
 | **Lint** | PR → master | ESLint + `tsc --noEmit` |
-| **Unit** | PR → master | Vitest + plumbing tests (skipped if no GPU) |
-| **Bundle Size** | manual | Runtime KB ceiling checks |
+| **Unit** | PR → master | Vitest + plumbing tests |
+| **Bundle Size** | PR → master | Runtime KB ceiling checks |
 | **Parity** | manual | Scene pixel-diff vs golden refs |
 | **Perf** | manual | RAF performance benchmarks |
-
-> **Note:** Plumbing tests auto-skip on CI runners without WebGPU. They run fully on local machines with GPU support.
 
 ## Troubleshooting
 

--- a/tests/parity/bundle-size.spec.ts
+++ b/tests/parity/bundle-size.spec.ts
@@ -26,17 +26,6 @@ const SCENES = allScenes.filter((s) => s.maxRawKB != null && s.maxGzipKB != null
 
 for (const scene of SCENES) {
     test(`${scene.name} bundle ≤ ${scene.maxRawKB} KB raw, ≤ ${scene.maxGzipKB} KB gzip`, async ({ page }) => {
-        // Check if WebGPU is actually functional (requires secure context)
-        await page.goto(`/bundle-scene${scene.id}.html`);
-        const hasWebGPU = await page.evaluate(async () => {
-            if (!navigator.gpu) {
-                return false;
-            }
-            const adapter = await navigator.gpu.requestAdapter();
-            return !!adapter;
-        });
-        test.skip(!hasWebGPU, "WebGPU not available — requires GPU hardware");
-
         const jsPayloads: { url: string; body: Buffer }[] = [];
 
         // Intercept every JS response served from /bundle/

--- a/tests/plumbing/dispose.spec.ts
+++ b/tests/plumbing/dispose.spec.ts
@@ -2,17 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Dispose", () => {
     test("scene.dispose() + engine.dispose() release GPU resources without errors", async ({ page }) => {
-        // Check if WebGPU is actually functional (requires secure context)
         await page.goto("/dispose-test.html");
-        const hasWebGPU = await page.evaluate(async () => {
-            if (!navigator.gpu) {
-                return false;
-            }
-            const adapter = await navigator.gpu.requestAdapter();
-            return !!adapter;
-        });
-        test.skip(!hasWebGPU, "WebGPU not available — requires GPU hardware");
-
         await page.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 20_000 });
 
         // Verify both cycles completed

--- a/tests/plumbing/material-swap.spec.ts
+++ b/tests/plumbing/material-swap.spec.ts
@@ -14,16 +14,7 @@ function getCenterPixel(pngPath: string): [number, number, number] {
 
 test.describe("Material Swap", () => {
     test("mesh.material = newMat changes rendering on next frame", async ({ page }) => {
-        // Check if WebGPU is actually functional (requires secure context)
         await page.goto("/material-swap-test.html");
-        const hasWebGPU = await page.evaluate(async () => {
-            if (!navigator.gpu) {
-                return false;
-            }
-            const adapter = await navigator.gpu.requestAdapter();
-            return !!adapter;
-        });
-        test.skip(!hasWebGPU, "WebGPU not available — requires GPU hardware");
 
         // Wait for red phase
         await page.waitForFunction(() => (window as any).phase === "red", { timeout: 10_000 });


### PR DESCRIPTION
Removes the WebGPU skip guards from dispose and material-swap tests to verify if SwiftShader Vulkan backend provides a working WebGPU adapter on CI runners.