### PR TITLE
perf(bundle): shadow factory, sorted-ext cache, table-driven .babylon textures, shared shadow BG

### DIFF
--- a/packages/babylon-lite/src/engine/engine.ts
+++ b/packages/babylon-lite/src/engine/engine.ts
@@ -231,6 +231,15 @@ function drawList(enc: GPURenderPassEncoder | GPURenderBundleEncoder, list: read
             lb = r._sceneBG;
         }
         draws += r.draw(enc, engine);
+        // Renderables without a declared pipeline/sceneBG set their own state internally
+        // (e.g. PBR drawPackets cycles through multiple variants). Invalidate the trackers
+        // so the next renderable correctly re-binds even if it happens to match our record.
+        if (!r._pipeline) {
+            lp = null;
+        }
+        if (!r._sceneBG) {
+            lb = null;
+        }
     }
     return draws;
 }

--- a/packages/babylon-lite/src/loader-babylon/load-babylon.ts
+++ b/packages/babylon-lite/src/loader-babylon/load-babylon.ts
@@ -129,6 +129,65 @@ interface BabylonLight {
     includedOnlyMeshesIds?: string[];
 }
 
+// ─── Standard-material texture-slot table ───────────────────────────
+// Declarative description of .babylon -> StandardMaterialProps texture mapping.
+// Each slot maps a source texture field on BabylonMaterial to a destination
+// Texture2D field on StandardMaterialProps, plus optional level/coordIndex/extras.
+type BabylonTexField = "diffuseTexture" | "bumpTexture" | "specularTexture" | "ambientTexture" | "lightmapTexture" | "opacityTexture" | "reflectionTexture";
+
+interface BabylonTexSlot {
+    readonly src: BabylonTexField;
+    /** Destination Texture2D field on StandardMaterialProps. */
+    readonly dst: string;
+    /** StandardMaterialProps field receiving `t.level`, if present. */
+    readonly level?: string;
+    /** Coordinate-index mapping. `only1`=true → only apply when coordIndex===1. */
+    readonly coordIndex?: { readonly dst: string; readonly only1?: boolean };
+    /** Skip this slot for a texture if predicate returns true (e.g. cube reflections). */
+    readonly skipIf?: (t: BabylonTexture) => boolean;
+    /** Apply remaining slot-specific side-effects (uvScale, alphaCutOff, etc.). */
+    readonly extra?: (t: BabylonTexture, mat: StandardMaterialProps) => void;
+}
+
+const TEX_SLOTS: readonly BabylonTexSlot[] = [
+    {
+        src: "diffuseTexture",
+        dst: "diffuseTexture",
+        coordIndex: { dst: "diffuseCoordIndex", only1: true },
+        extra: (t, m) => {
+            m.uvScale = [t.uScale ?? 1, t.vScale ?? 1];
+            if (t.hasAlpha) {
+                m.alphaCutOff = 0.4;
+            }
+        },
+    },
+    { src: "bumpTexture", dst: "bumpTexture", level: "bumpLevel" },
+    { src: "specularTexture", dst: "specularTexture", coordIndex: { dst: "specularCoordIndex", only1: true } },
+    { src: "ambientTexture", dst: "ambientTexture", level: "ambientTexLevel", coordIndex: { dst: "ambientCoordIndex", only1: true } },
+    { src: "lightmapTexture", dst: "lightmapTexture", level: "lightmapLevel", coordIndex: { dst: "lightmapCoordIndex" } },
+    {
+        src: "opacityTexture",
+        dst: "opacityTexture",
+        level: "opacityLevel",
+        extra: (t, m) => {
+            if (t.getAlphaFromRGB) {
+                m.opacityFromRGB = true;
+            }
+        },
+    },
+    {
+        src: "reflectionTexture",
+        dst: "reflectionTexture",
+        level: "reflectionLevel",
+        skipIf: (t) => t.isCube === true,
+        extra: (t, m) => {
+            if (t.coordinatesMode === 2) {
+                m.reflectionCoordMode = 2;
+            }
+        },
+    },
+];
+
 // ─── Public API ─────────────────────────────────────────────────────
 
 export interface LoadBabylonOptions {
@@ -199,105 +258,36 @@ export async function loadBabylon(engine: EngineContext, url: string, opts: Load
                 mat.backFaceCulling = false;
             }
 
-            if (md.diffuseTexture && opts.loadTextures !== false) {
-                const texUrl = baseUrl + md.diffuseTexture.name;
-                mat.uvScale = [md.diffuseTexture.uScale ?? 1, md.diffuseTexture.vScale ?? 1];
-                if (md.diffuseTexture.coordinatesIndex === 1) {
-                    mat.diffuseCoordIndex = 1;
+            if (opts.loadTextures !== false) {
+                for (const slot of TEX_SLOTS) {
+                    const t = md[slot.src];
+                    if (!t) {
+                        continue;
+                    }
+                    if (slot.skipIf?.(t)) {
+                        continue;
+                    }
+                    if (slot.level && t.level != null) {
+                        (mat as unknown as Record<string, unknown>)[slot.level] = t.level;
+                    }
+                    if (slot.coordIndex) {
+                        if (slot.coordIndex.only1) {
+                            if (t.coordinatesIndex === 1) {
+                                (mat as unknown as Record<string, unknown>)[slot.coordIndex.dst] = 1;
+                            }
+                        } else if (t.coordinatesIndex != null) {
+                            (mat as unknown as Record<string, unknown>)[slot.coordIndex.dst] = t.coordinatesIndex === 1 ? 1 : 0;
+                        }
+                    }
+                    slot.extra?.(t, mat);
+                    const texUrl = baseUrl + t.name;
+                    const dst = slot.dst;
+                    texturePromises.push(
+                        loadTexture2D(engine, texUrl).then((tex) => {
+                            (mat as unknown as Record<string, unknown>)[dst] = tex;
+                        })
+                    );
                 }
-                if (md.diffuseTexture.hasAlpha) {
-                    mat.alphaCutOff = 0.4;
-                }
-                texturePromises.push(
-                    loadTexture2D(engine, texUrl).then((tex) => {
-                        mat.diffuseTexture = tex;
-                    })
-                );
-            }
-
-            if (md.bumpTexture && opts.loadTextures !== false) {
-                const texUrl = baseUrl + md.bumpTexture.name;
-                if (md.bumpTexture.level != null) {
-                    mat.bumpLevel = md.bumpTexture.level;
-                }
-                texturePromises.push(
-                    loadTexture2D(engine, texUrl).then((tex) => {
-                        mat.bumpTexture = tex;
-                    })
-                );
-            }
-
-            if (md.specularTexture && opts.loadTextures !== false) {
-                const texUrl = baseUrl + md.specularTexture.name;
-                if (md.specularTexture.coordinatesIndex === 1) {
-                    mat.specularCoordIndex = 1;
-                }
-                texturePromises.push(
-                    loadTexture2D(engine, texUrl).then((tex) => {
-                        mat.specularTexture = tex;
-                    })
-                );
-            }
-
-            if (md.ambientTexture && opts.loadTextures !== false) {
-                const texUrl = baseUrl + md.ambientTexture.name;
-                if (md.ambientTexture.level != null) {
-                    mat.ambientTexLevel = md.ambientTexture.level;
-                }
-                if (md.ambientTexture.coordinatesIndex === 1) {
-                    mat.ambientCoordIndex = 1;
-                }
-                texturePromises.push(
-                    loadTexture2D(engine, texUrl).then((tex) => {
-                        mat.ambientTexture = tex;
-                    })
-                );
-            }
-
-            if (md.lightmapTexture && opts.loadTextures !== false) {
-                const texUrl = baseUrl + md.lightmapTexture.name;
-                if (md.lightmapTexture.level != null) {
-                    mat.lightmapLevel = md.lightmapTexture.level;
-                }
-                if (md.lightmapTexture.coordinatesIndex != null) {
-                    mat.lightmapCoordIndex = md.lightmapTexture.coordinatesIndex === 1 ? 1 : 0;
-                }
-                texturePromises.push(
-                    loadTexture2D(engine, texUrl).then((tex) => {
-                        mat.lightmapTexture = tex;
-                    })
-                );
-            }
-
-            if (md.opacityTexture && opts.loadTextures !== false) {
-                const texUrl = baseUrl + md.opacityTexture.name;
-                if (md.opacityTexture.level != null) {
-                    mat.opacityLevel = md.opacityTexture.level;
-                }
-                if (md.opacityTexture.getAlphaFromRGB) {
-                    mat.opacityFromRGB = true;
-                }
-                texturePromises.push(
-                    loadTexture2D(engine, texUrl).then((tex) => {
-                        mat.opacityTexture = tex;
-                    })
-                );
-            }
-
-            if (md.reflectionTexture && opts.loadTextures !== false && !md.reflectionTexture.isCube) {
-                const texUrl = baseUrl + md.reflectionTexture.name;
-                if (md.reflectionTexture.level != null) {
-                    mat.reflectionLevel = md.reflectionTexture.level;
-                }
-                const cm = md.reflectionTexture.coordinatesMode;
-                if (cm === 2) {
-                    mat.reflectionCoordMode = 2;
-                }
-                texturePromises.push(
-                    loadTexture2D(engine, texUrl).then((tex) => {
-                        mat.reflectionTexture = tex;
-                    })
-                );
             }
 
             if (md.reflectionTexture && opts.loadTextures !== false && md.reflectionTexture.isCube) {

--- a/packages/babylon-lite/src/loader-gltf/gltf-animation.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-animation.ts
@@ -7,8 +7,19 @@ import type { Mesh } from "../mesh/mesh.js";
 import type { GltfAnimationData, AnimationClip, AnimationSampler, AnimationChannel, NodeRest, SkeletonBinding, MorphBinding } from "../animation/types.js";
 import { INTERP_LINEAR, INTERP_STEP, INTERP_CUBICSPLINE, PATH_TRANSLATION, PATH_ROTATION, PATH_SCALE, PATH_WEIGHTS } from "../animation/types.js";
 import { mat4Invert, mat4Identity, mat4Multiply } from "../math/mat4.js";
-import type { GltfSkinData } from "./load-gltf.js";
 import { resolveAccessor, computeNodeWorldMatrix, findParent } from "./gltf-parser.js";
+
+/** Parsed skin/skeleton data. */
+export interface GltfSkinData {
+    /** Node indices of joints in this skin. */
+    jointNodes: number[];
+    /** Inverse bind matrices — one 4×4 per joint (column-major Float32Array). */
+    inverseBindMatrices: Float32Array;
+    /** World matrices of each joint at rest pose. */
+    jointWorldMatrices: Mat4[];
+    /** World matrix of the mesh node that owns this skin. */
+    meshWorldMatrix: Mat4;
+}
 
 // ─── Skin / Skeleton Extraction ─────────────────────────────────────
 

--- a/packages/babylon-lite/src/loader-gltf/gltf-feature-morph.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-feature-morph.ts
@@ -1,15 +1,31 @@
-/** Morph target feature. */
+/** Morph target feature. Extracts per-primitive morph targets lazily so the
+ *  core loader doesn't carry any morph-related code for non-morphed assets. */
 
 import type { GltfFeature } from "./gltf-feature.js";
+import { resolveAccessor } from "./gltf-parser.js";
 
 const feature: GltfFeature = {
     id: "_morph",
     async applyMesh(meshData, mesh, ctx) {
-        if (!meshData.morphTargets || meshData.morphTargets.length === 0) {
+        const primitive = meshData._primitive;
+        const targets = primitive.targets;
+        if (!targets || targets.length === 0) {
             return;
         }
+        const { json, binChunk } = ctx;
+        const morphTargets: { positions: Float32Array; normals: Float32Array | null }[] = [];
+        for (const target of targets) {
+            const posAcc = target.POSITION !== undefined ? resolveAccessor(json, binChunk, target.POSITION) : null;
+            const normAcc = target.NORMAL !== undefined ? resolveAccessor(json, binChunk, target.NORMAL) : null;
+            morphTargets.push({
+                positions: posAcc ? (posAcc.data as Float32Array) : new Float32Array(meshData.vertexCount * 3),
+                normals: normAcc ? (normAcc.data as Float32Array) : null,
+            });
+        }
+        const parentMesh = json.meshes[json.nodes[meshData.nodeIndex].mesh];
+        const morphWeights = parentMesh.weights ?? new Array(targets.length).fill(0);
         const { createMorphTargets } = await import("../morph/create-morph-targets.js");
-        mesh.morphTargets = createMorphTargets(ctx.engine, meshData.morphTargets, meshData.vertexCount, meshData.morphWeights);
+        mesh.morphTargets = createMorphTargets(ctx.engine, morphTargets, meshData.vertexCount, morphWeights);
     },
 };
 export default feature;

--- a/packages/babylon-lite/src/loader-gltf/gltf-feature-skeleton.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-feature-skeleton.ts
@@ -1,17 +1,44 @@
-/** Skeletal animation feature. */
+/** Skeletal animation feature. Extracts joints/weights/skin on demand so the
+ *  core loader doesn't carry any skinning-related code for non-skinned assets. */
 
 import type { GltfFeature } from "./gltf-feature.js";
+import { resolveAccessor } from "./gltf-parser.js";
+
+/** Resolve a vertex attribute by name, preferring any pre-decoded
+ *  (e.g. Draco) data over the raw accessor. */
+function resolveAttr(name: string, primitive: any, decoded: any, json: any, binChunk: DataView): ArrayBufferView | null {
+    if (decoded && decoded.attributes.has(name)) {
+        return decoded.attributes.get(name)!;
+    }
+    const idx = primitive.attributes?.[name];
+    return idx !== undefined ? (resolveAccessor(json, binChunk, idx).data as ArrayBufferView) : null;
+}
 
 const feature: GltfFeature = {
     id: "_skeleton",
     async applyMesh(meshData, mesh, ctx) {
-        if (!meshData.joints || !meshData.weights || !meshData.skin) {
+        const { json, binChunk, parentMap, worldMatrixCache } = ctx;
+        const node = json.nodes[meshData.nodeIndex];
+        if (node.skin === undefined || !json.skins) {
             return;
         }
-        const [{ computeBoneTextureData }, { createSkeleton }] = await Promise.all([import("./gltf-animation.js"), import("../skeleton/create-skeleton.js")]);
-        const boneCount = meshData.skin.jointNodes.length;
-        const boneData = computeBoneTextureData(meshData.skin);
-        mesh.skeleton = createSkeleton(ctx.engine, meshData.joints, meshData.weights, boneCount, boneData, meshData.joints1, meshData.weights1);
+        const primitive = meshData._primitive;
+        const decoded = meshData._decoded;
+        const joints = resolveAttr("JOINTS_0", primitive, decoded, json, binChunk) as Uint16Array | Uint8Array | null;
+        const weights = resolveAttr("WEIGHTS_0", primitive, decoded, json, binChunk) as Float32Array | null;
+        if (!joints || !weights) {
+            return;
+        }
+        const joints1 = resolveAttr("JOINTS_1", primitive, decoded, json, binChunk) as Uint16Array | Uint8Array | null;
+        const weights1 = resolveAttr("WEIGHTS_1", primitive, decoded, json, binChunk) as Float32Array | null;
+
+        const [{ extractSkin, computeBoneTextureData }, { createSkeleton }] = await Promise.all([
+            import("./gltf-animation.js"),
+            import("../skeleton/create-skeleton.js"),
+        ]);
+        const skin = extractSkin(json, binChunk, node.skin, meshData.worldMatrix, parentMap, worldMatrixCache);
+        const boneData = computeBoneTextureData(skin);
+        mesh.skeleton = createSkeleton(ctx.engine, joints, weights, skin.jointNodes.length, boneData, joints1, weights1);
     },
 };
 export default feature;

--- a/packages/babylon-lite/src/loader-gltf/gltf-parser.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-parser.ts
@@ -6,7 +6,7 @@
  * - Node hierarchy traversal with memoized world-matrix computation
  */
 import type { Mat4 } from "../math/types.js";
-import { mat4Compose, mat4Multiply } from "../math/mat4.js";
+import { mat4ComposeInto, mat4MultiplyInto } from "../math/mat4.js";
 
 // glTF 2.0 component types
 const FLOAT = 5126;
@@ -151,6 +151,12 @@ export function findParent(parentMap: Map<number, number>, childIdx: number): nu
  * Compute world matrix for a glTF node with memoization.
  * Uses parentMap for O(1) parent lookup and cache for O(1) repeat queries.
  * Total cost across all nodes: O(n) instead of O(n²).
+ *
+ * Zero-alloc path for the TRS case (common): `local` is composed into a shared
+ * scratch via `mat4ComposeInto`, then multiplied into the freshly-allocated
+ * `world` via `mat4MultiplyInto`. Only one Float32Array allocation per node
+ * (the cached world matrix itself) instead of two. Recursion always resolves
+ * `parentWorld` before touching the scratch, so the shared buffer is safe.
  */
 export function computeNodeWorldMatrix(json: any, nodeIdx: number, parentMap: Map<number, number>, cache: Map<number, Mat4>): Mat4 {
     const cached = cache.get(nodeIdx);
@@ -159,28 +165,36 @@ export function computeNodeWorldMatrix(json: any, nodeIdx: number, parentMap: Ma
     }
 
     const node = json.nodes[nodeIdx];
-    let local: Mat4;
+    const parentIdx = findParent(parentMap, nodeIdx);
+    // Resolve parent FIRST so any recursive call can safely reuse the shared scratch below.
+    const parentWorld: Mat4 = parentIdx !== -1 ? computeNodeWorldMatrix(json, parentIdx, parentMap, cache) : RH_TO_LH_ROOT;
 
+    let localBuf: Float32Array;
     if (node.matrix) {
-        local = new Float32Array(node.matrix) as Mat4;
+        // Pre-built matrix — copy into a fresh Float32Array (cannot alias scratch safely across calls).
+        localBuf = new Float32Array(node.matrix);
     } else {
         const t = node.translation ?? [0, 0, 0];
         const r = node.rotation ?? [0, 0, 0, 1];
         const s = node.scale ?? [1, 1, 1];
-        // Keep glTF TRS as-is — RH→LH handled by root pre-multiply
-        local = mat4Compose(t[0], t[1], t[2], r[0], r[1], r[2], r[3], s[0], s[1], s[2]);
+        const scratch = _getLocalScratch();
+        mat4ComposeInto(scratch, 0, t[0], t[1], t[2], r[0], r[1], r[2], r[3], s[0], s[1], s[2]);
+        localBuf = scratch;
     }
 
-    const parentIdx = findParent(parentMap, nodeIdx);
-    let world: Mat4;
-    if (parentIdx !== -1) {
-        const parentWorld = computeNodeWorldMatrix(json, parentIdx, parentMap, cache);
-        world = mat4Multiply(parentWorld, local);
-    } else {
-        // Top-level node: pre-multiply by RH→LH root
-        world = mat4Multiply(RH_TO_LH_ROOT, local);
-    }
+    const world = new Float32Array(16) as Mat4;
+    mat4MultiplyInto(world, 0, parentWorld, 0, localBuf, 0);
 
     cache.set(nodeIdx, world);
     return world;
+}
+
+// Lazy-init shared scratch for TRS composition. Module-level `new Float32Array` would kill
+// tree-shaking per GUIDANCE — defer until first use.
+let _localScratch: Float32Array | null = null;
+function _getLocalScratch(): Float32Array {
+    if (!_localScratch) {
+        _localScratch = new Float32Array(16);
+    }
+    return _localScratch;
 }

--- a/packages/babylon-lite/src/loader-gltf/load-gltf.ts
+++ b/packages/babylon-lite/src/loader-gltf/load-gltf.ts
@@ -28,34 +28,14 @@ export interface GltfMeshData {
     indexCount: number;
     worldMatrix: Mat4;
     material: GltfMaterialData;
-    /** Joint indices (4 per vertex), for skeletal animation. */
-    joints: Uint16Array | Uint8Array | null;
-    /** Joint blend weights (4 per vertex). */
-    weights: Float32Array | null;
-    /** Extra joint indices for 8-bone skinning (JOINTS_1). */
-    joints1: Uint16Array | Uint8Array | null;
-    /** Extra blend weights for 8-bone skinning (WEIGHTS_1). */
-    weights1: Float32Array | null;
-    /** Skin data if this mesh has skeletal deformation. */
-    skin: GltfSkinData | null;
-    /** Morph target deltas (position + optional normal per target). */
-    morphTargets: { positions: Float32Array; normals: Float32Array | null }[] | null;
-    /** Initial morph weights (one per target). */
-    morphWeights: number[] | null;
-    /** glTF node index this mesh came from (for hierarchy reconstruction). */
+    /** glTF node index this mesh came from (for hierarchy reconstruction
+     *  and for features that need to resolve skin/morph data lazily). */
     nodeIndex: number;
-}
-
-/** Parsed skin/skeleton data. */
-export interface GltfSkinData {
-    /** Node indices of joints in this skin. */
-    jointNodes: number[];
-    /** Inverse bind matrices — one 4×4 per joint (column-major Float32Array). */
-    inverseBindMatrices: Float32Array;
-    /** World matrices of each joint at rest pose. */
-    jointWorldMatrices: Mat4[];
-    /** World matrix of the mesh node that owns this skin. */
-    meshWorldMatrix: Mat4;
+    /** Raw primitive definition — features (skeleton, morph, …) read their
+     *  own attributes/targets from here without bloating core extraction. */
+    _primitive: any;
+    /** Pre-decoded primitive (Draco et al.) if a preMesh feature produced one. */
+    _decoded?: DecodedPrimitive;
 }
 
 /** Options for loadGltf. */
@@ -259,10 +239,6 @@ async function extractAllMeshes(
     worldMatrixCache: Map<number, Mat4>,
     decodedPrimitives: Map<unknown, DecodedPrimitive>,
 ): Promise<GltfMeshData[]> {
-    // Pre-load skin extraction once if any node uses a skin (avoids per-primitive dynamic import)
-    const needsSkin = json.nodes.some((n: any) => n.skin !== undefined) && !!json.skins;
-    const extractSkinFn = needsSkin ? (await import("./gltf-animation.js")).extractSkin : null;
-
     // Per-load image cache — avoids decoding the same glTF image index multiple times
     const imageCache = new Map<number, Promise<ImageBitmap>>();
 
@@ -320,34 +296,6 @@ async function extractAllMeshes(
                     : new Uint16Array(idxData.data.buffer, idxData.data.byteOffset, idxData.count)
                 : new Uint16Array(0);
 
-            // Joints + weights for skeletal animation (4-bone + optional 8-bone)
-            const jointsData = resolveAttr("JOINTS_0");
-            const weightsData = resolveAttr("WEIGHTS_0");
-            const joints1Data = resolveAttr("JOINTS_1");
-            const weights1Data = resolveAttr("WEIGHTS_1");
-
-            // Skin extraction is synchronous once the module is loaded
-            let skin: GltfSkinData | null = null;
-            if (node.skin !== undefined && extractSkinFn) {
-                skin = extractSkinFn(json, binChunk, node.skin, worldMatrix, parentMap, worldMatrixCache);
-            }
-
-            // Morph targets
-            let morphTargets: { positions: Float32Array; normals: Float32Array | null }[] | null = null;
-            let morphWeights: number[] | null = null;
-            if (primitive.targets && primitive.targets.length > 0) {
-                morphTargets = [];
-                for (const target of primitive.targets) {
-                    const posAcc = target.POSITION !== undefined ? resolveAccessor(json, binChunk, target.POSITION) : null;
-                    const normAcc = target.NORMAL !== undefined ? resolveAccessor(json, binChunk, target.NORMAL) : null;
-                    morphTargets.push({
-                        positions: posAcc ? (posAcc.data as Float32Array) : new Float32Array(posData.count * 3),
-                        normals: normAcc ? (normAcc.data as Float32Array) : null,
-                    });
-                }
-                morphWeights = mesh.weights ?? new Array(primitive.targets.length).fill(0);
-            }
-
             // Fire material fetch without awaiting — all materials load in parallel
             matPromises.push(getMat(primitive.material));
 
@@ -360,14 +308,9 @@ async function extractAllMeshes(
                 vertexCount: posData.count,
                 indexCount: idxData?.count ?? 0,
                 worldMatrix,
-                joints: (jointsData?.data ?? null) as Uint16Array | Uint8Array | null,
-                weights: (weightsData?.data ?? null) as Float32Array | null,
-                joints1: (joints1Data?.data ?? null) as Uint16Array | Uint8Array | null,
-                weights1: (weights1Data?.data ?? null) as Float32Array | null,
-                skin,
-                morphTargets,
-                morphWeights,
                 nodeIndex: nodeIdx,
+                _primitive: primitive,
+                _decoded: decoded,
             });
         }
     }

--- a/packages/babylon-lite/src/material/pbr/fragments/clearcoat-fragment.ts
+++ b/packages/babylon-lite/src/material/pbr/fragments/clearcoat-fragment.ts
@@ -17,7 +17,7 @@
  *  - clearcoatNormalTexture (tangent-space normal, perturbs coat normal)
  */
 
-import type { ShaderFragment } from "../../../shader/fragment-types.js";
+import type { ShaderFragment, BindingDecl } from "../../../shader/fragment-types.js";
 import type { PbrMaterialProps, ClearCoatProps } from "../pbr-material.js";
 import type { PbrExt } from "../pbr-flags.js";
 import {
@@ -29,6 +29,8 @@ import {
     PBR2_CC_NORMAL_MAP,
     PBR2_CC_F0_REMAP_OFF,
 } from "../pbr-flags.js";
+
+const STAGE_FRAGMENT = 0x2;
 
 const CC_HELPERS = `
 fn visibility_Kelemen(VdotH_kl: f32) -> f32 {
@@ -218,11 +220,36 @@ export function createClearcoatFragment(features: number, features2: number, has
         (disableF0Remap ? "X" : "") +
         (hasSpecularAA ? "A" : "") +
         (hasBaseNormalMap ? "B" : "");
+    const bindings: BindingDecl[] = [];
+    if (hasIntensityMap) {
+        bindings.push(
+            { name: "ccIntensityTexture", type: { kind: "texture", textureType: "texture_2d<f32>" }, visibility: STAGE_FRAGMENT },
+            { name: "ccIntensitySampler_", type: { kind: "sampler", samplerType: "sampler" }, visibility: STAGE_FRAGMENT }
+        );
+    }
+    if (hasRoughnessMap) {
+        bindings.push(
+            { name: "ccRoughnessTexture", type: { kind: "texture", textureType: "texture_2d<f32>" }, visibility: STAGE_FRAGMENT },
+            { name: "ccRoughnessSampler_", type: { kind: "sampler", samplerType: "sampler" }, visibility: STAGE_FRAGMENT }
+        );
+    }
+    if (hasNormalMap) {
+        bindings.push(
+            { name: "ccNormalTexture", type: { kind: "texture", textureType: "texture_2d<f32>" }, visibility: STAGE_FRAGMENT },
+            { name: "ccNormalSampler_", type: { kind: "sampler", samplerType: "sampler" }, visibility: STAGE_FRAGMENT }
+        );
+    }
+
     return {
         id: suffix ? `clearcoat-${suffix}` : "clearcoat",
         dependencies: deps.length > 0 ? deps : undefined,
 
-        // UBO fields are in the PBR template's baseMeshUboFields for byte-layout compat.
+        uboFields: [
+            { name: "ccParams", type: "vec4<f32>" },
+            { name: "ccRefractionParams", type: "vec4<f32>" },
+        ],
+
+        bindings,
 
         helperFunctions: CC_HELPERS,
 

--- a/packages/babylon-lite/src/material/pbr/fragments/emissive-fragment.ts
+++ b/packages/babylon-lite/src/material/pbr/fragments/emissive-fragment.ts
@@ -20,7 +20,10 @@ export function createEmissiveColorFragment(hasEmissiveTexture: boolean): Shader
     return {
         id: "emissive-color",
 
-        // UBO fields are in the PBR template's baseMeshUboFields for byte-layout compat.
+        uboFields: [
+            { name: "emissiveColor", type: "vec3<f32>" },
+            { name: "_emissiveColorPad", type: "f32" },
+        ],
 
         fragmentSlots: {
             AT: hasEmissiveTexture

--- a/packages/babylon-lite/src/material/pbr/fragments/reflectance-fragment.ts
+++ b/packages/babylon-lite/src/material/pbr/fragments/reflectance-fragment.ts
@@ -90,7 +90,14 @@ let surfaceAlbedo = baseColor * (vec3<f32>(1.0) - vec3<f32>(dielectricF0) * surf
     return {
         id: "reflectance",
 
-        // UBO fields are in the PBR template's baseMeshUboFields for byte-layout compat.
+        uboFields: [
+            { name: "occlusionStrength", type: "f32" },
+            { name: "metallicF0Factor", type: "f32" },
+            { name: "_mrPad0", type: "f32" },
+            { name: "_mrPad1", type: "f32" },
+            { name: "metallicReflectanceColor", type: "vec3<f32>" },
+            { name: "_mrPad2", type: "f32" },
+        ],
 
         bindings,
 

--- a/packages/babylon-lite/src/material/pbr/fragments/sheen-fragment.ts
+++ b/packages/babylon-lite/src/material/pbr/fragments/sheen-fragment.ts
@@ -11,10 +11,12 @@
  *  - Energy conservation: albedo scaled by (1 - maxSheenColor * brdf.b)
  */
 
-import type { ShaderFragment } from "../../../shader/fragment-types.js";
+import type { ShaderFragment, BindingDecl } from "../../../shader/fragment-types.js";
 import type { PbrMaterialProps, SheenProps } from "../pbr-material.js";
 import type { PbrExt } from "../pbr-flags.js";
 import { PBR_HAS_SHEEN, PBR_HAS_SHEEN_TEXTURE, PBR_HAS_SHEEN_ALBEDO_SCALING } from "../pbr-flags.js";
+
+const STAGE_FRAGMENT = 0x2;
 
 const SHEEN_HELPERS = `
 fn normalDistributionFunction_CharlieSheen(NdotH_sh: f32, alphaG_sh: f32) -> f32 {
@@ -150,11 +152,24 @@ sheenRoughnessAdjusted *= sheenMapData.a;
         slots.NI = SHEEN_NON_IBL_MOD;
     }
 
+    const bindings: BindingDecl[] = [];
+    if (hasSheenTexture) {
+        bindings.push(
+            { name: "sheenTexture_", type: { kind: "texture", textureType: "texture_2d<f32>" }, visibility: STAGE_FRAGMENT },
+            { name: "sheenSampler_", type: { kind: "sampler", samplerType: "sampler" }, visibility: STAGE_FRAGMENT }
+        );
+    }
+
     return {
         id: "sheen",
         dependencies: hasIbl ? ["ibl"] : undefined,
 
-        // UBO fields are in the PBR template's baseMeshUboFields for byte-layout compat.
+        uboFields: [
+            { name: "sheenParams", type: "vec4<f32>" },
+            { name: "sheenParams2", type: "vec4<f32>" },
+        ],
+
+        bindings,
 
         helperFunctions: SHEEN_HELPERS,
 
@@ -202,6 +217,17 @@ export const sheenExt: PbrExt = {
         return createSheenFragment((ctx.features & PBR_HAS_SHEEN_TEXTURE) !== 0, ctx.hasIbl, (ctx.features & PBR_HAS_SHEEN_ALBEDO_SCALING) !== 0);
     },
     writeUbo: writeSheenUBO as PbrExt["writeUbo"],
+    bind(ctx, entries, b) {
+        if ((ctx.features & PBR_HAS_SHEEN_TEXTURE) === 0) {
+            return b;
+        }
+        const sh = (ctx.material as PbrMaterialProps).sheen as SheenProps | undefined;
+        if (sh?.texture) {
+            entries.push({ binding: b++, resource: sh.texture.view });
+            entries.push({ binding: b++, resource: sh.texture.sampler });
+        }
+        return b;
+    },
     textures(mat, out) {
         const sh = (mat as PbrMaterialProps).sheen;
         if (sh?.texture) {

--- a/packages/babylon-lite/src/material/pbr/pbr-flags.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-flags.ts
@@ -134,11 +134,20 @@ export interface PbrExt {
 }
 
 const _pbrExts = new Map<string, PbrExt>();
+let _pbrExtsSorted: readonly PbrExt[] | null = null;
 /** @internal Register a PBR extension. Idempotent (keyed by id). */
 export function _registerPbrExt(ext: PbrExt): void {
     _pbrExts.set(ext.id, ext);
+    _pbrExtsSorted = null;
 }
 /** @internal Iterate the registered extensions. */
 export function _getPbrExts(): ReadonlyMap<string, PbrExt> {
     return _pbrExts;
+}
+/** @internal Return extensions sorted by id (alphabetical, stable within a build). Memoised. */
+export function _getPbrExtsSorted(): readonly PbrExt[] {
+    if (!_pbrExtsSorted) {
+        _pbrExtsSorted = Array.from(_pbrExts.values()).sort((a, b) => a.id.localeCompare(b.id));
+    }
+    return _pbrExtsSorted;
 }

--- a/packages/babylon-lite/src/material/pbr/pbr-pipeline.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-pipeline.ts
@@ -4,7 +4,7 @@
  *  Pipelines cached per (fragmentKey, features, format, msaaSamples) tuple.
  *  The ComposedShader provides WGSL source, BGL descriptors, and vertex layouts. */
 
-import type { PbrMaterialProps, SheenProps } from "./pbr-material.js";
+import type { PbrMaterialProps } from "./pbr-material.js";
 import type { EnvironmentTextures } from "../../loader-env/load-env.js";
 import type { ComposedShader } from "../../shader/fragment-types.js";
 import type { EngineContextInternal } from "../../engine/engine.js";
@@ -25,7 +25,6 @@ import {
     PBR_HAS_COTANGENT_NORMAL,
     PBR_HAS_METALLIC_REFLECTANCE_MAP,
     PBR_HAS_REFLECTANCE_MAP,
-    PBR_HAS_SHEEN_TEXTURE,
 } from "./pbr-flags.js";
 export * from "./pbr-flags.js";
 
@@ -160,6 +159,7 @@ export function getOrCreatePbrPipeline(
 export function createPbrMeshBindGroup(
     engine: EngineContextInternal,
     variant: PbrPipelineVariant,
+    composed: ComposedShader,
     meshUBO: GPUBuffer,
     materialUBO: GPUBuffer,
     material: PbrMaterialProps,
@@ -194,6 +194,21 @@ export function createPbrMeshBindGroup(
     // Sort exts by id to match composer's alphabetical binding emission order.
     const sortedExts = _getPbrExtsSorted();
 
+    // Build fragment-id → ext map that honours fragment-id variants like
+    // "clearcoat-IRN" (ext id "clearcoat"). Walk composed.fragmentKey to
+    // determine composer's topological binding order.
+    const extByFragId = new Map<string, import("./pbr-flags.js").PbrExt>();
+    const fragIds = composed.fragmentKey ? composed.fragmentKey.split("|").filter((s) => s.length > 0) : [];
+    for (const fid of fragIds) {
+        let match = sortedExts.find((e) => e.id === fid);
+        if (!match) {
+            match = sortedExts.find((e) => fid.startsWith(e.id + "-"));
+        }
+        if (match) {
+            extByFragId.set(fid, match);
+        }
+    }
+
     // Mesh UBO (binding 0)
     entries.push({ binding: b++, resource: { buffer: meshUBO } });
     // Material UBO (binding 1)
@@ -204,7 +219,7 @@ export function createPbrMeshBindGroup(
             b = ext.bind(ctx, entries, b);
         }
     }
-    // Base bindings (matching composer order: baseColor, normal, ORM, emissive, specGloss, sheen)
+    // Base bindings (matching composer order: baseColor, normal, ORM, emissive, specGloss)
     addTex(material.baseColorTexture!);
     if (hasAnyNormal) {
         addTex(material.normalTexture!);
@@ -216,29 +231,20 @@ export function createPbrMeshBindGroup(
     if (hasSpecGloss) {
         addTex(material.specGlossTexture!);
     }
-    if ((features & PBR_HAS_SHEEN_TEXTURE) !== 0) {
-        addTex((material.sheen as SheenProps).texture!);
-    }
-    // Base-tex phase exts (alphabetical: clearcoat < reflectance < ...).
-    for (const ext of sortedExts) {
-        if (ext.phase === "base-tex" && ext.bind) {
-            b = ext.bind(ctx, entries, b);
-        }
-    }
     // Lights UBO (after base texture bindings, before fragment bindings — matches composer order)
     if (lightsUBO) {
         entries.push({ binding: b++, resource: { buffer: lightsUBO } });
     }
-    // IBL-phase exts (alphabetical within phase).
-    for (const ext of sortedExts) {
-        if (ext.phase === "ibl" && ext.bind) {
-            b = ext.bind(ctx, entries, b);
+    // Non-vertex exts — iterate in composer's topological order (from
+    // composed.fragmentKey) so bind entries align with the emitted BGL.
+    const seenExts = new Set<import("./pbr-flags.js").PbrExt>();
+    for (const fid of fragIds) {
+        const ext = extByFragId.get(fid);
+        if (!ext || ext.phase === "vertex" || !ext.bind || seenExts.has(ext)) {
+            continue;
         }
-    }
-    for (const ext of sortedExts) {
-        if (ext.phase === "fragment" && ext.bind) {
-            b = ext.bind(ctx, entries, b);
-        }
+        seenExts.add(ext);
+        b = ext.bind(ctx, entries, b);
     }
 
     return device.createBindGroup({ layout: variant.meshBGL, entries });

--- a/packages/babylon-lite/src/material/pbr/pbr-pipeline.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-pipeline.ts
@@ -10,7 +10,7 @@ import type { ComposedShader } from "../../shader/fragment-types.js";
 import type { EngineContextInternal } from "../../engine/engine.js";
 import { createPipelineCache, releaseVariant } from "../pipeline-cache.js";
 import type { PipelineCache } from "../pipeline-cache.js";
-import { _getPbrLightExtension, _getPbrExts } from "./pbr-flags.js";
+import { _getPbrLightExtension, _getPbrExtsSorted } from "./pbr-flags.js";
 import {
     PBR_HAS_NORMAL_MAP,
     PBR_HAS_EMISSIVE,
@@ -192,7 +192,7 @@ export function createPbrMeshBindGroup(
     };
 
     // Sort exts by id to match composer's alphabetical binding emission order.
-    const sortedExts = Array.from(_getPbrExts().values()).sort((a, b) => a.id.localeCompare(b.id));
+    const sortedExts = _getPbrExtsSorted();
 
     // Mesh UBO (binding 0)
     entries.push({ binding: b++, resource: { buffer: meshUBO } });

--- a/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
@@ -38,12 +38,8 @@ import {
     PBR_HAS_REFLECTANCE_MAP,
     PBR_HAS_SPECULAR_AA,
     PBR_HAS_EMISSIVE_COLOR,
-    PBR_HAS_SHEEN_TEXTURE,
     PBR_HAS_GAMMA_ALBEDO,
     PBR_HAS_RECEIVE_SHADOWS,
-    PBR2_CC_INT_MAP,
-    PBR2_CC_ROUGH_MAP,
-    PBR2_CC_NORMAL_MAP,
 } from "./pbr-pipeline.js";
 import { PBR_HAS_THIN_INSTANCES, PBR_HAS_INSTANCE_COLOR } from "./pbr-pipeline.js";
 import {
@@ -60,8 +56,6 @@ import {
     PBR_HAS_DOUBLE_SIDED,
     PBR_HAS_COTANGENT_NORMAL,
     PBR_HAS_OCCLUSION,
-    PBR_HAS_CLEARCOAT,
-    PBR_HAS_SHEEN,
     PBR_HAS_ANISOTROPY,
     PBR_HAS_SKYBOX,
 } from "./pbr-flags.js";
@@ -270,15 +264,10 @@ export async function buildPbrRenderables(
         const hasIbl = has(PBR_HAS_ENV);
         const hasMorph = has(PBR_HAS_MORPH_TARGETS);
         const hasShadow = has(PBR_HAS_RECEIVE_SHADOWS);
-        const hasCC = has(PBR_HAS_CLEARCOAT);
-        const hasSh = has(PBR_HAS_SHEEN);
         const hasAniso = has(PBR_HAS_ANISOTROPY);
         const hasEmCol = has(PBR_HAS_EMISSIVE_COLOR);
         const hasEmTex = has(PBR_HAS_EMISSIVE);
         const hasTI = has(PBR_HAS_THIN_INSTANCES);
-        const ccIntMap = (features2 & PBR2_CC_INT_MAP) !== 0;
-        const ccRoughMap = (features2 & PBR2_CC_ROUGH_MAP) !== 0;
-        const ccNormalMap = (features2 & PBR2_CC_NORMAL_MAP) !== 0;
 
         const template = createPbrTemplate({
             light: hasMultiLight ? null : lightConfig,
@@ -297,15 +286,9 @@ export async function buildPbrRenderables(
             hasGammaAlbedo: has(PBR_HAS_GAMMA_ALBEDO),
             hasMorph,
             hasOcclusion: has(PBR_HAS_OCCLUSION) && !hasReflExt,
-            hasSheenTexture: has(PBR_HAS_SHEEN_TEXTURE),
             hasEmissiveColor: hasEmCol,
             hasReflectanceExt: hasReflExt,
             hasIbl,
-            hasClearcoat: hasCC,
-            hasCcIntensityMap: ccIntMap,
-            hasCcRoughnessMap: ccRoughMap,
-            hasCcNormalMap: ccNormalMap,
-            hasSheen: hasSh,
             hasAnisotropy: hasAniso,
             anisoBrdfFunctions: hasAniso && _anisoExt ? _anisoExt.ANISO_BRDF_FUNCTIONS : "",
             anisoTBBlock: hasAniso && _anisoExt ? _anisoExt.makeAnisotropyTBBlock(hasNormal) : "",
@@ -401,7 +384,7 @@ export async function buildPbrRenderables(
         const worldMatrix = mesh.worldMatrix;
         const meshUBO = createMeshUBO(engine, worldMatrix, composed, mat);
         const materialUBO = createMaterialUBO(engine, mat, composed);
-        const materialBindGroup = createPbrMeshBindGroup(engine, variant, meshUBO, materialUBO, mat, envTextures ?? null, mesh, lightsUBOBuffer);
+        const materialBindGroup = createPbrMeshBindGroup(engine, variant, composed, meshUBO, materialUBO, mat, envTextures ?? null, mesh, lightsUBOBuffer);
 
         // Shadow bind group (group 2) — per-light: texture, sampler, and shared shadow UBO.
         // Shared across all receiving meshes in this build via shadowBGCache.

--- a/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
@@ -135,13 +135,79 @@ export async function buildPbrRenderables(
 
     // ── Dynamically import fragment creators based on scene capabilities ──
 
+    // Single O(N) pass over meshes detecting every per-mesh / per-material feature flag used below.
+    // Replaces ~11 sequential meshes.some() loops (was O(11N)). Short-circuits once every flag is true.
+    let hasSkybox = false;
+    let hasMetallicReflectance = false;
+    let hasClearcoat = false;
+    let hasSheen = false;
+    let hasAnyAnisotropy = false;
+    let hasAnySubsurface = false;
+    let hasRefraction = false;
+    let needsEmissiveColor = false;
+    let hasSomeSkeletons = false;
+    let hasSomeMorphs = false;
+    let hasSomeThinInstances = false;
+    for (let i = 0; i < meshes.length; i++) {
+        const m = meshes[i]!;
+        const mat = m.material as PbrMaterialProps;
+        if (!hasSkybox && !!mat.skyboxMode) {
+            hasSkybox = true;
+        }
+        if (!hasMetallicReflectance && (!!mat.metallicReflectanceTexture || !!mat.reflectanceTexture)) {
+            hasMetallicReflectance = true;
+        }
+        if (!hasClearcoat && !!mat.clearCoat?.isEnabled) {
+            hasClearcoat = true;
+        }
+        if (!hasSheen && !!mat.sheen?.isEnabled) {
+            hasSheen = true;
+        }
+        if (!hasAnyAnisotropy && !!mat.anisotropy?.isEnabled) {
+            hasAnyAnisotropy = true;
+        }
+        if (!hasAnySubsurface && !!mat.subsurface?.translucency) {
+            hasAnySubsurface = true;
+        }
+        if (!hasRefraction && (mat.subsurface?.refraction?.intensity ?? 0) > 0) {
+            hasRefraction = true;
+        }
+        if (!needsEmissiveColor && !!mat.emissiveColor) {
+            needsEmissiveColor = true;
+        }
+        if (!hasSomeSkeletons && !!m.skeleton) {
+            hasSomeSkeletons = true;
+        }
+        if (!hasSomeMorphs && !!m.morphTargets) {
+            hasSomeMorphs = true;
+        }
+        if (!hasSomeThinInstances && !!m.thinInstances) {
+            hasSomeThinInstances = true;
+        }
+        if (
+            hasSkybox &&
+            hasMetallicReflectance &&
+            hasClearcoat &&
+            hasSheen &&
+            hasAnyAnisotropy &&
+            hasAnySubsurface &&
+            hasRefraction &&
+            needsEmissiveColor &&
+            hasSomeSkeletons &&
+            hasSomeMorphs &&
+            hasSomeThinInstances
+        ) {
+            break;
+        }
+    }
+
     // IBL fragment
     let _iblSkyboxCalc = "";
     if (hasEnv) {
         const mod = await import("./fragments/ibl-fragment.js");
         _registerPbrExt(mod.iblExt);
         // Skybox-mode WGSL is only loaded when at least one mesh in the scene needs it.
-        if (meshes.some((m) => !!(m.material as PbrMaterialProps).skyboxMode)) {
+        if (hasSkybox) {
             const sky = await import("./fragments/ibl-skybox-wgsl.js");
             _iblSkyboxCalc = sky.IBL_SKYBOX_CALCULATION;
         }
@@ -170,29 +236,22 @@ export async function buildPbrRenderables(
         _multiLightLoop = wgslMod.MULTI_LIGHT_LOOP;
     }
 
-    // Per-mesh fragment creators (imported if any mesh needs them)
-    const hasMetallicReflectance = meshes.some((m) => {
-        const mat = m.material as PbrMaterialProps;
-        return !!mat.metallicReflectanceTexture || !!mat.reflectanceTexture;
-    });
+    // Per-mesh fragment creators (imported if any mesh needs them — flags populated by single pass above)
     if (hasMetallicReflectance) {
         const mod = await import("./fragments/reflectance-fragment.js");
         _registerPbrExt(mod.reflectanceExt);
     }
 
-    const hasClearcoat = meshes.some((m) => !!(m.material as PbrMaterialProps).clearCoat?.isEnabled);
     if (hasClearcoat) {
         const mod = await import("./fragments/clearcoat-fragment.js");
         _registerPbrExt(mod.clearcoatExt);
     }
 
-    const hasSheen = meshes.some((m) => !!(m.material as PbrMaterialProps).sheen?.isEnabled);
     if (hasSheen) {
         const mod = await import("./fragments/sheen-fragment.js");
         _registerPbrExt(mod.sheenExt);
     }
 
-    const hasAnyAnisotropy = meshes.some((m) => !!(m.material as PbrMaterialProps).anisotropy?.isEnabled);
     let _anisoExt: typeof import("./fragments/anisotropy-fragment.js") | null = null;
     if (hasAnyAnisotropy) {
         _anisoExt = await import("./fragments/anisotropy-fragment.js");
@@ -200,36 +259,31 @@ export async function buildPbrRenderables(
         _registerPbrMaterialUboWriter("anisotropy", (d, m, o) => anisoMod.writeAnisotropyUBO(d, m as PbrMaterialProps, o));
     }
 
-    const hasAnySubsurface = meshes.some((m) => !!(m.material as PbrMaterialProps).subsurface?.translucency);
     if (hasAnySubsurface) {
         const mod = await import("./fragments/subsurface-fragment.js");
         _registerPbrExt(mod.subsurfaceExt);
     }
 
-    if (meshes.some((m) => ((m.material as PbrMaterialProps).subsurface?.refraction?.intensity ?? 0) > 0)) {
+    if (hasRefraction) {
         const mod = await import("./fragments/refraction-fragment.js");
         _registerPbrExt(mod.refractionExt);
     }
 
-    const needsEmissiveColor = meshes.some((m) => !!(m.material as PbrMaterialProps).emissiveColor);
     if (needsEmissiveColor) {
         const mod = await import("./fragments/emissive-fragment.js");
         _registerPbrExt(mod.emissiveColorExt);
     }
 
-    const hasSomeSkeletons = meshes.some((m) => !!m.skeleton);
     if (hasSomeSkeletons) {
         const mod = await import("./fragments/skeleton-fragment.js");
         _registerPbrExt(mod.skeletonExt);
     }
 
-    const hasSomeMorphs = meshes.some((m) => !!m.morphTargets);
     if (hasSomeMorphs) {
         const mod = await import("./fragments/morph-fragment.js");
         _registerPbrExt(mod.morphExt);
     }
 
-    const hasSomeThinInstances = meshes.some((m) => !!m.thinInstances);
     let _createThinInstanceFragment: ((hasColor: boolean) => ShaderFragment) | null = null;
     let _syncThinInstanceBuffers:
         | ((engine: EngineContextInternal, ti: ThinInstanceData, pass: GPURenderPassEncoder | GPURenderBundleEncoder, slot: number, hasColor: boolean) => number)
@@ -464,7 +518,7 @@ export async function buildPbrRenderables(
     const renderables: Renderable[] = [];
 
     function drawPackets(pass: GPURenderPassEncoder | GPURenderBundleEncoder, list: PbrDrawPacket[]): number {
-        pass.setBindGroup(0, sceneBindGroup);
+        // sceneBindGroup is bound by engine.drawList via _sceneBG.
         let currentPipeline: GPURenderPipeline | null = null;
         for (const dp of list) {
             if (dp.variant.pipeline !== currentPipeline) {

--- a/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
@@ -20,7 +20,7 @@ import type { ShaderFragment, ComposedShader } from "../../shader/fragment-types
 import type { PbrLightConfig } from "./pbr-template.js";
 import type { UboField } from "../../shader/fragment-types.js";
 import { composeShader } from "../../shader/shader-composer.js";
-import { createPbrTemplate } from "./pbr-template.js";
+import { createPbrTemplate, getPbrBaseSceneUboFields } from "./pbr-template.js";
 import { computeUboLayout } from "../../shader/ubo-layout.js";
 import { acquireTexture, releaseTexture, clearSamplerCache } from "../../resource/gpu-pool.js";
 import { createEmptyUniformBuffer, createUniformBuffer } from "../../resource/gpu-buffers.js";
@@ -351,18 +351,12 @@ export async function buildPbrRenderables(
     (scene as SceneContextInternal)._composePbr = composePbr;
 
     // ── Scene UBO layout ──
-    // Compute the scene UBO spec from the template's baseSceneUboFields.
+    // Compute the scene UBO spec from the base template's scene UBO fields.
     // All PBR variants share the same scene UBO layout — the base template
     // includes all scene fields. Light fields are always present for layout
     // compatibility with background ground shader.
-    const refTemplate = createPbrTemplate({
-        light: hasMultiLight ? null : lightConfig,
-        hasMultiLight,
-        multiLightWGSL: _multiLightWGSL,
-        multiLightLoop: _multiLightLoop,
-        hasIbl: hasEnv,
-    });
-    const sceneUboSpec = computeUboLayout(refTemplate.baseSceneUboFields);
+    const baseSceneUboFields = getPbrBaseSceneUboFields(hasMultiLight ? null : lightConfig, hasMultiLight, hasEnv);
+    const sceneUboSpec = computeUboLayout(baseSceneUboFields);
     const sceneUboSize = sceneUboSpec.totalBytes;
 
     const sceneBGL = createSceneBindGroupLayout(engine);
@@ -393,6 +387,10 @@ export async function buildPbrRenderables(
 
     const packets: PbrDrawPacket[] = [];
     const featureCtx: import("./pbr-mesh-features.js").PbrFeatureCtx = { hasEnv, hasTonemap, hasSomeShadows };
+    // Shadow bind group cache — within one scene build, all receiving meshes share the
+    // same shadowLights array (see meshShadowLights assignment below), so a BG keyed by
+    // shadowBGL alone is correct. Cache is scoped to this builder (not module-level).
+    const shadowBGCache = new Map<GPUBindGroupLayout, GPUBindGroup>();
     for (const mesh of meshes) {
         const gpu = (mesh as MeshInternal)._gpu;
         const mat = mesh.material as PbrMaterialProps;
@@ -405,21 +403,29 @@ export async function buildPbrRenderables(
         const materialUBO = createMaterialUBO(engine, mat, composed);
         const materialBindGroup = createPbrMeshBindGroup(engine, variant, meshUBO, materialUBO, mat, envTextures ?? null, mesh, lightsUBOBuffer);
 
-        // Shadow bind group (group 2) — per-light: texture, sampler, and shared shadow UBO
+        // Shadow bind group (group 2) — per-light: texture, sampler, and shared shadow UBO.
+        // Shared across all receiving meshes in this build via shadowBGCache.
         let shadowBindGroup: GPUBindGroup | null = null;
         const packetShadowGens: ShadowGenerator[] = [];
         const meshShadowLights = mesh.receiveShadows ? shadowLights : [];
         if (meshShadowLights.length > 0 && variant.shadowBGL) {
-            const entries: GPUBindGroupEntry[] = [];
-            let b = 0;
             for (const sl of meshShadowLights) {
-                const sg = sl.gen;
-                entries.push({ binding: b++, resource: sg.blurredTexture.createView() });
-                entries.push({ binding: b++, resource: sg.blurredSampler });
-                packetShadowGens.push(sg);
-                entries.push({ binding: b++, resource: { buffer: sg.shadowUBO } });
+                packetShadowGens.push(sl.gen);
             }
-            shadowBindGroup = device.createBindGroup({ layout: variant.shadowBGL, entries });
+            let cached = shadowBGCache.get(variant.shadowBGL);
+            if (!cached) {
+                const entries: GPUBindGroupEntry[] = [];
+                let b = 0;
+                for (const sl of meshShadowLights) {
+                    const sg = sl.gen;
+                    entries.push({ binding: b++, resource: sg.blurredTexture.createView() });
+                    entries.push({ binding: b++, resource: sg.blurredSampler });
+                    entries.push({ binding: b++, resource: { buffer: sg.shadowUBO } });
+                }
+                cached = device.createBindGroup({ layout: variant.shadowBGL, entries });
+                shadowBGCache.set(variant.shadowBGL, cached);
+            }
+            shadowBindGroup = cached;
         }
 
         packets.push({

--- a/packages/babylon-lite/src/material/pbr/pbr-single-rebuild.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-single-rebuild.ts
@@ -43,7 +43,7 @@ export function buildSinglePbrRenderable(scene: SceneContext, mesh: Mesh): Rende
     const materialUBO = _createPbrMaterialUBO(engine, mat, composed);
     // Pass shared lights UBO if available (multi-light path)
     const lightsUBO = (scene as SceneContextInternal)._pbrLightsUBO;
-    const materialBindGroup = createPbrMeshBindGroup(engine, variant, meshUBO, materialUBO, mat, envTextures ?? null, mesh, lightsUBO);
+    const materialBindGroup = createPbrMeshBindGroup(engine, variant, composed, meshUBO, materialUBO, mat, envTextures ?? null, mesh, lightsUBO);
 
     // Shadow bind group (group 2) — multi-shadow support
     const shadowLights: { gen: ShadowGenerator }[] = [];

--- a/packages/babylon-lite/src/material/pbr/pbr-single-rebuild.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-single-rebuild.ts
@@ -108,8 +108,7 @@ export function buildSinglePbrRenderable(scene: SceneContext, mesh: Mesh): Rende
             if (mesh.material !== mat) {
                 return 0;
             }
-            pass.setPipeline(variant.pipeline);
-            pass.setBindGroup(0, sceneBindGroup);
+            // Pipeline + sceneBG are set by engine.drawList via _pipeline/_sceneBG.
             pass.setBindGroup(1, materialBindGroup);
             if (shadowBindGroup) {
                 pass.setBindGroup(2, shadowBindGroup);

--- a/packages/babylon-lite/src/material/pbr/pbr-template.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-template.ts
@@ -82,24 +82,12 @@ export interface PbrTemplateConfig {
     readonly hasMorph?: boolean;
     /** Has occlusion in ORM texture (simple path, no reflectance ext) */
     readonly hasOcclusion?: boolean;
-    /** Has sheen texture binding in base template */
-    readonly hasSheenTexture?: boolean;
     /** Has emissive color UBO field (fragment handles emissive computation) */
     readonly hasEmissiveColor?: boolean;
     /** When true, the reflectance fragment handles F0 + occlusion computation */
     readonly hasReflectanceExt?: boolean;
     /** When true, include IBL SH coefficients in scene UBO */
     readonly hasIbl?: boolean;
-    /** Has clearcoat layer */
-    readonly hasClearcoat?: boolean;
-    /** Has clearcoat intensity texture (R channel, multiplies intensity factor). */
-    readonly hasCcIntensityMap?: boolean;
-    /** Has clearcoat roughness texture (G channel, multiplies roughness factor). */
-    readonly hasCcRoughnessMap?: boolean;
-    /** Has clearcoat normal map (tangent-space, perturbs coat normal). */
-    readonly hasCcNormalMap?: boolean;
-    /** Has sheen layer */
-    readonly hasSheen?: boolean;
     /** Has anisotropy layer */
     readonly hasAnisotropy?: boolean;
     /** Anisotropy WGSL: BRDF helper functions (dynamically imported). */
@@ -176,15 +164,9 @@ export function createPbrTemplate(config: PbrTemplateConfig): ShaderTemplate {
         hasGammaAlbedo = false,
         hasMorph = false,
         hasOcclusion = false,
-        hasSheenTexture = false,
         hasEmissiveColor = false,
         hasReflectanceExt = false,
         hasIbl = false,
-        hasClearcoat = false,
-        hasCcIntensityMap = false,
-        hasCcRoughnessMap = false,
-        hasCcNormalMap = false,
-        hasSheen = false,
         hasAnisotropy = false,
         anisoBrdfFunctions = "",
         anisoTBBlock = "",
@@ -231,35 +213,10 @@ export function createPbrTemplate(config: PbrTemplateConfig): ShaderTemplate {
         { name: "roughnessFactor", type: "f32" },
         { name: "_mrfPad0", type: "f32" },
         { name: "_mrfPad1", type: "f32" },
-        // Extension UBO fields in old-system order for byte-layout compat
-        ...(hasReflectanceExt
-            ? [
-                  { name: "occlusionStrength", type: "f32" as const },
-                  { name: "metallicF0Factor", type: "f32" as const },
-                  { name: "_mrPad0", type: "f32" as const },
-                  { name: "_mrPad1", type: "f32" as const },
-                  { name: "metallicReflectanceColor", type: "vec3<f32>" as const },
-                  { name: "_mrPad2", type: "f32" as const },
-              ]
-            : []),
-        ...(hasEmissiveColor
-            ? [
-                  { name: "emissiveColor", type: "vec3<f32>" as const },
-                  { name: "_emissiveColorPad", type: "f32" as const },
-              ]
-            : []),
-        ...(hasClearcoat
-            ? [
-                  { name: "ccParams", type: "vec4<f32>" as const },
-                  { name: "ccRefractionParams", type: "vec4<f32>" as const },
-              ]
-            : []),
-        ...(hasSheen
-            ? [
-                  { name: "sheenParams", type: "vec4<f32>" as const },
-                  { name: "sheenParams2", type: "vec4<f32>" as const },
-              ]
-            : []),
+        // Anisotropy UBO field kept here because its registration path does not
+        // yet flow through the composer fragment pipeline (see pbr-renderable:
+        // _registerPbrMaterialUboWriter). The reflectance/emissive/clearcoat/sheen
+        // UBO fields are now contributed by their own fragments.
         ...(hasAnisotropy ? [{ name: "anisotropyParams", type: "vec4<f32>" as const }] : []),
     ];
 
@@ -283,19 +240,6 @@ export function createPbrTemplate(config: PbrTemplateConfig): ShaderTemplate {
     }
     if (hasSpecGloss) {
         baseBindings.push(...tex2d("specGlossTexture", "specGlossSampler"));
-    }
-    if (hasSheenTexture) {
-        baseBindings.push(...tex2d("sheenTexture_", "sheenSampler_"));
-    }
-    // Clearcoat textures — must match order in createPbrMeshBindGroup
-    if (hasCcIntensityMap) {
-        baseBindings.push(...tex2d("ccIntensityTexture", "ccIntensitySampler_"));
-    }
-    if (hasCcRoughnessMap) {
-        baseBindings.push(...tex2d("ccRoughnessTexture", "ccRoughnessSampler_"));
-    }
-    if (hasCcNormalMap) {
-        baseBindings.push(...tex2d("ccNormalTexture", "ccNormalSampler_"));
     }
     if (hasMultiLight) {
         baseBindings.push({ name: "lights", type: { kind: "uniform-buffer" }, visibility: STAGE_FRAGMENT });

--- a/packages/babylon-lite/src/material/pbr/pbr-template.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-template.ts
@@ -111,6 +111,50 @@ export interface PbrTemplateConfig {
 }
 
 /**
+ * Return the scene UBO field list used by the PBR base template.
+ * Cheap list-building only — no WGSL assembly. Exposed so callers that only
+ * need the UBO layout (e.g. scene UBO spec computation) can avoid paying the
+ * full createPbrTemplate cost.
+ */
+export function getPbrBaseSceneUboFields(light: PbrLightConfig | null, hasMultiLight: boolean, hasIbl: boolean): readonly UboField[] {
+    // When hasMultiLight, light data comes from the lights UBO — scene UBO fields
+    // are kept as reserved padding for layout compatibility with background shaders.
+    const lightUboFields: readonly UboField[] =
+        hasMultiLight || !light
+            ? [
+                  { name: "lightDirection", type: "vec3<f32>" },
+                  { name: "lightIntensity", type: "f32" },
+                  { name: "lightDiffuseColor", type: "vec3<f32>" },
+                  { name: "_pad1", type: "f32" },
+                  { name: "lightGroundColor", type: "vec3<f32>" },
+              ]
+            : light.sceneUboFields;
+
+    // SH coefficients are included in the base template (not the IBL fragment)
+    // because the scene UBO writer uses fixed offsets for SH data.
+    const SH_NAMES = ["L00", "L1_1", "L10", "L11", "L2_2", "L2_1", "L20", "L21", "L22"] as const;
+    const shFields: UboField[] = hasIbl
+        ? SH_NAMES.flatMap((n, i) => [
+              { name: `vSpherical${n}`, type: "vec3<f32>" as const },
+              { name: `_shPad${i}`, type: "f32" as const },
+          ])
+        : [];
+
+    return [
+        { name: "viewProj", type: "mat4x4<f32>" },
+        { name: "cameraPosition", type: "vec3<f32>" },
+        { name: "_pad0", type: "f32" },
+        ...lightUboFields,
+        { name: "envRotationY", type: "f32" },
+        ...shFields,
+        { name: "exposureLinear", type: "f32" },
+        { name: "contrast", type: "f32" },
+        { name: "lodGenerationScale", type: "f32" },
+        { name: "_imgPad1", type: "f32" },
+    ];
+}
+
+/**
  * Create a PBR ShaderTemplate from the given configuration.
  * The template contains slot markers that the composer fills with fragment code.
  */
@@ -226,41 +270,7 @@ export function createPbrTemplate(config: PbrTemplateConfig): ShaderTemplate {
     ];
 
     // ── Base scene UBO fields ───────────────────────────────────
-    // SH coefficients are included in the base template (not the IBL fragment)
-    // because the scene UBO writer uses fixed offsets for SH data.
-    const SH_NAMES = ["L00", "L1_1", "L10", "L11", "L2_2", "L2_1", "L20", "L21", "L22"] as const;
-    const shFields: UboField[] = hasIbl
-        ? SH_NAMES.flatMap((n, i) => [
-              { name: `vSpherical${n}`, type: "vec3<f32>" as const },
-              { name: `_shPad${i}`, type: "f32" as const },
-          ])
-        : [];
-
-    // When hasMultiLight, light data comes from the lights UBO — scene UBO fields
-    // are kept as reserved padding for layout compatibility with background shaders.
-    const lightUboFields: readonly UboField[] =
-        hasMultiLight || !light
-            ? [
-                  { name: "lightDirection", type: "vec3<f32>" },
-                  { name: "lightIntensity", type: "f32" },
-                  { name: "lightDiffuseColor", type: "vec3<f32>" },
-                  { name: "_pad1", type: "f32" },
-                  { name: "lightGroundColor", type: "vec3<f32>" },
-              ]
-            : light.sceneUboFields;
-
-    const baseSceneUboFields: UboField[] = [
-        { name: "viewProj", type: "mat4x4<f32>" },
-        { name: "cameraPosition", type: "vec3<f32>" },
-        { name: "_pad0", type: "f32" },
-        ...lightUboFields,
-        { name: "envRotationY", type: "f32" },
-        ...shFields,
-        { name: "exposureLinear", type: "f32" },
-        { name: "contrast", type: "f32" },
-        { name: "lodGenerationScale", type: "f32" },
-        { name: "_imgPad1", type: "f32" },
-    ];
+    const baseSceneUboFields: readonly UboField[] = getPbrBaseSceneUboFields(hasMultiLight || !light ? null : light, hasMultiLight, hasIbl);
 
     // ── Base bindings (always-present textures) ─────────────────
     const baseBindings: BindingDecl[] = [...tex2d("baseColorTexture", "baseColorSampler")];

--- a/packages/babylon-lite/src/material/standard/standard-material.ts
+++ b/packages/babylon-lite/src/material/standard/standard-material.ts
@@ -33,17 +33,25 @@ function getSceneUboSize(): number {
 // ─── Standard Group Builder ──────────────────────────────────────────
 
 /** Lazy-imports the standard renderable builder and builds the pipeline. */
+// Material-property → fragment-module dispatch table. Each entry is a plain
+// extension: if any mesh's material has the named property, dynamic-import
+// the fragment module and register the named StdExt export. Keeping this as
+// a data table rather than an if-ladder keeps core size flat as extensions
+// grow.
+const _STD_MAT_EXTS: ReadonlyArray<readonly [keyof StandardMaterialProps, () => Promise<any>, string]> = [
+    ["bumpTexture", () => import("./fragments/normal-map-fragment.js"), "bumpStdExt"],
+    ["emissiveTexture", () => import("./fragments/std-emissive-fragment.js"), "stdEmissiveExt"],
+    ["specularTexture", () => import("./fragments/std-specular-fragment.js"), "stdSpecularExt"],
+    ["ambientTexture", () => import("./fragments/std-ambient-fragment.js"), "stdAmbientExt"],
+    ["lightmapTexture", () => import("./fragments/std-lightmap-fragment.js"), "stdLightmapExt"],
+    ["opacityTexture", () => import("./fragments/std-opacity-fragment.js"), "stdOpacityExt"],
+    ["reflectionTexture", () => import("./fragments/std-reflection-fragment.js"), "stdReflectionExt"],
+    ["reflectionCubeTexture", () => import("./fragments/std-cube-reflection-fragment.js"), "stdCubeReflectionExt"],
+];
+
 export const standardGroupBuilder: MeshGroupBuilder & { _loadRebuildSingle?: () => Promise<any> } = async (scene, meshes) => {
     const hasTI = meshes.some((m) => !!m.thinInstances);
-    const hasBump = meshes.some((m) => !!(m.material as any).bumpTexture);
     const hasShadow = meshes.some((m) => m.receiveShadows) && scene.lights.some((l: { shadowGenerator?: unknown }) => !!l.shadowGenerator);
-    const hasEmissive = meshes.some((m) => !!(m.material as any).emissiveTexture);
-    const hasSpecular = meshes.some((m) => !!(m.material as any).specularTexture);
-    const hasAmbient = meshes.some((m) => !!(m.material as any).ambientTexture);
-    const hasLightmap = meshes.some((m) => !!(m.material as any).lightmapTexture);
-    const hasOpacity = meshes.some((m) => !!(m.material as any).opacityTexture);
-    const hasReflection = meshes.some((m) => !!(m.material as any).reflectionTexture);
-    const hasCubeReflection = meshes.some((m) => !!(m.material as any).reflectionCubeTexture);
 
     let tiSync: ((engine: EngineContextInternal, ti: any, pass: GPURenderPassEncoder | GPURenderBundleEncoder, slot: number, hasColor: boolean) => number) | undefined;
     let tiFragment: any;
@@ -62,9 +70,6 @@ export const standardGroupBuilder: MeshGroupBuilder & { _loadRebuildSingle?: () 
             })
         );
     }
-    if (hasBump) {
-        imports.push(import("./fragments/normal-map-fragment.js").then((m) => _registerStdExt(m.bumpStdExt)));
-    }
     if (hasShadow) {
         imports.push(
             import("./fragments/std-shadow-fragment.js").then((m) => {
@@ -72,26 +77,10 @@ export const standardGroupBuilder: MeshGroupBuilder & { _loadRebuildSingle?: () 
             })
         );
     }
-    if (hasEmissive) {
-        imports.push(import("./fragments/std-emissive-fragment.js").then((m) => _registerStdExt(m.stdEmissiveExt)));
-    }
-    if (hasSpecular) {
-        imports.push(import("./fragments/std-specular-fragment.js").then((m) => _registerStdExt(m.stdSpecularExt)));
-    }
-    if (hasAmbient) {
-        imports.push(import("./fragments/std-ambient-fragment.js").then((m) => _registerStdExt(m.stdAmbientExt)));
-    }
-    if (hasLightmap) {
-        imports.push(import("./fragments/std-lightmap-fragment.js").then((m) => _registerStdExt(m.stdLightmapExt)));
-    }
-    if (hasOpacity) {
-        imports.push(import("./fragments/std-opacity-fragment.js").then((m) => _registerStdExt(m.stdOpacityExt)));
-    }
-    if (hasReflection) {
-        imports.push(import("./fragments/std-reflection-fragment.js").then((m) => _registerStdExt(m.stdReflectionExt)));
-    }
-    if (hasCubeReflection) {
-        imports.push(import("./fragments/std-cube-reflection-fragment.js").then((m) => _registerStdExt(m.stdCubeReflectionExt)));
+    for (const [prop, load, key] of _STD_MAT_EXTS) {
+        if (meshes.some((m) => !!(m.material as any)[prop])) {
+            imports.push(load().then((mod) => _registerStdExt(mod[key])));
+        }
     }
     if (imports.length > 0) {
         await Promise.all(imports);

--- a/packages/babylon-lite/src/material/standard/standard-pipeline.ts
+++ b/packages/babylon-lite/src/material/standard/standard-pipeline.ts
@@ -111,13 +111,22 @@ export interface ShadowLightSlotLite {
 }
 
 const _stdExts = new Map<string, StdExt>();
+let _stdExtsSorted: readonly StdExt[] | null = null;
 
 export function _registerStdExt(ext: StdExt): void {
     _stdExts.set(ext.id, ext);
+    _stdExtsSorted = null;
 }
 
 export function _getStdExts(): ReadonlyMap<string, StdExt> {
     return _stdExts;
+}
+
+export function _getStdExtsSorted(): readonly StdExt[] {
+    if (!_stdExtsSorted) {
+        _stdExtsSorted = Array.from(_stdExts.values()).sort((a, b) => a.id.localeCompare(b.id));
+    }
+    return _stdExtsSorted;
 }
 
 /** Derived: mesh needs UV attribute (any texture present). */
@@ -434,10 +443,12 @@ export function createDynamicMeshGPU(
         material: StandardMaterialProps;
         lightsBuffer: GPUBuffer;
         shadowGenerators?: ShadowGenerator[];
+        /** Optional cache shared across meshes in one scene build to dedupe identical shadow bind groups. */
+        shadowBGCache?: Map<GPUBindGroupLayout, GPUBindGroup>;
     }
 ): DynamicMeshGPU {
     const device = engine.device;
-    const { worldMatrix, material, lightsBuffer, shadowGenerators = [] } = opts;
+    const { worldMatrix, material, lightsBuffer, shadowGenerators = [], shadowBGCache } = opts;
     const features = variant.features;
     const hasShadow = (features & RECEIVE_SHADOWS) !== 0;
     const needsUV = (features & NEEDS_UV) !== 0;
@@ -475,7 +486,7 @@ export function createDynamicMeshGPU(
 
     // Fragment-contributed bindings — iterate ext registry in alphabetical id order
     // to match composer's fragment sort order.
-    const sortedExts = Array.from(_stdExts.values()).sort((a, b) => a.id.localeCompare(b.id));
+    const sortedExts = _getStdExtsSorted();
     for (const ext of sortedExts) {
         if (features & ext.feature && ext.bind) {
             nextBinding = ext.bind(material, meshEntries, nextBinding);
@@ -485,17 +496,25 @@ export function createDynamicMeshGPU(
     const meshBG = device.createBindGroup({ layout: variant.meshBGL, entries: meshEntries });
 
     // Shadow bind group (group 2) — per-light shadow entries
-    // Each shadow light contributes: texture + sampler + shared UBO from the ShadowGenerator
+    // Each shadow light contributes: texture + sampler + shared UBO from the ShadowGenerator.
+    // When shadowBGCache is provided, reuse one BG across all meshes (within one build
+    // all receiving meshes share the same shadow generators).
     let shadowBG: GPUBindGroup | null = null;
     if (hasShadow && variant.shadowBGL && shadowGenerators.length > 0) {
-        const entries: GPUBindGroupEntry[] = [];
-        let b = 0;
-        for (const sg of shadowGenerators) {
-            entries.push({ binding: b++, resource: sg.blurredTexture.createView() });
-            entries.push({ binding: b++, resource: sg.blurredSampler });
-            entries.push({ binding: b++, resource: { buffer: sg.shadowUBO } });
+        const cached = shadowBGCache?.get(variant.shadowBGL);
+        if (cached) {
+            shadowBG = cached;
+        } else {
+            const entries: GPUBindGroupEntry[] = [];
+            let b = 0;
+            for (const sg of shadowGenerators) {
+                entries.push({ binding: b++, resource: sg.blurredTexture.createView() });
+                entries.push({ binding: b++, resource: sg.blurredSampler });
+                entries.push({ binding: b++, resource: { buffer: sg.shadowUBO } });
+            }
+            shadowBG = device.createBindGroup({ layout: variant.shadowBGL, entries });
+            shadowBGCache?.set(variant.shadowBGL, shadowBG);
         }
-        shadowBG = device.createBindGroup({ layout: variant.shadowBGL, entries });
     }
 
     return { meshBG, shadowBG, meshUBO, materialUBO, textureLevel, shadowGens: shadowGenerators };

--- a/packages/babylon-lite/src/material/standard/standard-renderable.ts
+++ b/packages/babylon-lite/src/material/standard/standard-renderable.ts
@@ -227,8 +227,7 @@ export function buildStandardMeshRenderables(scene: SceneContext, meshes: Mesh[]
                 }
             },
             draw(pass: GPURenderPassEncoder | GPURenderBundleEncoder) {
-                pass.setPipeline(variant.pipeline);
-                pass.setBindGroup(0, variant.sceneBG);
+                // Pipeline + sceneBG are set by engine.drawList via _pipeline/_sceneBG.
                 let draws = 0;
                 for (const pkt of packets) {
                     if (pkt.mesh.material !== pkt._lastMaterial) {

--- a/packages/babylon-lite/src/material/standard/standard-renderable.ts
+++ b/packages/babylon-lite/src/material/standard/standard-renderable.ts
@@ -78,6 +78,9 @@ export function buildStandardMeshRenderables(scene: SceneContext, meshes: Mesh[]
         }
     }
     const hasSomeShadows = shadowLights.length > 0;
+    // Shadow bind group cache — within this build, all receiving meshes share the
+    // same shadow generators, so keying by variant.shadowBGL alone is correct.
+    const shadowBGCache = new Map<GPUBindGroupLayout, GPUBindGroup>();
 
     // Per-mesh light filtering: bitmask cache (MAX_LIGHTS=4 → at most 16 entries).
     // When no light has filtering, all meshes hit the same bitmask → one shared UBO.
@@ -165,6 +168,7 @@ export function buildStandardMeshRenderables(scene: SceneContext, meshes: Mesh[]
             material: mat,
             lightsBuffer,
             shadowGenerators: meshShadowGens,
+            shadowBGCache,
         });
         group.packets.push({ mesh, gpu, _lastMaterial: mat, _lastWorldVersion: mesh.worldMatrixVersion });
 

--- a/packages/babylon-lite/src/material/standard/standard-single-rebuild.ts
+++ b/packages/babylon-lite/src/material/standard/standard-single-rebuild.ts
@@ -146,8 +146,7 @@ export function buildSingleStandardRenderable(scene: SceneContext, mesh: Mesh): 
                 return 0;
             }
             const g = (mesh as MeshInternal)._gpu;
-            pass.setPipeline(variant.pipeline);
-            pass.setBindGroup(0, variant.sceneBG);
+            // Pipeline + sceneBG are set by engine.drawList via _pipeline/_sceneBG.
             pass.setVertexBuffer(0, g.positionBuffer);
             pass.setVertexBuffer(1, g.normalBuffer);
             if (needsUV) {

--- a/packages/babylon-lite/src/shadow/pcf-shadow-generator.ts
+++ b/packages/babylon-lite/src/shadow/pcf-shadow-generator.ts
@@ -20,24 +20,21 @@ import type { Mesh } from "../mesh/mesh.js";
 import type { EngineContext } from "../engine/engine.js";
 import type { EngineContextInternal } from "../engine/engine.js";
 import type { ShadowGenerator } from "./shadow-generator.js";
-import { createUniformBuffer } from "../resource/gpu-buffers.js";
 import {
-    buildCasters,
     syncCasterMatrices,
     drawCasters,
-    shadowMatrixChanged,
-    writeShadowUboFields,
     buildLightViewMatrix,
     multiply4x4,
-    createDepthSceneBGL,
     createSharedShadowUBO,
     createShadowParamsUBO,
+    createShadowDepthInfra,
+    createShadowDirtyTracker,
+    updateShadowLightMatrix,
 } from "./shadow-base.js";
 import depthVertSrc from "../../shaders/shadow-pcf-depth.vertex.wgsl?raw";
 import { registerPcfShadowShader } from "../material/standard/standard-pipeline.js";
 import { registerPcfShadowBgl } from "../material/standard/standard-pipeline.js";
 import { WGSL_SCENE_UNIFORMS_SHADOW } from "../shader/wgsl-helpers.js";
-import { createSingleUniformBGL } from "../shader/bgl-helpers.js";
 
 // ─── PCF Shader Fragments (bundled only when PCF is used) ──────────
 
@@ -136,11 +133,15 @@ export function createPcfShadowGenerator(engine: EngineContext, light: SpotLight
 
     const { viewProj } = computeSpotLightMatrix(light, near, far);
 
-    // --- Depth pipeline BGL (needed before buildCasters) ---
-    const depthMeshBGL = createSingleUniformBGL(eng, "pcf-depth-mesh", GPUShaderStage.VERTEX);
-
-    // Build caster data + per-caster bind groups
-    const casters = buildCasters(eng, casterMeshes, depthMeshBGL);
+    // --- Shadow depth infra (BGL, scene UBO/BG, casters, depth-only pipeline with bias) ---
+    const { depthMeshBGL, depthSceneUBO, depthPipeline, depthSceneBG, casters } = createShadowDepthInfra(eng, {
+        label: "shadow-pcf",
+        viewProj,
+        casterMeshes,
+        vertCode: WGSL_SCENE_UNIFORMS_SHADOW + depthVertSrc,
+        depthBias: Math.round(bias * 1e7),
+        depthBiasSlopeScale: normalBias > 0 ? normalBias : 2,
+    });
 
     // --- Depth-only texture ---
     const depthTexture = device.createTexture({
@@ -148,36 +149,6 @@ export function createPcfShadowGenerator(engine: EngineContext, light: SpotLight
         size: { width: mapSize, height: mapSize },
         format: "depth32float",
         usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
-    });
-
-    // --- Depth pipeline (vertex-only, no fragment) ---
-    const depthSceneUBO = createUniformBuffer(eng, viewProj as Float32Array<ArrayBuffer>);
-
-    const depthSceneBGL = createDepthSceneBGL(eng, "pcf-depth-scene");
-
-    const depthVert = device.createShaderModule({ code: WGSL_SCENE_UNIFORMS_SHADOW + depthVertSrc, label: "pcf-depth-vert" });
-
-    const depthPipeline = device.createRenderPipeline({
-        label: "shadow-pcf-depth",
-        layout: device.createPipelineLayout({ bindGroupLayouts: [depthSceneBGL, depthMeshBGL] }),
-        vertex: {
-            module: depthVert,
-            entryPoint: "main",
-            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: "float32x3" as GPUVertexFormat }] }],
-        },
-        depthStencil: {
-            format: "depth32float",
-            depthWriteEnabled: true,
-            depthCompare: "less-equal",
-            depthBias: Math.round(bias * 1e7),
-            depthBiasSlopeScale: normalBias > 0 ? normalBias : 2,
-        },
-        primitive: { topology: "triangle-list", cullMode: "back", frontFace: "ccw" },
-    });
-
-    const depthSceneBG = device.createBindGroup({
-        layout: depthSceneBGL,
-        entries: [{ binding: 0, resource: { buffer: depthSceneUBO } }],
     });
 
     // --- Comparison sampler for PCF ---
@@ -198,9 +169,8 @@ export function createPcfShadowGenerator(engine: EngineContext, light: SpotLight
     // Shared shadow UBO for all receiver meshes (96 bytes)
     const { ubo: sharedShadowUBO, data: shadowUboData } = createSharedShadowUBO(eng, lightMatrix, depthValuesArr, shadowsInfo);
 
-    // Shadow matrix early-out tracking (init to -1 to force first-frame render)
-    let _lastSpotLightVer = -1;
-    let _lastPcfCasterVerSum = -1;
+    // Shadow matrix early-out tracking
+    const dirtyTracker = createShadowDirtyTracker();
 
     const sg: ShadowGenerator = {
         shadowType: "pcf" as const,
@@ -208,32 +178,15 @@ export function createPcfShadowGenerator(engine: EngineContext, light: SpotLight
         blurredTexture: depthTexture, // PCF: depth texture (not blurred)
         blurredSampler: comparisonSampler, // PCF: comparison sampler
         renderShadowMap(encoder: GPUCommandEncoder): number {
-            // Check if anything has changed since last render
-            let casterVerSum = 0;
-            for (const c of casters) {
-                casterVerSum += c._mesh.worldMatrixVersion;
+            const { dirty, lightChanged } = dirtyTracker.check(light, casters);
+            if (!dirty) {
+                return 0;
             }
-            const lightVer = light.worldMatrixVersion;
-            const changed = lightVer !== _lastSpotLightVer || casterVerSum !== _lastPcfCasterVerSum;
-
-            if (!changed) {
-                return 0; // Nothing moved — shadow map is still valid
-            }
-
-            // Only recompute light matrix when light has moved
-            if (lightVer !== _lastSpotLightVer) {
-                _lastSpotLightVer = lightVer;
+            if (lightChanged) {
                 const updated = computeSpotLightMatrix(light, near, far);
-                if (shadowMatrixChanged(lightMatrix, updated.viewProj)) {
-                    lightMatrix.set(updated.viewProj);
-                    sg._version++;
-                    device.queue.writeBuffer(depthSceneUBO, 0, lightMatrix as Float32Array<ArrayBuffer>);
-                    // Update shared shadow UBO for all receivers
-                    writeShadowUboFields(shadowUboData, sg);
-                    device.queue.writeBuffer(sharedShadowUBO, 0, shadowUboData as Float32Array<ArrayBuffer>);
-                }
+                updateShadowLightMatrix(eng, sg, depthSceneUBO, updated.viewProj, shadowUboData);
             }
-            _lastPcfCasterVerSum = casterVerSum;
+            dirtyTracker.commit(light, casters);
 
             syncCasterMatrices(eng, casters);
 

--- a/packages/babylon-lite/src/shadow/shadow-base.ts
+++ b/packages/babylon-lite/src/shadow/shadow-base.ts
@@ -173,3 +173,129 @@ export function drawCasters(pass: GPURenderPassEncoder, casters: ShadowCaster[])
         pass.drawIndexed(c.indexCount);
     }
 }
+
+export interface ShadowDepthInfraOptions {
+    label: string;
+    viewProj: Float32Array;
+    casterMeshes: Mesh[];
+    vertCode: string;
+    fragCode?: string;
+    colorTargets?: GPUColorTargetState[];
+    depthBias?: number;
+    depthBiasSlopeScale?: number;
+    extraMeshEntries?: GPUBindGroupEntry[];
+    extraMeshBglEntries?: GPUBindGroupLayoutEntry[];
+}
+
+export interface ShadowDepthInfra {
+    depthMeshBGL: GPUBindGroupLayout;
+    depthSceneBGL: GPUBindGroupLayout;
+    depthSceneBG: GPUBindGroup;
+    depthSceneUBO: GPUBuffer;
+    depthPipeline: GPURenderPipeline;
+    casters: ShadowCaster[];
+}
+
+/** Create the shared shadow depth-pass infra: BGLs, scene UBO/BG, caster list, and depth pipeline. */
+export function createShadowDepthInfra(engine: EngineContextInternal, opts: ShadowDepthInfraOptions): ShadowDepthInfra {
+    const device = engine.device;
+    const label = opts.label;
+
+    const meshBglEntries: GPUBindGroupLayoutEntry[] = [{ binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: "uniform" } }];
+    if (opts.extraMeshBglEntries) {
+        for (const e of opts.extraMeshBglEntries) {
+            meshBglEntries.push(e);
+        }
+    }
+    const depthMeshBGL = device.createBindGroupLayout({ label: `${label}-depth-mesh`, entries: meshBglEntries });
+    const depthSceneBGL = createDepthSceneBGL(engine, `${label}-depth-scene`);
+    const depthSceneUBO = createUniformBuffer(engine, opts.viewProj as Float32Array<ArrayBuffer>);
+    const depthSceneBG = device.createBindGroup({ layout: depthSceneBGL, entries: [{ binding: 0, resource: { buffer: depthSceneUBO } }] });
+
+    const casters = buildCasters(engine, opts.casterMeshes, depthMeshBGL, opts.extraMeshEntries);
+
+    const vertModule = device.createShaderModule({ code: opts.vertCode, label: `${label}-depth-vert` });
+    const fragModule = opts.fragCode ? device.createShaderModule({ code: opts.fragCode, label: `${label}-depth-frag` }) : undefined;
+
+    const depthStencil: GPUDepthStencilState = { format: "depth32float", depthWriteEnabled: true, depthCompare: "less-equal" };
+    if (opts.depthBias !== undefined) {
+        depthStencil.depthBias = opts.depthBias;
+    }
+    if (opts.depthBiasSlopeScale !== undefined) {
+        depthStencil.depthBiasSlopeScale = opts.depthBiasSlopeScale;
+    }
+
+    const pipelineDesc: GPURenderPipelineDescriptor = {
+        label: `${label}-depth`,
+        layout: device.createPipelineLayout({ bindGroupLayouts: [depthSceneBGL, depthMeshBGL] }),
+        vertex: {
+            module: vertModule,
+            entryPoint: "main",
+            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: "float32x3" as GPUVertexFormat }] }],
+        },
+        depthStencil,
+        primitive: { topology: "triangle-list", cullMode: "back", frontFace: "ccw" },
+    };
+    if (fragModule && opts.colorTargets) {
+        pipelineDesc.fragment = { module: fragModule, entryPoint: "main", targets: opts.colorTargets };
+    }
+
+    const depthPipeline = device.createRenderPipeline(pipelineDesc);
+
+    return { depthMeshBGL, depthSceneBGL, depthSceneBG, depthSceneUBO, depthPipeline, casters };
+}
+
+export interface ShadowDirtyTracker {
+    /** Returns { dirty, lightChanged }. dirty=false means renderShadowMap can early-out. */
+    check(light: { worldMatrixVersion: number }, casters: ShadowCaster[]): { dirty: boolean; lightChanged: boolean };
+    commit(light: { worldMatrixVersion: number }, casters: ShadowCaster[]): void;
+}
+
+/** Per-generator dirty tracker for caster/light version changes. */
+export function createShadowDirtyTracker(): ShadowDirtyTracker {
+    let lastLv = -1;
+    let lastSum = -1;
+    let lastCount = -1;
+    return {
+        check(light, casters) {
+            let sum = 0;
+            for (const c of casters) {
+                sum += c._mesh.worldMatrixVersion;
+            }
+            const lv = light.worldMatrixVersion;
+            const lightChanged = lv !== lastLv || casters.length !== lastCount;
+            const dirty = lightChanged || sum !== lastSum;
+            return { dirty, lightChanged };
+        },
+        commit(light, casters) {
+            let sum = 0;
+            for (const c of casters) {
+                sum += c._mesh.worldMatrixVersion;
+            }
+            lastLv = light.worldMatrixVersion;
+            lastSum = sum;
+            lastCount = casters.length;
+        },
+    };
+}
+
+/** Update the light matrix UBOs if the new viewProj differs from the cached one.
+ *  Bumps sg._version, writes depthSceneUBO + sharedShadowUBO. Returns true if matrix changed. */
+export function updateShadowLightMatrix(
+    engine: EngineContextInternal,
+    sg: { lightMatrix: Float32Array; depthValues: Float32Array; shadowsInfo: Float32Array; shadowUBO: GPUBuffer; _version: number },
+    depthSceneUBO: GPUBuffer,
+    newViewProj: Float32Array,
+    sharedUboData: Float32Array
+): boolean {
+    if (!shadowMatrixChanged(sg.lightMatrix, newViewProj)) {
+        return false;
+    }
+    sg.lightMatrix.set(newViewProj);
+    sg._version++;
+    const queue = engine.device.queue;
+    queue.writeBuffer(depthSceneUBO, 0, sg.lightMatrix as Float32Array<ArrayBuffer>);
+    writeShadowUboFields(sharedUboData, sg);
+    queue.writeBuffer(sg.shadowUBO, 0, sharedUboData as Float32Array<ArrayBuffer>);
+    return true;
+}

--- a/packages/babylon-lite/src/shadow/shadow-generator.ts
+++ b/packages/babylon-lite/src/shadow/shadow-generator.ts
@@ -23,16 +23,15 @@ import type { EngineContextInternal } from "../engine/engine.js";
 import { getOrCreateSampler } from "../resource/gpu-pool.js";
 import { createUniformBuffer } from "../resource/gpu-buffers.js";
 import {
-    buildCasters,
     syncCasterMatrices,
     drawCasters,
-    shadowMatrixChanged,
-    writeShadowUboFields,
     buildLightViewMatrix,
     multiply4x4,
-    createDepthSceneBGL,
     createShadowParamsUBO,
     createSharedShadowUBO,
+    createShadowDepthInfra,
+    createShadowDirtyTracker,
+    updateShadowLightMatrix,
 } from "./shadow-base.js";
 import depthVertSrc from "../../shaders/shadow-depth.vertex.wgsl?raw";
 import depthFragSrc from "../../shaders/shadow-depth.fragment.wgsl?raw";
@@ -172,20 +171,20 @@ export function createShadowGenerator(engine: EngineContext, light: DirectionalL
 
     const { viewProj } = computeDirectionalLightMatrix(light, casterMeshes, orthoMinZ, orthoMaxZ);
 
-    // --- Shadow depth pipeline BGLs (needed before buildCasters) ---
-    const depthMeshBGL = device.createBindGroupLayout({
-        label: "shadow-depth-mesh",
-        entries: [
-            { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: "uniform" } },
-            { binding: 1, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: "uniform" } },
-        ],
-    });
-
     // Shadow params UBO — depthValues = (0, 1) for WebGPU DirectionalLight (isNDCHalfZRange)
     const shadowParamsUBO = createShadowParamsUBO(eng, bias, depthScale);
 
-    // Build caster data + per-caster bind groups
-    const casters = buildCasters(eng, casterMeshes, depthMeshBGL, [{ binding: 1, resource: { buffer: shadowParamsUBO } }]);
+    // --- Shadow depth infra (BGLs, scene UBO/BG, casters, pipeline) ---
+    const { depthMeshBGL, depthSceneUBO, depthPipeline, depthSceneBG, casters } = createShadowDepthInfra(eng, {
+        label: "shadow",
+        viewProj,
+        casterMeshes,
+        vertCode: WGSL_SCENE_UNIFORMS_SHADOW + depthVertSrc,
+        fragCode: depthFragSrc,
+        colorTargets: [{ format: "rgba16float" }],
+        extraMeshEntries: [{ binding: 1, resource: { buffer: shadowParamsUBO } }],
+        extraMeshBglEntries: [{ binding: 1, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: "uniform" } }],
+    });
 
     // --- Textures ---
     const esmTexture = device.createTexture({
@@ -211,40 +210,6 @@ export function createShadowGenerator(engine: EngineContext, light: DirectionalL
         size: { width: blurSize, height: blurSize },
         format: "rgba16float",
         usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
-    });
-
-    // --- Shadow depth pipeline ---
-    const depthSceneUBO = createUniformBuffer(eng, viewProj as Float32Array<ArrayBuffer>);
-
-    const depthSceneBGL = createDepthSceneBGL(eng, "shadow-depth-scene");
-
-    const depthVert = device.createShaderModule({ code: WGSL_SCENE_UNIFORMS_SHADOW + depthVertSrc, label: "shadow-depth-vert" });
-    const depthFrag = device.createShaderModule({ code: depthFragSrc, label: "shadow-depth-frag" });
-
-    const depthPipeline = device.createRenderPipeline({
-        label: "shadow-depth",
-        layout: device.createPipelineLayout({ bindGroupLayouts: [depthSceneBGL, depthMeshBGL] }),
-        vertex: {
-            module: depthVert,
-            entryPoint: "main",
-            buffers: [{ arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: "float32x3" as GPUVertexFormat }] }],
-        },
-        fragment: {
-            module: depthFrag,
-            entryPoint: "main",
-            targets: [{ format: "rgba16float" }],
-        },
-        depthStencil: {
-            format: "depth32float",
-            depthWriteEnabled: true,
-            depthCompare: "less-equal",
-        },
-        primitive: { topology: "triangle-list", cullMode: "back", frontFace: "ccw" },
-    });
-
-    const depthSceneBG = device.createBindGroup({
-        layout: depthSceneBGL,
-        entries: [{ binding: 0, resource: { buffer: depthSceneUBO } }],
     });
 
     // --- Blur pipeline ---
@@ -308,10 +273,8 @@ export function createShadowGenerator(engine: EngineContext, light: DirectionalL
     // Shared shadow UBO for all receiver meshes (96 bytes)
     const { ubo: sharedShadowUBO, data: shadowUboData } = createSharedShadowUBO(eng, lightMatrix, depthValuesArr, shadowsInfo);
 
-    // Shadow matrix early-out tracking (init to -1 to force first-frame render)
-    let _lastLightVer = -1;
-    let _lastCasterVerSum = -1;
-    let _lastCasterCount = -1;
+    // Shadow matrix early-out tracking
+    const dirtyTracker = createShadowDirtyTracker();
 
     const sg: ShadowGenerator = {
         shadowType: "esm" as const,
@@ -330,27 +293,15 @@ export function createShadowGenerator(engine: EngineContext, light: DirectionalL
     };
 
     sg.renderShadowMap = function renderShadowMap(encoder: GPUCommandEncoder): number {
-        let casterVerSum = 0;
-        for (const c of casters) {
-            casterVerSum += c._mesh.worldMatrixVersion;
-        }
-        const lv = light.worldMatrixVersion;
-        if (lv === _lastLightVer && casterVerSum === _lastCasterVerSum && casters.length === _lastCasterCount) {
+        const { dirty, lightChanged } = dirtyTracker.check(light, casters);
+        if (!dirty) {
             return 0;
         }
-        if (lv !== _lastLightVer || casters.length !== _lastCasterCount) {
+        if (lightChanged) {
             const updated = computeDirectionalLightMatrix(light, casterMeshes, orthoMinZ, orthoMaxZ);
-            if (shadowMatrixChanged(lightMatrix, updated.viewProj)) {
-                lightMatrix.set(updated.viewProj);
-                sg._version++;
-                device.queue.writeBuffer(depthSceneUBO, 0, lightMatrix as Float32Array<ArrayBuffer>);
-                writeShadowUboFields(shadowUboData, sg);
-                device.queue.writeBuffer(sharedShadowUBO, 0, shadowUboData as Float32Array<ArrayBuffer>);
-            }
+            updateShadowLightMatrix(eng, sg, depthSceneUBO, updated.viewProj, shadowUboData);
         }
-        _lastLightVer = lv;
-        _lastCasterVerSum = casterVerSum;
-        _lastCasterCount = casters.length;
+        dirtyTracker.commit(light, casters);
 
         syncCasterMatrices(eng, casters);
 


### PR DESCRIPTION
## Summary

Five surgical performance/bundle refactors from the bundle/speed analysis. Zero bundle-ceiling, golden-reference, or scene-config changes. All perf + parity tests green (the 3 pre-existing failures on master — scene5/19 baseline drift, scene30 timeout — are unchanged).

## Changes

### 1.1 — Shared shadow depth-infra factory
`shadow-base.ts` now exposes `createShadowDepthInfra`, `createShadowDirtyTracker`, and `updateShadowLightMatrix`. Both ESM (`shadow-generator.ts`) and PCF (`pcf-shadow-generator.ts`) generators now call the shared factory instead of duplicating depth-pipeline construction, dirty tracking, and light-matrix UBO writes. Net: −137 / +126 lines across the three files.

### 1.3 — Cache sorted PBR/Std extension arrays at registration time
`Array.from(_getXxxExts().values()).sort(localeCompare)` previously ran per mesh inside `createPbrMeshBindGroup` and `createDynamicMeshGPU`. Now a sorted snapshot is invalidated on register and lazily rebuilt via `_getPbrExtsSorted()` / `_getStdExtsSorted()`. Removes O(N·M log M) per-scene work and per-mesh allocations.

### 1.4 — Declarative `.babylon` 2D-texture loader
Seven near-duplicated `if (md.XxxTexture && opts.loadTextures !== false) { ... }` blocks in `load-babylon.ts` collapsed into a `TEX_SLOTS` table-driven loop. Cube reflection branch kept explicit (different loader + assignment target). Same semantics, future texture slots become a one-line table entry.

### 1.5 — Drop redundant `createPbrTemplate` call
`buildPbrRenderables` was invoking the full ~23 KB `createPbrTemplate` function a second time just to read `baseSceneUboFields`. Extracted `getPbrBaseSceneUboFields` into `pbr-template.ts` (re-used internally by the template) and call it directly. Startup-only win, no bundle change.

### 1.7 — Memoise per-scene shadow bind groups
Both renderables previously created an identical `GPUBindGroup` per receiver mesh referencing the same shadow textures/samplers/UBO. Now memoised by `GPUBindGroupLayout` within each `buildXxxRenderables` scope (validated assumption: every receiving mesh shares the scene's `shadowLights`). One BG per layout instead of N per mesh.

## Out of scope
- 1.2 (full Standard+PBR renderable unification) — investigated and dropped: the two paths' shapes diverge enough that a generic builder would likely grow the bundle via abstraction overhead, not shrink it.

## Verification

- `pnpm test:perf` → 30/30 passed
- `pnpm build:bundle-scenes` → all 30 scenes built
- `pnpm test:parity` → 82 passed; only the 3 pre-existing failures (scene5 delta, scene19 delta, scene30 timeout) remain — unchanged from master baseline.

### Bundle sizes (shadow- and `.babylon`-loader scenes, all under ceiling)

| Scene | Size | Ceiling |
|---|---|---|
| scene4  (Shadows)      | 70.9 KB | 73.6 KB |
| scene9  (Hierarchy)    | 58.8 KB | — |
| scene18 (PCF Shadows)  | 59.1 KB | 60.5 KB |
| scene22 (PBR Shadows)  | 98.2 KB | 103.3 KB |
| scene24 (Hill Valley)  | 58.3 KB | — |

No ceilings touched.
