### PR TITLE
feat(engine): decouple engine from scene; multi-scene rendering via RenderingContext

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Pick the next available scene number (e.g., `23`) and a descriptive slug:
 **`lab/src/lite/sceneN.ts`**
 
 ```typescript
-import { createEngine, createSceneContext, createDefaultCamera, attachControl } from "babylon-lite";
+import { createEngine, createSceneContext, createDefaultCamera, attachControl, registerScene, startEngine } from "babylon-lite";
 
 async function main(): Promise<void> {
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
@@ -61,7 +61,8 @@ async function main(): Promise<void> {
     const cam = createDefaultCamera(scene);
     attachControl(cam, canvas, scene);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.ready = "true";
 }
 

--- a/GUIDANCE.md
+++ b/GUIDANCE.md
@@ -46,7 +46,7 @@
 
 - **All public interfaces are pure state — no attached methods.**
 - `EngineContext`, `SceneContext`, `Camera`, `ArcRotateCamera`, `FreeCamera`, `Mesh`, `LightBase`, etc. are plain data objects.
-- Behaviour is provided by standalone functions that accept the interface as their first argument: `startEngine(engine, scene)`, `addToScene(scene, entity)`, `getViewMatrix(camera)`, etc.
+- Behaviour is provided by standalone functions that accept the interface as their first argument: `registerScene(engine, scene)`, `startEngine(engine)`, `addToScene(scene, entity)`, `getViewMatrix(camera)`, etc.
 - This maximises tree-shakability: unused functions are fully eliminated. Methods on interfaces cannot be tree-shaken.
 - Internal interfaces (`SceneContextInternal`, `EngineContextInternal`) follow the same rule — no methods.
 
@@ -110,7 +110,8 @@ async function main(): Promise<void> {
     camera.alpha += Math.PI;
 
     // Materials own their renderable builders — no explicit pipeline building
-    await startEngine(engine, scene); // resolves after first frame rendered
+    await registerScene(engine, scene); // builds deferred work, partitions renderables
+    await startEngine(engine); // resolves after first frame rendered; renders all registered scenes
 }
 ```
 

--- a/lab/leak-test.html
+++ b/lab/leak-test.html
@@ -21,7 +21,7 @@
      * renders a few frames, then disposes everything. Exposes lifecycle hooks
      * on window so Playwright can drive the cadence and measure heap between cycles.
      */
