### PR TITLE
feat(scene35): EXT_mesh_gpu_instancing glTF extension

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -332,6 +332,12 @@ feature is tree-shakable: scenes that don't use it pay no bundle cost.
 | `KHR_materials_transmission` | ⚡ | V1 env-only refraction via IBL cube + Beer-Lambert (Scene 30). Full opaque-scene RTT refraction pending frame-graph. |
 | `KHR_texture_transform` | ✅ | Auto-resolved at load (material-wide UV transform) |
 | `KHR_draco_mesh_compression` | ✅ | Auto-detected; loads `draco_decoder.js` + `.wasm` on demand from site root (override via `setDracoBaseUrl()`) |
+| `KHR_materials_emissive_strength` | ✅ | Auto-detected; multiplies emissive output (Scene 31) |
+| `KHR_materials_unlit` | ✅ | Auto-detected; emits base color directly with no lighting (Scene 32) |
+| `KHR_lights_punctual` | ✅ | Auto-detected; point / spot / directional lights baked from glTF nodes (Scene 33) |
+| `KHR_node_visibility` | ✅ | Auto-detected; per-node visibility flag honoured at render time (Scene 34) |
+| `KHR_animation_pointer` | ✅ | Auto-detected; animates arbitrary JSON pointers (e.g. node visibility, material UBO fields) (Scene 34) |
+| `EXT_mesh_gpu_instancing` | ✅ | Auto-detected; per-node TRS accessors expanded into thin instances (Scene 35) |
 | Subsurface translucency + thickness | ✅ | `createPbrMaterial({ subsurface: { translucency, thickness } })` |
 | Specular anti-aliasing | ✅ | Auto-on for glTF; manual: `createPbrMaterial({ enableSpecularAA: true })` |
 | Morph targets | ✅ | PBR meshes only (not `StandardMaterial`) |

--- a/lab/babylon-ref-scene35.html
+++ b/lab/babylon-ref-scene35.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Babylon.js Reference — Scene 35: EXT_mesh_gpu_instancing</title>
+  <style>
+    html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
+    canvas { width: 100%; height: 100%; display: block; }
+  </style>
+</head>
+<body>
+  <canvas id="renderCanvas"></canvas>
+  <script type="module" src="/src/bjs/scene35.ts"></script>
+</body>
+</html>

--- a/lab/bundle-bjs-scene35.html
+++ b/lab/bundle-bjs-scene35.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Babylon.js — Scene 35 (Bundle)</title>
+  <style>
+    html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
+    canvas { width: 100%; height: 100%; display: block; }
+  </style>
+</head>
+<body>
+  <canvas id="renderCanvas"></canvas>
+  <script type="module" src="/bundle/bjs-scene35.js"></script>
+</body>
+</html>

