### PR TITLE
Add an engine option for alphaMode

### DIFF
--- a/packages/babylon-lite/src/engine/engine.ts
+++ b/packages/babylon-lite/src/engine/engine.ts
@@ -46,6 +46,7 @@ export interface EngineContextInternal extends EngineContext {
     readonly device: GPUDevice;
     readonly context: GPUCanvasContext;
     readonly format: GPUTextureFormat;
+    readonly alphaMode: GPUCanvasAlphaMode;
     _targets: RenderTargets;
     _animFrameId: number;
     _renderFn: ((now: number) => void) | null;
@@ -102,6 +103,11 @@ export interface RenderTargetSize {
  */
 export interface EngineOptions {
     msaaSamples?: 1 | 4;
+    /**
+     * WebGPU canvas alpha mode. Use "premultiplied" to enable canvas transparency (clear color
+     * with alpha < 1 will let HTML content underneath show through). Defaults to "opaque".
+     */
+    alphaMode?: GPUCanvasAlphaMode;
 }
 
 /** Create the Babylon Lite engine. Acquires GPU adapter + device, configures swapchain. */
@@ -127,7 +133,8 @@ export async function createEngine(canvas: HTMLCanvasElement, options?: EngineOp
     }
 
     const format = navigator.gpu.getPreferredCanvasFormat();
-    context.configure({ device, format, alphaMode: "opaque" });
+    const alphaMode: GPUCanvasAlphaMode = options?.alphaMode ?? "opaque";
+    context.configure({ device, format, alphaMode });
 
     const versionToLog = `Babylon Lite v${VERSION}`;
     // eslint-disable-next-line no-console
@@ -143,6 +150,7 @@ export async function createEngine(canvas: HTMLCanvasElement, options?: EngineOp
         device,
         context,
         format,
+        alphaMode,
         canvas,
         msaaSamples,
         drawCallCount: 0,
@@ -166,7 +174,7 @@ export function resizeEngine(engine: EngineContext): void {
     }
     canvas.width = w;
     canvas.height = h;
-    eng.context.configure({ device: eng.device, format: eng.format, alphaMode: "opaque" });
+    eng.context.configure({ device: eng.device, format: eng.format, alphaMode: eng.alphaMode });
     if (eng._targets.msaaTexture) {
         eng._targets.msaaTexture.destroy();
     }

--- a/packages/babylon-lite/src/loader-env/load-env.ts
+++ b/packages/babylon-lite/src/loader-env/load-env.ts
@@ -103,7 +103,7 @@ export async function loadEnvironment(
     // Skybox is treated as .env when the URL has an .env extension OR when it matches the
     // lighting URL (which we just loaded successfully as .env). The latter handles data URIs
     // and other extensionless URLs where the caller wants to reuse the IBL cubemap as a skybox.
-    const skyboxIsEnv = skyboxUrl != null && (skyboxUrl.toLowerCase().endsWith(".env") || skyboxUrl === url);
+    const skyboxIsEnv = skyboxUrl != null && (skyboxUrl === url || skyboxUrl.toLowerCase().endsWith(".env"));
     const bgOptions = {
         skipSkybox: skyboxIsDds || skyboxIsEnv || options?.skipSkybox,
         skipGround: options?.skipGround,

--- a/packages/babylon-lite/src/loader-env/load-env.ts
+++ b/packages/babylon-lite/src/loader-env/load-env.ts
@@ -100,7 +100,10 @@ export async function loadEnvironment(
         : undefined;
     const skyboxUrl = options?.skyboxUrl;
     const skyboxIsDds = skyboxUrl != null && skyboxUrl.toLowerCase().endsWith(".dds");
-    const skyboxIsEnv = skyboxUrl != null && skyboxUrl.toLowerCase().endsWith(".env");
+    // Skybox is treated as .env when the URL has an .env extension OR when it matches the
+    // lighting URL (which we just loaded successfully as .env). The latter handles data URIs
+    // and other extensionless URLs where the caller wants to reuse the IBL cubemap as a skybox.
+    const skyboxIsEnv = skyboxUrl != null && (skyboxUrl.toLowerCase().endsWith(".env") || skyboxUrl === url);
     const bgOptions = {
         skipSkybox: skyboxIsDds || skyboxIsEnv || options?.skipSkybox,
         skipGround: options?.skipGround,


### PR DESCRIPTION
- Add alphaMode option (needed for Viewer)
- Fix `skyboxIsEnv` check when the skyboxUrl is the same as the env url, but the url does not end with .env