-    import { createEngine, startEngine, stopEngine, disposeEngine,
+    import { createEngine, startEngine, stopEngine, disposeEngine, registerScene,
              createSceneContext, createDefaultCamera, addToScene, disposeScene,
              createSphere, createArcRotateCamera, createDirectionalLight,
              createHemisphericLight, createPointLight, loadGltf, loadEnvironment,
@@ -48,7 +48,8 @@
 
           await setupScene(engine, scene, sceneNum);
 
-          await startEngine(engine, scene);
+          await registerScene(engine, scene);
+          await startEngine(engine);
 
           // Render a few extra frames
           for (let i = 0; i < RENDER_FRAMES; i++) {

--- a/lab/src/dispose-test.ts
+++ b/lab/src/dispose-test.ts
@@ -1,7 +1,7 @@
 /** Dispose test — creates a scene, renders one frame, disposes everything,
  *  then recreates to prove no stale state. Tracks GPU errors via error scopes. */
 
-import { disposeScene, addToScene, disposeEngine, stopEngine, startEngine, createEngine, createSceneContext, createDefaultCamera, createSphere, createStandardMaterial } from "babylon-lite";
+import { disposeScene, addToScene, disposeEngine, stopEngine, startEngine, createEngine, createSceneContext, createDefaultCamera, createSphere, createStandardMaterial, registerScene } from "babylon-lite";
 import type { EngineContextInternal } from "babylon-lite/engine/engine";
 
 const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
@@ -21,7 +21,8 @@ async function createAndRender() {
     createDefaultCamera(scene);
 
     // Render one frame
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
 
     // Stop and wait a tick for GPU work to complete
     stopEngine(engine);
@@ -57,7 +58,8 @@ async function run() {
         sphere2.material = createStandardMaterial();
         addToScene(scene2, sphere2);
         createDefaultCamera(scene2);
-        await startEngine(engine2, scene2);
+        await registerScene(engine2, scene2);
+    await startEngine(engine2);
         stopEngine(engine2);
         await new Promise((r) => setTimeout(r, 100));
         const err2 = await (engine2 as EngineContextInternal).device.popErrorScope();

--- a/lab/src/lite/scene1.ts
+++ b/lab/src/lite/scene1.ts
@@ -1,4 +1,4 @@
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -21,7 +21,8 @@ async function main(): Promise<void> {
 
     addToScene(scene, createHemisphericLight([0, 1, 0], 1.0));
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene10.ts
+++ b/lab/src/lite/scene10.ts
@@ -1,16 +1,7 @@
 // Scene 10: PBR Metallic-Roughness Sphere — matches Babylon #2FDQT5#12
 // PBRMetallicRoughnessMaterial with golden color, metallic=0, roughness=1, hemispheric light only.
 
-import { addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    createHemisphericLight,
-    createSphere,
-    createPbrMaterial,
-    createSolidTexture2D,
-    attachControl,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createHemisphericLight, createSphere, createPbrMaterial, createSolidTexture2D, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -34,7 +25,8 @@ async function main(): Promise<void> {
     });
     addToScene(scene, sphere);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene11.ts
+++ b/lab/src/lite/scene11.ts
@@ -2,7 +2,7 @@
 // Animated shark model, rotated camera to show the side profile.
 // Only plays the "swimming" animation for deterministic parity.
 
-import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, createHemisphericLight, loadGltf, attachControl, stopAnimation, goToFrame, pauseAnimation } from "babylon-lite";
+import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, createHemisphericLight, loadGltf, attachControl, stopAnimation, goToFrame, pauseAnimation, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -57,7 +57,8 @@ async function main(): Promise<void> {
         }
     });
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene12.ts
+++ b/lab/src/lite/scene12.ts
@@ -1,17 +1,4 @@
-import { onBeforeRender, addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    createDirectionalLight,
-    cloneTransformNode,
-    attachControl,
-    loadGltf,
-    loadEnvironment,
-    loadTexture2D,
-    createPbrMaterial,
-    createSolidTexture2D,
-    goToFrame,
-} from "babylon-lite";
+import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createDirectionalLight, cloneTransformNode, attachControl, loadGltf, loadEnvironment, loadTexture2D, createPbrMaterial, createSolidTexture2D, goToFrame, registerScene } from "babylon-lite";
 import type { TransformNode } from "babylon-lite";
 
 export async function scene12(canvas: HTMLCanvasElement): Promise<void> {
@@ -133,7 +120,8 @@ export async function scene12(canvas: HTMLCanvasElement): Promise<void> {
         }
     });
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene13.ts
+++ b/lab/src/lite/scene13.ts
@@ -2,7 +2,7 @@
 // Loads PBR_Spheres.glb with varying metallic/roughness/baseColor materials.
 // Uses default environment (environmentSpecular.env) + hemispheric light.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -23,7 +23,8 @@ async function main(): Promise<void> {
 
     addToScene(scene, createHemisphericLight([0, 1, 0], 1.0));
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene14.ts
+++ b/lab/src/lite/scene14.ts
@@ -2,7 +2,7 @@
 // Loads flightHelmet.glb with default environment + DDS cube skybox.
 // Static PBR model, no animation.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -25,7 +25,8 @@ async function main(): Promise<void> {
 
     addToScene(scene, createHemisphericLight([0, 1, 0], 1.0));
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.camAlpha = String(cam.alpha);
     canvas.dataset.camBeta = String(cam.beta);

--- a/lab/src/lite/scene15.ts
+++ b/lab/src/lite/scene15.ts
@@ -1,7 +1,7 @@
 // Scene 15: Two SpotLights + Ground — demonstrates multi-light support.
 // Matches Babylon playground #20OAV9#3.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createSpotLight, createGround, createStandardMaterial, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createSpotLight, createGround, createStandardMaterial, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -30,7 +30,8 @@ async function main(): Promise<void> {
     ground.material = createStandardMaterial();
     addToScene(scene, ground);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene16.ts
+++ b/lab/src/lite/scene16.ts
@@ -1,7 +1,7 @@
 // Scene 16: Thin Instances — 64K colored cubes
 // Matches BJS playground #V1JE4Z#1
 
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createBox, createStandardMaterial, setThinInstances, setThinInstanceColors, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createBox, createStandardMaterial, setThinInstances, setThinInstanceColors, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -59,7 +59,8 @@ async function main(): Promise<void> {
     setThinInstanceColors(box, colorData);
     addToScene(scene, box);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene17.ts
+++ b/lab/src/lite/scene17.ts
@@ -4,24 +4,7 @@
 // Cube 2 (Std): default standard material, 2 thin instances (green/blue), negative X scale
 // Ground: 6×6 standard material
 
-import { addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    createHemisphericLight,
-    createBox,
-    createGround,
-    createPbrMaterial,
-    createStandardMaterial,
-    createSolidTexture2D,
-    loadTexture2D,
-    setThinInstances,
-    setThinInstanceColors,
-    attachControl,
-    mat4Identity,
-    mat4Translation,
-    mat4Compose,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createHemisphericLight, createBox, createGround, createPbrMaterial, createStandardMaterial, createSolidTexture2D, loadTexture2D, setThinInstances, setThinInstanceColors, attachControl, mat4Identity, mat4Translation, mat4Compose, registerScene } from "babylon-lite";
 import { loadDdsEnvironment } from "babylon-lite/loader-env/load-dds-env";
 
 async function main(): Promise<void> {
@@ -98,7 +81,8 @@ async function main(): Promise<void> {
     ground.material = createStandardMaterial();
     addToScene(scene, ground);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene18.ts
+++ b/lab/src/lite/scene18.ts
@@ -1,18 +1,7 @@
 // Scene 18: Spotlight Hard Shadows (PCF) — FreeCamera + SpotLight + PCF Shadow Generator
 // Demonstrates new FreeCamera type and PCF shadow mapping for spot lights.
 
-import { addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createFreeCamera,
-    createSpotLight,
-    createGround,
-    createBox,
-    createStandardMaterial,
-    createPcfShadowGenerator,
-    loadTexture2D,
-    attachFreeControl,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createFreeCamera, createSpotLight, createGround, createBox, createStandardMaterial, createPcfShadowGenerator, loadTexture2D, attachFreeControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -57,7 +46,8 @@ async function main(): Promise<void> {
         far: cam.farPlane,
     });
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene19.ts
+++ b/lab/src/lite/scene19.ts
@@ -4,16 +4,7 @@
 // clearcoat enabled with IOR=2.0. No direct light — only IBL from DDS env +
 // default hemispheric light from createDefaultCamera equivalent.
 
-import { addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    createHemisphericLight,
-    createSphere,
-    createPbrMaterial,
-    createSolidTexture2D,
-    attachControl,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createHemisphericLight, createSphere, createPbrMaterial, createSolidTexture2D, attachControl, registerScene } from "babylon-lite";
 import { loadDdsEnvironment } from "babylon-lite/loader-env/load-dds-env";
 
 async function main(): Promise<void> {
@@ -57,7 +48,8 @@ async function main(): Promise<void> {
     });
 
     addToScene(scene, sphere);
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
 
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);

--- a/lab/src/lite/scene2.ts
+++ b/lab/src/lite/scene2.ts
@@ -1,6 +1,6 @@
 // Scene 2: Sphere + DirectionalLight — matches Babylon #20OAV9#1
 
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createDirectionalLight, createSphere, createStandardMaterial, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createDirectionalLight, createSphere, createStandardMaterial, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -22,7 +22,8 @@ async function main(): Promise<void> {
     sphere.material = createStandardMaterial();
     addToScene(scene, sphere);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene20.ts
+++ b/lab/src/lite/scene20.ts
@@ -1,18 +1,7 @@
 // Scene 20: PBR Emissive Spheres Grid — 2500 spheres with random emissive colors
 // Based on playground #6HWS9M#85 (without performancePriority)
 
-import { onBeforeRender, addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    attachControl,
-    createSphere,
-    createPbrMaterial,
-    createSolidTexture2D,
-    loadEnvironment,
-    createHemisphericLight,
-    setParent,
-} from "babylon-lite";
+import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, attachControl, createSphere, createPbrMaterial, createSolidTexture2D, loadEnvironment, createHemisphericLight, setParent, registerScene } from "babylon-lite";
 
 // Seeded PRNG for deterministic positions/colors across BJS and Lite
 function seededRandom(seed: number): () => number {
@@ -135,7 +124,8 @@ async function main(): Promise<void> {
         }
     });
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
 
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);

--- a/lab/src/lite/scene21.ts
+++ b/lab/src/lite/scene21.ts
@@ -2,17 +2,7 @@
 // Matches BJS playground: cloth mesh with PBR sheen material.
 // Static model, no animation.
 
-import { addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    attachControl,
-    loadEnvironment,
-    loadGltf,
-    createPbrMaterial,
-    createSolidTexture2D,
-    loadTexture2D,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, attachControl, loadEnvironment, loadGltf, createPbrMaterial, createSolidTexture2D, loadTexture2D, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -65,7 +55,8 @@ async function main(): Promise<void> {
         m.material = sheenMat;
     }
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene22.ts
+++ b/lab/src/lite/scene22.ts
@@ -1,22 +1,6 @@
 // Scene 22: PBR Shadows — scene4 variant with PBR ground material + multi-light shadows
 
-import { onBeforeRender, addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    createDirectionalLight,
-    createSpotLight,
-    createTorus,
-    createSphere,
-    createGroundFromHeightMap,
-    createShadowGenerator,
-    createPcfShadowGenerator,
-    createStandardMaterial,
-    createPbrMaterial,
-    createSolidTexture2D,
-    loadTexture2D,
-    attachControl,
-} from "babylon-lite";
+import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createDirectionalLight, createSpotLight, createTorus, createSphere, createGroundFromHeightMap, createShadowGenerator, createPcfShadowGenerator, createStandardMaterial, createPbrMaterial, createSolidTexture2D, loadTexture2D, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -141,7 +125,8 @@ async function main(): Promise<void> {
     });
     document.body.appendChild(btnOrbit);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene23.ts
+++ b/lab/src/lite/scene23.ts
@@ -1,16 +1,7 @@
 // Scene 23: PBR Anisotropy — metallic sphere with anisotropic reflections
 // Based on playground #FEEK7G#1175
 
-import { addToScene, startEngine, onBeforeRender,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    attachControl,
-    createSphere,
-    createPbrMaterial,
-    createSolidTexture2D,
-    loadEnvironment,
-} from "babylon-lite";
+import { addToScene, startEngine, onBeforeRender, createEngine, createSceneContext, createArcRotateCamera, attachControl, createSphere, createPbrMaterial, createSolidTexture2D, loadEnvironment, registerScene } from "babylon-lite";
 import { installPbrTracking } from "babylon-lite/material/tracking/pbr-tracking";
 
 async function main(): Promise<void> {
@@ -76,7 +67,8 @@ async function main(): Promise<void> {
         });
     }
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
 
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);

