### PR TITLE
feat(lab): add Report tab with live subproject progress

### DIFF
--- a/lab/index.html
+++ b/lab/index.html
@@ -1043,6 +1043,128 @@
                 opacity: 0.85;
                 color: #58a6ff;
             }
+            /* ── Report tab ── */
+            .report-summary {
+                display: flex;
+                gap: 1.5rem;
+                justify-content: center;
+                flex-wrap: wrap;
+            }
+            .report-summary-card {
+                background: #161b22;
+                border: 1px solid #21262d;
+                border-radius: 12px;
+                padding: 1.2rem 2rem;
+                text-align: center;
+                min-width: 150px;
+            }
+            .report-summary-card .num {
+                font-size: 2rem;
+                font-weight: 700;
+            }
+            .report-summary-card .label {
+                color: #8b949e;
+                font-size: 0.8rem;
+                text-transform: uppercase;
+                letter-spacing: 0.05em;
+                margin-top: 0.25rem;
+            }
+            .report-card {
+                background: #161b22;
+                border: 1px solid #21262d;
+                border-radius: 12px;
+                padding: 1.25rem 1.4rem;
+                display: flex;
+                flex-direction: column;
+                gap: 0.8rem;
+                transition: border-color 0.2s;
+            }
+            .report-card:hover {
+                border-color: #58a6ff;
+            }
+            .report-card-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: flex-start;
+                gap: 0.6rem;
+            }
+            .report-card-title {
+                font-size: 0.95rem;
+                font-weight: 600;
+                line-height: 1.35;
+            }
+            .report-card-title a {
+                color: #e6edf3;
+                text-decoration: none;
+            }
+            .report-card-title a:hover {
+                color: #58a6ff;
+            }
+            .report-card-number {
+                color: #8b949e;
+                font-size: 0.8rem;
+                flex-shrink: 0;
+            }
+            .report-assignee {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.35rem;
+                font-size: 0.8rem;
+                color: #8b949e;
+            }
+            .report-assignee img {
+                width: 20px;
+                height: 20px;
+                border-radius: 50%;
+            }
+            .report-progress-wrap {
+                display: flex;
+                align-items: center;
+                gap: 0.7rem;
+            }
+            .report-progress-bar {
+                flex: 1;
+                height: 8px;
+                background: #30363d;
+                border-radius: 4px;
+                overflow: hidden;
+            }
+            .report-progress-fill {
+                height: 100%;
+                border-radius: 4px;
+                transition: width 0.4s ease;
+            }
+            .report-progress-label {
+                font-size: 0.8rem;
+                font-weight: 600;
+                min-width: 3.5rem;
+                text-align: right;
+            }
+            .report-badge {
+                display: inline-block;
+                font-size: 0.7rem;
+                font-weight: 600;
+                padding: 0.15rem 0.55rem;
+                border-radius: 999px;
+                text-transform: uppercase;
+                letter-spacing: 0.03em;
+            }
+            .report-badge-green {
+                background: rgba(63, 185, 80, 0.15);
+                color: #3fb950;
+            }
+            .report-badge-yellow {
+                background: rgba(210, 153, 34, 0.15);
+                color: #d29922;
+            }
+            .report-badge-red {
+                background: rgba(248, 81, 73, 0.12);
+                color: #f85149;
+            }
+            .report-badge-muted {
+                background: rgba(139, 148, 158, 0.12);
+                color: #8b949e;
+            }
         </style>
     </head>
     <body>
@@ -2270,6 +2392,7 @@
             <button class="tab" data-tab="parity">Parity <span class="tab-badge" style="background: #1a3a1a; color: #3fb950">diff</span></button>
             <button class="tab" data-tab="bundle">Bundle <span class="tab-badge tab-badge-bundle">dist</span></button>
             <button class="tab" data-tab="perf">Perf</button>
