### PR TITLE
refactor(material): lazy-init PBR/Standard extension registries

### DIFF
--- a/packages/babylon-lite/src/material/pbr/pbr-flags.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-flags.ts
@@ -131,21 +131,25 @@ export interface PbrExt {
     textures?(mat: unknown, out: Texture2D[]): void;
 }
 
-const _pbrExts = new Map<string, PbrExt>();
+// Lazy-init: a module-level `new Map()` would defeat tree-shaking for any
+// consumer that imports from pbr-flags.ts without actually registering or
+// iterating extensions. See GUIDANCE.md §4 ("Zero module-level side effects").
+let _pbrExts: Map<string, PbrExt> | null = null;
 let _pbrExtsSorted: readonly PbrExt[] | null = null;
 /** @internal Register a PBR extension. Idempotent (keyed by id). */
 export function _registerPbrExt(ext: PbrExt): void {
-    _pbrExts.set(ext.id, ext);
+    (_pbrExts ??= new Map()).set(ext.id, ext);
     _pbrExtsSorted = null;
 }
 /** @internal Iterate the registered extensions. */
 export function _getPbrExts(): ReadonlyMap<string, PbrExt> {
-    return _pbrExts;
+    return (_pbrExts ??= new Map());
 }
 /** @internal Return extensions sorted by id (alphabetical, stable within a build). Memoised. */
 export function _getPbrExtsSorted(): readonly PbrExt[] {
     if (!_pbrExtsSorted) {
-        _pbrExtsSorted = Array.from(_pbrExts.values()).sort((a, b) => a.id.localeCompare(b.id));
+        const map = _pbrExts;
+        _pbrExtsSorted = map ? Array.from(map.values()).sort((a, b) => a.id.localeCompare(b.id)) : [];
     }
     return _pbrExtsSorted;
 }

--- a/packages/babylon-lite/src/material/standard/standard-pipeline.ts
+++ b/packages/babylon-lite/src/material/standard/standard-pipeline.ts
@@ -110,21 +110,25 @@ export interface ShadowLightSlotLite {
     shadowType: "esm" | "pcf";
 }
 
-const _stdExts = new Map<string, StdExt>();
+// Lazy-init: avoids a module-level `new Map()` that defeats tree-shaking for
+// consumers importing from standard-pipeline.ts without using extensions.
+// See GUIDANCE.md §4 ("Zero module-level side effects").
+let _stdExts: Map<string, StdExt> | null = null;
 let _stdExtsSorted: readonly StdExt[] | null = null;
 
 export function _registerStdExt(ext: StdExt): void {
-    _stdExts.set(ext.id, ext);
+    (_stdExts ??= new Map()).set(ext.id, ext);
     _stdExtsSorted = null;
 }
 
 export function _getStdExts(): ReadonlyMap<string, StdExt> {
-    return _stdExts;
+    return (_stdExts ??= new Map());
 }
 
 export function _getStdExtsSorted(): readonly StdExt[] {
     if (!_stdExtsSorted) {
-        _stdExtsSorted = Array.from(_stdExts.values()).sort((a, b) => a.id.localeCompare(b.id));
+        const map = _stdExts;
+        _stdExtsSorted = map ? Array.from(map.values()).sort((a, b) => a.id.localeCompare(b.id)) : [];
     }
     return _stdExtsSorted;
 }


### PR DESCRIPTION
Module-level
ew Map() allocations defeat tree-shaking because bundlers treat them as side-effectful. Both _pbrExts (pbr-flags.ts) and _stdExts`n(standard-pipeline.ts) now use the lazy-init pattern blessed by GUIDANCE.md §4.

This keeps scenes that never touch PBR/Standard extension machinery from paying for registry scaffolding at import time.