--- a/lab/src/lite/scene24.ts
+++ b/lab/src/lite/scene24.ts
@@ -1,7 +1,7 @@
 // Scene 24: Hill Valley (.babylon) — pre-baked lighting, standard materials
 // Based on playground #TJIGQ1#349
 
-import { addToScene, startEngine, createEngine, createSceneContext, attachFreeControl, loadBabylon } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, attachFreeControl, loadBabylon, registerScene } from "babylon-lite";
 import type { FreeCamera } from "babylon-lite";
 
 async function main(): Promise<void> {
@@ -15,7 +15,8 @@ async function main(): Promise<void> {
 
     attachFreeControl(scene.camera as FreeCamera, canvas, scene);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene25.ts
+++ b/lab/src/lite/scene25.ts
@@ -1,18 +1,7 @@
 // Scene 25: KTX Texture — matches Babylon #1SCH7H#182
 // Ground plane with KTX compressed texture (auto-format selection), UV tiling, FreeCamera, hemispheric light.
 
-import {
-    addToScene,
-    startEngine,
-    createEngine,
-    createSceneContext,
-    createFreeCamera,
-    attachFreeControl,
-    createHemisphericLight,
-    createGround,
-    createStandardMaterial,
-    loadKtxTexture2D,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createFreeCamera, attachFreeControl, createHemisphericLight, createGround, createStandardMaterial, loadKtxTexture2D, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -43,7 +32,8 @@ async function main(): Promise<void> {
 
     addToScene(scene, ground);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene26.ts
+++ b/lab/src/lite/scene26.ts
@@ -2,22 +2,7 @@
 // Based on playground #5H0H89#5 (Georgia Tech Dragon)
 // Dragon with translucent teal PBR material, thickness map, point light, DDS environment
 
-import {
-    addToScene,
-    startEngine,
-    onBeforeRender,
-    createEngine,
-    createSceneContext,
-    createDefaultCamera,
-    attachControl,
-    createPbrMaterial,
-    createPointLight,
-    createSphere,
-    createBox,
-    createSolidTexture2D,
-    loadGltf,
-    loadTexture2D,
-} from "babylon-lite";
+import { addToScene, startEngine, onBeforeRender, createEngine, createSceneContext, createDefaultCamera, attachControl, createPbrMaterial, createPointLight, createSphere, createBox, createSolidTexture2D, loadGltf, loadTexture2D, registerScene } from "babylon-lite";
 import { loadDdsEnvironment } from "babylon-lite/loader-env/load-dds-env";
 
 async function main(): Promise<void> {
@@ -142,7 +127,8 @@ async function main(): Promise<void> {
         });
     }
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
 
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);

--- a/lab/src/lite/scene27.ts
+++ b/lab/src/lite/scene27.ts
@@ -1,7 +1,7 @@
 // Scene 27: Material Variants — matches playground #C1QH9J#78
 // Loads a refrigerator glTF with KHR_materials_variants, selects "White" variant.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createHemisphericLight, loadGltf, attachControl, selectVariant } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createHemisphericLight, loadGltf, attachControl, selectVariant, registerScene } from "babylon-lite";
 
 const MODEL_URL = "https://brave-engine-bucket.s3.ap-southeast-1.amazonaws.com/s3-public/assets/models/props/var_Refrigerator.glb";
 
@@ -23,7 +23,8 @@ async function main(): Promise<void> {
 
     addToScene(scene, createHemisphericLight([0, 1, 0], 5));
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene28.ts
+++ b/lab/src/lite/scene28.ts
@@ -3,7 +3,7 @@
 // default environment (IBL only — no ground, no skybox), and a default camera
 // flipped by +π to face the front of the test.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -24,7 +24,8 @@ async function main(): Promise<void> {
     cam.alpha += Math.PI;
     attachControl(cam, canvas, scene);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.camAlpha = String(cam.alpha);
     canvas.dataset.camBeta = String(cam.beta);

--- a/lab/src/lite/scene29.ts
+++ b/lab/src/lite/scene29.ts
@@ -3,7 +3,7 @@
 // (IBL only — no ground, no skybox), and a default camera flipped by +π to face
 // the front of the cloth.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -24,7 +24,8 @@ async function main(): Promise<void> {
     cam.alpha += Math.PI;
     attachControl(cam, canvas, scene);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.camAlpha = String(cam.alpha);
     canvas.dataset.camBeta = String(cam.beta);

--- a/lab/src/lite/scene3.ts
+++ b/lab/src/lite/scene3.ts
@@ -1,6 +1,6 @@
 // Scene 3: Fog + Boxes — matches Babylon #7G0IQW
 
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createPointLight, createBox, createStandardMaterial, loadSkybox, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createPointLight, createBox, createStandardMaterial, loadSkybox, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -29,7 +29,8 @@ async function main(): Promise<void> {
 
     await loadSkybox(scene, "https://playground.babylonjs.com/textures/skybox", ".jpg");
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene30.ts
+++ b/lab/src/lite/scene30.ts
@@ -5,7 +5,7 @@
 // absorption from KHR_materials_volume attenuation. Opaque-scene RTT refraction
 // is follow-up work.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, loadEnvironment, loadGltf, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, loadEnvironment, loadGltf, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -31,7 +31,8 @@ async function main(): Promise<void> {
         }),
     ]);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.camAlpha = String(cam.alpha);
     canvas.dataset.camBeta = String(cam.beta);