+            <button class="tab" data-tab="report">Report <span class="tab-badge" style="background: #2d1f4e; color: #bc8cff">progress</span></button>
         </div>
 
         <div id="panel-source" class="tab-panel active">
@@ -2321,6 +2444,16 @@
             </div>
 
             <div class="perf-grid" id="perf-grid"></div>
+        </div>
+
+        <div id="panel-report" class="tab-panel">
+            <div class="tab-hint">
+                💡 Subproject milestone progress from GitHub Issues (label: <code>sub-project</code>).
+                <button class="btn" id="report-refresh-btn" onclick="refreshReport()" style="margin-left: 1rem; font-size: 0.8rem; padding: 0.3rem 0.8rem">🔄 Refresh</button>
+                <span id="report-status" style="margin-left: 0.5rem; font-size: 0.8rem; color: #8b949e"></span>
+            </div>
+            <div class="summary" id="report-summary" style="display: none; margin: 1.5rem 2rem 0;"></div>
+            <div class="grid" id="report-grid" style="padding-top: 1rem"></div>
         </div>
 
         <script>
@@ -3254,6 +3387,125 @@
                     }).join("");
                 });
             }
+
+            // ── Report tab ──
+            var _reportLoaded = false;
+
+            function escapeHtml(str) {
+                var div = document.createElement("div");
+                div.appendChild(document.createTextNode(str));
+                return div.innerHTML;
+            }
+
+            function reportBarColor(done, total) {
+                if (total === 0) return "#30363d";
+                var pct = done / total * 100;
+                if (pct === 100) return "#3fb950";
+                if (pct > 0) return "#d29922";
+                return "#f85149";
+            }
+
+            function reportBadge(done, total) {
+                if (total === 0) return '<span class="report-badge report-badge-muted">No milestones</span>';
+                var pct = done / total * 100;
+                if (pct === 100) return '<span class="report-badge report-badge-green">Complete</span>';
+                if (pct > 0) return '<span class="report-badge report-badge-yellow">In Progress</span>';
+                return '<span class="report-badge report-badge-red">Not Started</span>';
+            }
+
+            function renderReport(result) {
+                var data = result.data || [];
+                var fetchedAt = result.fetchedAt;
+                var summary = document.getElementById("report-summary");
+                var grid = document.getElementById("report-grid");
+                var status = document.getElementById("report-status");
+
+                if (data.length === 0) {
+                    summary.style.display = "none";
+                    grid.innerHTML = '<div style="padding: 2rem; color: #8b949e; text-align: center">No report data available. Make sure <code>gh</code> CLI is installed and authenticated.</div>';
+                    if (status) status.textContent = "";
+                    return;
+                }
+
+                var totalMilestones = data.reduce(function(s, d) { return s + d.total; }, 0);
+                var totalDone = data.reduce(function(s, d) { return s + d.done; }, 0);
+                var overallPct = totalMilestones > 0 ? Math.round(totalDone / totalMilestones * 100) : 0;
+
+                summary.style.display = "flex";
+                summary.className = "report-summary";
+                summary.innerHTML =
+                    '<div class="report-summary-card"><div class="num" style="color: #58a6ff">' + data.length + '</div><div class="label">Subprojects</div></div>' +
+                    '<div class="report-summary-card"><div class="num" style="color: #3fb950">' + totalDone + ' / ' + totalMilestones + '</div><div class="label">Milestones Done</div></div>' +
+                    '<div class="report-summary-card"><div class="num" style="color: #d29922">' + overallPct + '%</div><div class="label">Overall Progress</div></div>';
+
+                data.sort(function(a, b) {
+                    function rank(d) { return d.total === 0 ? 2 : d.done === 0 ? 1 : 0; }
+                    return rank(a) - rank(b);
+                });
+
+                grid.innerHTML = data.map(function(d) {
+                    var pct = d.total > 0 ? Math.round(d.done / d.total * 100) : 0;
+                    var label = d.total > 0 ? d.done + "/" + d.total : "—";
+                    var color = reportBarColor(d.done, d.total);
+                    return '<div class="report-card">' +
+                        '<div class="report-card-header">' +
+                            '<div class="report-card-title"><a href="https://github.com/BabylonJS/Babylon-Lite/issues/' + d.num + '" target="_blank">' + escapeHtml(d.title) + '</a></div>' +
+                            '<span class="report-card-number">#' + d.num + '</span>' +
+                        '</div>' +
+                        '<div class="report-assignee"><img src="https://github.com/' + encodeURIComponent(d.assignee) + '.png?size=40" alt="" /> @' + escapeHtml(d.assignee) + '</div>' +
+                        '<div class="report-progress-wrap">' +
+                            '<div class="report-progress-bar"><div class="report-progress-fill" style="width:' + (d.total > 0 ? pct : 0) + '%;background:' + color + '"></div></div>' +
+                            '<span class="report-progress-label" style="color:' + color + '">' + label + '</span>' +
+                        '</div>' +
+                        '<div>' + reportBadge(d.done, d.total) + '</div>' +
+                    '</div>';
+                }).join("");
+
+                if (status && fetchedAt) {
+                    status.textContent = "Updated " + new Date(fetchedAt).toLocaleString();
+                }
+            }
+
+            function loadReport() {
+                if (_reportLoaded) return;
+                _reportLoaded = true;
+                var grid = document.getElementById("report-grid");
+                grid.innerHTML = '<div style="padding: 2rem; color: #8b949e; text-align: center">Loading report data…</div>';
+                fetch("/api/report.json")
+                    .then(function(r) { return r.json(); })
+                    .then(renderReport)
+                    .catch(function() {
+                        grid.innerHTML = '<div style="padding: 2rem; color: #f85149; text-align: center">Failed to load report data. Is <code>gh</code> CLI available?</div>';
+                    });
+            }
+
+            function refreshReport() {
+                var btn = document.getElementById("report-refresh-btn");
+                var status = document.getElementById("report-status");
+                btn.disabled = true;
+                btn.textContent = "⏳ Refreshing…";
+                if (status) status.textContent = "";
+                fetch("/api/report-refresh", { method: "POST" })
+                    .then(function(r) { return r.json(); })
+                    .then(function(result) {
+                        renderReport(result);
+                        btn.disabled = false;
+                        btn.textContent = "🔄 Refresh";
+                    })
+                    .catch(function() {
+                        if (status) status.textContent = "Refresh failed";
+                        btn.disabled = false;
+                        btn.textContent = "🔄 Refresh";
+                    });
+            }
+
+            // Hook into tab switching to lazy-load report data
+            var _origActivateTab = activateTab;
+            activateTab = function(tabName, restoreScroll) {
+                _origActivateTab(tabName, restoreScroll);
+                if (tabName === "report") loadReport();
+            };
+            if (_currentTab === "report") loadReport();
         </script>
 
         <!-- Fullscreen lightbox for parity diff images -->