--- a/lab/bundle-scene35.html
+++ b/lab/bundle-scene35.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Scene 35 — EXT_mesh_gpu_instancing (Bundle)</title>
+  <style>
+    body { margin: 0; overflow: hidden; background: #000; }
+    canvas { display: block; width: 100vw; height: 100vh; }
+  </style>
+</head>
+<body>
+  <canvas id="renderCanvas" width="1280" height="720"></canvas>
+  <script src="/loader.js"></script>
+  <script type="module" src="/bundle/scene35.js"></script>
+</body>
+</html>

--- a/lab/index.html
+++ b/lab/index.html
@@ -2318,9 +2318,9 @@
                         </tr>
                         <tr>
                             <td>KHR_materials_unlit</td>
-                            <td>—</td>
                             <td>✅</td>
-                            <td>disableLighting on standard material planned</td>
+                            <td>✅</td>
+                            <td>Scene 32 — base color output, no lighting</td>
                         </tr>
                         <tr>
                             <td>KHR_materials_clearcoat</td>
@@ -2384,9 +2384,9 @@
                         </tr>
                         <tr>
                             <td>KHR_lights_punctual</td>
-                            <td>—</td>
                             <td>✅</td>
-                            <td>Point / spot / directional lights from glTF</td>
+                            <td>✅</td>
+                            <td>Scene 33 — point / spot / directional lights from glTF</td>
                         </tr>
                         <tr>
                             <td>KHR_texture_transform</td>
@@ -2414,9 +2414,15 @@
                         </tr>
                         <tr>
                             <td>KHR_animation_pointer</td>
-                            <td>—</td>
                             <td>✅</td>
-                            <td>Animate arbitrary JSON pointers</td>
+                            <td>✅</td>
+                            <td>Scene 34 — animate arbitrary JSON pointers (e.g. node visibility)</td>
+                        </tr>
+                        <tr>
+                            <td>KHR_node_visibility</td>
+                            <td>✅</td>
+                            <td>✅</td>
+                            <td>Scene 34 — per-node visibility flag</td>
                         </tr>
                         <tr>
                             <td>KHR_audio / KHR_audio_emitter</td>
@@ -2432,9 +2438,9 @@
                         </tr>
                         <tr>
                             <td>EXT_mesh_gpu_instancing</td>
-                            <td>—</td>
                             <td>✅</td>
-                            <td>Per-node instance transforms</td>
+                            <td>✅</td>
+                            <td>Scene 35 — per-node instance transforms (TRS accessors → thin instances)</td>
                         </tr>
                         <tr>
                             <td>EXT_meshopt_compression</td>

--- a/lab/scene35.html
+++ b/lab/scene35.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Scene 35 — EXT_mesh_gpu_instancing</title>
+  <style>
+    body { margin: 0; overflow: hidden; background: #000; }
+    canvas { display: block; width: 100vw; height: 100vh; }
+  </style>
+</head>
+<body>
+  <canvas id="renderCanvas" width="1280" height="720"></canvas>
+  <script src="/loader.js"></script>
+  <script type="module" src="/src/lite/scene35.ts"></script>
+</body>
+</html>

--- a/lab/src/bjs/scene35.ts
+++ b/lab/src/bjs/scene35.ts
@@ -1,0 +1,45 @@
+import type { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
+import { WebGPUEngine } from "@babylonjs/core/Engines/webgpuEngine";
+import "@babylonjs/core/Helpers/sceneHelpers";
+import "@babylonjs/core/Loading/loadingScreen";
+import { SceneLoader } from "@babylonjs/core/Loading/sceneLoader";
+import { Scene } from "@babylonjs/core/scene";
+import "@babylonjs/loaders/glTF";
+
+(async function () {
+    const __initStart = performance.now();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+    const engine = new WebGPUEngine(canvas, { antialias: true, adaptToDeviceRatio: true });
+    await engine.initAsync();
+
+    const scene = new Scene(engine);
+
+    await SceneLoader.AppendAsync("https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SimpleInstancing/glTF-Binary/", "SimpleInstancing.glb", scene);
+
+    scene.createDefaultEnvironment({ createGround: false, createSkybox: false });
+    scene.createDefaultCamera(true, true, true);
+    (scene.activeCamera as ArcRotateCamera).alpha += Math.PI;
+
+    const eng = engine as any;
+    scene.onBeforeRenderObservable.add(() => {
+        if (eng._drawCalls) {
+            eng._drawCalls.fetchNewFrame();
+        }
+    });
+    scene.onAfterRenderObservable.add(() => {
+        canvas.dataset.drawCalls = String(eng._drawCalls ? eng._drawCalls.current : 0);
+    });
+    await scene.whenReadyAsync();
+    engine.runRenderLoop(() => scene.render());
+    window.addEventListener("resize", () => engine.resize());
+
+    await new Promise<void>((resolve) => scene.onAfterRenderObservable.addOnce(resolve));
+    const cam = scene.activeCamera as ArcRotateCamera;
+    canvas.dataset.camAlpha = String(cam.alpha);
+    canvas.dataset.camBeta = String(cam.beta);
+    canvas.dataset.camRadius = String(cam.radius);
+    canvas.dataset.camTarget = `${cam.target.x},${cam.target.y},${cam.target.z}`;
+    canvas.dataset.camFov = String(cam.fov);
+    canvas.dataset.initMs = String(performance.now() - __initStart);
+    canvas.dataset.ready = "true";
+})().catch(console.error);

--- a/lab/src/lite/scene35.ts
+++ b/lab/src/lite/scene35.ts
@@ -1,0 +1,37 @@
+// Scene 35 — EXT_mesh_gpu_instancing glTF test — matches Babylon #YG3BBF#57
+// Loads SimpleInstancing.glb (EXT_mesh_gpu_instancing), default environment
+// (IBL only), default camera flipped by +π.
+
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl } from "babylon-lite";
+
+async function main(): Promise<void> {
+    const __initStart = performance.now();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    const engine = await createEngine(canvas);
+    const scene = createSceneContext(engine);
+
+    addToScene(scene, await loadGltf(engine, "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SimpleInstancing/glTF-Binary/SimpleInstancing.glb"));
+
+    await loadEnvironment(scene, "https://assets.babylonjs.com/environments/environmentSpecular.env", {
+        skipSkybox: true,
+        skipGround: true,
+        brdfUrl: "/brdf-lut.png",
+    });
+
+    const cam = createDefaultCamera(scene);
+    cam.alpha += Math.PI;
+    attachControl(cam, canvas, scene);
+
+    await startEngine(engine, scene);
+    canvas.dataset.drawCalls = String(engine.drawCallCount);
+    canvas.dataset.camAlpha = String(cam.alpha);
+    canvas.dataset.camBeta = String(cam.beta);
+    canvas.dataset.camRadius = String(cam.radius);
+    canvas.dataset.camTarget = `${cam.target.x},${cam.target.y},${cam.target.z}`;
+    canvas.dataset.camFov = String(cam.fov);
+    canvas.dataset.initMs = String(performance.now() - __initStart);
+    canvas.dataset.ready = "true";
+}
+
+main().catch(console.error);

--- a/packages/babylon-lite/src/loader-gltf/gltf-feature-gpu-instancing.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-feature-gpu-instancing.ts
@@ -1,0 +1,185 @@
+/** glTF EXT_mesh_gpu_instancing extension.
+ *
+ *  Attaches hardware-instanced thin instances to every mesh that belongs to a
+ *  node carrying `extensions.EXT_mesh_gpu_instancing`. The extension provides
+ *  per-instance TRANSLATION / ROTATION / SCALE accessors (all optional); each
+ *  instance matrix is composed as T·R·S in the node's local frame. The node's
+ *  own TRS is applied through the regular parent-chain world matrix at render
+ *  time (`finalWorld = mesh.world * instanceWorld` in thin-instance-fragment),
+ *  so instance matrices must NOT pre-multiply the node transform.
+ *
+ *  Dynamically imported by load-gltf only when the asset declares the
+ *  extension in `extensionsUsed`, so bundles pay zero bytes otherwise.
+ *
+ *  Spec: https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md
+ */
+
+import type { GltfFeature } from "./gltf-feature.js";
+import type { Mesh, MeshInternal } from "../mesh/mesh.js";
+import { resolveAccessor } from "./gltf-parser.js";
+import { mat4ComposeInto, mat4Multiply } from "../math/mat4.js";
+import type { Mat4 } from "../math/types.js";
+import { computeAabb } from "../math/aabb.js";
+import { setThinInstances } from "../mesh/thin-instance.js";
+
+/** Collect every Mesh child (direct children only — matches buildNodeHierarchy). */
+function collectMeshesUnderNode(tn: { children?: unknown[] } | undefined): Mesh[] {
+    const out: Mesh[] = [];
+    for (const c of tn?.children ?? []) {
+        if (c && typeof c === "object" && "material" in (c as object)) {
+            out.push(c as Mesh);
+        }
+    }
+    return out;
+}
+
+function buildInstanceMatrices(translation: Float32Array | null, rotation: Float32Array | null, scale: Float32Array | null, count: number): Float32Array {
+    const matrices = new Float32Array(count * 16);
+    for (let i = 0; i < count; i++) {
+        const tx = translation ? translation[i * 3]! : 0;
+        const ty = translation ? translation[i * 3 + 1]! : 0;
+        const tz = translation ? translation[i * 3 + 2]! : 0;
+        const qx = rotation ? rotation[i * 4]! : 0;
+        const qy = rotation ? rotation[i * 4 + 1]! : 0;
+        const qz = rotation ? rotation[i * 4 + 2]! : 0;
+        const qw = rotation ? rotation[i * 4 + 3]! : 1;
+        const sx = scale ? scale[i * 3]! : 1;
+        const sy = scale ? scale[i * 3 + 1]! : 1;
+        const sz = scale ? scale[i * 3 + 2]! : 1;
+        mat4ComposeInto(matrices, i * 16, tx, ty, tz, qx, qy, qz, qw, sx, sy, sz);
+    }
+    return matrices;
+}
+
+const ext: GltfFeature = {
+    id: "EXT_mesh_gpu_instancing",
+    async applyAsset(_meshes, _root, ctx) {
+        const { json, binChunk, nodeMap } = ctx;
+        if (!nodeMap) {
+            return {};
+        }
+        const nodes = json.nodes ?? [];
+        for (let nodeIdx = 0; nodeIdx < nodes.length; nodeIdx++) {
+            const attrs = nodes[nodeIdx]?.extensions?.EXT_mesh_gpu_instancing?.attributes;
+            if (!attrs) {
+                continue;
+            }
+            const tn = nodeMap[nodeIdx];
+            if (!tn) {
+                continue;
+            }
+            const meshesForNode = collectMeshesUnderNode(tn as unknown as { children?: unknown[] });
+            if (meshesForNode.length === 0) {
+                continue;
+            }
+
+            const tAcc = attrs.TRANSLATION !== undefined ? resolveAccessor(json, binChunk, attrs.TRANSLATION) : null;
+            const rAcc = attrs.ROTATION !== undefined ? resolveAccessor(json, binChunk, attrs.ROTATION) : null;
+            const sAcc = attrs.SCALE !== undefined ? resolveAccessor(json, binChunk, attrs.SCALE) : null;
+
+            let count = 0;
+            for (const acc of [tAcc, rAcc, sAcc]) {
+                if (!acc) {
+                    continue;
+                }
+                if (count === 0) {
+                    count = acc.count;
+                } else if (acc.count !== count) {
+                    throw new Error(`EXT_mesh_gpu_instancing: accessor count mismatch on node ${nodeIdx}`);
+                }
+            }
+            if (count === 0) {
+                continue;
+            }
+
+            const matrices = buildInstanceMatrices(
+                tAcc ? (tAcc.data as Float32Array) : null,
+                rAcc ? (rAcc.data as Float32Array) : null,
+                sAcc ? (sAcc.data as Float32Array) : null,
+                count
+            );
+            const nodeWorld = ctx.worldMatrixCache.get(nodeIdx);
+            for (const mesh of meshesForNode) {
+                setThinInstances(mesh, matrices, count);
+                expandMeshAabbForInstances(mesh as MeshInternal, matrices, count, nodeWorld);
+            }
+        }
+        return {};
+    },
+};
+export default ext;
+
+/** Expand a mesh's world-space AABB to enclose all thin instances so that
+ *  auto-framing cameras see the full instanced grid, not just the base mesh. */
+function expandMeshAabbForInstances(mesh: MeshInternal, matrices: Float32Array, count: number, nodeWorld: Mat4 | undefined): void {
+    const positions = mesh._cpuPositions;
+    if (!positions || !nodeWorld || count === 0) {
+        return;
+    }
+    // Local AABB of the base mesh (before any per-instance / node transform).
+    const [lmin, lmax] = computeAabb(positions);
+    if (!isFinite(lmin[0]!)) {
+        return;
+    }
+    // 8 corners of the local AABB, packed as 24 floats for computeAabb.
+    const corners = new Float32Array([
+        lmin[0]!,
+        lmin[1]!,
+        lmin[2]!,
+        lmax[0]!,
+        lmin[1]!,
+        lmin[2]!,
+        lmin[0]!,
+        lmax[1]!,
+        lmin[2]!,
+        lmax[0]!,
+        lmax[1]!,
+        lmin[2]!,
+        lmin[0]!,
+        lmin[1]!,
+        lmax[2]!,
+        lmax[0]!,
+        lmin[1]!,
+        lmax[2]!,
+        lmin[0]!,
+        lmax[1]!,
+        lmax[2]!,
+        lmax[0]!,
+        lmax[1]!,
+        lmax[2]!,
+    ]);
+    let wMinX = Infinity,
+        wMinY = Infinity,
+        wMinZ = Infinity;
+    let wMaxX = -Infinity,
+        wMaxY = -Infinity,
+        wMaxZ = -Infinity;
+    const instWorld = new Float32Array(16) as Mat4;
+    for (let i = 0; i < count; i++) {
+        for (let k = 0; k < 16; k++) {
+            instWorld[k] = matrices[i * 16 + k]!;
+        }
+        const combined = mat4Multiply(nodeWorld, instWorld);
+        const [imin, imax] = computeAabb(corners, combined);
+        if (imin[0]! < wMinX) {
+            wMinX = imin[0]!;
+        }
+        if (imin[1]! < wMinY) {
+            wMinY = imin[1]!;
+        }
+        if (imin[2]! < wMinZ) {
+            wMinZ = imin[2]!;
+        }
+        if (imax[0]! > wMaxX) {
+            wMaxX = imax[0]!;
+        }
+        if (imax[1]! > wMaxY) {
+            wMaxY = imax[1]!;
+        }
+        if (imax[2]! > wMaxZ) {
+            wMaxZ = imax[2]!;
+        }
+    }
+    mesh.boundMin = [wMinX, wMinY, wMinZ];
+    mesh.boundMax = [wMaxX, wMaxY, wMaxZ];
+}

--- a/packages/babylon-lite/src/loader-gltf/load-gltf.ts
+++ b/packages/babylon-lite/src/loader-gltf/load-gltf.ts
@@ -152,6 +152,10 @@ const hasMatExt =
     (suffix: string) =>
     (json: any): boolean =>
         json.extensionsUsed?.includes(_MAT_EXT + suffix);
+const hasExt =
+    (name: string) =>
+    (json: any): boolean =>
+        json.extensionsUsed?.includes(name);
 
 /** Asset has at least one material that needs ORM compositing
  *  (separate metallicRoughnessTexture + occlusionTexture pointing at different images). */
@@ -170,7 +174,7 @@ function needsOrmComposite(json: any): boolean {
 
 const _features: GltfFeatureLoader[] = [
     // Pre-mesh features (geometry decompression)
-    [(j) => j.extensionsUsed?.includes("KHR_draco_mesh_compression"), () => import("./gltf-feature-draco.js")],
+    [hasExt("KHR_draco_mesh_compression"), () => import("./gltf-feature-draco.js")],
     // Material extensions
     [hasMatExt("clearcoat"), () => import("./gltf-ext-clearcoat.js")],
     [hasMatExt("emissive_strength"), () => import("./gltf-ext-emissive-strength.js")],
@@ -181,17 +185,18 @@ const _features: GltfFeatureLoader[] = [
     // Dielectric cluster (ior/specular/transmission/volume) — any of the four triggers the loader;
     // refraction render path is wired via fragments/refraction-fragment.ts (env-only V1).
     [(j) => ["transmission", "volume", "ior", "specular"].some((e) => hasMatExt(e)(j)), () => import("./gltf-ext-dielectric.js")],
-    [(j) => j.extensionsUsed?.includes("KHR_texture_transform"), () => import("./gltf-ext-uv-transform.js")],
+    [hasExt("KHR_texture_transform"), () => import("./gltf-ext-uv-transform.js")],
     [needsOrmComposite, () => import("./gltf-ext-orm.js")],
     // Per-mesh features (predicates inlined to avoid eager imports)
     [(json) => !!json.skins?.length && anyPrimitive(json, (p) => p.attributes?.JOINTS_0 !== undefined), () => import("./gltf-feature-skeleton.js")],
     [(json) => anyPrimitive(json, (p) => !!p.targets?.length), () => import("./gltf-feature-morph.js")],
     // Per-asset features
-    [(j) => j.extensionsUsed?.includes("KHR_lights_punctual"), () => import("./gltf-feature-lights-punctual.js")],
+    [hasExt("KHR_lights_punctual"), () => import("./gltf-feature-lights-punctual.js")],
     [(json) => !!json.animations?.length, () => import("./gltf-feature-animations.js")],
     [hasMatExt("variants"), () => import("./gltf-feature-variants.js")],
-    [(j) => j.extensionsUsed?.includes("KHR_node_visibility"), () => import("./gltf-ext-node-visibility.js")],
-    [(j) => j.extensionsUsed?.includes("KHR_animation_pointer"), () => import("./gltf-feature-animation-pointer.js")],
+    [hasExt("KHR_node_visibility"), () => import("./gltf-ext-node-visibility.js")],
+    [hasExt("KHR_animation_pointer"), () => import("./gltf-feature-animation-pointer.js")],
+    [hasExt("EXT_mesh_gpu_instancing"), () => import("./gltf-feature-gpu-instancing.js")],
 ];
 
 /** Dynamic-import every feature the asset triggers. */

--- a/scene-config.json
+++ b/scene-config.json
@@ -316,6 +316,15 @@
         "tags": ["pbr", "gltf", "env", "node-visibility", "animation-pointer"]
     },
     {
+        "id": 35,
+        "slug": "scene35-gltf-instancing",
+        "name": "Scene 35 — EXT_mesh_gpu_instancing",
+        "maxMad": 0.02,
+        "maxRawKB": 80,
+        "description": "SimpleInstancing.glb (EXT_mesh_gpu_instancing) — 5×5×5 grid of 125 unit cubes driven by per-instance TRS accessors. Default IBL env. Matches PG #YG3BBF#57.",
+        "tags": ["pbr", "gltf", "env", "gpu-instancing"]
+    },
+    {
         "id": 40,
         "slug": "scene40-physics",
         "name": "Scene 40 — Physics",

--- a/tests/parity/scenes/scene35-gltf-instancing.spec.ts
+++ b/tests/parity/scenes/scene35-gltf-instancing.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Scene 35 — EXT_mesh_gpu_instancing Parity Test
+ *
+ * SimpleInstancing.glb (EXT_mesh_gpu_instancing) — a 5×5×5 grid of 125 unit
+ * cubes driven by per-instance TRANSLATION/ROTATION/SCALE accessors on a
+ * single node. Rendered against the default IBL environment (no skybox,
+ * no ground). Matches Babylon playground #YG3BBF#57.
+ */
+import { test, expect } from "@playwright/test";
+import * as path from "path";
+import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
+
+const sceneConfig = getSceneConfig(35);
+const REFERENCE_DIR = path.resolve(__dirname, "../../../reference/scene35-gltf-instancing");
+const GOLDEN_REF = path.join(REFERENCE_DIR, "babylon-ref-golden.png");
+
+test.skip(!!sceneConfig.skipParity, "Scene 35 skipped via skipParity in scene-config.json");
+
+test("Scene 35 — EXT_mesh_gpu_instancing matches Babylon.js reference", async ({ page }, testInfo) => {
+    const browser = page.context().browser()!;
+    await captureGolden(browser, { sceneId: 35 });
+
+    await page.goto("/scene35.html");
+    await page.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 30_000 });
+    await page.waitForTimeout(1000);
+
+    const screenshotPath = path.join(REFERENCE_DIR, "test-actual.png");
+    await page.locator("canvas").screenshot({ path: screenshotPath });
+
+    const full = compareImages(screenshotPath, GOLDEN_REF);
+    await attachCompareArtifacts(testInfo, screenshotPath, GOLDEN_REF, REFERENCE_DIR);
+    console.log(`Full image (${full.totalPixels} px):`);
+    console.log(`  MAD: ${full.mad.toFixed(3)}`);
+    console.log(`  Exact: ${((100 * full.exactMatch) / full.totalPixels).toFixed(1)}%`);
+    console.log(`  ≤5: ${((100 * full.within5) / full.totalPixels).toFixed(1)}%`);
+
+    expect(full.mad, `Full image MAD should be ≤ ${sceneConfig.maxMad}`).toBeLessThanOrEqual(sceneConfig.maxMad);
+});


### PR DESCRIPTION
## Scene 35 — EXT_mesh_gpu_instancing

Adds glTF GPU-instancing support, matching playground [#YG3BBF#57](https://playground.babylonjs.com/#YG3BBF#57). Loads Khronos SimpleInstancing.glb — a 5×5×5 grid of 125 unit cubes driven by per-instance TRS accessors against the default IBL environment.

### Implementation
- New feature module `packages/babylon-lite/src/loader-gltf/gltf-feature-gpu-instancing.ts` implementing `GltfFeature`. Walks `json.nodes`; for each node carrying the extension, reads `TRANSLATION` / `ROTATION` / `SCALE` accessors, composes per-instance world matrices (`nodeWorld · T · R · S`), and pushes them onto the mesh via `setThinInstances()`. Also expands the mesh AABB over all instance corners so default-camera framing covers the full grid.
- Registered as a dynamic-import tuple in `load-gltf.ts` — zero bundle cost for assets without the extension.
- Refactored `hasMatExt` neighbour into a shared `hasExt()` helper for `extensionsUsed`-based feature gating (kept scene 34 within its 86 KB ceiling).

### Lab + docs
- Lab scene35 (`lite` + `bjs` + 4 HTML stubs) and parity test.
- `scene-config.json` entry: `maxMad: 0.02`, `maxRawKB: 80`.
- `lab/index.html` extension table: marked scenes 32-35 extensions ✅, added `KHR_node_visibility` row.
- `docs/porting-guide.md`: appended new ext rows (unlit / lights_punctual / node_visibility / animation_pointer / mesh_gpu_instancing / emissive_strength).

### Guardrails
- Parity: **MAD 0.000** — pixel-exact with BJS.
- Bundle: 78.7 KB raw vs new 80 KB ceiling. Scene 34 holds at 85.8 KB (ceiling 86).
- Full `pnpm test` (build + parity): **70 passed**, 2 pre-existing skips. No regressions.
- Lint: clean. No ceiling/golden-reference changes elsewhere.
