### PR TITLE
refactor: unify scene hierarchy with SceneNode base and bidirectional EulerProxy

### DIFF
--- a/packages/babylon-lite/src/camera/arc-rotate.ts
+++ b/packages/babylon-lite/src/camera/arc-rotate.ts
@@ -4,6 +4,7 @@ import { mat4LookAtLH, mat4PerspectiveLH, mat4Multiply, mat4Identity } from "../
 import type { IWorldMatrixProvider, IParentable } from "../scene/parentable.js";
 import { createWorldMatrixState } from "../scene/world-matrix-state.js";
 import { ObservableVec3 } from "../math/observable-vec3.js";
+import type { SceneNode } from "../scene/scene-node.js";
 
 /** ArcRotateCamera — orbits around a target point.
  *  Uses Babylon.js convention: left-handed, alpha=rotation around Y, beta=elevation.
@@ -23,6 +24,7 @@ export interface ArcRotateCamera extends IWorldMatrixProvider, IParentable {
     fov: number;
     nearPlane: number;
     farPlane: number;
+    children: SceneNode[];
 
     /** Inertia coefficient for rotation and zoom (0 = instant stop, 0.9 = default, 1 = no decay). */
     inertia: number;
@@ -108,6 +110,7 @@ export function createArcRotateCamera(alpha: number, beta: number, radius: numbe
         fov: 0.8,
         nearPlane: 0.1,
         farPlane: 1000,
+        children: [] as SceneNode[],
 
         inertia: 0.9,
         panningInertia: 0.9,

--- a/packages/babylon-lite/src/camera/camera.ts
+++ b/packages/babylon-lite/src/camera/camera.ts
@@ -1,4 +1,5 @@
 import type { Vec3, Mat4 } from "../math/types.js";
+import type { SceneNode } from "../scene/scene-node.js";
 
 /** Minimal camera contract — any camera that can provide view/projection matrices.
  *  Both ArcRotateCamera and FreeCamera implement this interface.
@@ -7,6 +8,7 @@ export interface Camera {
     fov: number;
     nearPlane: number;
     farPlane: number;
+    children: SceneNode[];
     readonly worldMatrixVersion: number;
     getViewMatrix(): Mat4;
     getProjectionMatrix(aspectRatio: number): Mat4;

--- a/packages/babylon-lite/src/camera/free-camera.ts
+++ b/packages/babylon-lite/src/camera/free-camera.ts
@@ -5,6 +5,7 @@ import { mat4LookAtLH, mat4PerspectiveLH, mat4Multiply, mat4Identity } from "../
 import type { IWorldMatrixProvider, IParentable } from "../scene/parentable.js";
 import { createWorldMatrixState } from "../scene/world-matrix-state.js";
 import { ObservableVec3 } from "../math/observable-vec3.js";
+import type { SceneNode } from "../scene/scene-node.js";
 
 /** FreeCamera — positioned in world space, looking at a target point.
  *  Matches Babylon.js FreeCamera: position + target, left-handed.
@@ -83,6 +84,7 @@ export function createFreeCamera(position: Vec3, target: Vec3): FreeCamera {
         speed: 2.0,
         angularSensitivity: 2000,
         inertia: 0.9,
+        children: [] as SceneNode[],
 
         get parent() {
             return wm.parent;

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -35,8 +35,9 @@ export type { LoaderResult } from "./loader-results.js";
 // ─── Hierarchy ───────────────────────────────────────────────────────
 export type { IWorldMatrixProvider, IParentable } from "./scene/parentable.js";
 export { setParent } from "./scene/set-parent.js";
-export { createTransformNode, cloneTransformNode, collectMeshes } from "./scene/transform-node.js";
+export { createTransformNode, cloneTransformNode } from "./scene/transform-node.js";
 export type { TransformNode } from "./scene/transform-node.js";
+export type { SceneNode } from "./scene/scene-node.js";
 export { loadBabylon } from "./loader-babylon/load-babylon.js";
 export { loadEnvironment } from "./loader-env/load-env.js";
 export { loadHdrEnvironment } from "./loader-hdr/load-hdr.js";

--- a/packages/babylon-lite/src/light/directional-light.ts
+++ b/packages/babylon-lite/src/light/directional-light.ts
@@ -2,6 +2,7 @@
  *  Push-based dirty tracking via ObservableVec3. */
 
 import type { LightBase } from "./types.js";
+import type { SceneNode } from "../scene/scene-node.js";
 import { createLightBase, applyWorldMatrixAccessors, ObservableVec3 } from "./light-base.js";
 import { localMatrixFromDirection } from "./light-matrix.js";
 
@@ -22,6 +23,7 @@ export function createDirectionalLight(direction: [number, number, number], inte
     const light = applyWorldMatrixAccessors<DirectionalLight>(
         {
             lightType: "directional" as const,
+            children: [] as SceneNode[],
             direction: new ObservableVec3(direction[0], direction[1], direction[2], onDirty),
             position: new ObservableVec3(0, 0, 0, onDirty),
             diffuse: [1, 1, 1] as [number, number, number],

--- a/packages/babylon-lite/src/light/hemispheric.ts
+++ b/packages/babylon-lite/src/light/hemispheric.ts
@@ -2,6 +2,7 @@
  *  Push-based dirty tracking via ObservableVec3. */
 
 import type { LightBase } from "./types.js";
+import type { SceneNode } from "../scene/scene-node.js";
 import { createLightBase, applyWorldMatrixAccessors, ObservableVec3 } from "./light-base.js";
 import { localMatrixFromDirection } from "./light-matrix.js";
 
@@ -21,6 +22,7 @@ export function createHemisphericLight(direction: [number, number, number] = [0,
     const light = applyWorldMatrixAccessors<HemisphericLight>(
         {
             lightType: "hemispheric" as const,
+            children: [] as SceneNode[],
             direction: new ObservableVec3(direction[0], direction[1], direction[2], onDirty),
             intensity,
             diffuseColor: [1, 1, 1] as [number, number, number],

--- a/packages/babylon-lite/src/light/point-light.ts
+++ b/packages/babylon-lite/src/light/point-light.ts
@@ -3,6 +3,7 @@
  *  Push-based dirty tracking via ObservableVec3. */
 
 import type { LightBase } from "./types.js";
+import type { SceneNode } from "../scene/scene-node.js";
 import { mat4Translation } from "../math/mat4.js";
 import { createLightBase, applyWorldMatrixAccessors, ObservableVec3 } from "./light-base.js";
 
@@ -21,6 +22,7 @@ export function createPointLight(position: [number, number, number], intensity =
     const light = applyWorldMatrixAccessors<PointLight>(
         {
             lightType: "point" as const,
+            children: [] as SceneNode[],
             position: new ObservableVec3(position[0], position[1], position[2], onDirty),
             diffuse: [1, 1, 1] as [number, number, number],
             specular: [1, 1, 1] as [number, number, number],

--- a/packages/babylon-lite/src/light/spot-light.ts
+++ b/packages/babylon-lite/src/light/spot-light.ts
@@ -3,6 +3,7 @@
  *  Push-based dirty tracking via ObservableVec3. */
 
 import type { LightBase } from "./types.js";
+import type { SceneNode } from "../scene/scene-node.js";
 import { createLightBase, applyWorldMatrixAccessors, ObservableVec3 } from "./light-base.js";
 import { localMatrixFromDirection } from "./light-matrix.js";
 
@@ -28,6 +29,7 @@ export function createSpotLight(position: [number, number, number], direction: [
     const light = applyWorldMatrixAccessors<SpotLight>(
         {
             lightType: "spot" as const,
+            children: [] as SceneNode[],
             position: new ObservableVec3(position[0], position[1], position[2], onDirty),
             direction: new ObservableVec3(direction[0], direction[1], direction[2], onDirty),
             angle,

--- a/packages/babylon-lite/src/light/types.ts
+++ b/packages/babylon-lite/src/light/types.ts
@@ -6,11 +6,13 @@
 
 import type { Mat4 } from "../math/types.js";
 import type { IWorldMatrixProvider, IParentable } from "../scene/parentable.js";
+import type { SceneNode } from "../scene/scene-node.js";
 
 /** Shared base for all light types.
  *  Provides pipeline integration callbacks so render pipelines are light-agnostic. */
 export interface LightBase extends IWorldMatrixProvider, IParentable {
     readonly lightType: string;
+    children: SceneNode[];
     /** Mesh IDs excluded from this light. If set, these meshes are NOT lit by this light. */
     excludedMeshIds?: ReadonlySet<string>;
     /** If non-empty, ONLY these mesh IDs are lit by this light. Takes priority over excludedMeshIds. */

--- a/packages/babylon-lite/src/loader-babylon/load-babylon.ts
+++ b/packages/babylon-lite/src/loader-babylon/load-babylon.ts
@@ -16,6 +16,7 @@ import type { LoaderResult } from "../loader-results.js";
 import type { LightBase } from "../light/types.js";
 import type { Mesh } from "../mesh/mesh.js";
 import type { TransformNode } from "../scene/transform-node.js";
+import type { SceneNode } from "../scene/scene-node.js";
 import { createTransformNode } from "../scene/transform-node.js";
 import { createStandardMaterial } from "../material/standard/standard-material.js";
 import type { StandardMaterialProps } from "../material/standard/standard-material.js";
@@ -23,7 +24,6 @@ import { uploadMeshToGPU, initMeshTransform } from "../mesh/mesh.js";
 import type { MeshInternal } from "../mesh/mesh.js";
 import { createPointLight } from "../light/point-light.js";
 import { loadTexture2D } from "../texture/texture-2d.js";
-
 // ─── .babylon JSON Types ───────────────────────────────────────────
 
 interface BabylonScene {
@@ -340,12 +340,12 @@ export async function loadBabylon(engine: Engine, url: string, opts: LoadBabylon
 
     // Meshes — each carries its own TRS; parentId links are used for world-matrix chaining.
     const allMeshes: Mesh[] = [];
+    const nodeMap = new Map<string, Mesh | TransformNode>();
+    const meshesByNodeId = new Map<string, Mesh[]>();
+    const childNodeIds = new Set<string>();
     if (data.meshes) {
         const maxMeshes = opts.maxMeshes ?? Infinity;
         let meshCount = 0;
-
-        // nodeMap: .babylon node id → first Mesh (geometry node) or TransformNode (container)
-        const nodeMap = new Map<string, Mesh | TransformNode>();
 
         // First pass: create Mesh(es) for geometry nodes; TransformNode for pure containers.
         for (const md of data.meshes) {
@@ -426,6 +426,10 @@ export async function loadBabylon(engine: Engine, url: string, opts: LoadBabylon
                     );
 
                     allMeshes.push(mesh as unknown as Mesh);
+                    if (!meshesByNodeId.has(md.id)) {
+                        meshesByNodeId.set(md.id, []);
+                    }
+                    meshesByNodeId.get(md.id)!.push(mesh as unknown as Mesh);
                     if (firstMesh === null) {
                         firstMesh = mesh as unknown as Mesh;
                     }
@@ -467,7 +471,7 @@ export async function loadBabylon(engine: Engine, url: string, opts: LoadBabylon
             }
         }
 
-        // Second pass: wire parent links so world matrices chain correctly.
+        // Second pass: wire parent links and children so world matrices chain correctly.
         for (const md of data.meshes) {
             if (md.isVisible === false || !md.parentId) {
                 continue;
@@ -476,15 +480,32 @@ export async function loadBabylon(engine: Engine, url: string, opts: LoadBabylon
             if (!parent) {
                 continue;
             }
-            // Wire every mesh belonging to this node to the parent.
-            for (const mesh of allMeshes) {
-                if ((mesh as Mesh).id === md.id) {
-                    (mesh as Mesh).parent = parent;
+            childNodeIds.add(md.id);
+            // Wire all mesh submeshes belonging to this node to the parent
+            const childMeshes = meshesByNodeId.get(md.id) ?? [];
+            for (const child of childMeshes) {
+                child.parent = parent;
+                (parent as unknown as { children: SceneNode[] }).children.push(child);
+            }
+            // Wire TransformNode children (container nodes with no geometry)
+            if (childMeshes.length === 0) {
+                const childNode = nodeMap.get(md.id);
+                if (childNode) {
+                    childNode.parent = parent;
+                    (parent as unknown as { children: SceneNode[] }).children.push(childNode);
                 }
             }
         }
     }
 
     // Return LoaderResult — scene.add() handles entity registration, clearColor, and cleanup.
-    return { entities: [...lights, ...allMeshes], clearColor };
+    // Only root entities (not children of any other node) are included; scene.add() recurses.
+    const rootMeshes = allMeshes.filter((m) => !childNodeIds.has(m.id!));
+    const rootTransformNodes: TransformNode[] = [];
+    for (const [id, node] of nodeMap) {
+        if (!childNodeIds.has(id) && !meshesByNodeId.has(id)) {
+            rootTransformNodes.push(node as TransformNode);
+        }
+    }
+    return { entities: [...lights, ...rootMeshes, ...rootTransformNodes], clearColor };
 }

--- a/packages/babylon-lite/src/loader-gltf/load-gltf.ts
+++ b/packages/babylon-lite/src/loader-gltf/load-gltf.ts
@@ -128,7 +128,7 @@ export async function loadGltf(engine: Engine, url: string): Promise<LoaderResul
 /** Build a TransformNode tree mirroring the glTF node hierarchy.
  *  Meshes are attached as children. Non-mesh nodes become
  *  pure TransformNodes preserving TRS for cloning/repositioning.
- *  Parent links are set by collectMeshes when the tree is added to the scene. */
+ *  Parent links are set by scene.add() when the tree is added to the scene. */
 function buildNodeHierarchy(json: any, meshes: Mesh[], meshDatas: GltfMeshData[]): TransformNode {
     // Map nodeIndex → uploaded Mesh[]
     const nodeToMeshes = new Map<number, Mesh[]>();

--- a/packages/babylon-lite/src/loader-results.ts
+++ b/packages/babylon-lite/src/loader-results.ts
@@ -1,5 +1,4 @@
-import type { Mesh } from "./mesh/mesh.js";
-import type { TransformNode } from "./scene/transform-node.js";
+import type { SceneNode } from "./scene/scene-node.js";
 import type { LightBase } from "./light/types.js";
 import type { AnimationGroup } from "./animation/animation-group.js";
 
@@ -8,11 +7,11 @@ import type { AnimationGroup } from "./animation/animation-group.js";
  * Pass directly to scene.add() — it handles all fields automatically.
  *
  * - glTF: entities = [root TransformNode], animationGroups = loaded clips
- * - .babylon: entities = flat array of Mesh + LightBase objects, clearColor from file
+ * - .babylon: entities = root SceneNodes (Mesh/TransformNode) + LightBase, clearColor from file
  */
 export interface LoaderResult {
-    /** Scene entities. glTF: [root TransformNode]. .babylon: flat [meshes…, lights…]. */
-    entities: Array<Mesh | TransformNode | LightBase>;
+    /** Scene entities. glTF: [root TransformNode]. .babylon: root nodes + lights. */
+    entities: Array<SceneNode | LightBase>;
     /** Animation groups from the file. scene.add() registers their per-frame tick automatically. */
     animationGroups?: AnimationGroup[];
     /** Scene background color declared in the file. scene.add() applies it to scene.clearColor. */

--- a/packages/babylon-lite/src/mesh/mesh.ts
+++ b/packages/babylon-lite/src/mesh/mesh.ts
@@ -1,15 +1,16 @@
 /** High-level Mesh — position/rotation/scaling + material + GPU geometry.
  *  Plain data (no scene reference). The scene collects meshes via scene.add(). */
 
-import type { Mat4 } from "../math/types.js";
-import { mat4Compose, mat4Translation, mat4Identity } from "../math/mat4.js";
+import { mat4Compose, mat4Identity } from "../math/mat4.js";
 import type { StandardMaterialProps } from "../material/standard/standard-material.js";
 import type { PbrMaterialProps } from "../material/pbr/pbr-material.js";
 import type { SkeletonData, MorphTargetData } from "../animation/types.js";
 import { ObservableVec3 } from "../math/observable-vec3.js";
+import { ObservableQuat } from "../math/observable-quat.js";
 import type { ThinInstanceData } from "./thin-instance.js";
-import type { IWorldMatrixProvider } from "../scene/parentable.js";
 import { createWorldMatrixState } from "../scene/world-matrix-state.js";
+import type { SceneNode } from "../scene/scene-node.js";
+import { eulerToQuat, createEulerProxy } from "../scene/scene-node.js";
 
 // ─── Mesh GPU Geometry ───────────────────────────────────────────────
 
@@ -28,14 +29,11 @@ export interface MeshGPU {
 // ─── Mesh ────────────────────────────────────────────────────────────
 
 /** A renderable mesh — plain data with transform, material, and GPU geometry.
- *  Works with both standard and PBR pipelines; routing is based on material type. */
-export interface Mesh {
-    name: string;
+ *  Works with both standard and PBR pipelines; routing is based on material type.
+ *  Extends SceneNode for the full TRS + parent + children hierarchy. */
+export interface Mesh extends SceneNode {
     /** Unique ID from source file (e.g. .babylon). Used for light include/exclude filtering. */
     id?: string;
-    position: ObservableVec3;
-    rotation: ObservableVec3;
-    scaling: ObservableVec3;
     material: StandardMaterialProps | PbrMaterialProps;
     receiveShadows: boolean;
     /** World-space bounding box (set by loaders for camera framing). */
@@ -50,10 +48,8 @@ export interface Mesh {
     renderOrder?: number;
     /** Thin instance data (CPU-side). GPU buffer managed by render system. */
     thinInstances?: ThinInstanceData | null;
-    // IWorldMatrixProvider + IParentable (installed by initMeshTransform)
-    parent: IWorldMatrixProvider | null;
-    readonly worldMatrix: Mat4;
-    readonly worldMatrixVersion: number;
+    // name, children, position, rotation, rotationQuaternion, scaling,
+    // parent, worldMatrix, worldMatrixVersion — all inherited from SceneNode
 }
 
 /** @internal Mesh with internal GPU fields — for engine/renderable code only. Not re-exported from index.ts. */
@@ -66,55 +62,28 @@ export interface MeshInternal extends Mesh {
     _cpuIndices?: Uint32Array;
 }
 
-/** Wire ObservableVec3 position/rotation/scaling onto a partially-built mesh object.
+/** Wire ObservableVec3/ObservableQuat TRS and children onto a partially-built mesh object.
  *  Used by all mesh creation paths (factories, loaders). */
 export function initMeshTransform(mesh: Mesh, px = 0, py = 0, pz = 0, rx = 0, ry = 0, rz = 0, sx = 1, sy = 1, sz = 1): void {
-    function meshLocalMatrix(): Mat4 {
-        const ppx = mesh.position.x,
-            ppy = mesh.position.y,
-            ppz = mesh.position.z;
-        const rrx = mesh.rotation.x,
-            rry = mesh.rotation.y,
-            rrz = mesh.rotation.z;
-        const ssx = mesh.scaling.x,
-            ssy = mesh.scaling.y,
-            ssz = mesh.scaling.z;
+    const wm = createWorldMatrixState(() => {
+        const p = mesh.position,
+            rq = mesh.rotationQuaternion,
+            s = mesh.scaling;
+        const isIdentity = p.x === 0 && p.y === 0 && p.z === 0 && rq.x === 0 && rq.y === 0 && rq.z === 0 && rq.w === 1 && s.x === 1 && s.y === 1 && s.z === 1;
+        return isIdentity ? mat4Identity() : mat4Compose(p.x, p.y, p.z, rq.x, rq.y, rq.z, rq.w, s.x, s.y, s.z);
+    });
+    const onWmDirty = () => wm.markLocalDirty();
 
-        // Fast path: no rotation → translation × scale
-        if (rrx === 0 && rry === 0 && rrz === 0) {
-            if (ssx === 1 && ssy === 1 && ssz === 1) {
-                return mat4Translation(ppx, ppy, ppz);
-            }
-            const m = mat4Identity();
-            m[0] = ssx;
-            m[5] = ssy;
-            m[10] = ssz;
-            m[12] = ppx;
-            m[13] = ppy;
-            m[14] = ppz;
-            return m;
-        }
+    const [iqx, iqy, iqz, iqw] = eulerToQuat(rx, ry, rz);
+    const rq = new ObservableQuat(iqx, iqy, iqz, iqw, onWmDirty);
+    mesh.rotationQuaternion = rq;
+    mesh.rotation = createEulerProxy(rq);
+    mesh.position = new ObservableVec3(px, py, pz, onWmDirty);
+    mesh.scaling = new ObservableVec3(sx, sy, sz, onWmDirty);
 
-        // Euler XYZ → quaternion → compose
-        const cx = Math.cos(rrx * 0.5),
-            sx2 = Math.sin(rrx * 0.5);
-        const cy = Math.cos(rry * 0.5),
-            sy2 = Math.sin(rry * 0.5);
-        const cz = Math.cos(rrz * 0.5),
-            sz2 = Math.sin(rrz * 0.5);
-        const qx = sx2 * cy * cz + cx * sy2 * sz2;
-        const qy = cx * sy2 * cz - sx2 * cy * sz2;
-        const qz = cx * cy * sz2 + sx2 * sy2 * cz;
-        const qw = cx * cy * cz - sx2 * sy2 * sz2;
-        return mat4Compose(ppx, ppy, ppz, qx, qy, qz, qw, ssx, ssy, ssz);
+    if (!(mesh as unknown as Record<string, unknown>).children) {
+        (mesh as unknown as Record<string, unknown>).children = [];
     }
-
-    const wm = createWorldMatrixState(meshLocalMatrix);
-    const onDirty = () => wm.markLocalDirty();
-
-    mesh.position = new ObservableVec3(px, py, pz, onDirty);
-    mesh.rotation = new ObservableVec3(rx, ry, rz, onDirty);
-    mesh.scaling = new ObservableVec3(sx, sy, sz, onDirty);
 
     Object.defineProperty(mesh, "parent", {
         get() {

--- a/packages/babylon-lite/src/scene/scene-core.ts
+++ b/packages/babylon-lite/src/scene/scene-core.ts
@@ -9,11 +9,11 @@ import type { ShadowGenerator } from "../shadow/shadow-generator.js";
 import type { FogConfig } from "../material/standard/standard-material.js";
 import type { Renderable, PrePassRenderable, SceneUniformUpdater, MeshGroupBuilder } from "../render/renderable.js";
 import type { TransformNode } from "./transform-node.js";
+import type { SceneNode } from "./scene-node.js";
 import type { SkyboxData } from "../loader-skybox/load-skybox.js";
 import type { EnvironmentTextures } from "../loader-env/load-env.js";
 import type { ComposedShader } from "../shader/fragment-types.js";
 import type { LoaderResult } from "../loader-results.js";
-import { collectMeshes, isTransformNode } from "./transform-node.js";
 
 /** Image processing configuration. */
 export interface ImageProcessingConfig {
@@ -76,8 +76,8 @@ export interface SceneContext {
     /** Run all deferred builders (called by engine.start before the render loop). */
     _build(): Promise<void>;
 
-    /** Add an entity (mesh, light, transform node, shadow generator, or loader result) to the scene. */
-    add(entity: Mesh | LightBase | ShadowGenerator | TransformNode | LoaderResult): void;
+    /** Add an entity (mesh, light, camera, transform node, shadow generator, or loader result) to the scene. */
+    add(entity: Mesh | LightBase | Camera | ShadowGenerator | TransformNode | LoaderResult): void;
 
     // ─── Dispose infrastructure ────────────────────────────────
 
@@ -285,7 +285,7 @@ export function createSceneContext(engine: Engine): SceneContext {
             ctx.shadowGenerators.length = 0;
             ctx.camera = null;
         },
-        add(entity: Mesh | LightBase | ShadowGenerator | TransformNode | LoaderResult) {
+        add(entity: Mesh | LightBase | Camera | ShadowGenerator | TransformNode | LoaderResult) {
             // LoaderResult from loadGltf / loadBabylon — process each field present
             if ("entities" in entity) {
                 const result = entity as LoaderResult;
@@ -307,16 +307,8 @@ export function createSceneContext(engine: Engine): SceneContext {
                 }
                 return;
             }
-            // TransformNode: set parent links and add all meshes to flat list
-            if (isTransformNode(entity)) {
-                const meshes = collectMeshes(entity, entity.parent ?? undefined);
-                for (const m of meshes) {
-                    ctx.add(m);
-                }
-                return;
-            }
             if ("_gpu" in entity && "material" in entity) {
-                const mesh = entity as Mesh;
+                const mesh = entity as unknown as Mesh;
                 ctx.meshes.push(mesh);
                 installMaterialSetter(ctx, mesh);
                 const build = mesh.material ? ((mesh.material as any)._buildGroup as MeshGroupBuilder | undefined) : undefined;
@@ -333,8 +325,16 @@ export function createSceneContext(engine: Engine): SceneContext {
                     }
                     group.push(mesh);
                 }
-            } else {
+            } else if ("lightType" in entity) {
                 ctx.lights.push(entity as LightBase);
+            }
+            // Recurse into children of meshes, lights, cameras — set parent links
+            const kids = (entity as unknown as SceneNode).children;
+            if (kids?.length) {
+                for (const child of kids) {
+                    (child as unknown as SceneNode).parent = entity as unknown as SceneNode;
+                    ctx.add(child);
+                }
             }
         },
     };

--- a/packages/babylon-lite/src/scene/scene-node.ts
+++ b/packages/babylon-lite/src/scene/scene-node.ts
@@ -1,0 +1,131 @@
+/** SceneNode — common base for all scene entities with TRS, parent, and children.
+ *
+ *  Provides position, rotationQuaternion (source of truth), rotation (Euler XYZ proxy),
+ *  scaling, parent, worldMatrix, worldMatrixVersion, and children. */
+
+import type { Mat4 } from "../math/types.js";
+import type { IWorldMatrixProvider } from "./parentable.js";
+import { mat4Compose, mat4Identity } from "../math/mat4.js";
+import { ObservableVec3 } from "../math/observable-vec3.js";
+import { ObservableQuat } from "../math/observable-quat.js";
+import { createWorldMatrixState } from "./world-matrix-state.js";
+
+// ─── EulerProxy ──────────────────────────────────────────────────────
+
+/** Bidirectional Euler XYZ view over a quaternion.
+ *  Reads decompose the current quaternion on the fly; writes convert Euler→quat atomically. */
+export interface EulerProxy {
+    x: number;
+    y: number;
+    z: number;
+    set(x: number, y: number, z: number): void;
+}
+
+// ─── SceneNode ───────────────────────────────────────────────────────
+
+export interface SceneNode {
+    name: string;
+    children: SceneNode[];
+    position: ObservableVec3;
+    /** Quaternion rotation — source of truth for the local matrix. */
+    rotationQuaternion: ObservableQuat;
+    /** Euler XYZ bidirectional proxy — reads decompose current quat; writes update quat atomically. */
+    rotation: EulerProxy;
+    scaling: ObservableVec3;
+    parent: IWorldMatrixProvider | null;
+    readonly worldMatrix: Mat4;
+    readonly worldMatrixVersion: number;
+}
+
+// ─── Math helpers ─────────────────────────────────────────────────────
+
+/** Euler XYZ → quaternion (intrinsic XYZ order). */
+export function eulerToQuat(rx: number, ry: number, rz: number): [number, number, number, number] {
+    const cx = Math.cos(rx * 0.5),
+        sx_ = Math.sin(rx * 0.5);
+    const cy = Math.cos(ry * 0.5),
+        sy_ = Math.sin(ry * 0.5);
+    const cz = Math.cos(rz * 0.5),
+        sz_ = Math.sin(rz * 0.5);
+    return [sx_ * cy * cz + cx * sy_ * sz_, cx * sy_ * cz - sx_ * cy * sz_, cx * cy * sz_ + sx_ * sy_ * cz, cx * cy * cz - sx_ * sy_ * sz_];
+}
+
+/** Quaternion → Euler XYZ (inverse of eulerToQuat). */
+export function quatToEulerXYZ(qx: number, qy: number, qz: number, qw: number): [number, number, number] {
+    const sinY = 2 * (qx * qz + qw * qy);
+    const ry = Math.asin(Math.max(-1, Math.min(1, sinY)));
+    const rx = Math.atan2(-(2 * (qy * qz - qw * qx)), 1 - 2 * (qx * qx + qy * qy));
+    const rz = Math.atan2(-(2 * (qx * qy - qw * qz)), 1 - 2 * (qy * qy + qz * qz));
+    return [rx, ry, rz];
+}
+
+/** Create a live bidirectional EulerProxy backed by the given ObservableQuat. */
+export function createEulerProxy(rq: ObservableQuat): EulerProxy {
+    const e = () => quatToEulerXYZ(rq.x, rq.y, rq.z, rq.w);
+    const s = (x: number, y: number, z: number) => {
+        const [a, b, c, d] = eulerToQuat(x, y, z);
+        rq.set(a, b, c, d);
+    };
+    return {
+        get x() {
+            return e()[0];
+        },
+        set x(v: number) {
+            const r = e();
+            s(v, r[1], r[2]);
+        },
+        get y() {
+            return e()[1];
+        },
+        set y(v: number) {
+            const r = e();
+            s(r[0], v, r[2]);
+        },
+        get z() {
+            return e()[2];
+        },
+        set z(v: number) {
+            const r = e();
+            s(r[0], r[1], v);
+        },
+        set: s,
+    };
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────
+
+/** Create a SceneNode with given TRS (position and scaling in cartesian, rotation as quaternion). */
+export function createSceneNode(name: string, px = 0, py = 0, pz = 0, qx = 0, qy = 0, qz = 0, qw = 1, sx = 1, sy = 1, sz = 1): SceneNode {
+    const wm = createWorldMatrixState(() => {
+        const p = node.position,
+            rq = node.rotationQuaternion,
+            s = node.scaling;
+        const isIdentity = p.x === 0 && p.y === 0 && p.z === 0 && rq.x === 0 && rq.y === 0 && rq.z === 0 && rq.w === 1 && s.x === 1 && s.y === 1 && s.z === 1;
+        return isIdentity ? mat4Identity() : mat4Compose(p.x, p.y, p.z, rq.x, rq.y, rq.z, rq.w, s.x, s.y, s.z);
+    });
+    const onWmDirty = () => wm.markLocalDirty();
+
+    const rq = new ObservableQuat(qx, qy, qz, qw, onWmDirty);
+
+    const node: SceneNode = {
+        name,
+        children: [],
+        position: new ObservableVec3(px, py, pz, onWmDirty),
+        rotationQuaternion: rq,
+        rotation: createEulerProxy(rq),
+        scaling: new ObservableVec3(sx, sy, sz, onWmDirty),
+        get parent() {
+            return wm.parent;
+        },
+        set parent(v) {
+            wm.parent = v;
+        },
+        get worldMatrix() {
+            return wm.getWorldMatrix();
+        },
+        get worldMatrixVersion() {
+            return wm.getWorldMatrixVersion();
+        },
+    };
+    return node;
+}

--- a/packages/babylon-lite/src/scene/transform-node.ts
+++ b/packages/babylon-lite/src/scene/transform-node.ts
@@ -1,67 +1,28 @@
-/** TransformNode — a live scene graph node with TRS, parent, and children.
+/** TransformNode — alias for SceneNode. A scene graph node with TRS, parent, and children.
  *
- *  Implements IWorldMatrixProvider (can be a parent) and IParentable (can have a parent).
- *  Uses shared createWorldMatrixState for version-based lazy caching.
- *  Position/scaling use ObservableVec3, rotation uses ObservableQuat. */
+ *  TransformNode is now a pure type alias for SceneNode, giving all scene entities
+ *  a common base. createTransformNode delegates to createSceneNode. */
 
-import type { Mat4 } from "../math/types.js";
 import type { Mesh } from "../mesh/mesh.js";
 import type { MeshInternal } from "../mesh/mesh.js";
 import { initMeshTransform } from "../mesh/mesh.js";
-import type { IWorldMatrixProvider, IParentable } from "./parentable.js";
-import { mat4Compose, mat4Identity } from "../math/mat4.js";
-import { ObservableVec3 } from "../math/observable-vec3.js";
-import { ObservableQuat } from "../math/observable-quat.js";
-import { createWorldMatrixState } from "./world-matrix-state.js";
+import type { SceneNode } from "./scene-node.js";
+import { createSceneNode } from "./scene-node.js";
 
-export interface TransformNode extends IWorldMatrixProvider, IParentable {
-    name: string;
-    position: ObservableVec3;
-    rotationQuaternion: ObservableQuat;
-    scaling: ObservableVec3;
-    children: (TransformNode | Mesh)[];
-    parent: IWorldMatrixProvider | null;
-    readonly worldMatrix: Mat4;
-    readonly worldMatrixVersion: number;
-}
+export type { SceneNode } from "./scene-node.js";
 
-/** Create a TransformNode with TRS values and lazy world matrix. */
+/** TransformNode is a SceneNode — pure type alias, no extra fields. */
+export type TransformNode = SceneNode;
+
+/** Create a TransformNode (SceneNode) with TRS values and lazy world matrix.
+ *  Parameters: name, position (px,py,pz), rotation quaternion (qx,qy,qz,qw), scaling (sx,sy,sz). */
 export function createTransformNode(name: string, px = 0, py = 0, pz = 0, qx = 0, qy = 0, qz = 0, qw = 1, sx = 1, sy = 1, sz = 1): TransformNode {
-    const wm = createWorldMatrixState(() => {
-        const p = node.position,
-            r = node.rotationQuaternion,
-            s = node.scaling;
-        const isIdentity = p.x === 0 && p.y === 0 && p.z === 0 && r.x === 0 && r.y === 0 && r.z === 0 && r.w === 1 && s.x === 1 && s.y === 1 && s.z === 1;
-        return isIdentity ? mat4Identity() : mat4Compose(p.x, p.y, p.z, r.x, r.y, r.z, r.w, s.x, s.y, s.z);
-    });
-
-    const onDirty = () => wm.markLocalDirty();
-
-    const node: TransformNode = {
-        name,
-        position: new ObservableVec3(px, py, pz, onDirty),
-        rotationQuaternion: new ObservableQuat(qx, qy, qz, qw, onDirty),
-        scaling: new ObservableVec3(sx, sy, sz, onDirty),
-        children: [],
-
-        get parent() {
-            return wm.parent;
-        },
-        set parent(v) {
-            wm.parent = v;
-        },
-        get worldMatrix() {
-            return wm.getWorldMatrix();
-        },
-        get worldMatrixVersion() {
-            return wm.getWorldMatrixVersion();
-        },
-    };
-    return node;
+    return createSceneNode(name, px, py, pz, qx, qy, qz, qw, sx, sy, sz);
 }
 
-/** Deep-clone a TransformNode tree. Meshes are shallow-cloned (shared GPU buffers). */
-export function cloneTransformNode(src: TransformNode): TransformNode {
+/** Deep-clone a SceneNode tree. Meshes are shallow-cloned (shared GPU buffers).
+ *  Lights, cameras, and other non-mesh/non-TN children are shallow-cloned. */
+export function cloneTransformNode(src: SceneNode): SceneNode {
     const clone = createTransformNode(
         src.name + "_clone",
         src.position.x,
@@ -76,12 +37,12 @@ export function cloneTransformNode(src: TransformNode): TransformNode {
         src.scaling.z
     );
     for (const child of src.children) {
-        if (isTransformNode(child)) {
+        if (!("_gpu" in child) && !("lightType" in child)) {
             const childClone = cloneTransformNode(child);
             childClone.parent = clone;
             clone.children.push(childClone);
-        } else {
-            const mesh = child as Mesh;
+        } else if ("_gpu" in child) {
+            const mesh = child as unknown as Mesh;
             const mi = mesh as MeshInternal;
             const meshClone = {
                 ...mesh,
@@ -103,32 +64,12 @@ export function cloneTransformNode(src: TransformNode): TransformNode {
             );
             meshClone.parent = clone;
             clone.children.push(meshClone);
+        } else {
+            // Lights, cameras, other node types — shallow clone with fresh children array
+            const childClone = { ...(child as Record<string, unknown>), name: (child as SceneNode).name + "_clone", children: [] } as unknown as SceneNode;
+            childClone.parent = clone;
+            clone.children.push(childClone);
         }
     }
     return clone;
-}
-
-/** Recursively collect all meshes in a subtree.
- *  Sets parent links so world matrices propagate through the hierarchy. */
-export function collectMeshes(node: TransformNode, parentProvider?: IWorldMatrixProvider): Mesh[] {
-    if (parentProvider) {
-        node.parent = parentProvider;
-    }
-    const result: Mesh[] = [];
-    for (const child of node.children) {
-        if (isTransformNode(child)) {
-            child.parent = node;
-            result.push(...collectMeshes(child, node));
-        } else {
-            const mesh = child as Mesh;
-            mesh.parent = node;
-            result.push(mesh);
-        }
-    }
-    return result;
-}
-
-/** Check if an object is a TransformNode (duck-typed). */
-export function isTransformNode(obj: unknown): obj is TransformNode {
-    return typeof obj === "object" && obj !== null && "children" in obj && "rotationQuaternion" in obj && !("_gpu" in obj);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,11 +64,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@25.5.0)(vite@6.4.1(@types/node@25.5.0)(terser@5.46.1)(tsx@4.21.0))
 
-  apps/manual-lab:
+  lab:
     dependencies:
       babylon-lite:
         specifier: workspace:*
-        version: link:../../packages/babylon-lite
+        version: link:../packages/babylon-lite
     devDependencies:
       '@babylonjs/core':
         specifier: ^8.56.2

--- a/scene-config.json
+++ b/scene-config.json
@@ -118,7 +118,7 @@
         "slug": "scene12-shader-balls",
         "name": "Scene 12 \u2014 PBR Shader Balls",
         "maxMad": 0.025,
-        "maxRawKB": 96,
+        "maxRawKB": 97,
         "maxGzipKB": 37,
         "description": "3 shader balls with metallic reflectance textures, directional light, env rotation.",
         "tags": ["pbr", "gltf"]


### PR DESCRIPTION
## Summary

Introduces a unified **SceneNode** base for all scene entities, replacing the previous flat/mesh-only hierarchy model.

### Key changes

- **SceneNode interface** — common base with \children: SceneNode[]\, TRS (position, rotationQuaternion, scaling), parent, worldMatrix
- **TransformNode = SceneNode** — pure type alias, no extra fields
- **Bidirectional EulerProxy** — \otation\ reads decompose from quaternion on the fly; writes convert Euler→quat atomically. Supports \
ode.rotation.x += 0.01\ patterns
- **Heterogeneous hierarchy** — \scene.add()\ correctly handles TN→Mesh→Light→Camera chains with explicit \lightType\ detection (no more assuming non-mesh = light)
- **\cloneTransformNode\** — handles all child types (TN deep clone, Mesh GPU clone, lights/cameras shallow clone)
- **Remove \collectMeshes\** — replaced by generic \children\ traversal in \scene.add()\
- **Loader updates** — \load-babylon.ts\ returns root nodes only with parentId-based hierarchy; children typed as \SceneNode[]\

### Files

| Area | Files |
|------|-------|
| Core | \scene-node.ts\ (new), \	ransform-node.ts\, \scene-core.ts\, \index.ts\ |
| Mesh | \mesh.ts\ (extends SceneNode, uses createEulerProxy) |
| Lights | \	ypes.ts\, \directional-light.ts\, \hemispheric.ts\, \point-light.ts\, \spot-light.ts\ |
| Cameras | \camera.ts\, \ree-camera.ts\, \rc-rotate.ts\ |
| Loaders | \load-babylon.ts\, \load-gltf.ts\, \loader-results.ts\ |