--- a/lab/src/lite/scene31.ts
+++ b/lab/src/lite/scene31.ts
@@ -3,7 +3,7 @@
 // KHR_materials_emissive_strength factors) against the default IBL environment
 // (no ground, no skybox).
 
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -27,7 +27,8 @@ async function main(): Promise<void> {
     cam.alpha += Math.PI;
     attachControl(cam, canvas, scene);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.camAlpha = String(cam.alpha);
     canvas.dataset.camBeta = String(cam.beta);

--- a/lab/src/lite/scene32.ts
+++ b/lab/src/lite/scene32.ts
@@ -2,7 +2,7 @@
 // Loads UnlitTest.glb (KHR_materials_unlit), default environment (IBL only),
 // default camera flipped by +π.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -23,7 +23,8 @@ async function main(): Promise<void> {
     cam.alpha += Math.PI;
     attachControl(cam, canvas, scene);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.camAlpha = String(cam.alpha);
     canvas.dataset.camBeta = String(cam.beta);

--- a/lab/src/lite/scene33.ts
+++ b/lab/src/lite/scene33.ts
@@ -2,7 +2,7 @@
 // Loads LightsPunctualLamp.glb (KHR_lights_punctual + KHR_materials_transmission),
 // default environment (IBL only), default camera flipped by +π.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -23,7 +23,8 @@ async function main(): Promise<void> {
     cam.alpha += Math.PI;
     attachControl(cam, canvas, scene);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.camAlpha = String(cam.alpha);
     canvas.dataset.camBeta = String(cam.beta);

--- a/lab/src/lite/scene34.ts
+++ b/lab/src/lite/scene34.ts
@@ -6,19 +6,7 @@
 // all animation groups after the first tick so parity tests can diff
 // against a stable golden.
 
-import {
-    onBeforeRender,
-    addToScene,
-    startEngine,
-    createEngine,
-    createSceneContext,
-    createDefaultCamera,
-    loadEnvironment,
-    loadGltf,
-    attachControl,
-    goToFrame,
-    pauseAnimation,
-} from "babylon-lite";
+import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl, goToFrame, pauseAnimation, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -68,7 +56,8 @@ async function main(): Promise<void> {
         }
     });
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     (window as any).__scene = scene;
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.camAlpha = String(cam.alpha);

--- a/lab/src/lite/scene35.ts
+++ b/lab/src/lite/scene35.ts
@@ -2,7 +2,7 @@
 // Loads SimpleInstancing.glb (EXT_mesh_gpu_instancing), default environment
 // (IBL only), default camera flipped by +π.
 
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -23,7 +23,8 @@ async function main(): Promise<void> {
     cam.alpha += Math.PI;
     attachControl(cam, canvas, scene);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.camAlpha = String(cam.alpha);
     canvas.dataset.camBeta = String(cam.beta);

--- a/lab/src/lite/scene4.ts
+++ b/lab/src/lite/scene4.ts
@@ -1,20 +1,6 @@
 // Scene 4: Shadows — matches Babylon #IIZ9UU
 
-import { onBeforeRender, addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    createDirectionalLight,
-    createSpotLight,
-    createTorus,
-    createSphere,
-    createGroundFromHeightMap,
-    createShadowGenerator,
-    createPcfShadowGenerator,
-    createStandardMaterial,
-    loadTexture2D,
-    attachControl,
-} from "babylon-lite";
+import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createDirectionalLight, createSpotLight, createTorus, createSphere, createGroundFromHeightMap, createShadowGenerator, createPcfShadowGenerator, createStandardMaterial, loadTexture2D, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -135,7 +121,8 @@ async function main(): Promise<void> {
     });
     document.body.appendChild(btnOrbit);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene40.ts
+++ b/lab/src/lite/scene40.ts
@@ -1,21 +1,7 @@
 // Scene 40: Physics V2 — Havok sphere drop (matches playground #Z8HTUN#1)
 
 import HavokPhysics from "@babylonjs/havok";
-import {
-    addToScene,
-    startEngine,
-    createEngine,
-    createSceneContext,
-    createFreeCamera,
-    createHemisphericLight,
-    createSphere,
-    createGround,
-    createStandardMaterial,
-    onBeforeRender,
-    createHavokWorld,
-    createPhysicsAggregate,
-    PhysicsShapeType,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createFreeCamera, createHemisphericLight, createSphere, createGround, createStandardMaterial, onBeforeRender, createHavokWorld, createPhysicsAggregate, PhysicsShapeType, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -73,7 +59,8 @@ async function main(): Promise<void> {
         }
     });
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
 }
 
 main().catch(console.error);

--- a/lab/src/lite/scene5.ts
+++ b/lab/src/lite/scene5.ts
@@ -1,4 +1,4 @@
-import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadGltf, createHemisphericLight, attachControl, goToFrame, pauseAnimation } from "babylon-lite";
+import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadGltf, createHemisphericLight, attachControl, goToFrame, pauseAnimation, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -50,7 +50,8 @@ async function main(): Promise<void> {
         }
     });
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene6.ts
+++ b/lab/src/lite/scene6.ts
@@ -3,7 +3,7 @@
 //   diffuseColor = specularColor = gold, glossiness = 0.4
 //   → metallic = 1.0, roughness = 0.6, baseColor = gold
 
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createPbrMaterial, createSphere, createSolidTexture2D, loadEnvironment, attachControl } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createPbrMaterial, createSphere, createSolidTexture2D, loadEnvironment, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -38,7 +38,8 @@ async function main(): Promise<void> {
     sphere.material = material;
     addToScene(scene, sphere);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene7.ts
+++ b/lab/src/lite/scene7.ts
@@ -1,4 +1,4 @@
-import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl, goToFrame, pauseAnimation } from "babylon-lite";
+import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl, goToFrame, pauseAnimation, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -56,7 +56,8 @@ async function main(): Promise<void> {
         }
     });
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     (window as any).__scene = scene;
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);

--- a/lab/src/lite/scene8.ts
+++ b/lab/src/lite/scene8.ts
@@ -1,17 +1,7 @@
 // Scene 8: HDR Glass Sphere — matches Babylon #19JGPR#13
 // PBR glass sphere with HDR environment, alpha transparency, and custom exposure/contrast.
 
-import { addToScene, startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    createSphere,
-    createPbrMaterial,
-    createSolidTexture2D,
-    createPointLight,
-    loadHdrEnvironment,
-    attachControl,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createSphere, createPbrMaterial, createSolidTexture2D, createPointLight, loadHdrEnvironment, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -54,7 +44,8 @@ async function main(): Promise<void> {
     });
     addToScene(scene, sphere);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/lite/scene9.ts
+++ b/lab/src/lite/scene9.ts
@@ -1,4 +1,4 @@
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, attachControl, loadBabylon } from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, attachControl, loadBabylon, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
@@ -19,7 +19,8 @@ async function main(): Promise<void> {
     scene.camera.farPlane = 10000;
     attachControl(scene.camera, canvas, scene);
 
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
     canvas.dataset.drawCalls = String(engine.drawCallCount);
     canvas.dataset.initMs = String(performance.now() - __initStart);
     canvas.dataset.ready = "true";

--- a/lab/src/material-swap-test.ts
+++ b/lab/src/material-swap-test.ts
@@ -1,7 +1,7 @@
 /** Material swap test — creates a sphere, renders it red, swaps to green,
  *  reports colors back to the test runner via window globals. */
 
-import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, createSphere, createStandardMaterial, createHemisphericLight } from "babylon-lite";
+import { onBeforeRender, addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, createSphere, createStandardMaterial, createHemisphericLight, registerScene } from "babylon-lite";
 
 const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
 (window as any).testResult = "pending";
