### PR TITLE
Show bundle deltas in lab

### DIFF
--- a/lab/index.html
+++ b/lab/index.html
@@ -600,6 +600,60 @@
                 color: #f85149;
                 font-weight: 600;
             }
+            .size-info .size-delta {
+                font-size: 0.7rem;
+                font-weight: 700;
+            }
+            .size-info .size-delta-improve {
+                color: #3fb950;
+            }
+            .size-info .size-delta-regress {
+                color: #f85149;
+            }
+            .size-info .size-delta-neutral {
+                color: #8b949e;
+            }
+            .bundle-master-status {
+                color: #8b949e;
+                margin-left: 0.35rem;
+            }
+            .bundle-master-status.ready {
+                color: #3fb950;
+            }
+            .bundle-master-status.missing {
+                color: #d29922;
+            }
+            .bundle-summary-panel {
+                margin: 0 2rem 1rem;
+                padding: 0.75rem;
+                background: #161b22;
+                border: 1px solid #30363d;
+                border-radius: 8px;
+            }
+            .bundle-summary-header {
+                display: flex;
+                align-items: center;
+                gap: 0.75rem;
+                margin-bottom: 0.6rem;
+                color: #e6edf3;
+                font-size: 0.85rem;
+            }
+            .bundle-summary-header span {
+                flex: 1;
+                color: #8b949e;
+                font-size: 0.75rem;
+            }
+            .bundle-summary-panel textarea {
+                width: 100%;
+                min-height: 20rem;
+                resize: vertical;
+                border: 1px solid #21262d;
+                border-radius: 6px;
+                padding: 0.75rem;
+                background: #0d1117;
+                color: #e6edf3;
+                font: 0.75rem/1.5 "SF Mono", "Cascadia Code", monospace;
+            }
 
             /* ── Perf Dashboard ─────────────────────────────────── */
             .perf-toolbar {
@@ -689,6 +743,7 @@
             .btn-primary:hover {
                 background: #388bfd;
             }
+            .btn.active-toggle,
             .parity-sort-btn.active,
             .bundle-sort-btn.active {
                 background: #1f6feb;
@@ -3138,14 +3193,26 @@
         </div>
 
         <div id="panel-bundle" class="tab-panel">
-            <div class="tab-hint">💡 Bundle sizes shown below come from <code>manifest.json</code>. To regenerate: <code>pnpm build:bundle-scenes</code></div>
+            <div class="tab-hint">
+                💡 Bundle sizes shown below come from <code>manifest.json</code>. Deltas compare against master via <code>master-manifest.json</code>. To regenerate:
+                <code>pnpm build:bundle-scenes</code><span id="bundle-master-status" class="bundle-master-status"></span>
+            </div>
             <div class="perf-toolbar">
                 <div class="perf-filter-pills" id="bundle-filter-pills"></div>
                 <div style="flex: 1"></div>
                 <button class="btn bundle-sort-btn active" onclick="sortBundleGrid('num')" data-sort="num" title="Sort by scene number">Scene #</button>
                 <button class="btn bundle-sort-btn" onclick="sortBundleGrid('asc')" data-sort="asc" title="Sort by Lite min size ascending">Size ↑</button>
                 <button class="btn bundle-sort-btn" onclick="sortBundleGrid('desc')" data-sort="desc" title="Sort by Lite min size descending">Size ↓</button>
+                <button class="btn" id="bundle-summary-btn" onclick="toggleBundleSummary()" title="Show copy-pastable bundle delta summary">📋 Summary</button>
                 <button class="btn" id="bundle-filter-btn" onclick="toggleBundleOverFilter()" title="Show only scenes over their size ceiling">🔴 Over Only</button>
+            </div>
+            <div class="bundle-summary-panel" id="bundle-summary-panel" hidden>
+                <div class="bundle-summary-header">
+                    <strong>Bundle delta summary</strong>
+                    <span>Markdown table, one row per scene, comparing current bundle size to master.</span>
+                    <button class="btn" id="bundle-summary-copy-btn" onclick="copyBundleSummary()">Copy</button>
+                </div>
+                <textarea id="bundle-summary-text" readonly spellcheck="false"></textarea>
             </div>
             <div class="grid" id="bundle-grid"></div>
         </div>
@@ -4026,16 +4093,168 @@
             }
 
             // ── Consolidated config fetch + init ──
-            function loadBundleManifest() {
-                fetch("/bundle/manifest.json")
+            function fetchOptionalJson(url) {
+                return fetch(url + "?t=" + Date.now(), { cache: "no-store" })
                     .then(function (r) {
-                        return r.json();
+                        return r.ok ? r.json() : null;
                     })
-                    .then(function (manifest) {
+                    .catch(function () {
+                        return null;
+                    });
+            }
+
+            function setBundleMasterStatus(masterManifest) {
+                var el = document.getElementById("bundle-master-status");
+                if (!el) return;
+                if (masterManifest) {
+                    el.textContent = " · comparing with master";
+                    el.className = "bundle-master-status ready";
+                } else {
+                    el.textContent = " · no master baseline";
+                    el.className = "bundle-master-status missing";
+                }
+            }
+
+            var bundleSummaryText = "";
+
+            function getBundleDelta(sizes, masterSizes) {
+                var currentRaw = parseFloat(sizes && sizes.rawKB);
+                var masterRaw = parseFloat(masterSizes && masterSizes.rawKB);
+                if (!isFinite(currentRaw) || !isFinite(masterRaw)) return null;
+
+                var roundedDelta = Math.round((currentRaw - masterRaw) * 10) / 10;
+                return {
+                    currentRaw: currentRaw,
+                    masterRaw: masterRaw,
+                    roundedDelta: roundedDelta,
+                    change: roundedDelta > 0 ? "increase" : roundedDelta < 0 ? "decrease" : "same",
+                };
+            }
+
+            function renderBundleMasterDelta(sizes, masterSizes) {
+                var delta = getBundleDelta(sizes, masterSizes);
+                if (!delta) return "";
+
+                if (delta.roundedDelta === 0) {
+                    return '<span class="size-delta size-delta-neutral" title="Master baseline: ' + delta.masterRaw + ' KB min">0.0 KB vs master</span>';
+                }
+
+                var cls = delta.roundedDelta > 0 ? "size-delta-regress" : "size-delta-improve";
+                var sign = delta.roundedDelta > 0 ? "+" : "-";
+                return (
+                    '<span class="size-delta ' +
+                    cls +
+                    '" title="Master baseline: ' +
+                    delta.masterRaw +
+                    ' KB min">' +
+                    sign +
+                    Math.abs(delta.roundedDelta).toFixed(1) +
+                    " KB vs master</span>"
+                );
+            }
+
+            function formatBundleDeltaValue(delta) {
+                if (!delta) return "\u2014";
+                if (delta.roundedDelta === 0) return "0.0 KB";
+                return (delta.roundedDelta > 0 ? "+" : "-") + Math.abs(delta.roundedDelta).toFixed(1) + " KB";
+            }
+
+            function buildBundleSummaryText(manifest, masterManifest) {
+                var scenes = (window.SCENE_CONFIG || []).map(function (cfg) {
+                    return "scene" + cfg.id;
+                });
+                if (scenes.length === 0) scenes = Object.keys(manifest || {});
+
+                var lines = ["| Scene | Change | Delta | Current | Master |", "| --- | --- | ---: | ---: | ---: |"];
+                scenes.forEach(function (scene) {
+                    var sizes = manifest && manifest[scene];
+                    var masterSizes = masterManifest && masterManifest[scene];
+                    if (!sizes) return;
+                    var delta = getBundleDelta(sizes, masterSizes);
+                    if (!delta || delta.roundedDelta === 0) return;
+                    lines.push(
+                        "| " +
+                            scene +
+                            " | " +
+                            delta.change +
+                            " | " +
+                            formatBundleDeltaValue(delta) +
+                            " | " +
+                            sizes.rawKB +
+                            " KB | " +
+                            (masterSizes && masterSizes.rawKB != null ? masterSizes.rawKB + " KB" : "\u2014") +
+                            " |"
+                    );
+                });
+                if (lines.length === 2) {
+                    return "No bundle size changes vs master.";
+                }
+                return lines.join("\n");
+            }
+
+            function updateBundleSummaryText(text) {
+                bundleSummaryText = text;
+                var textarea = document.getElementById("bundle-summary-text");
+                if (textarea) textarea.value = text;
+            }
+
+            function toggleBundleSummary() {
+                var panel = document.getElementById("bundle-summary-panel");
+                var btn = document.getElementById("bundle-summary-btn");
+                var textarea = document.getElementById("bundle-summary-text");
+                if (!panel || !textarea) return;
+                panel.hidden = !panel.hidden;
+                if (btn) btn.classList.toggle("active-toggle", !panel.hidden);
+                textarea.value = bundleSummaryText || "No bundle manifest loaded yet.";
+                if (!panel.hidden) {
+                    textarea.focus();
+                    textarea.select();
+                }
+            }
+
+            function copyBundleSummary() {
+                var textarea = document.getElementById("bundle-summary-text");
+                var btn = document.getElementById("bundle-summary-copy-btn");
+                if (!textarea) return;
+                textarea.value = bundleSummaryText || textarea.value;
+                textarea.focus();
+                textarea.select();
+                var markCopied = function () {
+                    if (!btn) return;
+                    var old = btn.textContent;
+                    btn.textContent = "Copied";
+                    setTimeout(function () {
+                        btn.textContent = old;
+                    }, 1200);
+                };
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(textarea.value).then(markCopied).catch(function () {
+                        document.execCommand("copy");
+                        markCopied();
+                    });
+                } else {
+                    document.execCommand("copy");
+                    markCopied();
+                }
+            }
+
+            function loadBundleManifest() {
+                Promise.all([
+                    fetch("/bundle/manifest.json?t=" + Date.now(), { cache: "no-store" }).then(function (r) {
+                        return r.json();
+                    }),
+                    fetchOptionalJson("/bundle/master-manifest.json"),
+                ])
+                    .then(function (r) {
+                        var manifest = r[0];
+                        var masterManifest = r[1];
+                        setBundleMasterStatus(masterManifest);
+                        updateBundleSummaryText(buildBundleSummaryText(manifest, masterManifest));
                         var bjsCount = 0;
                         for (var scene in manifest) {
                             if (!manifest.hasOwnProperty(scene)) continue;
                             var sizes = manifest[scene];
+                            var masterSizes = masterManifest && masterManifest[scene];
                             var card = document.querySelector('[data-scene="' + scene + '"] .size-info');
                             if (!card) continue;
                             var html =
@@ -4045,7 +4264,9 @@
                                 "</span> KB min</span>" +
                                 '<span class="size-gzip">' +
                                 sizes.gzipKB +
-                                " KB gzip</span></div>";
+                                " KB gzip</span>" +
+                                renderBundleMasterDelta(sizes, masterSizes) +
+                                "</div>";
                             var cfg = (window.SCENE_CONFIG || []).find(function (c) {
                                 return "scene" + c.id === scene;
                             });
@@ -4078,11 +4299,19 @@
                                     ratio +
                                     "\u00d7</span></div>";
                             }
+                            var sceneCard = card.closest(".card");
                             card.innerHTML = html;
-                            card.closest(".card").dataset.rawKb = sizes.rawKB;
-                            card.closest(".card").dataset.gzipKb = sizes.gzipKB;
+                            sceneCard.dataset.rawKb = sizes.rawKB;
+                            sceneCard.dataset.gzipKb = sizes.gzipKB;
+                            if (masterSizes && masterSizes.rawKB != null) {
+                                sceneCard.dataset.masterRawKb = masterSizes.rawKB;
+                                sceneCard.dataset.bundleDeltaKb = (sizes.rawKB - masterSizes.rawKB).toFixed(1);
+                            } else {
+                                delete sceneCard.dataset.masterRawKb;
+                                delete sceneCard.dataset.bundleDeltaKb;
+                            }
                             if (cfg && cfg.maxRawKB != null) {
-                                card.closest(".card").dataset.maxRawKb = cfg.maxRawKB;
+                                sceneCard.dataset.maxRawKb = cfg.maxRawKB;
                             }
                         }
                         // Re-apply stored sort now that size data is available
@@ -4269,7 +4498,7 @@
                         var prev = _lastSig;
                         _lastSig = sig;
                         if (!prev) return;
-                        if (sig.bundle !== prev.bundle) {
+                        if (sig.bundle !== prev.bundle || sig.bundleMaster !== prev.bundleMaster) {
                             loadBundleManifest();
                         }
                         if (sig.perf !== prev.perf) {

--- a/lab/vite.config.ts
+++ b/lab/vite.config.ts
@@ -32,9 +32,10 @@ function serveReferenceImages(): Plugin {
                     // so the dashboard can auto-refresh only when data actually changes.
                     const sig: {
                         bundle: number | null;
+                        bundleMaster: number | null;
                         perf: number | null;
                         parity: Record<string, number>;
-                    } = { bundle: null, perf: null, parity: {} };
+                    } = { bundle: null, bundleMaster: null, perf: null, parity: {} };
                     const mtime = (p: string): number | null => {
                         try {
                             return existsSync(p) ? statSync(p).mtimeMs : null;
@@ -43,6 +44,7 @@ function serveReferenceImages(): Plugin {
                         }
                     };
                     sig.bundle = mtime(resolve(__dirname, "public/bundle/manifest.json"));
+                    sig.bundleMaster = mtime(resolve(__dirname, "public/bundle/master-manifest.json"));
                     sig.perf = mtime(resolve(__dirname, "public/perf-manifest.json"));
                     try {
                         const cfgPath = resolve(__dirname, "../scene-config.json");

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -10,6 +10,7 @@
  * correctly excluded from the manifest numbers.
  */
 import { build, type Plugin } from "vite";
+import { execFileSync } from "child_process";
 import { resolve, dirname, join, extname } from "path";
 import { rmSync, readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { initialize as initMiniray, minify as minifyWgslMiniray } from "miniray";
@@ -416,6 +417,47 @@ export const labDir = resolve(ROOT, "lab");
 export const outDir = resolve(labDir, "public/bundle");
 export const bundleInfoDir = resolve(outDir, "bundle-info");
 export const srcDir = resolve(ROOT, "packages/babylon-lite/src");
+const MANIFEST_GIT_PATH = "lab/public/bundle/manifest.json";
+const MANIFEST_FILE = "manifest.json";
+const MASTER_MANIFEST_FILE = "master-manifest.json";
+
+interface BundleManifestEntry {
+    rawKB: number;
+    gzipKB: number;
+    ignoredRawKB?: number;
+    bjsRawKB?: number;
+    bjsGzipKB?: number;
+    runtimeChunks?: string[];
+}
+
+type BundleManifest = Record<string, BundleManifestEntry>;
+
+function readMasterBundleManifest(): { ref: string; manifest: BundleManifest } | null {
+    const errors: string[] = [];
+    for (const ref of ["origin/master", "master"]) {
+        try {
+            const json = execFileSync("git", ["show", `${ref}:${MANIFEST_GIT_PATH}`], { cwd: ROOT, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+            return { ref, manifest: JSON.parse(json) as BundleManifest };
+        } catch (err) {
+            errors.push(`${ref}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    console.warn(`Could not read ${MANIFEST_GIT_PATH} from master; bundle delta UI will not have a master baseline. ${errors.join(" | ")}`);
+    return null;
+}
+
+function writeMasterBundleManifest(): void {
+    const masterManifestPath = resolve(outDir, MASTER_MANIFEST_FILE);
+    const baseline = readMasterBundleManifest();
+    if (!baseline) {
+        rmSync(masterManifestPath, { force: true });
+        return;
+    }
+
+    writeFileSync(masterManifestPath, JSON.stringify(baseline.manifest, null, 2));
+    console.log(`✓ Bundle master baseline manifest (${baseline.ref}) written to ${masterManifestPath}`);
+}
 
 /**
  * Normalize an absolute module id to a compact, repo-relative display path.
@@ -668,6 +710,7 @@ export async function buildBundleScenes(): Promise<void> {
     // Do NOT wipe outDir — keep existing data live in the lab tab during the build.
     // Each scene is updated atomically (new files written, stale old chunks removed).
     mkdirSync(outDir, { recursive: true });
+    writeMasterBundleManifest();
 
     // ── 1. Build all scenes ──────────────────────────────────────────────
     const NAME_POLYFILL = 'var __name=(fn,name)=>(Object.defineProperty(fn,"name",{value:name,configurable:true}),fn);';
@@ -785,8 +828,8 @@ export async function buildBundleScenes(): Promise<void> {
     }
 
     // Load existing manifest to check for cached BJS sizes
-    const manifestPath = resolve(outDir, "manifest.json");
-    let existingManifest: Record<string, { rawKB: number; gzipKB: number; ignoredRawKB?: number; bjsRawKB?: number; bjsGzipKB?: number; runtimeChunks?: string[] }> = {};
+    const manifestPath = resolve(outDir, MANIFEST_FILE);
+    let existingManifest: BundleManifest = {};
     if (existsSync(manifestPath)) {
         try {
             existingManifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
@@ -866,13 +909,13 @@ export async function buildBundleScenes(): Promise<void> {
  * bundle-sceneN.html, and measure only the /bundle/*.js bytes that are
  * actually fetched at runtime.
  */
-async function measureLiveSizes(): Promise<Record<string, { rawKB: number; gzipKB: number; ignoredRawKB?: number; bjsRawKB?: number; bjsGzipKB?: number; runtimeChunks?: string[] }>> {
+async function measureLiveSizes(): Promise<BundleManifest> {
     const { chromium } = await import("@playwright/test");
     const { server, port } = await startStaticServer(labDir);
-    const manifestPath = resolve(outDir, "manifest.json");
+    const manifestPath = resolve(outDir, MANIFEST_FILE);
 
     // Load existing manifest so we can update incrementally (UI can refresh mid-build)
-    let manifest: Record<string, { rawKB: number; gzipKB: number; ignoredRawKB?: number; bjsRawKB?: number; bjsGzipKB?: number; runtimeChunks?: string[] }> = {};
+    let manifest: BundleManifest = {};
     if (existsSync(manifestPath)) {
         try {
             manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
@@ -921,6 +964,16 @@ async function measureLiveSizes(): Promise<Record<string, { rawKB: number; gzipK
         await browser.close();
     } finally {
         server.close();
+    }
+
+    if (!process.env.BUNDLE_SCENES) {
+        const currentScenes = new Set(SCENES);
+        for (const scene of Object.keys(manifest)) {
+            if (!currentScenes.has(scene)) {
+                delete manifest[scene];
+            }
+        }
+        flush();
     }
 
     return manifest;

--- a/tests/parity/bundle-size.spec.ts
+++ b/tests/parity/bundle-size.spec.ts
@@ -13,9 +13,11 @@
  *
  * Ceilings are set ~5 KB above baseline to catch regressions while allowing
  * natural growth.  Per-scene ceilings live in scene-config.json (maxRawKB).
+ * If lab/public/bundle/master-manifest.json is available, bundle-size increases
+ * relative to master are emitted as warnings only; ceilings remain the blocker.
  */
 import { test, expect } from "@playwright/test";
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { resolve } from "path";
 
 import type { SceneConfig } from "./compare-utils";
@@ -23,8 +25,29 @@ import { IGNORED_BUNDLE_MODULE_PATTERN, summarizeRuntimeBundle } from "../../scr
 
 const CONFIG_PATH = resolve(__dirname, "../../scene-config.json");
 const BUNDLE_INFO_DIR = resolve(__dirname, "../../lab/public/bundle/bundle-info");
+const MASTER_MANIFEST_PATH = resolve(__dirname, "../../lab/public/bundle/master-manifest.json");
 const allScenes: SceneConfig[] = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 const SCENES = allScenes.filter((s) => s.maxRawKB != null);
+
+interface BundleManifestEntry {
+    rawKB?: number;
+}
+
+type BundleManifest = Record<string, BundleManifestEntry>;
+
+function loadMasterManifest(): BundleManifest | null {
+    if (!existsSync(MASTER_MANIFEST_PATH)) {
+        return null;
+    }
+
+    return JSON.parse(readFileSync(MASTER_MANIFEST_PATH, "utf-8")) as BundleManifest;
+}
+
+function roundedKB(value: number): number {
+    return Math.round(value * 10) / 10;
+}
+
+const MASTER_MANIFEST = loadMasterManifest();
 
 for (const scene of SCENES) {
     test(`${scene.name} bundle ≤ ${scene.maxRawKB} KB raw`, async ({ page }) => {
@@ -62,8 +85,16 @@ for (const scene of SCENES) {
         const rawKB = summary.rawBytes / 1024;
         const gzipKB = summary.gzipBytes / 1024;
         const ignoredRawKB = summary.ignoredRawBytes / 1024;
+        const sceneKey = `scene${scene.id}`;
 
         console.log(`  ${scene.name}: ${rawKB.toFixed(1)} KB raw (limit: ${scene.maxRawKB} KB), ${gzipKB.toFixed(1)} KB gzip (informational)`);
+        const masterRawKB = MASTER_MANIFEST?.[sceneKey]?.rawKB;
+        const currentRawKB = roundedKB(rawKB);
+        if (masterRawKB != null && currentRawKB > masterRawKB) {
+            console.warn(
+                `  ⚠ ${scene.name}: bundle increased vs master by ${(currentRawKB - masterRawKB).toFixed(1)} KB raw (${currentRawKB.toFixed(1)} KB vs ${masterRawKB.toFixed(1)} KB)`
+            );
+        }
         if (summary.ignoredRawBytes > 0) {
             console.log(`  Ignored ${ignoredRawKB.toFixed(1)} KB raw from local ${IGNORED_BUNDLE_MODULE_PATTERN} modules:`);
             for (const module of summary.ignoredModules) {


### PR DESCRIPTION
## Summary
- generate a master bundle-size manifest alongside current bundle builds
- show red/green per-scene size deltas on Bundle tab cards
- add a copyable changed-scenes summary table
- emit non-blocking bundle-size warnings when current measured size grows vs master

## Validation
- skipped per request