### PR TITLE
chore(lab): bump @babylonjs/* to 9.3.4

### DIFF
--- a/lab/package.json
+++ b/lab/package.json
@@ -11,9 +11,10 @@
     "babylon-lite": "workspace:*"
   },
   "devDependencies": {
-    "@babylonjs/core": "^8.56.2",
+    "@babylonjs/core": "^9.3.4",
     "@babylonjs/havok": "^1.3.12",
-    "@babylonjs/loaders": "^8.56.2",
+    "@babylonjs/loaders": "^9.3.4",
+    "babylonjs-gltf2interface": "^9.3.4",
     "@webgpu/types": "^0.1.52",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,17 +77,20 @@ importers:
         version: link:../packages/babylon-lite
     devDependencies:
       '@babylonjs/core':
-        specifier: ^8.56.2
-        version: 8.56.2
+        specifier: ^9.3.4
+        version: 9.3.4
       '@babylonjs/havok':
         specifier: ^1.3.12
         version: 1.3.12
       '@babylonjs/loaders':
-        specifier: ^8.56.2
-        version: 8.56.2(@babylonjs/core@8.56.2)(babylonjs-gltf2interface@8.56.2)
+        specifier: ^9.3.4
+        version: 9.3.4(@babylonjs/core@9.3.4)(babylonjs-gltf2interface@9.3.4)
       '@webgpu/types':
         specifier: ^0.1.52
         version: 0.1.69
+      babylonjs-gltf2interface:
+        specifier: ^9.3.4
+        version: 9.3.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -113,17 +116,17 @@ importers:
 
 packages:
 
-  '@babylonjs/core@8.56.2':
-    resolution: {integrity: sha512-UShs1pt8tSTLYOoITWclXPNrUZUpuHvB2Ur2L1D+uM8c9qaAYOi9gjkurOkQwIlbPGqwQHWImGEyiyix0mQ1dg==}
+  '@babylonjs/core@9.3.4':
+    resolution: {integrity: sha512-ZwaIfw9o9kpvloErFaV28QEyofubZu67gFKzxSOcbZwqqitIF8p7xbvt6QHAnIhczEKVYLYilzqyKIlNqYcaqw==}
 
   '@babylonjs/havok@1.3.12':
     resolution: {integrity: sha512-KR5Z7DBkVEgdvHLMDh2VWe/nHvUG8+MdLBiAE0iM19KIHAPqPRVITPAZKx4SQusK5nqm4ZXDcKv5OYtViIxLzA==}
 
-  '@babylonjs/loaders@8.56.2':
-    resolution: {integrity: sha512-I2klIhTl4HLVVQEMsBpEh5YqbCCi1hA1oajRVCUcy+9Vfh0owzHEGau0GsVRlAOeYEBDNUrfOj0N6nFGTjNQ6g==}
+  '@babylonjs/loaders@9.3.4':
+    resolution: {integrity: sha512-3HA8OUaqa5/Q9Jl7g2poN+YGQy1qGd0CHbYkkZoKeKE68fZNtWPQbKHMJzP+0wmoJHorVaLLwDxZFsG9oG0xQA==}
     peerDependencies:
-      '@babylonjs/core': ^8.0.0
-      babylonjs-gltf2interface: ^8.0.0
+      '@babylonjs/core': ^9.0.0
+      babylonjs-gltf2interface: ^9.0.0
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -1034,8 +1037,8 @@ packages:
       react-native-b4a:
         optional: true
 
-  babylonjs-gltf2interface@8.56.2:
-    resolution: {integrity: sha512-c2k14C9mPR0pnfksjBdC4uXEos3t2IAYxcMgn5tI1OSC3aDfr6JAq4kADM4gfN9cUo2qIiDdSg6geUVeU8vi6w==}
+  babylonjs-gltf2interface@9.3.4:
+    resolution: {integrity: sha512-Eqs/j1hF8bOhFBwnS9DjhNOdCC27Ax2Z9JauoDu1tiHdKmhG2zgyIsWwY+hP0KjtdFxMIg9CAyuB/JDBFapzbQ==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2951,16 +2954,16 @@ packages:
 
 snapshots:
 
-  '@babylonjs/core@8.56.2': {}
+  '@babylonjs/core@9.3.4': {}
 
   '@babylonjs/havok@1.3.12':
     dependencies:
       '@types/emscripten': 1.41.5
 
-  '@babylonjs/loaders@8.56.2(@babylonjs/core@8.56.2)(babylonjs-gltf2interface@8.56.2)':
+  '@babylonjs/loaders@9.3.4(@babylonjs/core@9.3.4)(babylonjs-gltf2interface@9.3.4)':
     dependencies:
-      '@babylonjs/core': 8.56.2
-      babylonjs-gltf2interface: 8.56.2
+      '@babylonjs/core': 9.3.4
+      babylonjs-gltf2interface: 9.3.4
 
   '@colors/colors@1.6.0': {}
 
@@ -3744,7 +3747,7 @@ snapshots:
 
   b4a@1.8.0: {}
 
-  babylonjs-gltf2interface@8.56.2: {}
+  babylonjs-gltf2interface@9.3.4: {}
 
   balanced-match@1.0.2: {}
 


### PR DESCRIPTION
Updates lab reference oracle to latest Babylon.js major (v8 -> v9). Adds babylonjs-gltf2interface ^9.3.4 to satisfy loaders peer dep. All 75 parity tests pass unchanged.