--- a/lab/vite.config.ts
+++ b/lab/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, type Plugin } from "vite";
 import { resolve } from "path";
 import { createReadStream, existsSync, readdirSync } from "fs";
+import { exec } from "child_process";
 
 /** Serve reference images from the repo-root reference/ directory */
 function serveReferenceImages(): Plugin {
@@ -33,8 +34,96 @@ function serveReferenceImages(): Plugin {
     };
 }
 
+/** Fetch subproject report data from GitHub Issues via gh CLI */
+function serveReportData(): Plugin {
+    interface ReportEntry {
+        num: number;
+        title: string;
+        assignee: string;
+        done: number;
+        total: number;
+    }
+    let cache: { data: ReportEntry[]; fetchedAt: string } | null = null;
+    let fetching = false;
+
+    function fetchReport(): Promise<{ data: ReportEntry[]; fetchedAt: string }> {
+        return new Promise((resolve) => {
+            fetching = true;
+            exec(
+                'gh issue list --repo BabylonJS/Babylon-Lite --label "sub-project" --state all --json number,title,body,assignees --limit 100',
+                { timeout: 30_000 },
+                (err, stdout) => {
+                    fetching = false;
+                    if (err) {
+                        console.warn("[report] gh CLI failed:", err.message);
+                        resolve(cache ?? { data: [], fetchedAt: "" });
+                        return;
+                    }
+                    try {
+                        const issues = JSON.parse(stdout) as {
+                            number: number;
+                            title: string;
+                            body?: string;
+                            assignees?: { login: string }[];
+                        }[];
+                        const data: ReportEntry[] = issues
+                            .sort((a, b) => a.number - b.number)
+                            .map((i) => {
+                                const body = i.body ?? "";
+                                const total = (body.match(/- \[[ x]\]/g) ?? []).length;
+                                const done = (body.match(/- \[x\]/g) ?? []).length;
+                                const assignee = i.assignees?.[0]?.login ?? "unassigned";
+                                return { num: i.number, title: i.title, assignee, done, total };
+                            });
+                        cache = { data, fetchedAt: new Date().toISOString() };
+                        resolve(cache);
+                    } catch {
+                        console.warn("[report] Failed to parse gh output");
+                        resolve(cache ?? { data: [], fetchedAt: "" });
+                    }
+                },
+            );
+        });
+    }
+
+    return {
+        name: "serve-report-data",
+        configureServer(server) {
+            // Eagerly fetch on server start (non-blocking)
+            fetchReport();
+
+            server.middlewares.use((req, res, next) => {
+                const url = (req.url ?? "").split("?")[0];
+
+                if (url === "/api/report.json" && req.method === "GET") {
+                    res.setHeader("Content-Type", "application/json");
+                    res.setHeader("Cache-Control", "no-cache");
+                    if (cache) {
+                        res.end(JSON.stringify(cache));
+                    } else if (fetching) {
+                        // Wait for the in-flight fetch to complete
+                        fetchReport().then((result) => res.end(JSON.stringify(result)));
+                    } else {
+                        fetchReport().then((result) => res.end(JSON.stringify(result)));
+                    }
+                    return;
+                }
+
+                if (url === "/api/report-refresh" && req.method === "POST") {
+                    res.setHeader("Content-Type", "application/json");
+                    res.setHeader("Cache-Control", "no-cache");
+                    fetchReport().then((result) => res.end(JSON.stringify(result)));
+                    return;
+                }
+
+                next();
+            });
+        },
+    };
+}
+
 export default defineConfig({
-    plugins: [serveReferenceImages()],
+    plugins: [serveReferenceImages(), serveReportData()],
     optimizeDeps: {
         // BJS uses prototype-patching side-effect imports (e.g. abstractEngine.dom.js).
         // babylon-lite uses ?raw WGSL imports that esbuild can't handle.


### PR DESCRIPTION
## Summary

Adds a **Report** tab to the lab dashboard (right of the Perf tab) that displays live subproject milestone progress from GitHub Issues.

### What's included

- **Vite plugin** (\serveReportData\) in \lab/vite.config.ts\:
  - Fetches issues labeled \sub-project\ via \gh\ CLI asynchronously on server start
  - Serves cached data at \GET /api/report.json\
  - Supports \POST /api/report-refresh\ to re-fetch live data on demand
  - Graceful error handling when \gh\ CLI is unavailable

- **Report tab UI** in \lab/index.html\:
  - Summary cards showing subproject count, milestones done, and overall progress %
  - Per-subproject progress cards with assignee avatars, progress bars, and status badges
  - 🔄 Refresh button to pull fresh data from GitHub
  - Lazy-loaded on first tab activation (no impact on other tabs' load time)
  - Consistent dark GitHub-style theme matching existing tabs

### Prerequisites

- \gh\ CLI installed and authenticated (\gh auth login\)
- If \gh\ is not available, the tab shows a friendly error state and all other tabs remain functional