@@ -22,7 +22,8 @@ async function run() {
     addToScene(scene, sphere);
 
     createDefaultCamera(scene);
-    await startEngine(engine, scene);
+    await registerScene(engine, scene);
+    await startEngine(engine);
 
     // Wait a few frames for red to be visible
     await new Promise((r) => setTimeout(r, 200));

--- a/lab/src/picking-test.ts
+++ b/lab/src/picking-test.ts
@@ -1,23 +1,7 @@
 /** GPU Picking test — creates a sphere at origin, picks center & corner,
  *  tests both basic and detailed picking. Exposes results on window for Playwright. */
 
-import {
-    createEngine,
-    startEngine,
-    stopEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    createHemisphericLight,
-    createSphere,
-    createStandardMaterial,
-    addToScene,
-    createGpuPicker,
-    pickAsync,
-    disposePicker,
-    enableDetailedPicking,
-    getPickedNormal,
-    getPickedUV,
-} from "babylon-lite";
+import { createEngine, startEngine, stopEngine, createSceneContext, createArcRotateCamera, createHemisphericLight, createSphere, createStandardMaterial, addToScene, createGpuPicker, pickAsync, disposePicker, enableDetailedPicking, getPickedNormal, getPickedUV, registerScene } from "babylon-lite";
 
 const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
 
@@ -62,7 +46,8 @@ async function run(): Promise<void> {
         sphere.material = createStandardMaterial();
         addToScene(scene, sphere);
 
-        await startEngine(engine, scene);
+        await registerScene(engine, scene);
+    await startEngine(engine);
 
         // Let a few frames render so GPU resources are fully initialized
         for (let i = 0; i < 5; i++) {

--- a/packages/babylon-lite/src/engine/engine.ts
+++ b/packages/babylon-lite/src/engine/engine.ts
@@ -1,14 +1,9 @@
-import type { SceneContext } from "../scene/scene.js";
-import type { SceneContextInternal } from "../scene/scene.js";
-import { buildScene, processMaterialSwaps } from "../scene/scene.js";
-import type { Renderable } from "../render/renderable.js";
-
 /** Babylon Lite version string. */
 export const VERSION = "0.1.0";
 
-// Module-scoped visibility epoch. `setSubtreeVisible` (scene/visibility.ts,
+// Module-scoped visibility epoch. setSubtreeVisible (scene/visibility.ts,
 // loaded only by KHR_node_visibility / KHR_animation_pointer features) bumps
-// this. drawList reads it to invalidate the cached opaque bundle.
+// this. Per-scene bundle caches compare against it for invalidation.
 export let _vis = 0;
 export function bumpVisibilityEpoch(): void {
     _vis = (_vis + 1) | 0;
@@ -23,6 +18,29 @@ export interface EngineContext {
     drawCallCount: number;
 }
 
+/**
+ * Minimal surface an engine sees for anything it renders. Scenes (and any other
+ * future renderable thing) register themselves as a `RenderingContext` and
+ * own their own update / record logic. Engine knows nothing of scene internals.
+ */
+/**
+ * Minimal surface an engine sees for anything it renders. Scenes (and any other
+ * future renderable thing) register themselves as a `RenderingContext` and
+ * own their own update / record logic. Engine knows nothing of scene internals.
+ */
+export interface RenderingContext {
+    /** Draw calls produced by pre-pass work during `_update` (shadows + pre-passes). */
+    _drawCallsPre: number;
+    /** Clear color used when this context is the first active one in a frame. */
+    clearColor: GPUColorDict;
+    /** Run per-frame update work (beforeRender hooks, shadow + pre-passes, UBO updates,
+     *  transparent sort, and any user _beforeMain hook). May finish+submit `encoder`
+     *  and return a new one. */
+    _update(encoder: GPUCommandEncoder, delta: number): GPUCommandEncoder;
+    /** Record main-pass draws into `pass`. Returns draw-call count. */
+    _record(pass: GPURenderPassEncoder): number;
+}
+
 /** @internal Engine with GPU internals exposed. Not re-exported from index.ts. */
 export interface EngineContextInternal extends EngineContext {
     readonly device: GPUDevice;
@@ -31,9 +49,8 @@ export interface EngineContextInternal extends EngineContext {
     _targets: RenderTargets;
     _animFrameId: number;
     _renderFn: ((now: number) => void) | null;
-    _opaqueBundle: GPURenderBundle | null;
-    _bundleVersion: number;
-    _bundleVis: number;
+    /** Registered rendering contexts in render order (first clears; subsequent overlay). */
+    _renderingContexts: RenderingContext[];
 }
 
 interface RenderTargets {
@@ -90,9 +107,7 @@ export async function createEngine(canvas: HTMLCanvasElement): Promise<EngineCon
         _targets: targets,
         _animFrameId: 0,
         _renderFn: null,
-        _opaqueBundle: null,
-        _bundleVersion: -1,
-        _bundleVis: 0,
+        _renderingContexts: [],
     };
 
     return engine;
@@ -115,49 +130,28 @@ export function resizeEngine(engine: EngineContext): void {
     eng._targets = createRenderTargets(eng.device, w, h, eng.format, eng.msaaSamples);
 }
 
-/** Start the render loop for the given scene. Resolves after the first frame has been rendered. */
-export function startEngine(engine: EngineContext, scene: SceneContext): Promise<void> {
+/**
+ * Start the render loop. Resolves after the first frame has been rendered.
+ * Scenes registered via `registerScene()` before this call are included in
+ * the first frame; later registrations join on subsequent frames.
+ */
+export function startEngine(engine: EngineContext): Promise<void> {
     const eng = engine as EngineContextInternal;
-    const sc = scene as SceneContextInternal;
     return new Promise<void>((resolve) => {
-        const boot = async () => {
-            // Run deferred builders (entities register these at add/load time)
-            await buildScene(scene);
-            // Split renderables: transparent → back-to-front each frame, transmissive → opaque but sampled,
-            // everything else → opaque-opaque.
-            for (const r of sc._renderables) {
-                const bucket = r.isTransparent ? sc._transparentRenderables : r.isTransmissive ? sc._transmissiveRenderables : sc._opaqueRenderables;
-                bucket.push(r);
+        let firstRafFrame = true;
+        let lastTime = 0;
+        eng._renderFn = (now: number) => {
+            const delta = firstRafFrame ? 0 : lastTime > 0 ? now - lastTime : 16.667;
+            lastTime = now;
+            resizeEngine(engine);
+            renderFrame(eng, delta);
+            if (firstRafFrame) {
+                firstRafFrame = false;
+                resolve();
             }
-            sc._opaqueRenderables.sort((a, b) => a.order - b.order);
-            sc._transmissiveRenderables.sort((a, b) => a.order - b.order);
-            // Also keep _renderables sorted for pre-passes and legacy consumers
-            sc._renderables.sort((a, b) => a.order - b.order);
-
-            let lastTime = 0;
-            let firstFrame = true;
-            eng._renderFn = (now: number) => {
-                // First frame: delta=0 (matches Babylon.js _localDelayOffset which
-                // absorbs the first accumulated deltaTime, so frame 1 evaluates at t=0)
-                const delta = firstFrame ? 0 : sc._fixedDeltaMs > 0 ? sc._fixedDeltaMs : lastTime > 0 ? now - lastTime : 16.667;
-                lastTime = now;
-                resizeEngine(engine);
-                for (const cb of sc._beforeRender) {
-                    cb(delta);
-                }
-                if (sc._materialSwapQueue.length > 0) {
-                    processMaterialSwaps(scene);
-                }
-                renderFrame(eng, eng._targets, sc);
-                if (firstFrame) {
-                    firstFrame = false;
-                    resolve();
-                }
-                eng._animFrameId = requestAnimationFrame(eng._renderFn!);
-            };
-            eng._animFrameId = requestAnimationFrame(eng._renderFn);
+            eng._animFrameId = requestAnimationFrame(eng._renderFn!);
         };
-        void boot();
+        eng._animFrameId = requestAnimationFrame(eng._renderFn);
     });
 }
 
@@ -171,36 +165,14 @@ export function stopEngine(engine: EngineContext): void {
     eng._renderFn = null;
 }
 
-/**
- * Render a single frame synchronously (CPU-side command encoding + submit).
- * The caller is responsible for calling this outside the RAF loop — use
- * `stopEngine()` first if the loop is running.
- *
- * Returns a promise that resolves after the GPU has finished executing
- * the submitted commands (`device.queue.onSubmittedWorkDone`).
- */
-export async function renderOneFrame(engine: EngineContext, scene: SceneContext): Promise<void> {
-    const eng = engine as EngineContextInternal;
-    const sc = scene as SceneContextInternal;
-    resizeEngine(engine);
-    for (const cb of sc._beforeRender) {
-        cb(0);
-    }
-    if (sc._materialSwapQueue.length > 0) {
-        processMaterialSwaps(scene);
-    }
-    renderFrame(eng, eng._targets, sc);
-    await eng.device.queue.onSubmittedWorkDone();
-}
-
 /** Release all engine-owned GPU resources (render targets, device). */
 export function disposeEngine(engine: EngineContext): void {
     const eng = engine as EngineContextInternal;
     stopEngine(engine);
+    eng._renderingContexts.length = 0;
     eng._targets.msaaTexture.destroy();
     eng._targets.depthTexture.destroy();
     eng.context.unconfigure();
-    // Pipeline caches auto-clear on device change (no side-effect registry needed)
     eng.device.destroy();
 }
 
@@ -227,99 +199,23 @@ function createRenderTargets(device: GPUDevice, width: number, height: number, f
     };
 }
 
-function drawList(enc: GPURenderPassEncoder | GPURenderBundleEncoder, list: readonly Renderable[], engine: EngineContextInternal): number {
-    let lp: GPURenderPipeline | null = null;
-    let lb: GPUBindGroup | null = null;
-    let draws = 0;
-    for (const r of list) {
-        if (r.mesh && r.mesh.visible === false) {
-            continue;
-        }
-        if (r._pipeline && r._pipeline !== lp) {
-            enc.setPipeline(r._pipeline);
-            lp = r._pipeline;
-        }
-        if (r._sceneBG && r._sceneBG !== lb) {
-            enc.setBindGroup(0, r._sceneBG);
-            lb = r._sceneBG;
-        }
-        draws += r.draw(enc, engine);
-        // Renderables without a declared pipeline/sceneBG set their own state internally
-        // (e.g. PBR drawPackets cycles through multiple variants). Invalidate the trackers
-        // so the next renderable correctly re-binds even if it happens to match our record.
-        if (!r._pipeline) {
-            lp = null;
-        }
-        if (!r._sceneBG) {
-            lb = null;
-        }
-    }
-    return draws;
-}
+function renderFrame(engine: EngineContextInternal, delta: number): void {
+    const targets = engine._targets;
+    const ctxs = engine._renderingContexts;
 
-function renderFrame(engine: EngineContextInternal, targets: RenderTargets, scene: SceneContextInternal): void {
     let encoder = engine.device.createCommandEncoder();
-
-    // Pre-passes: shadow maps from lights that have shadow generators
     let drawCalls = 0;
-    for (const light of scene.lights) {
-        const sg = light.shadowGenerator;
-        if (sg) {
-            drawCalls += sg.renderShadowMap(encoder);
-        }
-    }
-    // Additional pre-passes (compute, etc.)
-    for (const pp of scene._prePasses) {
-        drawCalls += pp.execute(encoder, engine);
-    }
+    let rendered = 0;
 
-    // Update scene uniforms (one per shared UBO)
-    for (const u of scene._uniformUpdaters) {
-        u.update(engine);
-    }
-
-    // Update per-mesh UBOs (world matrices) for dynamic transforms — iterates the
-    // pre-built renderables union so we pay one loop regardless of opaque/transmissive/transparent split.
-    for (const r of scene._renderables) {
-        if (r.updateUBOs) {
-            r.updateUBOs();
-        }
-    }
-
-    // Per-frame transparent sort by camera distance (back-to-front)
-    const cam = scene.camera;
-    if (scene._transparentRenderables.length > 1 && cam) {
-        const w = cam.worldMatrix;
-        const cx = w[12]!,
-            cy = w[13]!,
-            cz = w[14]!;
-        for (const r of scene._transparentRenderables) {
-            if (r._worldCenter) {
-                const [wx, wy, wz] = r._worldCenter;
-                r._sortDistance = (wx - cx) ** 2 + (wy - cy) ** 2 + (wz - cz) ** 2;
-            }
-        }
-        scene._transparentRenderables.sort((a, b) => (b._sortDistance ?? 0) - (a._sortDistance ?? 0) || a.order - b.order);
-    }
-
-    // Lazy hook: refraction/transmission module inserts the opaque-scene RTT + mipmap submit here,
-    // then hands back a fresh encoder that the main pass uses. Also lets the hook decide when to
-    // acquire the swap-chain view (late, after mid-frame submit).
-    if (scene._beforeMain) {
-        encoder = scene._beforeMain(engine, scene, encoder);
-    }
-    const swapChainView = engine.context.getCurrentTexture().createView();
-
-    const pass = encoder.beginRenderPass({
-        colorAttachments: [
-            {
-                view: targets.msaaView,
-                resolveTarget: swapChainView,
-                clearValue: scene.clearColor,
-                loadOp: "clear",
-                storeOp: "store",
-            },
-        ],
+    const colorAtt: GPURenderPassColorAttachment = {
+        view: targets.msaaView,
+        resolveTarget: undefined,
+        clearValue: { r: 0, g: 0, b: 0, a: 1 },
+        loadOp: "clear",
+        storeOp: "store",
+    };
+    const desc: GPURenderPassDescriptor = {
+        colorAttachments: [colorAtt],
         depthStencilAttachment: {
             view: targets.depthView,
             depthClearValue: 1.0,
@@ -329,33 +225,25 @@ function renderFrame(engine: EngineContextInternal, targets: RenderTargets, scen
             stencilLoadOp: "clear",
             stencilStoreOp: "store",
         },
-    });
+    };
 
-    pass.setViewport(0, 0, targets.width, targets.height, 0, 1);
+    for (let i = 0; i < ctxs.length; i++) {
+        const s = ctxs[i]!;
+        encoder = s._update(encoder, delta);
+        drawCalls += s._drawCallsPre;
+        if (rendered === 0) {
+            colorAtt.resolveTarget = engine.context.getCurrentTexture().createView();
+            colorAtt.clearValue = s.clearColor;
+        } else {
+            colorAtt.loadOp = "load";
+        }
+        rendered++;
 
-    // Opaque pass bundle cache: invalidated on renderable list change or
-    // visibility epoch bump (KHR_node_visibility / KHR_animation_pointer).
-    if (engine._bundleVersion !== scene._renderableVersion || engine._bundleVis !== _vis || !engine._opaqueBundle) {
-        const bundleEncoder = engine.device.createRenderBundleEncoder({
-            colorFormats: [engine.format],
-            depthStencilFormat: "depth24plus-stencil8",
-            sampleCount: engine.msaaSamples,
-        });
-        drawList(bundleEncoder, scene._opaqueRenderables, engine);
-        engine._opaqueBundle = bundleEncoder.finish();
-        engine._bundleVersion = scene._renderableVersion;
-        engine._bundleVis = _vis;
+        const pass = encoder.beginRenderPass(desc);
+        drawCalls += s._record(pass);
+        pass.end();
     }
-    drawCalls += scene._opaqueRenderables.length;
-    pass.executeBundles([engine._opaqueBundle]);
 
-    // ─── Transmissive pass: direct-encoded after opaque, before transparent ───
-    drawCalls += drawList(pass, scene._transmissiveRenderables, engine);
-
-    // ─── Transparent pass: direct-encoded (re-sorted every frame) ───
-    drawCalls += drawList(pass, scene._transparentRenderables, engine);
-
-    pass.end();
     engine.device.queue.submit([encoder.finish()]);
     engine.drawCallCount = drawCalls;
 }

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -2,8 +2,8 @@
 // Tree-shakable: import only what you use.
 
 // ─── Core ────────────────────────────────────────────────────────────
-export { createEngine, startEngine, stopEngine, resizeEngine, disposeEngine, renderOneFrame, VERSION } from "./engine/engine.js";
-export { createSceneContext, createDefaultCamera, removeFromScene, onBeforeRender, addToScene, disposeScene } from "./scene/scene.js";
+export { createEngine, startEngine, stopEngine, resizeEngine, disposeEngine, VERSION } from "./engine/engine.js";
+export { createSceneContext, createDefaultCamera, removeFromScene, onBeforeRender, addToScene, disposeScene, registerScene, unregisterScene } from "./scene/scene.js";
 
 // ─── Camera ──────────────────────────────────────────────────────────
 export { createArcRotateCamera } from "./camera/arc-rotate.js";

--- a/packages/babylon-lite/src/scene/scene-core.ts
+++ b/packages/babylon-lite/src/scene/scene-core.ts
@@ -1,5 +1,6 @@
-import type { EngineContext } from "../engine/engine.js";
+import type { EngineContext, RenderingContext } from "../engine/engine.js";
 import type { EngineContextInternal } from "../engine/engine.js";
+import { _vis } from "../engine/engine.js";
 import type { Camera } from "../camera/camera.js";
 import type { LightBase } from "../light/types.js";
 import type { Mesh } from "../mesh/mesh.js";
@@ -56,8 +57,8 @@ export interface SceneContext {
 }
 
 /** @internal SceneContext with internal rendering state — for renderable/loader code only. Not re-exported from index.ts. */
-export interface SceneContextInternal extends SceneContext {
-    /** Sorted list of renderables. Built lazily by startEngine(). */
+export interface SceneContextInternal extends SceneContext, RenderingContext {
+    /** Sorted list of renderables. Built lazily by registerScene(). */
     _renderables: Renderable[];
     /** Opaque renderables — sorted by order at build time. */
     _opaqueRenderables: Renderable[];
@@ -87,8 +88,6 @@ export interface SceneContextInternal extends SceneContext {
     _meshDisposables: Map<Mesh, (() => void)[]>;
     /** Meshes whose material was changed via setter — drained before each render frame. */
     _materialSwapQueue: Mesh[];
-    /** Whether this scene has been disposed. */
-    _disposed: boolean;
     /** Monotonic counter bumped when the renderable list changes (add/remove/rebuild). */
     _renderableVersion: number;
 
@@ -135,6 +134,11 @@ function installMaterialSetter(scene: SceneContextInternal, mesh: Mesh): void {
 
 /** Create an empty scene context bound to the given engine. */
 export function createSceneContext(engine: EngineContext): SceneContext {
+    const eng = engine as EngineContextInternal;
+    let opaqueBundle: GPURenderBundle | null = null;
+    let bundleVersion = -1;
+    let bundleVis = 0;
+
     const ctx: SceneContextInternal = {
         engine,
         clearColor: { r: 0.2, g: 0.2, b: 0.3, a: 1.0 },
@@ -164,10 +168,101 @@ export function createSceneContext(engine: EngineContext): SceneContext {
         _disposables: [],
         _meshDisposables: new Map(),
         _materialSwapQueue: [],
-        _disposed: false,
         _renderableVersion: 0,
+        _drawCallsPre: 0,
+
+        _update(encoder: GPUCommandEncoder, delta: number): GPUCommandEncoder {
+            const d = ctx._fixedDeltaMs > 0 ? ctx._fixedDeltaMs : delta;
+            let draws = 0;
+            for (const cb of ctx._beforeRender) {
+                cb(d);
+            }
+            if (ctx._materialSwapQueue.length > 0) {
+                processMaterialSwaps(ctx);
+            }
+            for (const light of ctx.lights) {
+                if (light.shadowGenerator) {
+                    draws += light.shadowGenerator.renderShadowMap(encoder);
+                }
+            }
+            for (const pp of ctx._prePasses) {
+                draws += pp.execute(encoder, eng);
+            }
+            for (const u of ctx._uniformUpdaters) {
+                u.update(eng);
+            }
+            for (const r of ctx._renderables) {
+                if (r.updateUBOs) {
+                    r.updateUBOs();
+                }
+            }
+            const cam = ctx.camera;
+            if (ctx._transparentRenderables.length > 1 && cam) {
+                const w = cam.worldMatrix;
+                const cx = w[12]!,
+                    cy = w[13]!,
+                    cz = w[14]!;
+                for (const r of ctx._transparentRenderables) {
+                    if (r._worldCenter) {
+                        const [wx, wy, wz] = r._worldCenter;
+                        r._sortDistance = (wx - cx) ** 2 + (wy - cy) ** 2 + (wz - cz) ** 2;
+                    }
+                }
+                ctx._transparentRenderables.sort((a, b) => (b._sortDistance ?? 0) - (a._sortDistance ?? 0) || a.order - b.order);
+            }
+            if (ctx._beforeMain) {
+                encoder = ctx._beforeMain(eng, ctx, encoder);
+            }
+            ctx._drawCallsPre = draws;
+            return encoder;
+        },
+        _record(pass: GPURenderPassEncoder): number {
+            if (bundleVersion !== ctx._renderableVersion || bundleVis !== _vis || !opaqueBundle) {
+                const be = eng.device.createRenderBundleEncoder({
+                    colorFormats: [eng.format],
+                    depthStencilFormat: "depth24plus-stencil8",
+                    sampleCount: eng.msaaSamples,
+                });
+                drawList(be, ctx._opaqueRenderables, eng);
+                opaqueBundle = be.finish();
+                bundleVersion = ctx._renderableVersion;
+                bundleVis = _vis;
+            }
+            let draws = ctx._opaqueRenderables.length;
+            pass.executeBundles([opaqueBundle]);
+            draws += drawList(pass, ctx._transmissiveRenderables, eng);
+            draws += drawList(pass, ctx._transparentRenderables, eng);
+            return draws;
+        },
     };
     return ctx;
+}
+
+function drawList(enc: GPURenderPassEncoder | GPURenderBundleEncoder, list: readonly Renderable[], engine: EngineContextInternal): number {
+    let lp: GPURenderPipeline | null = null;
+    let lb: GPUBindGroup | null = null;
+    let draws = 0;
+    for (const r of list) {
+        if (r.mesh && r.mesh.visible === false) {
+            continue;
+        }
+        if (r._pipeline && r._pipeline !== lp) {
+            enc.setPipeline(r._pipeline);
+            lp = r._pipeline;
+        }
+        if (r._sceneBG && r._sceneBG !== lb) {
+            enc.setBindGroup(0, r._sceneBG);
+            lb = r._sceneBG;
+        }
+        draws += r.draw(enc, engine);
+        if (!r._pipeline) {
+            lp = null;
+        }
+        if (!r._sceneBG) {
+            lb = null;
+        }
+    }
+    return draws;
 }
 
 /** Register a callback to run before each rendered frame. */
@@ -238,10 +333,11 @@ export function addToScene(scene: SceneContext, entity: Mesh | LightBase | Camer
 /** Release all GPU resources owned by this scene. */
 export function disposeScene(scene: SceneContext): void {
     const ctx = scene as SceneContextInternal;
-    if (ctx._disposed) {
-        return;
+    const eng = ctx.engine as EngineContextInternal;
+    const i = eng._renderingContexts.indexOf(ctx);
+    if (i >= 0) {
+        eng._renderingContexts.splice(i, 1);
     }
-    ctx._disposed = true;
     for (const fn of ctx._disposables) {
         fn();
     }
@@ -271,7 +367,7 @@ export function disposeScene(scene: SceneContext): void {
     ctx.camera = null;
 }
 
-/** @internal Run all deferred builders (called by startEngine before the render loop). */
+/** @internal Run all deferred builders (called by registerScene's boot step before the first frame). */
 export async function buildScene(scene: SceneContext): Promise<void> {
     const ctx = scene as SceneContextInternal;
     while (ctx._deferredBuilders.length > 0) {
@@ -284,6 +380,34 @@ export async function buildScene(scene: SceneContext): Promise<void> {
     }
     ctx._materialSwapQueue.length = 0;
     ctx._renderableVersion++;
+}
+
+/**
+ * Register a scene with the engine. Builds deferred work, partitions renderables,
+ * and adds the scene to the engine's render list in overlay order.
+ */
+export async function registerScene(engine: EngineContext, scene: SceneContext): Promise<void> {
+    const ctx = scene as SceneContextInternal;
+    await buildScene(scene);
+    for (const r of ctx._renderables) {
+        const bucket = r.isTransparent ? ctx._transparentRenderables : r.isTransmissive ? ctx._transmissiveRenderables : ctx._opaqueRenderables;
+        bucket.push(r);
+    }
+    ctx._opaqueRenderables.sort(byOrder);
+    ctx._transmissiveRenderables.sort(byOrder);
+    ctx._renderables.sort(byOrder);
+    (engine as EngineContextInternal)._renderingContexts.push(ctx);
+}
+
+const byOrder = (a: Renderable, b: Renderable): number => a.order - b.order;
+
+/** Remove a previously-registered scene. Idempotent. Does not dispose scene resources. */
+export function unregisterScene(engine: EngineContext, scene: SceneContext): void {
+    const eng = engine as EngineContextInternal;
+    const i = eng._renderingContexts.indexOf(scene as SceneContextInternal);
+    if (i >= 0) {
+        eng._renderingContexts.splice(i, 1);
+    }
 }
 
 /** @internal Drain _materialSwapQueue: dispose old resources and rebuild renderables. */

--- a/packages/babylon-lite/src/scene/scene.ts
+++ b/packages/babylon-lite/src/scene/scene.ts
@@ -1,4 +1,4 @@
-export { createSceneContext, onBeforeRender, addToScene, disposeScene, buildScene, processMaterialSwaps } from "./scene-core.js";
+export { createSceneContext, onBeforeRender, addToScene, disposeScene, buildScene, processMaterialSwaps, registerScene, unregisterScene } from "./scene-core.js";
 export type { SceneContext, SceneContextInternal, ImageProcessingConfig } from "./scene-core.js";
 export { createDefaultCamera } from "./scene-camera.js";
 export { removeFromScene } from "./scene-remove.js";


### PR DESCRIPTION
## Summary

Refactor the engine so it no longer knows about scenes. Scenes register themselves with the engine via the new `RenderingContext` interface and own their own per-frame update + record logic. This unlocks rendering multiple scenes (or other future renderable things) in a single frame.

## API changes

Before:
```ts
await startEngine(engine, scene); // single-scene
```

After:
```ts
await registerScene(engine, scene);
await startEngine(engine);
// optional: registerScene(engine, hudScene); // overlays in same frame
```

- **New**: `registerScene(engine, scene)` — builds deferred work, partitions renderables, joins the scene to the engine's render list.
- **New**: `unregisterScene(engine, scene)` — idempotent removal without disposal.
- **New**: `RenderingContext` public interface — minimal surface the engine sees (`_update`, `_record`, `_drawCallsPre`, `clearColor`).
- **Changed**: `startEngine(engine)` — no scene arg; drives all registered contexts.
- **Changed**: `disposeScene(scene)` — also unregisters from the engine.
- **Removed**: `renderOneFrame` (was unused).

## Render semantics

- First active context in render order clears the framebuffer with its `clearColor`; subsequent contexts load + overlay.
- MSAA always resolves to the swap-chain view (enables overlay rendering with no extra resolves in the common single-scene case).
- Per-context `_update` can mid-submit and return a new encoder (preserves the lazy transmission/refraction hook).

## Engine has zero knowledge of scenes

- `EngineContextInternal._renderingContexts: RenderingContext[]` (not `_scenes`)
- Engine does not import `SceneContextInternal` or any scene internals.
- All scene state (renderables, shadow generators, pre-passes, bundle caches, materialSwapQueue) is encapsulated in closures inside `createSceneContext`.

## Validation

- ✅ All 65 pixel-parity tests pass
- ✅ All bundle-size ceilings respected — **no ceiling bumps**
- ✅ Lint clean (eslint + tsc)

## Migration

Every scene in `lab/` was migrated to the new two-call pattern. Docs (`GUIDANCE.md`, `CONTRIBUTING.md`) updated.