### PR TITLE
fix: skip perf test for scenes without a baseline bundle

### DIFF
--- a/tests/perf/perf-regression.spec.ts
+++ b/tests/perf/perf-regression.spec.ts
@@ -226,6 +226,13 @@ if (!hasBaseline) {
     test.describe("Performance: Current vs Stable", () => {
         for (const scene of SCENES) {
             test(`${scene.name} — current ≤ ${REGRESSION_PCT}% slower than baseline`, async ({ browser }) => {
+                // New scenes added in a PR won't have a baseline bundle — skip gracefully
+                const baselineHtml = resolve(__dirname, `../../lab/bundle-baseline-scene${scene.id}.html`);
+                if (!existsSync(baselineHtml)) {
+                    test.skip();
+                    return;
+                }
+
                 const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
 
                 const currentUrl = `/bundle-scene${scene.id}.html`;


### PR DESCRIPTION
## Problem

New scenes added in a PR don't exist in the baseline build (built from the last release tag). The perf test tries to load `bundle-baseline-scene{N}.html` for every scene in `scene-config.json`, causing load failures for new scenes:

```
[NOT A PERFORMANCE ISSUE] Baseline scene failed to load/render: ...
```

## Fix

Before running each perf test, check if the baseline HTML page exists on disk. If it doesn't (new scene with no baseline to compare against), gracefully `test.skip()` instead of failing.

## Changes

- `tests/perf/perf-regression.spec.ts`: Added `existsSync` check for `lab/bundle-baseline-scene{N}.html` before each test, skipping when absent.