### PR TITLE
Add CSG scenes and Manifold-backed Scene91 CSG2

### DIFF
--- a/lab/babylon-ref-scene90.html
+++ b/lab/babylon-ref-scene90.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Babylon.js Reference — Scene 90: CSG Operations</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #33334d;
+            }
+            canvas {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas id="renderCanvas"></canvas>
+        <script type="module" src="/src/bjs/scene90.ts"></script>
+    </body>
+</html>

--- a/lab/babylon-ref-scene91.html
+++ b/lab/babylon-ref-scene91.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Babylon.js Reference — Scene 91: CSG2 Operations</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #33334d;
+            }
+            canvas {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas id="renderCanvas"></canvas>
+        <script type="module" src="/src/bjs/scene91.ts"></script>
+    </body>
+</html>

--- a/lab/bundle-bjs-scene90.html
+++ b/lab/bundle-bjs-scene90.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Babylon.js — Scene 90: CSG Operations (Bundle)</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #33334d;
+            }
+            canvas {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas id="renderCanvas"></canvas>
+        <script type="module" src="/bundle/bjs-scene90.js"></script>
+    </body>
+</html>

--- a/lab/bundle-bjs-scene91.html
+++ b/lab/bundle-bjs-scene91.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Babylon.js — Scene 91: CSG2 Operations (Bundle)</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #33334d;
+            }
+            canvas {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas id="renderCanvas"></canvas>
+        <script type="module" src="/bundle/bjs-scene91.js"></script>
+    </body>
+</html>

--- a/lab/bundle-scene90.html
+++ b/lab/bundle-scene90.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Babylon Lite — Scene 90: CSG Operations (Bundle)</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #33334d;
+            }
+            canvas {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas id="renderCanvas"></canvas>
+        <script src="/loader.js"></script>
+        <script type="module" src="/bundle/scene90.js"></script>
+    </body>
+</html>

--- a/lab/bundle-scene91.html
+++ b/lab/bundle-scene91.html
@@ -23,6 +23,13 @@
     <body>
         <canvas id="renderCanvas"></canvas>
         <script src="/loader.js"></script>
+        <script type="importmap">
+            {
+                "imports": {
+                    "manifold-3d": "/vendor/manifold-3d/manifold.js"
+                }
+            }
+        </script>
         <script type="module" src="/bundle/scene91.js"></script>
     </body>
 </html>

--- a/lab/bundle-scene91.html
+++ b/lab/bundle-scene91.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Babylon Lite — Scene 91: CSG2 Operations (Bundle)</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #33334d;
+            }
+            canvas {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas id="renderCanvas"></canvas>
+        <script src="/loader.js"></script>
+        <script type="module" src="/bundle/scene91.js"></script>
+    </body>
+</html>

--- a/lab/index.html
+++ b/lab/index.html
@@ -2266,7 +2266,7 @@
                             <td>CSG (Boolean Ops)</td>
                             <td>✅</td>
                             <td>✅</td>
-                            <td>Scene 90 — mesh-based subtract, intersect, and union operations</td>
+                            <td>Scenes 90/91 — mesh-based subtract, intersect, and union/add operations</td>
                         </tr>
                         <tr>
                             <td>Instanced Meshes</td>

--- a/lab/index.html
+++ b/lab/index.html
@@ -1900,6 +1900,12 @@
                             <td>✅</td>
                             <td>Scene 76 — Texture2D + sampler binding via setEffectTexture()</td>
                         </tr>
+                        <tr>
+                            <td>Frame-Graph RTT Material Override</td>
+                            <td>✅</td>
+                            <td>✅</td>
+                            <td>Scene 110 — offscreen pass renders selected meshes with an override material and camera, then samples the RTT in the main pass</td>
+                        </tr>
 
                         <!-- Materials -->
                         <tr class="feat-cat">
@@ -2015,9 +2021,9 @@
                         </tr>
                         <tr>
                             <td>Node Material</td>
-                            <td>⚡</td>
                             <td>✅</td>
-                            <td>NME snippet parser + core blocks (Scenes 60-73); not full Babylon NodeMaterial editor/runtime</td>
+                            <td>✅</td>
+                            <td>NME snippet parser with lab-proven core, compatibility, PBR, math/modes, color, UV/texture/procedural, normal/screen/depth/matrix/scene-state, loop, and storage blocks (Scenes 60-89)</td>
                         </tr>
                         <tr>
                             <td>Shader Material</td>
@@ -2065,7 +2071,7 @@
                             <td>PBR Iridescence</td>
                             <td>—</td>
                             <td>✅</td>
-                            <td></td>
+                            <td>Native PBR material/glTF iridescence pending</td>
                         </tr>
 
                         <!-- Lights -->
@@ -2101,6 +2107,12 @@
                             <td>✅</td>
                             <td>✅</td>
                             <td>Dynamic UBO packing</td>
+                        </tr>
+                        <tr>
+                            <td>Per-Mesh Light Inclusion</td>
+                            <td>✅</td>
+                            <td>✅</td>
+                            <td>Scene 111 — includedOnlyMeshIds-style light selection across Standard, PBR, NME, and supported shadow generators</td>
                         </tr>
                         <tr>
                             <td>Light Intensity / Color</td>
@@ -2252,9 +2264,9 @@
                         </tr>
                         <tr>
                             <td>CSG (Boolean Ops)</td>
-                            <td>—</td>
                             <td>✅</td>
-                            <td></td>
+                            <td>✅</td>
+                            <td>Scene 90 — mesh-based subtract, intersect, and union operations</td>
                         </tr>
                         <tr>
                             <td>Instanced Meshes</td>
@@ -2812,7 +2824,7 @@
                             <td>Render Target Textures</td>
                             <td>✅</td>
                             <td>✅</td>
-                            <td>Frame-graph RTT + sampled Texture2D (Scenes 52, 75)</td>
+                            <td>Frame-graph RTT + sampled Texture2D, including pass-local material override (Scenes 75, 110)</td>
                         </tr>
                         <tr>
                             <td>Multi-Render Targets</td>

--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -1476,7 +1476,7 @@
     "bjsGzipKB": 597.9
   },
   "scene90": {
-    "rawKB": 57.1,
+    "rawKB": 57.2,
     "gzipKB": 21.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -1489,16 +1489,17 @@
     "bjsGzipKB": 345.4
   },
   "scene91": {
-    "rawKB": 57.1,
+    "rawKB": 56.2,
     "gzipKB": 21.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene91-generate-mipmaps-C77tBDk9.js",
+      "scene91-manifold-DzfOEtRz.js",
       "scene91-standard-renderable-4BuEN-Pd.js",
       "scene91-wgsl-helpers-WTsokIfK.js",
       "scene91.js"
     ],
-    "bjsRawKB": 1447.9,
-    "bjsGzipKB": 344.9
+    "bjsRawKB": 1448.5,
+    "bjsGzipKB": 345
   }
 }

--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -1487,5 +1487,18 @@
     ],
     "bjsRawKB": 1451.1,
     "bjsGzipKB": 345.4
+  },
+  "scene91": {
+    "rawKB": 57.1,
+    "gzipKB": 21.6,
+    "ignoredRawKB": 0,
+    "runtimeChunks": [
+      "scene91-generate-mipmaps-C77tBDk9.js",
+      "scene91-standard-renderable-4BuEN-Pd.js",
+      "scene91-wgsl-helpers-WTsokIfK.js",
+      "scene91.js"
+    ],
+    "bjsRawKB": 1447.9,
+    "bjsGzipKB": 344.9
   }
 }

--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -1474,5 +1474,18 @@
     ],
     "bjsRawKB": 2587,
     "bjsGzipKB": 597.9
+  },
+  "scene90": {
+    "rawKB": 57.1,
+    "gzipKB": 21.6,
+    "ignoredRawKB": 0,
+    "runtimeChunks": [
+      "scene90-generate-mipmaps-B5dVntwn.js",
+      "scene90-standard-renderable-CynlfnDc.js",
+      "scene90-wgsl-helpers-WTsokIfK.js",
+      "scene90.js"
+    ],
+    "bjsRawKB": 1451.1,
+    "bjsGzipKB": 345.4
   }
 }

--- a/lab/scene90.html
+++ b/lab/scene90.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Babylon Lite — Scene 90: CSG Operations</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #33334d;
+            }
+            canvas {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas id="renderCanvas"></canvas>
+        <script type="module" src="/src/lite/scene90.ts"></script>
+    </body>
+</html>

--- a/lab/scene91.html
+++ b/lab/scene91.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Babylon Lite — Scene 91: CSG2 Operations</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #33334d;
+            }
+            canvas {
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas id="renderCanvas"></canvas>
+        <script type="module" src="/src/lite/scene91.ts"></script>
+    </body>
+</html>

--- a/lab/src/bjs/scene90.ts
+++ b/lab/src/bjs/scene90.ts
@@ -1,0 +1,138 @@
+// Babylon.js reference for Scene 90: CSG operations — adapted from playground #0MDAYA.
+
+import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
+import { WebGPUEngine } from "@babylonjs/core/Engines/webgpuEngine";
+import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
+import { Material } from "@babylonjs/core/Materials/material";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { CSG } from "@babylonjs/core/Meshes/csg";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
+import { Scene } from "@babylonjs/core/scene";
+
+const GRASS_URL = "https://playground.babylonjs.com/textures/grass.png";
+const CRATE_URL = "https://playground.babylonjs.com/textures/crate.png";
+
+interface DrawCallCounter {
+    current: number;
+    fetchNewFrame?: () => void;
+}
+
+function labelTextureUrl(text: string): string {
+    const canvas = document.createElement("canvas");
+    canvas.width = 256;
+    canvas.height = 128;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+        throw new Error("Scene 90 labels require a 2D canvas context.");
+    }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "black";
+    ctx.font = "700 64px Arial, Helvetica, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "alphabetic";
+    ctx.fillText(text, 128, 78);
+    return canvas.toDataURL("image/png");
+}
+
+function createTextureMaterial(scene: Scene, name: string, url: string): StandardMaterial {
+    const material = new StandardMaterial(name, scene);
+    material.diffuseTexture = new Texture(url, scene, { invertY: true });
+    return material;
+}
+
+function createLabelMaterial(scene: Scene, text: string): StandardMaterial {
+    const material = new StandardMaterial(`label-${text}`, scene);
+    const texture = new Texture(labelTextureUrl(text), scene, {
+        noMipmap: true,
+        invertY: true,
+        samplingMode: Texture.BILINEAR_SAMPLINGMODE,
+    });
+    texture.hasAlpha = true;
+    material.diffuseTexture = texture;
+    material.useAlphaFromDiffuseTexture = true;
+    material.emissiveColor = Color3.White();
+    material.disableLighting = true;
+    material.transparencyMode = Material.MATERIAL_ALPHATEST;
+    material.alphaCutOff = 0.5;
+    material.backFaceCulling = false;
+    return material;
+}
+
+function setMeshPosition(mesh: Mesh, x: number, y: number, z = 0): void {
+    mesh.position.set(x, y, z);
+}
+
+(async function () {
+    const initStart = performance.now();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+    const engine = new WebGPUEngine(canvas, { antialias: true, adaptToDeviceRatio: true });
+    await engine.initAsync();
+
+    const scene = new Scene(engine);
+    scene.clearColor = new Color4(0.2, 0.2, 0.3, 1);
+
+    new ArcRotateCamera("camera", -1.5, 1.6, 18, Vector3.Zero(), scene);
+    new HemisphericLight("hemi", new Vector3(0, 1, 0), scene);
+
+    const crateMaterial = createTextureMaterial(scene, "crate", CRATE_URL);
+    const grassMaterial = createTextureMaterial(scene, "grass", GRASS_URL);
+    const resultMaterial = createTextureMaterial(scene, "result", CRATE_URL);
+    const subtractLabel = createLabelMaterial(scene, "-");
+    const intersectLabel = createLabelMaterial(scene, "∩");
+    const unionLabel = createLabelMaterial(scene, "+");
+    const equalsLabel = createLabelMaterial(scene, "=");
+
+    const rows: Array<{ y: number; label: StandardMaterial; op: "subtract" | "intersect" | "union" }> = [
+        { y: -4, label: subtractLabel, op: "subtract" },
+        { y: 0, label: intersectLabel, op: "intersect" },
+        { y: 4, label: unionLabel, op: "union" },
+    ];
+
+    for (const row of rows) {
+        const box = MeshBuilder.CreateBox(`box-${row.op}`, { size: 2 }, scene);
+        const sphere = MeshBuilder.CreateSphere(`sphere-${row.op}`, { diameter: 2.5, segments: 32 }, scene);
+        box.material = crateMaterial;
+        sphere.material = grassMaterial;
+
+        const boxCsg = CSG.FromMesh(box);
+        const sphereCsg = CSG.FromMesh(sphere);
+        const resultCsg = row.op === "subtract" ? boxCsg.subtract(sphereCsg) : row.op === "intersect" ? boxCsg.intersect(sphereCsg) : boxCsg.union(sphereCsg);
+        const result = resultCsg.toMesh(`csg-${row.op}`, resultMaterial, scene);
+
+        setMeshPosition(box, -4, row.y);
+        setMeshPosition(sphere, 0.2, row.y);
+        setMeshPosition(result, 4, row.y);
+
+        const label = MeshBuilder.CreatePlane(`label-${row.op}`, { width: 1.4, height: 0.7 }, scene);
+        label.material = row.label;
+        setMeshPosition(label, -2, row.y);
+
+        const equals = MeshBuilder.CreatePlane(`equals-${row.op}`, { width: 1.4, height: 0.7 }, scene);
+        equals.material = equalsLabel;
+        setMeshPosition(equals, 2, row.y);
+    }
+
+    const engineWithDrawCalls = engine as unknown as { _drawCalls?: DrawCallCounter };
+    scene.onBeforeRenderObservable.add(() => {
+        engineWithDrawCalls._drawCalls?.fetchNewFrame?.();
+    });
+    scene.onAfterRenderObservable.add(() => {
+        canvas.dataset.drawCalls = String(engineWithDrawCalls._drawCalls?.current ?? 0);
+    });
+    await scene.whenReadyAsync();
+    engine.runRenderLoop(() => scene.render());
+    window.addEventListener("resize", () => engine.resize());
+    await new Promise<void>((resolve) => scene.onAfterRenderObservable.addOnce(resolve));
+    canvas.dataset.initMs = String(performance.now() - initStart);
+    canvas.dataset.ready = "true";
+})().catch((err) => {
+    console.error(err);
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement | null;
+    if (canvas) {
+        canvas.dataset.error = String(err);
+    }
+});

--- a/lab/src/bjs/scene91.ts
+++ b/lab/src/bjs/scene91.ts
@@ -82,7 +82,6 @@ function setMeshPosition(mesh: Mesh, x: number, y: number, z = 0): void {
 
     const crateMaterial = createTextureMaterial(scene, "crate", CRATE_URL);
     const grassMaterial = createTextureMaterial(scene, "grass", GRASS_URL);
-    const resultMaterial = createTextureMaterial(scene, "result", CRATE_URL);
     const subtractLabel = createLabelMaterial(scene, "-");
     const intersectLabel = createLabelMaterial(scene, "∩");
     const unionLabel = createLabelMaterial(scene, "+");
@@ -106,7 +105,7 @@ function setMeshPosition(mesh: Mesh, x: number, y: number, z = 0): void {
         let resultCsg: CSG2 | undefined;
         try {
             resultCsg = row.op === "subtract" ? boxCsg.subtract(sphereCsg) : row.op === "intersect" ? boxCsg.intersect(sphereCsg) : boxCsg.add(sphereCsg);
-            result = resultCsg.toMesh(`csg-${row.op}`, scene, { materialToUse: resultMaterial });
+            result = resultCsg.toMesh(`csg-${row.op}`, scene);
         } finally {
             boxCsg.dispose();
             sphereCsg.dispose();

--- a/lab/src/bjs/scene91.ts
+++ b/lab/src/bjs/scene91.ts
@@ -1,0 +1,148 @@
+// Babylon.js reference for Scene 91: CSG2 operations — adapted from playground #0MDAYA.
+
+import { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";
+import { WebGPUEngine } from "@babylonjs/core/Engines/webgpuEngine";
+import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
+import { Material } from "@babylonjs/core/Materials/material";
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { Texture } from "@babylonjs/core/Materials/Textures/texture";
+import { Color3, Color4 } from "@babylonjs/core/Maths/math.color";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
+import { CSG2, InitializeCSG2Async } from "@babylonjs/core/Meshes/csg2";
+import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { MeshBuilder } from "@babylonjs/core/Meshes/meshBuilder";
+import { Scene } from "@babylonjs/core/scene";
+
+const GRASS_URL = "https://playground.babylonjs.com/textures/grass.png";
+const CRATE_URL = "https://playground.babylonjs.com/textures/crate.png";
+
+interface DrawCallCounter {
+    current: number;
+    fetchNewFrame?: () => void;
+}
+
+function labelTextureUrl(text: string): string {
+    const canvas = document.createElement("canvas");
+    canvas.width = 256;
+    canvas.height = 128;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+        throw new Error("Scene 91 labels require a 2D canvas context.");
+    }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "black";
+    ctx.font = "700 64px Arial, Helvetica, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "alphabetic";
+    ctx.fillText(text, 128, 78);
+    return canvas.toDataURL("image/png");
+}
+
+function createTextureMaterial(scene: Scene, name: string, url: string): StandardMaterial {
+    const material = new StandardMaterial(name, scene);
+    material.diffuseTexture = new Texture(url, scene, { invertY: true });
+    return material;
+}
+
+function createLabelMaterial(scene: Scene, text: string): StandardMaterial {
+    const material = new StandardMaterial(`label-${text}`, scene);
+    const texture = new Texture(labelTextureUrl(text), scene, {
+        noMipmap: true,
+        invertY: true,
+        samplingMode: Texture.BILINEAR_SAMPLINGMODE,
+    });
+    texture.hasAlpha = true;
+    material.diffuseTexture = texture;
+    material.useAlphaFromDiffuseTexture = true;
+    material.emissiveColor = Color3.White();
+    material.disableLighting = true;
+    material.transparencyMode = Material.MATERIAL_ALPHATEST;
+    material.alphaCutOff = 0.5;
+    material.backFaceCulling = false;
+    return material;
+}
+
+function setMeshPosition(mesh: Mesh, x: number, y: number, z = 0): void {
+    mesh.position.set(x, y, z);
+}
+
+(async function () {
+    const initStart = performance.now();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+    const engine = new WebGPUEngine(canvas, { antialias: true, adaptToDeviceRatio: true });
+    await engine.initAsync();
+
+    await InitializeCSG2Async();
+
+    const scene = new Scene(engine);
+    scene.clearColor = new Color4(0.2, 0.2, 0.3, 1);
+
+    new ArcRotateCamera("camera", -1.5, 1.6, 18, Vector3.Zero(), scene);
+    new HemisphericLight("hemi", new Vector3(0, 1, 0), scene);
+
+    const crateMaterial = createTextureMaterial(scene, "crate", CRATE_URL);
+    const grassMaterial = createTextureMaterial(scene, "grass", GRASS_URL);
+    const resultMaterial = createTextureMaterial(scene, "result", CRATE_URL);
+    const subtractLabel = createLabelMaterial(scene, "-");
+    const intersectLabel = createLabelMaterial(scene, "∩");
+    const unionLabel = createLabelMaterial(scene, "+");
+    const equalsLabel = createLabelMaterial(scene, "=");
+
+    const rows: Array<{ y: number; label: StandardMaterial; op: "subtract" | "intersect" | "union" }> = [
+        { y: -4, label: subtractLabel, op: "subtract" },
+        { y: 0, label: intersectLabel, op: "intersect" },
+        { y: 4, label: unionLabel, op: "union" },
+    ];
+
+    for (const row of rows) {
+        const box = MeshBuilder.CreateBox(`box-${row.op}`, { size: 2 }, scene);
+        const sphere = MeshBuilder.CreateSphere(`sphere-${row.op}`, { diameter: 2.5, segments: 32 }, scene);
+        box.material = crateMaterial;
+        sphere.material = grassMaterial;
+
+        const boxCsg = CSG2.FromMesh(box);
+        const sphereCsg = CSG2.FromMesh(sphere);
+        let result: Mesh;
+        let resultCsg: CSG2 | undefined;
+        try {
+            resultCsg = row.op === "subtract" ? boxCsg.subtract(sphereCsg) : row.op === "intersect" ? boxCsg.intersect(sphereCsg) : boxCsg.add(sphereCsg);
+            result = resultCsg.toMesh(`csg-${row.op}`, scene, { materialToUse: resultMaterial });
+        } finally {
+            boxCsg.dispose();
+            sphereCsg.dispose();
+            resultCsg?.dispose();
+        }
+
+        setMeshPosition(box, -4, row.y);
+        setMeshPosition(sphere, 0.2, row.y);
+        setMeshPosition(result, 4, row.y);
+
+        const label = MeshBuilder.CreatePlane(`label-${row.op}`, { width: 1.4, height: 0.7 }, scene);
+        label.material = row.label;
+        setMeshPosition(label, -2, row.y);
+
+        const equals = MeshBuilder.CreatePlane(`equals-${row.op}`, { width: 1.4, height: 0.7 }, scene);
+        equals.material = equalsLabel;
+        setMeshPosition(equals, 2, row.y);
+    }
+
+    const engineWithDrawCalls = engine as unknown as { _drawCalls?: DrawCallCounter };
+    scene.onBeforeRenderObservable.add(() => {
+        engineWithDrawCalls._drawCalls?.fetchNewFrame?.();
+    });
+    scene.onAfterRenderObservable.add(() => {
+        canvas.dataset.drawCalls = String(engineWithDrawCalls._drawCalls?.current ?? 0);
+    });
+    await scene.whenReadyAsync();
+    engine.runRenderLoop(() => scene.render());
+    window.addEventListener("resize", () => engine.resize());
+    await new Promise<void>((resolve) => scene.onAfterRenderObservable.addOnce(resolve));
+    canvas.dataset.initMs = String(performance.now() - initStart);
+    canvas.dataset.ready = "true";
+})().catch((err) => {
+    console.error(err);
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement | null;
+    if (canvas) {
+        canvas.dataset.error = String(err);
+    }
+});

--- a/lab/src/lite/scene90.ts
+++ b/lab/src/lite/scene90.ts
@@ -1,0 +1,142 @@
+// Scene 90: CSG operations — adapted from Babylon playground #0MDAYA.
+
+import {
+    addToScene,
+    attachControl,
+    createArcRotateCamera,
+    createBox,
+    createCsgFromMesh,
+    createEngine,
+    createHemisphericLight,
+    createMeshFromCsg,
+    createPlane,
+    createSceneContext,
+    createSphere,
+    createStandardMaterial,
+    csgIntersect,
+    csgSubtract,
+    csgUnion,
+    loadTexture2D,
+    registerScene,
+    startEngine,
+} from "babylon-lite";
+import type { EngineContext, Mesh, StandardMaterialProps } from "babylon-lite";
+
+const GRASS_URL = "https://playground.babylonjs.com/textures/grass.png";
+const CRATE_URL = "https://playground.babylonjs.com/textures/crate.png";
+
+function labelTextureUrl(text: string): string {
+    const canvas = document.createElement("canvas");
+    canvas.width = 256;
+    canvas.height = 128;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+        throw new Error("Scene 90 labels require a 2D canvas context.");
+    }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "black";
+    ctx.font = "700 64px Arial, Helvetica, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "alphabetic";
+    ctx.fillText(text, 128, 78);
+    return canvas.toDataURL("image/png");
+}
+
+async function createLabelMaterial(engine: EngineContext, text: string): Promise<StandardMaterialProps> {
+    const material = createStandardMaterial();
+    material.disableLighting = true;
+    material.emissiveColor = [1, 1, 1];
+    material.diffuseTexture = await loadTexture2D(engine, labelTextureUrl(text), {
+        mipMaps: false,
+        addressModeU: "clamp-to-edge",
+        addressModeV: "clamp-to-edge",
+    });
+    material.alphaCutOff = 0.5;
+    material.backFaceCulling = false;
+    return material;
+}
+
+function setMeshPosition(mesh: Mesh, x: number, y: number, z = 0): void {
+    mesh.position.x = x;
+    mesh.position.y = y;
+    mesh.position.z = z;
+}
+
+async function main(): Promise<void> {
+    const initStart = performance.now();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+    const engine = await createEngine(canvas);
+    const scene = createSceneContext(engine);
+
+    scene.camera = createArcRotateCamera(-1.5, 1.6, 18, { x: 0, y: 0, z: 0 });
+    scene.camera.nearPlane = 0.1;
+    scene.camera.farPlane = 1000;
+    attachControl(scene.camera, canvas, scene);
+
+    addToScene(scene, createHemisphericLight([0, 1, 0], 1));
+
+    const [grassTexture, crateTexture, subtractLabel, intersectLabel, unionLabel, equalsLabel] = await Promise.all([
+        loadTexture2D(engine, GRASS_URL, { invertY: true }),
+        loadTexture2D(engine, CRATE_URL, { invertY: true }),
+        createLabelMaterial(engine, "-"),
+        createLabelMaterial(engine, "∩"),
+        createLabelMaterial(engine, "+"),
+        createLabelMaterial(engine, "="),
+    ]);
+
+    const crateMaterial = createStandardMaterial();
+    crateMaterial.diffuseTexture = crateTexture;
+    const grassMaterial = createStandardMaterial();
+    grassMaterial.diffuseTexture = grassTexture;
+    const resultMaterial = createStandardMaterial();
+    resultMaterial.diffuseTexture = crateTexture;
+
+    const rows: Array<{ y: number; label: StandardMaterialProps; op: "subtract" | "intersect" | "union" }> = [
+        { y: -4, label: subtractLabel, op: "subtract" },
+        { y: 0, label: intersectLabel, op: "intersect" },
+        { y: 4, label: unionLabel, op: "union" },
+    ];
+
+    for (const row of rows) {
+        const box = createBox(engine, 2);
+        const sphere = createSphere(engine, { diameter: 2.5, segments: 32 });
+        const boxSolid = createCsgFromMesh(box);
+        const sphereSolid = createCsgFromMesh(sphere);
+        const resultSolid = row.op === "subtract" ? csgSubtract(boxSolid, sphereSolid) : row.op === "intersect" ? csgIntersect(boxSolid, sphereSolid) : csgUnion(boxSolid, sphereSolid);
+        const result = createMeshFromCsg(engine, resultSolid, `csg-${row.op}`);
+
+        box.material = crateMaterial;
+        sphere.material = grassMaterial;
+        result.material = resultMaterial;
+        setMeshPosition(box, -4, row.y);
+        setMeshPosition(sphere, 0.2, row.y);
+        setMeshPosition(result, 4, row.y);
+        addToScene(scene, box);
+        addToScene(scene, sphere);
+        addToScene(scene, result);
+
+        const label = createPlane(engine, { width: 1.4, height: 0.7 });
+        label.material = row.label;
+        setMeshPosition(label, -2, row.y);
+        addToScene(scene, label);
+
+        const equals = createPlane(engine, { width: 1.4, height: 0.7 });
+        equals.material = equalsLabel;
+        setMeshPosition(equals, 2, row.y);
+        addToScene(scene, equals);
+    }
+
+    await registerScene(engine, scene);
+    await startEngine(engine);
+    canvas.dataset.drawCalls = String(engine.drawCallCount);
+    canvas.dataset.initMs = String(performance.now() - initStart);
+    canvas.dataset.ready = "true";
+}
+
+main().catch((err) => {
+    console.error(err);
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement | null;
+    if (canvas) {
+        canvas.dataset.error = String(err);
+    }
+});

--- a/lab/src/lite/scene91.ts
+++ b/lab/src/lite/scene91.ts
@@ -1,0 +1,142 @@
+// Scene 91: CSG2 operations — adapted from Babylon playground #0MDAYA.
+
+import {
+    addToScene,
+    attachControl,
+    createArcRotateCamera,
+    createBox,
+    createCsgFromMesh,
+    createEngine,
+    createHemisphericLight,
+    createMeshFromCsg,
+    createPlane,
+    createSceneContext,
+    createSphere,
+    createStandardMaterial,
+    csgIntersect,
+    csgSubtract,
+    csgUnion,
+    loadTexture2D,
+    registerScene,
+    startEngine,
+} from "babylon-lite";
+import type { EngineContext, Mesh, StandardMaterialProps } from "babylon-lite";
+
+const GRASS_URL = "https://playground.babylonjs.com/textures/grass.png";
+const CRATE_URL = "https://playground.babylonjs.com/textures/crate.png";
+
+function labelTextureUrl(text: string): string {
+    const canvas = document.createElement("canvas");
+    canvas.width = 256;
+    canvas.height = 128;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+        throw new Error("Scene 91 labels require a 2D canvas context.");
+    }
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "black";
+    ctx.font = "700 64px Arial, Helvetica, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "alphabetic";
+    ctx.fillText(text, 128, 78);
+    return canvas.toDataURL("image/png");
+}
+
+async function createLabelMaterial(engine: EngineContext, text: string): Promise<StandardMaterialProps> {
+    const material = createStandardMaterial();
+    material.disableLighting = true;
+    material.emissiveColor = [1, 1, 1];
+    material.diffuseTexture = await loadTexture2D(engine, labelTextureUrl(text), {
+        mipMaps: false,
+        addressModeU: "clamp-to-edge",
+        addressModeV: "clamp-to-edge",
+    });
+    material.alphaCutOff = 0.5;
+    material.backFaceCulling = false;
+    return material;
+}
+
+function setMeshPosition(mesh: Mesh, x: number, y: number, z = 0): void {
+    mesh.position.x = x;
+    mesh.position.y = y;
+    mesh.position.z = z;
+}
+
+async function main(): Promise<void> {
+    const initStart = performance.now();
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+    const engine = await createEngine(canvas);
+    const scene = createSceneContext(engine);
+
+    scene.camera = createArcRotateCamera(-1.5, 1.6, 18, { x: 0, y: 0, z: 0 });
+    scene.camera.nearPlane = 0.1;
+    scene.camera.farPlane = 1000;
+    attachControl(scene.camera, canvas, scene);
+
+    addToScene(scene, createHemisphericLight([0, 1, 0], 1));
+
+    const [grassTexture, crateTexture, subtractLabel, intersectLabel, unionLabel, equalsLabel] = await Promise.all([
+        loadTexture2D(engine, GRASS_URL, { invertY: true }),
+        loadTexture2D(engine, CRATE_URL, { invertY: true }),
+        createLabelMaterial(engine, "-"),
+        createLabelMaterial(engine, "∩"),
+        createLabelMaterial(engine, "+"),
+        createLabelMaterial(engine, "="),
+    ]);
+
+    const crateMaterial = createStandardMaterial();
+    crateMaterial.diffuseTexture = crateTexture;
+    const grassMaterial = createStandardMaterial();
+    grassMaterial.diffuseTexture = grassTexture;
+    const resultMaterial = createStandardMaterial();
+    resultMaterial.diffuseTexture = crateTexture;
+
+    const rows: Array<{ y: number; label: StandardMaterialProps; op: "subtract" | "intersect" | "union" }> = [
+        { y: -4, label: subtractLabel, op: "subtract" },
+        { y: 0, label: intersectLabel, op: "intersect" },
+        { y: 4, label: unionLabel, op: "union" },
+    ];
+
+    for (const row of rows) {
+        const box = createBox(engine, 2);
+        const sphere = createSphere(engine, { diameter: 2.5, segments: 32 });
+        const boxSolid = createCsgFromMesh(box);
+        const sphereSolid = createCsgFromMesh(sphere);
+        const resultSolid = row.op === "subtract" ? csgSubtract(boxSolid, sphereSolid) : row.op === "intersect" ? csgIntersect(boxSolid, sphereSolid) : csgUnion(boxSolid, sphereSolid);
+        const result = createMeshFromCsg(engine, resultSolid, `csg-${row.op}`);
+
+        box.material = crateMaterial;
+        sphere.material = grassMaterial;
+        result.material = resultMaterial;
+        setMeshPosition(box, -4, row.y);
+        setMeshPosition(sphere, 0.2, row.y);
+        setMeshPosition(result, 4, row.y);
+        addToScene(scene, box);
+        addToScene(scene, sphere);
+        addToScene(scene, result);
+
+        const label = createPlane(engine, { width: 1.4, height: 0.7 });
+        label.material = row.label;
+        setMeshPosition(label, -2, row.y);
+        addToScene(scene, label);
+
+        const equals = createPlane(engine, { width: 1.4, height: 0.7 });
+        equals.material = equalsLabel;
+        setMeshPosition(equals, 2, row.y);
+        addToScene(scene, equals);
+    }
+
+    await registerScene(engine, scene);
+    await startEngine(engine);
+    canvas.dataset.drawCalls = String(engine.drawCallCount);
+    canvas.dataset.initMs = String(performance.now() - initStart);
+    canvas.dataset.ready = "true";
+}
+
+main().catch((err) => {
+    console.error(err);
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement | null;
+    if (canvas) {
+        canvas.dataset.error = String(err);
+    }
+});

--- a/lab/src/lite/scene91.ts
+++ b/lab/src/lite/scene91.ts
@@ -5,22 +5,24 @@ import {
     attachControl,
     createArcRotateCamera,
     createBox,
-    createCsgFromMesh,
+    createCsg2FromMesh,
     createEngine,
     createHemisphericLight,
-    createMeshFromCsg,
+    createMeshesFromCsg2,
     createPlane,
     createSceneContext,
     createSphere,
     createStandardMaterial,
-    csgIntersect,
-    csgSubtract,
-    csgUnion,
+    csg2Add,
+    csg2Intersect,
+    csg2Subtract,
+    disposeCsg2,
+    initializeCsg2Async,
     loadTexture2D,
     registerScene,
     startEngine,
 } from "babylon-lite";
-import type { EngineContext, Mesh, StandardMaterialProps } from "babylon-lite";
+import type { Csg2Solid, EngineContext, Mesh, StandardMaterialProps } from "babylon-lite";
 
 const GRASS_URL = "https://playground.babylonjs.com/textures/grass.png";
 const CRATE_URL = "https://playground.babylonjs.com/textures/crate.png";
@@ -66,6 +68,7 @@ async function main(): Promise<void> {
     const initStart = performance.now();
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
     const engine = await createEngine(canvas);
+    await initializeCsg2Async();
     const scene = createSceneContext(engine);
 
     scene.camera = createArcRotateCamera(-1.5, 1.6, 18, { x: 0, y: 0, z: 0 });
@@ -88,8 +91,6 @@ async function main(): Promise<void> {
     crateMaterial.diffuseTexture = crateTexture;
     const grassMaterial = createStandardMaterial();
     grassMaterial.diffuseTexture = grassTexture;
-    const resultMaterial = createStandardMaterial();
-    resultMaterial.diffuseTexture = crateTexture;
 
     const rows: Array<{ y: number; label: StandardMaterialProps; op: "subtract" | "intersect" | "union" }> = [
         { y: -4, label: subtractLabel, op: "subtract" },
@@ -100,20 +101,31 @@ async function main(): Promise<void> {
     for (const row of rows) {
         const box = createBox(engine, 2);
         const sphere = createSphere(engine, { diameter: 2.5, segments: 32 });
-        const boxSolid = createCsgFromMesh(box);
-        const sphereSolid = createCsgFromMesh(sphere);
-        const resultSolid = row.op === "subtract" ? csgSubtract(boxSolid, sphereSolid) : row.op === "intersect" ? csgIntersect(boxSolid, sphereSolid) : csgUnion(boxSolid, sphereSolid);
-        const result = createMeshFromCsg(engine, resultSolid, `csg-${row.op}`);
-
         box.material = crateMaterial;
         sphere.material = grassMaterial;
-        result.material = resultMaterial;
+        const boxCsg = createCsg2FromMesh(box, 0);
+        const sphereCsg = createCsg2FromMesh(sphere, 1);
+        let resultCsg: Csg2Solid | undefined;
+        let resultMeshes: Mesh[] = [];
+        try {
+            resultCsg = row.op === "subtract" ? csg2Subtract(boxCsg, sphereCsg) : row.op === "intersect" ? csg2Intersect(boxCsg, sphereCsg) : csg2Add(boxCsg, sphereCsg);
+            resultMeshes = createMeshesFromCsg2(engine, resultCsg, [crateMaterial, grassMaterial], `csg-${row.op}`);
+        } finally {
+            disposeCsg2(boxCsg);
+            disposeCsg2(sphereCsg);
+            if (resultCsg) {
+                disposeCsg2(resultCsg);
+            }
+        }
+
         setMeshPosition(box, -4, row.y);
         setMeshPosition(sphere, 0.2, row.y);
-        setMeshPosition(result, 4, row.y);
         addToScene(scene, box);
         addToScene(scene, sphere);
-        addToScene(scene, result);
+        for (const result of resultMeshes) {
+            setMeshPosition(result, 4, row.y);
+            addToScene(scene, result);
+        }
 
         const label = createPlane(engine, { width: 1.4, height: 0.7 });
         label.material = row.label;

--- a/packages/babylon-lite/package.json
+++ b/packages/babylon-lite/package.json
@@ -38,6 +38,7 @@
         "vite-plugin-dts": "^4.5.4"
     },
     "dependencies": {
-        "draco3d": "^1.5.7"
+        "draco3d": "^1.5.7",
+        "manifold-3d": "3.4.0"
     }
 }

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -59,6 +59,8 @@ export { createSphereData } from "./mesh/create-sphere.js";
 export type { SphereMeshData } from "./mesh/create-sphere.js";
 export { createCsgFromMesh, csgSubtract, csgIntersect, csgUnion, createMeshFromCsg } from "./mesh/csg.js";
 export type { CsgSolid } from "./mesh/csg.js";
+export { initializeCsg2Async, isCsg2Ready, createCsg2FromMesh, csg2Subtract, csg2Intersect, csg2Add, createMeshFromCsg2, createMeshesFromCsg2, disposeCsg2 } from "./mesh/csg2.js";
+export type { Csg2Solid } from "./mesh/csg2.js";
 
 // ─── Textures ────────────────────────────────────────────────────────
 export { createSolidTexture2D } from "./texture/solid-texture.js";

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -57,6 +57,8 @@ export {
 } from "./mesh/mesh-factories.js";
 export { createSphereData } from "./mesh/create-sphere.js";
 export type { SphereMeshData } from "./mesh/create-sphere.js";
+export { createCsgFromMesh, csgSubtract, csgIntersect, csgUnion, createMeshFromCsg } from "./mesh/csg.js";
+export type { CsgSolid } from "./mesh/csg.js";
 
 // ─── Textures ────────────────────────────────────────────────────────
 export { createSolidTexture2D } from "./texture/solid-texture.js";

--- a/packages/babylon-lite/src/mesh/csg.ts
+++ b/packages/babylon-lite/src/mesh/csg.ts
@@ -2,6 +2,7 @@ import type { EngineContext } from "../engine/engine.js";
 import type { EngineContextInternal } from "../engine/engine.js";
 import type { Mesh, MeshInternal } from "./mesh.js";
 import type { Mat4 } from "../math/types.js";
+import type { Material } from "../material/material.js";
 import { mat4Invert } from "../math/mat4.js";
 import { createMeshFromData } from "./mesh-factories.js";
 
@@ -49,12 +50,15 @@ class CsgPlane {
 class CsgPolygon {
     public plane: CsgPlane;
 
-    constructor(public vertices: CsgVertex[]) {
+    constructor(
+        public vertices: CsgVertex[],
+        public readonly materialSlot = 0
+    ) {
         this.plane = planeFromVertices(vertices[0]!, vertices[1]!, vertices[2]!);
     }
 
     clone(): CsgPolygon {
-        return new CsgPolygon(this.vertices.map(cloneVertex));
+        return new CsgPolygon(this.vertices.map(cloneVertex), this.materialSlot);
     }
 
     flip(): void {
@@ -269,10 +273,10 @@ function splitPolygon(plane: CsgPlane, polygon: CsgPolygon, coplanarFront: CsgPo
         }
     }
     if (frontVertices.length >= 3) {
-        front.push(new CsgPolygon(frontVertices));
+        front.push(new CsgPolygon(frontVertices, polygon.materialSlot));
     }
     if (backVertices.length >= 3) {
-        back.push(new CsgPolygon(backVertices));
+        back.push(new CsgPolygon(backVertices, polygon.materialSlot));
     }
 }
 
@@ -313,7 +317,7 @@ function requireCpuGeometry(mesh: Mesh): MeshInternal {
     return internal;
 }
 
-export function createCsgFromMesh(mesh: Mesh): CsgSolid {
+export function createCsgFromMesh(mesh: Mesh, materialSlot = 0): CsgSolid {
     const internal = requireCpuGeometry(mesh);
     const positions = internal._cpuPositions!;
     const normals = internal._cpuNormals!;
@@ -336,7 +340,7 @@ export function createCsgFromMesh(mesh: Mesh): CsgSolid {
         if (triangleArea2(vertices[0]!, vertices[1]!, vertices[2]!) <= EPSILON * EPSILON) {
             continue;
         }
-        polygons.push(new CsgPolygon(vertices));
+        polygons.push(new CsgPolygon(vertices, materialSlot));
     }
 
     return solidFromPolygons(polygons);
@@ -381,8 +385,7 @@ export function csgIntersect(a: CsgSolid, b: CsgSolid): CsgSolid {
     return solidFromPolygons(an.allPolygons());
 }
 
-export function createMeshFromCsg(engine: EngineContext, solid: CsgSolid, name = "csg"): Mesh {
-    const polygons = internalSolid(solid)._polygons;
+function createMeshFromPolygons(engine: EngineContext, polygons: readonly CsgPolygon[], name: string): Mesh {
     const positions: number[] = [];
     const normals: number[] = [];
     const uvs: number[] = [];
@@ -401,4 +404,32 @@ export function createMeshFromCsg(engine: EngineContext, solid: CsgSolid, name =
     }
 
     return createMeshFromData(engine as EngineContextInternal, name, new Float32Array(positions), new Float32Array(normals), new Uint32Array(indices), new Float32Array(uvs));
+}
+
+export function createMeshFromCsg(engine: EngineContext, solid: CsgSolid, name = "csg"): Mesh {
+    return createMeshFromPolygons(engine, internalSolid(solid)._polygons, name);
+}
+
+export function createMeshesFromCsg(engine: EngineContext, solid: CsgSolid, materials: readonly Material[], name = "csg"): Mesh[] {
+    const polygons = internalSolid(solid)._polygons;
+    const slots: number[] = [];
+    for (const polygon of polygons) {
+        if (!slots.includes(polygon.materialSlot)) {
+            slots.push(polygon.materialSlot);
+        }
+    }
+    slots.sort((a, b) => a - b);
+
+    const meshes: Mesh[] = [];
+    for (const slot of slots) {
+        const material = materials[slot];
+        if (!material) {
+            throw new Error(`createMeshesFromCsg("${name}") missing material for CSG material slot ${slot}.`);
+        }
+        const slotPolygons = polygons.filter((p) => p.materialSlot === slot);
+        const mesh = createMeshFromPolygons(engine, slotPolygons, `${name}_sub${slot}`);
+        mesh.material = material;
+        meshes.push(mesh);
+    }
+    return meshes;
 }

--- a/packages/babylon-lite/src/mesh/csg.ts
+++ b/packages/babylon-lite/src/mesh/csg.ts
@@ -1,0 +1,404 @@
+import type { EngineContext } from "../engine/engine.js";
+import type { EngineContextInternal } from "../engine/engine.js";
+import type { Mesh, MeshInternal } from "./mesh.js";
+import type { Mat4 } from "../math/types.js";
+import { mat4Invert } from "../math/mat4.js";
+import { createMeshFromData } from "./mesh-factories.js";
+
+declare const csgSolidBrand: unique symbol;
+
+export interface CsgSolid {
+    readonly [csgSolidBrand]: true;
+}
+
+interface CsgSolidInternal extends CsgSolid {
+    readonly _polygons: readonly CsgPolygon[];
+}
+
+interface CsgVertex {
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+    readonly nx: number;
+    readonly ny: number;
+    readonly nz: number;
+    readonly u: number;
+    readonly v: number;
+}
+
+class CsgPlane {
+    constructor(
+        public nx: number,
+        public ny: number,
+        public nz: number,
+        public w: number
+    ) {}
+
+    clone(): CsgPlane {
+        return new CsgPlane(this.nx, this.ny, this.nz, this.w);
+    }
+
+    flip(): void {
+        this.nx = -this.nx;
+        this.ny = -this.ny;
+        this.nz = -this.nz;
+        this.w = -this.w;
+    }
+}
+
+class CsgPolygon {
+    public plane: CsgPlane;
+
+    constructor(public vertices: CsgVertex[]) {
+        this.plane = planeFromVertices(vertices[0]!, vertices[1]!, vertices[2]!);
+    }
+
+    clone(): CsgPolygon {
+        return new CsgPolygon(this.vertices.map(cloneVertex));
+    }
+
+    flip(): void {
+        this.vertices.reverse();
+        this.vertices = this.vertices.map((v) => ({ ...v, nx: -v.nx, ny: -v.ny, nz: -v.nz }));
+        this.plane.flip();
+    }
+}
+
+class CsgNode {
+    private plane: CsgPlane | null = null;
+    private polygons: CsgPolygon[] = [];
+    private front: CsgNode | null = null;
+    private back: CsgNode | null = null;
+
+    constructor(polygons: CsgPolygon[] = []) {
+        if (polygons.length > 0) {
+            this.build(polygons);
+        }
+    }
+
+    clone(): CsgNode {
+        const node = new CsgNode();
+        node.plane = this.plane?.clone() ?? null;
+        node.polygons = this.polygons.map((p) => p.clone());
+        node.front = this.front?.clone() ?? null;
+        node.back = this.back?.clone() ?? null;
+        return node;
+    }
+
+    invert(): void {
+        for (const polygon of this.polygons) {
+            polygon.flip();
+        }
+        this.plane?.flip();
+        this.front?.invert();
+        this.back?.invert();
+        const temp = this.front;
+        this.front = this.back;
+        this.back = temp;
+    }
+
+    clipPolygons(polygons: CsgPolygon[]): CsgPolygon[] {
+        if (!this.plane) {
+            return polygons.map((p) => p.clone());
+        }
+        let front: CsgPolygon[] = [];
+        let back: CsgPolygon[] = [];
+        for (const polygon of polygons) {
+            splitPolygon(this.plane, polygon, front, back, front, back);
+        }
+        if (this.front) {
+            front = this.front.clipPolygons(front);
+        }
+        if (this.back) {
+            back = this.back.clipPolygons(back);
+        } else {
+            back = [];
+        }
+        return front.concat(back);
+    }
+
+    clipTo(other: CsgNode): void {
+        this.polygons = other.clipPolygons(this.polygons);
+        this.front?.clipTo(other);
+        this.back?.clipTo(other);
+    }
+
+    allPolygons(): CsgPolygon[] {
+        let polygons = this.polygons.map((p) => p.clone());
+        if (this.front) {
+            polygons = polygons.concat(this.front.allPolygons());
+        }
+        if (this.back) {
+            polygons = polygons.concat(this.back.allPolygons());
+        }
+        return polygons;
+    }
+
+    build(polygons: CsgPolygon[]): void {
+        if (polygons.length === 0) {
+            return;
+        }
+        if (!this.plane) {
+            this.plane = polygons[0]!.plane.clone();
+        }
+        const front: CsgPolygon[] = [];
+        const back: CsgPolygon[] = [];
+        for (const polygon of polygons) {
+            splitPolygon(this.plane, polygon, this.polygons, this.polygons, front, back);
+        }
+        if (front.length > 0) {
+            if (!this.front) {
+                this.front = new CsgNode();
+            }
+            this.front.build(front);
+        }
+        if (back.length > 0) {
+            if (!this.back) {
+                this.back = new CsgNode();
+            }
+            this.back.build(back);
+        }
+    }
+}
+
+const EPSILON = 1e-5;
+const COPLANAR = 0;
+const FRONT = 1;
+const BACK = 2;
+const SPANNING = 3;
+
+function cloneVertex(v: CsgVertex): CsgVertex {
+    return { x: v.x, y: v.y, z: v.z, nx: v.nx, ny: v.ny, nz: v.nz, u: v.u, v: v.v };
+}
+
+function normalize3(x: number, y: number, z: number): [number, number, number] {
+    const len = Math.hypot(x, y, z);
+    if (len <= 1e-20) {
+        return [0, 1, 0];
+    }
+    return [x / len, y / len, z / len];
+}
+
+function planeFromVertices(a: CsgVertex, b: CsgVertex, c: CsgVertex): CsgPlane {
+    const bax = b.x - a.x;
+    const bay = b.y - a.y;
+    const baz = b.z - a.z;
+    const cax = c.x - a.x;
+    const cay = c.y - a.y;
+    const caz = c.z - a.z;
+    const [nx, ny, nz] = normalize3(cay * baz - caz * bay, caz * bax - cax * baz, cax * bay - cay * bax);
+    return new CsgPlane(nx, ny, nz, nx * a.x + ny * a.y + nz * a.z);
+}
+
+function triangleArea2(a: CsgVertex, b: CsgVertex, c: CsgVertex): number {
+    const bax = b.x - a.x;
+    const bay = b.y - a.y;
+    const baz = b.z - a.z;
+    const cax = c.x - a.x;
+    const cay = c.y - a.y;
+    const caz = c.z - a.z;
+    const cx = bay * caz - baz * cay;
+    const cy = baz * cax - bax * caz;
+    const cz = bax * cay - bay * cax;
+    return cx * cx + cy * cy + cz * cz;
+}
+
+function interpolateVertex(a: CsgVertex, b: CsgVertex, t: number): CsgVertex {
+    const nx = a.nx + (b.nx - a.nx) * t;
+    const ny = a.ny + (b.ny - a.ny) * t;
+    const nz = a.nz + (b.nz - a.nz) * t;
+    const [nnx, nny, nnz] = normalize3(nx, ny, nz);
+    return {
+        x: a.x + (b.x - a.x) * t,
+        y: a.y + (b.y - a.y) * t,
+        z: a.z + (b.z - a.z) * t,
+        nx: nnx,
+        ny: nny,
+        nz: nnz,
+        u: a.u + (b.u - a.u) * t,
+        v: a.v + (b.v - a.v) * t,
+    };
+}
+
+function splitPolygon(plane: CsgPlane, polygon: CsgPolygon, coplanarFront: CsgPolygon[], coplanarBack: CsgPolygon[], front: CsgPolygon[], back: CsgPolygon[]): void {
+    let polygonType = 0;
+    const types: number[] = [];
+    for (const vertex of polygon.vertices) {
+        const t = plane.nx * vertex.x + plane.ny * vertex.y + plane.nz * vertex.z - plane.w;
+        const type = t < -EPSILON ? BACK : t > EPSILON ? FRONT : COPLANAR;
+        polygonType |= type;
+        types.push(type);
+    }
+
+    if (polygonType === COPLANAR) {
+        const facing = plane.nx * polygon.plane.nx + plane.ny * polygon.plane.ny + plane.nz * polygon.plane.nz;
+        (facing > 0 ? coplanarFront : coplanarBack).push(polygon);
+        return;
+    }
+    if (polygonType === FRONT) {
+        front.push(polygon);
+        return;
+    }
+    if (polygonType === BACK) {
+        back.push(polygon);
+        return;
+    }
+
+    const frontVertices: CsgVertex[] = [];
+    const backVertices: CsgVertex[] = [];
+    for (let i = 0; i < polygon.vertices.length; i++) {
+        const j = (i + 1) % polygon.vertices.length;
+        const vi = polygon.vertices[i]!;
+        const vj = polygon.vertices[j]!;
+        const ti = types[i]!;
+        const tj = types[j]!;
+        if (ti !== BACK) {
+            frontVertices.push(cloneVertex(vi));
+        }
+        if (ti !== FRONT) {
+            backVertices.push(cloneVertex(vi));
+        }
+        if ((ti | tj) === SPANNING) {
+            const denom = plane.nx * (vj.x - vi.x) + plane.ny * (vj.y - vi.y) + plane.nz * (vj.z - vi.z);
+            if (Math.abs(denom) > 1e-20) {
+                const t = (plane.w - plane.nx * vi.x - plane.ny * vi.y - plane.nz * vi.z) / denom;
+                const vertex = interpolateVertex(vi, vj, t);
+                frontVertices.push(vertex);
+                backVertices.push(cloneVertex(vertex));
+            }
+        }
+    }
+    if (frontVertices.length >= 3) {
+        front.push(new CsgPolygon(frontVertices));
+    }
+    if (backVertices.length >= 3) {
+        back.push(new CsgPolygon(backVertices));
+    }
+}
+
+function solidFromPolygons(polygons: CsgPolygon[]): CsgSolid {
+    return { _polygons: polygons } as unknown as CsgSolidInternal;
+}
+
+function internalSolid(solid: CsgSolid): CsgSolidInternal {
+    return solid as CsgSolidInternal;
+}
+
+function clonePolygons(solid: CsgSolid): CsgPolygon[] {
+    return internalSolid(solid)._polygons.map((p) => p.clone());
+}
+
+function transformPoint(m: Mat4, x: number, y: number, z: number): [number, number, number] {
+    return [m[0]! * x + m[4]! * y + m[8]! * z + m[12]!, m[1]! * x + m[5]! * y + m[9]! * z + m[13]!, m[2]! * x + m[6]! * y + m[10]! * z + m[14]!];
+}
+
+function transformNormal(m: Mat4, inv: Mat4 | null, x: number, y: number, z: number): [number, number, number] {
+    if (inv) {
+        return normalize3(inv[0]! * x + inv[1]! * y + inv[2]! * z, inv[4]! * x + inv[5]! * y + inv[6]! * z, inv[8]! * x + inv[9]! * y + inv[10]! * z);
+    }
+    return normalize3(m[0]! * x + m[4]! * y + m[8]! * z, m[1]! * x + m[5]! * y + m[9]! * z, m[2]! * x + m[6]! * y + m[10]! * z);
+}
+
+function requireCpuGeometry(mesh: Mesh): MeshInternal {
+    const internal = mesh as MeshInternal;
+    if (!internal._cpuPositions) {
+        throw new Error(`createCsgFromMesh("${mesh.name}") requires CPU positions. Use a Babylon Lite mesh factory or loader that retains CPU geometry.`);
+    }
+    if (!internal._cpuIndices) {
+        throw new Error(`createCsgFromMesh("${mesh.name}") requires CPU indices. Use a Babylon Lite mesh factory or loader that retains CPU geometry.`);
+    }
+    if (!internal._cpuNormals) {
+        throw new Error(`createCsgFromMesh("${mesh.name}") requires CPU normals. Use a Babylon Lite mesh factory or loader that retains CPU geometry.`);
+    }
+    return internal;
+}
+
+export function createCsgFromMesh(mesh: Mesh): CsgSolid {
+    const internal = requireCpuGeometry(mesh);
+    const positions = internal._cpuPositions!;
+    const normals = internal._cpuNormals!;
+    const indices = internal._cpuIndices!;
+    const uvs = internal._cpuUvs;
+    const world = mesh.worldMatrix;
+    const invWorld = mat4Invert(world);
+    const polygons: CsgPolygon[] = [];
+
+    for (let i = 0; i < indices.length; i += 3) {
+        const vertices: CsgVertex[] = [];
+        for (let corner = 0; corner < 3; corner++) {
+            const index = indices[i + corner]!;
+            const p = index * 3;
+            const uv = index * 2;
+            const [x, y, z] = transformPoint(world, positions[p]!, positions[p + 1]!, positions[p + 2]!);
+            const [nx, ny, nz] = transformNormal(world, invWorld, normals[p]!, normals[p + 1]!, normals[p + 2]!);
+            vertices.push({ x, y, z, nx, ny, nz, u: uvs?.[uv] ?? 0, v: uvs?.[uv + 1] ?? 0 });
+        }
+        if (triangleArea2(vertices[0]!, vertices[1]!, vertices[2]!) <= EPSILON * EPSILON) {
+            continue;
+        }
+        polygons.push(new CsgPolygon(vertices));
+    }
+
+    return solidFromPolygons(polygons);
+}
+
+export function csgUnion(a: CsgSolid, b: CsgSolid): CsgSolid {
+    const an = new CsgNode(clonePolygons(a));
+    const bn = new CsgNode(clonePolygons(b));
+    an.clipTo(bn);
+    bn.clipTo(an);
+    bn.invert();
+    bn.clipTo(an);
+    bn.invert();
+    an.build(bn.allPolygons());
+    return solidFromPolygons(an.allPolygons());
+}
+
+export function csgSubtract(a: CsgSolid, b: CsgSolid): CsgSolid {
+    const an = new CsgNode(clonePolygons(a));
+    const bn = new CsgNode(clonePolygons(b));
+    an.invert();
+    an.clipTo(bn);
+    bn.clipTo(an);
+    bn.invert();
+    bn.clipTo(an);
+    bn.invert();
+    an.build(bn.allPolygons());
+    an.invert();
+    return solidFromPolygons(an.allPolygons());
+}
+
+export function csgIntersect(a: CsgSolid, b: CsgSolid): CsgSolid {
+    const an = new CsgNode(clonePolygons(a));
+    const bn = new CsgNode(clonePolygons(b));
+    an.invert();
+    bn.clipTo(an);
+    bn.invert();
+    an.clipTo(bn);
+    bn.clipTo(an);
+    an.build(bn.allPolygons());
+    an.invert();
+    return solidFromPolygons(an.allPolygons());
+}
+
+export function createMeshFromCsg(engine: EngineContext, solid: CsgSolid, name = "csg"): Mesh {
+    const polygons = internalSolid(solid)._polygons;
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const uvs: number[] = [];
+    const indices: number[] = [];
+
+    for (const polygon of polygons) {
+        const base = positions.length / 3;
+        for (const vertex of polygon.vertices) {
+            positions.push(vertex.x, vertex.y, vertex.z);
+            normals.push(vertex.nx, vertex.ny, vertex.nz);
+            uvs.push(vertex.u, vertex.v);
+        }
+        for (let i = 2; i < polygon.vertices.length; i++) {
+            indices.push(base, base + i - 1, base + i);
+        }
+    }
+
+    return createMeshFromData(engine as EngineContextInternal, name, new Float32Array(positions), new Float32Array(normals), new Uint32Array(indices), new Float32Array(uvs));
+}

--- a/packages/babylon-lite/src/mesh/csg2.ts
+++ b/packages/babylon-lite/src/mesh/csg2.ts
@@ -1,0 +1,299 @@
+import type { Manifold, ManifoldToplevel, Mesh as ManifoldMesh } from "manifold-3d";
+import type { EngineContext } from "../engine/engine.js";
+import type { EngineContextInternal } from "../engine/engine.js";
+import type { Material } from "../material/material.js";
+import type { Mat4 } from "../math/types.js";
+import type { Mesh, MeshInternal } from "./mesh.js";
+import { mat4Invert } from "../math/mat4.js";
+import { createMeshFromData } from "./mesh-factories.js";
+
+declare const csg2SolidBrand: unique symbol;
+
+const MATERIAL_ID_RESERVE_COUNT = 65536;
+
+export interface Csg2Solid {
+    readonly [csg2SolidBrand]: true;
+}
+
+interface Csg2SolidInternal extends Csg2Solid {
+    _manifold: Manifold | null;
+    readonly _numProp: number;
+}
+
+interface Csg2Runtime {
+    readonly Manifold: typeof Manifold;
+    readonly Mesh: typeof ManifoldMesh;
+    readonly firstMaterialId: number;
+}
+
+interface GeometryBuffers {
+    readonly positions: Float32Array;
+    readonly normals: Float32Array;
+    readonly indices: Uint32Array;
+    readonly uvs: Float32Array | undefined;
+}
+
+let csg2Runtime: Csg2Runtime | null = null;
+let csg2RuntimePromise: Promise<Csg2Runtime> | null = null;
+
+export function isCsg2Ready(): boolean {
+    return csg2Runtime !== null;
+}
+
+export async function initializeCsg2Async(): Promise<void> {
+    await getRuntimeAsync();
+}
+
+async function getRuntimeAsync(): Promise<Csg2Runtime> {
+    if (csg2Runtime) {
+        return csg2Runtime;
+    }
+    if (csg2RuntimePromise) {
+        return csg2RuntimePromise;
+    }
+
+    csg2RuntimePromise = (async () => {
+        const [module, wasm] = await Promise.all([import("manifold-3d"), import("manifold-3d/manifold.wasm?url")]);
+        const manifoldModule: ManifoldToplevel = await module.default({
+            locateFile: () => new URL(wasm.default, import.meta.url).href,
+        });
+        manifoldModule.setup();
+        const runtime = {
+            Manifold: manifoldModule.Manifold,
+            Mesh: manifoldModule.Mesh,
+            firstMaterialId: manifoldModule.Manifold.reserveIDs(MATERIAL_ID_RESERVE_COUNT),
+        };
+        csg2Runtime = runtime;
+        return runtime;
+    })();
+
+    return csg2RuntimePromise;
+}
+
+function requireRuntime(): Csg2Runtime {
+    if (!csg2Runtime) {
+        throw new Error("CSG2 is not initialized. Call and await initializeCsg2Async() before using CSG2 operations.");
+    }
+    return csg2Runtime;
+}
+
+function internalSolid(solid: Csg2Solid): Csg2SolidInternal {
+    return solid as Csg2SolidInternal;
+}
+
+function requireSolidManifold(solid: Csg2Solid, operation: string): Manifold {
+    const manifold = internalSolid(solid)._manifold;
+    if (!manifold) {
+        throw new Error(`${operation} cannot use a disposed CSG2 solid.`);
+    }
+    return manifold;
+}
+
+function solidFromManifold(manifold: Manifold, numProp: number): Csg2Solid {
+    return { _manifold: manifold, _numProp: numProp } as unknown as Csg2SolidInternal;
+}
+
+function normalize3(x: number, y: number, z: number): [number, number, number] {
+    const len = Math.hypot(x, y, z);
+    if (len <= 1e-20) {
+        return [0, 1, 0];
+    }
+    return [x / len, y / len, z / len];
+}
+
+function transformPoint(m: Mat4, x: number, y: number, z: number): [number, number, number] {
+    return [m[0]! * x + m[4]! * y + m[8]! * z + m[12]!, m[1]! * x + m[5]! * y + m[9]! * z + m[13]!, m[2]! * x + m[6]! * y + m[10]! * z + m[14]!];
+}
+
+function transformNormal(m: Mat4, inv: Mat4 | null, x: number, y: number, z: number): [number, number, number] {
+    if (inv) {
+        return normalize3(inv[0]! * x + inv[1]! * y + inv[2]! * z, inv[4]! * x + inv[5]! * y + inv[6]! * z, inv[8]! * x + inv[9]! * y + inv[10]! * z);
+    }
+    return normalize3(m[0]! * x + m[4]! * y + m[8]! * z, m[1]! * x + m[5]! * y + m[9]! * z, m[2]! * x + m[6]! * y + m[10]! * z);
+}
+
+function requireCpuGeometry(mesh: Mesh): GeometryBuffers {
+    const internal = mesh as MeshInternal;
+    if (!internal._cpuPositions) {
+        throw new Error(`createCsg2FromMesh("${mesh.name}") requires CPU positions. Use a Babylon Lite mesh factory or loader that retains CPU geometry.`);
+    }
+    if (!internal._cpuIndices) {
+        throw new Error(`createCsg2FromMesh("${mesh.name}") requires CPU indices. Use a Babylon Lite mesh factory or loader that retains CPU geometry.`);
+    }
+    if (!internal._cpuNormals) {
+        throw new Error(`createCsg2FromMesh("${mesh.name}") requires CPU normals. Use a Babylon Lite mesh factory or loader that retains CPU geometry.`);
+    }
+    return {
+        positions: internal._cpuPositions,
+        normals: internal._cpuNormals,
+        indices: internal._cpuIndices,
+        uvs: internal._cpuUvs,
+    };
+}
+
+export function createCsg2FromMesh(mesh: Mesh, materialSlot = 0): Csg2Solid {
+    const runtime = requireRuntime();
+    if (materialSlot < 0 || materialSlot >= MATERIAL_ID_RESERVE_COUNT || !Number.isInteger(materialSlot)) {
+        throw new Error(`createCsg2FromMesh("${mesh.name}") materialSlot must be an integer from 0 to ${MATERIAL_ID_RESERVE_COUNT - 1}.`);
+    }
+
+    const geometry = requireCpuGeometry(mesh);
+    const vertexCount = geometry.positions.length / 3;
+    const numProp = 8;
+    const vertProperties = new Float32Array(vertexCount * numProp);
+    const world = mesh.worldMatrix;
+    const invWorld = mat4Invert(world);
+
+    for (let i = 0; i < vertexCount; i++) {
+        const p = i * 3;
+        const uv = i * 2;
+        const out = i * numProp;
+        const [x, y, z] = transformPoint(world, geometry.positions[p]!, geometry.positions[p + 1]!, geometry.positions[p + 2]!);
+        const [nx, ny, nz] = transformNormal(world, invWorld, geometry.normals[p]!, geometry.normals[p + 1]!, geometry.normals[p + 2]!);
+        vertProperties[out] = x;
+        vertProperties[out + 1] = y;
+        vertProperties[out + 2] = z;
+        vertProperties[out + 3] = nx;
+        vertProperties[out + 4] = ny;
+        vertProperties[out + 5] = nz;
+        vertProperties[out + 6] = geometry.uvs?.[uv] ?? 0;
+        vertProperties[out + 7] = geometry.uvs?.[uv + 1] ?? 0;
+    }
+
+    const triVerts = new Uint32Array(geometry.indices.length);
+    for (let i = 0; i < geometry.indices.length; i += 3) {
+        triVerts[i] = geometry.indices[i + 2]!;
+        triVerts[i + 1] = geometry.indices[i + 1]!;
+        triVerts[i + 2] = geometry.indices[i]!;
+    }
+
+    const manifoldMesh = new runtime.Mesh({
+        numProp,
+        vertProperties,
+        triVerts,
+        runIndex: new Uint32Array([0]),
+        runOriginalID: new Uint32Array([runtime.firstMaterialId + materialSlot]),
+    });
+    manifoldMesh.merge();
+
+    try {
+        return solidFromManifold(new runtime.Manifold(manifoldMesh), numProp);
+    } catch (err) {
+        throw new Error(`Error while creating CSG2 from mesh "${mesh.name}".`, { cause: err });
+    }
+}
+
+function runBooleanOperation(operation: "difference" | "intersection" | "union", a: Csg2Solid, b: Csg2Solid): Csg2Solid {
+    const runtime = requireRuntime();
+    const ai = internalSolid(a);
+    const bi = internalSolid(b);
+    if (ai._numProp !== bi._numProp) {
+        throw new Error("CSG2 operations require solids with the same vertex property layout.");
+    }
+    return solidFromManifold(runtime.Manifold[operation](requireSolidManifold(a, `csg2 ${operation}`), requireSolidManifold(b, `csg2 ${operation}`)), ai._numProp);
+}
+
+export function csg2Subtract(a: Csg2Solid, b: Csg2Solid): Csg2Solid {
+    return runBooleanOperation("difference", a, b);
+}
+
+export function csg2Intersect(a: Csg2Solid, b: Csg2Solid): Csg2Solid {
+    return runBooleanOperation("intersection", a, b);
+}
+
+export function csg2Add(a: Csg2Solid, b: Csg2Solid): Csg2Solid {
+    return runBooleanOperation("union", a, b);
+}
+
+export function disposeCsg2(solid: Csg2Solid): void {
+    const internal = internalSolid(solid);
+    if (internal._manifold) {
+        internal._manifold.delete();
+        internal._manifold = null;
+    }
+}
+
+function materialSlotFromOriginalId(runtime: Csg2Runtime, originalId: number, name: string): number {
+    const materialSlot = originalId - runtime.firstMaterialId;
+    if (materialSlot < 0 || materialSlot >= MATERIAL_ID_RESERVE_COUNT) {
+        throw new Error(`createMeshesFromCsg2("${name}") received an unknown Manifold material original ID ${originalId}.`);
+    }
+    return materialSlot;
+}
+
+function appendTriangle(
+    output: { positions: number[]; normals: number[]; uvs: number[]; indices: number[] },
+    mesh: ManifoldMesh,
+    triVerts: Uint32Array,
+    numProp: number,
+    triIndex: number
+): void {
+    const base = output.positions.length / 3;
+    for (let corner = 2; corner >= 0; corner--) {
+        const vertexIndex = triVerts[triIndex + corner]!;
+        const prop = vertexIndex * numProp;
+        output.positions.push(mesh.vertProperties[prop]!, mesh.vertProperties[prop + 1]!, mesh.vertProperties[prop + 2]!);
+        output.normals.push(mesh.vertProperties[prop + 3]!, mesh.vertProperties[prop + 4]!, mesh.vertProperties[prop + 5]!);
+        output.uvs.push(mesh.vertProperties[prop + 6]!, mesh.vertProperties[prop + 7]!);
+        output.indices.push(base + (2 - corner));
+    }
+}
+
+function createMeshFromOutput(engine: EngineContext, name: string, output: { positions: number[]; normals: number[]; uvs: number[]; indices: number[] }): Mesh {
+    if (output.positions.length === 0) {
+        throw new Error(`Unable to build CSG2 mesh "${name}". Manifold has 0 vertices for this output.`);
+    }
+    return createMeshFromData(
+        engine as EngineContextInternal,
+        name,
+        new Float32Array(output.positions),
+        new Float32Array(output.normals),
+        new Uint32Array(output.indices),
+        new Float32Array(output.uvs)
+    );
+}
+
+export function createMeshFromCsg2(engine: EngineContext, solid: Csg2Solid, name = "csg2"): Mesh {
+    requireRuntime();
+    const internal = internalSolid(solid);
+    const mesh = requireSolidManifold(solid, `createMeshFromCsg2("${name}")`).getMesh();
+    const output = { positions: [] as number[], normals: [] as number[], uvs: [] as number[], indices: [] as number[] };
+    for (let i = 0; i < mesh.triVerts.length; i += 3) {
+        appendTriangle(output, mesh, mesh.triVerts, internal._numProp, i);
+    }
+    return createMeshFromOutput(engine, name, output);
+}
+
+export function createMeshesFromCsg2(engine: EngineContext, solid: Csg2Solid, materials: readonly Material[], name = "csg2"): Mesh[] {
+    const runtime = requireRuntime();
+    const internal = internalSolid(solid);
+    const mesh = requireSolidManifold(solid, `createMeshesFromCsg2("${name}")`).getMesh();
+    const outputs: Array<{ materialSlot: number; positions: number[]; normals: number[]; uvs: number[]; indices: number[] }> = [];
+
+    for (let run = 0; run < mesh.numRun; run++) {
+        const originalId = mesh.runOriginalID[run]!;
+        const materialSlot = materialSlotFromOriginalId(runtime, originalId, name);
+        let output = outputs.find((entry) => entry.materialSlot === materialSlot);
+        if (!output) {
+            output = { materialSlot, positions: [], normals: [], uvs: [], indices: [] };
+            outputs.push(output);
+        }
+
+        const start = mesh.runIndex[run] ?? 0;
+        const end = mesh.runIndex[run + 1] ?? mesh.triVerts.length;
+        for (let i = start; i < end; i += 3) {
+            appendTriangle(output, mesh, mesh.triVerts, internal._numProp, i);
+        }
+    }
+
+    outputs.sort((a, b) => a.materialSlot - b.materialSlot);
+    return outputs.map((output) => {
+        const material = materials[output.materialSlot];
+        if (!material) {
+            throw new Error(`createMeshesFromCsg2("${name}") missing material for CSG2 material slot ${output.materialSlot}.`);
+        }
+        const result = createMeshFromOutput(engine, `${name}_sub${output.materialSlot}`, output);
+        result.material = material;
+        return result;
+    });
+}

--- a/packages/babylon-lite/src/mesh/mesh-factories.ts
+++ b/packages/babylon-lite/src/mesh/mesh-factories.ts
@@ -35,7 +35,7 @@ import type { ExtrudeShapeOptions } from "./create-extrude.js";
 
 /** Create a Mesh from raw geometry data + GPU device.
  *  No material is assigned — the caller must set mesh.material before adding to scene. */
-function createMeshFromData(
+export function createMeshFromData(
     engine: EngineContextInternal,
     name: string,
     positions: Float32Array,

--- a/packages/babylon-lite/vite.config.ts
+++ b/packages/babylon-lite/vite.config.ts
@@ -24,6 +24,7 @@ function emitPackageJson(outDir: string): Plugin {
         sideEffects: false,
         dependencies: {
           draco3d: '^1.5.7',
+          'manifold-3d': '3.4.0',
         },
       };
       writeFileSync(resolve(outDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');

--- a/philosophy.md
+++ b/philosophy.md
@@ -1,0 +1,15 @@
+# Lite Philosophy
+
+Babylon.js was built around broad usability: simple APIs, strong developer ergonomics, performance, and long-term compatibility across many use cases. Bundle size was not its primary constraint.
+
+Babylon Lite has a different center of gravity. Lite is built around **minimal size** and **maximum performance** first. Simplicity is still valuable, and we should absolutely keep APIs clean when we can, but simplicity must never come at the expense of size or performance.
+
+When tradeoffs conflict, Lite prioritizes:
+
+1. **Size** - unused features must cost zero bytes whenever possible.
+2. **Performance** - runtime paths should be direct, modern, and WebGPU-native.
+3. **Simplicity** - desirable, but subordinate to size and performance.
+
+This means Lite is not a compatibility layer and does not try to preserve every Babylon.js behavior, abstraction, or historical API shape. Familiarity with Babylon.js matters, especially for portability, but **backward compatibility is not a first-class goal** for Lite. APIs may be narrower, features may be opt-in, and implementation complexity is acceptable when it protects bundle size, runtime performance, or tree-shaking.
+
+The goal is not to make Lite dumb or difficult to use. The goal is to make it **slim, fast, and precise**: the smallest practical code that produces Babylon.js-quality results without carrying the weight of unused features or legacy constraints.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       draco3d:
         specifier: ^1.5.7
         version: 1.5.7
+      manifold-3d:
+        specifier: 3.4.0
+        version: 3.4.0(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)
     devDependencies:
       '@webgpu/types':
         specifier: ^0.1.52
@@ -154,6 +157,9 @@ packages:
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -506,6 +512,15 @@ packages:
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@gltf-transform/core@4.3.0':
+    resolution: {integrity: sha512-ZeaQfszGJ9LYwELszu45CuDQCsE26lJNNe36FVmN8xclaT6WDdCj7fwGpQXo0/l/YgAVAHX+uO7YNBW75/SRYw==}
+
+  '@gltf-transform/extensions@4.3.0':
+    resolution: {integrity: sha512-XDAjQPYVMHa/VDpSbfCBwI+/1muwRJCaXhUpLgnUzAjn0D//PgvIAcbNm1EwBl3LIWBSwjDUCn2LiMAjp+aXVw==}
+
+  '@gltf-transform/functions@4.3.0':
+    resolution: {integrity: sha512-FZggHVgt3DHOezgESBrf2vDzuD2FYQYaNT2sT/aP316SIwhuiIwby3z7rhV9joDvWqqUaPkf1UmkjlOaY9riSQ==}
+
   '@google-cloud/compute@4.12.0':
     resolution: {integrity: sha512-N3isWbxIMd02qzdlFFxHxEM+2B/vNgn9N7WMpteY2sfwN1yT9PJHcilKDLyw+uIwuQAoErNxBM+JOLq3r/Tv+Q==}
     engines: {node: '>=14.0.0'}
@@ -553,6 +568,143 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -571,6 +723,9 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@jscadui/3mf-export@0.5.0':
+    resolution: {integrity: sha512-y5vZktqCjyi7wA38zqNlLIdZUIRZoOO9vCjLzwmL4bR0hk7B/Zm1IeffzJPFe1vFc0C1IEv3hm8caDv3doRk9g==}
 
   '@jsep-plugin/assignment@1.3.0':
     resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
@@ -897,6 +1052,9 @@ packages:
 
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
+  '@types/ndarray@1.0.14':
+    resolution: {integrity: sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==}
 
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
@@ -1362,6 +1520,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -1414,6 +1576,9 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  cwise-compiler@1.1.3:
+    resolution: {integrity: sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==}
 
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
@@ -1473,6 +1638,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -1574,6 +1743,11 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  esbuild-wasm@0.27.7:
+    resolution: {integrity: sha512-1k03e2/tGz+sLz3/xzoZmUsIqtaGIvJa8k4UqUeqCUry83nHmlxQYZUUES0WBFUYilSQUf7nDUGAciIIklljSg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1732,6 +1906,9 @@ packages:
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2023,6 +2200,9 @@ packages:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
 
+  iota-array@1.0.0:
+    resolution: {integrity: sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -2030,6 +2210,9 @@ packages:
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -2198,6 +2381,9 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
+  ktx-parse@1.1.0:
+    resolution: {integrity: sha512-mKp3y+FaYgR7mXWAbyyzpa/r1zDWeaunH+INJO4fou3hb45XuNSwar+7llrRyvpMWafxSIi99RNFJ05MHedaJQ==}
+
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
@@ -2247,6 +2433,16 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  manifold-3d@3.4.0:
+    resolution: {integrity: sha512-GD5PrrJRG8YTfELvxWl00YYHdlpk+qUEkJ7weYrGUKwoUHQ7CfXSz0aWM4Obw6iIh7PnQIz6+QCMXmEX9n6Uhg==}
+    deprecated: published content was not up to date
+    hasBin: true
+    peerDependencies:
+      '@gltf-transform/core': ^4.2.0
+      '@gltf-transform/extensions': ^4.2.0
+      '@gltf-transform/functions': ^4.2.0
+      esbuild-wasm: ^0.27.3
 
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
@@ -2326,6 +2522,18 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  ndarray-lanczos@0.3.0:
+    resolution: {integrity: sha512-5kBmmG3Zvyj77qxIAC4QFLKuYdDIBJwCG+DukT6jQHNa1Ft74/hPH1z5mbQXeHBt8yvGPBGVrr3wEOdJPYYZYg==}
+
+  ndarray-ops@1.2.2:
+    resolution: {integrity: sha512-BppWAFRjMYF7N/r6Ie51q6D4fs0iiGmeXIACKY66fLpnwIui3Wc3CXiD/30mgLbDjPpSLrsqcp3Z62+IcHZsDw==}
+
+  ndarray-pixels@5.0.1:
+    resolution: {integrity: sha512-IBtrpefpqlI8SPDCGjXk4v5NV5z7r3JSuCbfuEEXaM0vrOJtNGgYUa4C3Lt5H+qWdYF4BCPVFsnXhNC7QvZwkw==}
+
+  ndarray@1.0.19:
+    resolution: {integrity: sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==}
 
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
@@ -2513,6 +2721,9 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  property-graph@4.1.0:
+    resolution: {integrity: sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -2682,6 +2893,10 @@ packages:
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2943,6 +3158,9 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  uniq@1.0.1:
+    resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
 
   unique-string@3.0.0:
     resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
@@ -3221,6 +3439,11 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -3411,6 +3634,24 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
+  '@gltf-transform/core@4.3.0':
+    dependencies:
+      property-graph: 4.1.0
+
+  '@gltf-transform/extensions@4.3.0':
+    dependencies:
+      '@gltf-transform/core': 4.3.0
+      ktx-parse: 1.1.0
+
+  '@gltf-transform/functions@4.3.0':
+    dependencies:
+      '@gltf-transform/core': 4.3.0
+      '@gltf-transform/extensions': 4.3.0
+      ktx-parse: 1.1.0
+      ndarray: 1.0.19
+      ndarray-lanczos: 0.3.0
+      ndarray-pixels: 5.0.1
+
   '@google-cloud/compute@4.12.0':
     dependencies:
       google-gax: 4.6.1
@@ -3468,6 +3709,102 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3488,6 +3825,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@jscadui/3mf-export@0.5.0': {}
 
   '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
     dependencies:
@@ -3802,6 +4141,8 @@ snapshots:
       '@types/node': 25.5.0
 
   '@types/long@4.0.2': {}
+
+  '@types/ndarray@1.0.14': {}
 
   '@types/node-fetch@2.6.13':
     dependencies:
@@ -4406,6 +4747,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@13.1.0: {}
+
   commander@2.20.3: {}
 
   compare-versions@6.1.1: {}
@@ -4465,6 +4808,10 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  cwise-compiler@1.1.3:
+    dependencies:
+      uniq: 1.0.1
+
   data-uri-to-buffer@6.0.2: {}
 
   de-indent@1.0.2: {}
@@ -4511,6 +4858,8 @@ snapshots:
       esprima: 4.0.1
 
   delayed-stream@1.0.0: {}
+
+  detect-libc@2.1.2: {}
 
   detect-node@2.1.0: {}
 
@@ -4601,6 +4950,8 @@ snapshots:
       hasown: 2.0.2
 
   es6-error@4.1.1: {}
+
+  esbuild-wasm@0.27.7: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -4808,6 +5159,8 @@ snapshots:
       picomatch: 4.0.3
 
   fecha@4.2.3: {}
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5165,12 +5518,16 @@ snapshots:
 
   ini@2.0.0: {}
 
+  iota-array@1.0.0: {}
+
   ip-address@10.1.0: {}
 
   is-arguments@1.2.0:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-buffer@1.1.6: {}
 
   is-callable@1.2.7: {}
 
@@ -5323,6 +5680,8 @@ snapshots:
 
   kolorist@1.8.0: {}
 
+  ktx-parse@1.1.0: {}
+
   kuler@2.0.0: {}
 
   latest-version@7.0.0:
@@ -5372,6 +5731,20 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  manifold-3d@3.4.0(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7):
+    dependencies:
+      '@gltf-transform/core': 4.3.0
+      '@gltf-transform/extensions': 4.3.0
+      '@gltf-transform/functions': 4.3.0
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/trace-mapping': 0.3.31
+      '@jscadui/3mf-export': 0.5.0
+      commander: 13.1.0
+      convert-source-map: 2.0.0
+      esbuild-wasm: 0.27.7
+      fflate: 0.8.2
+      magic-string: 0.30.21
 
   matcher@3.0.0:
     dependencies:
@@ -5431,6 +5804,27 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  ndarray-lanczos@0.3.0:
+    dependencies:
+      '@types/ndarray': 1.0.14
+      ndarray: 1.0.19
+
+  ndarray-ops@1.2.2:
+    dependencies:
+      cwise-compiler: 1.1.3
+
+  ndarray-pixels@5.0.1:
+    dependencies:
+      '@types/ndarray': 1.0.14
+      ndarray: 1.0.19
+      ndarray-ops: 1.2.2
+      sharp: 0.34.5
+
+  ndarray@1.0.19:
+    dependencies:
+      iota-array: 1.0.0
+      is-buffer: 1.1.6
 
   netmask@2.1.1: {}
 
@@ -5615,6 +6009,8 @@ snapshots:
       graceful-fs: 4.2.11
       retry: 0.12.0
       signal-exit: 3.0.7
+
+  property-graph@4.1.0: {}
 
   proto-list@1.2.4: {}
 
@@ -5820,6 +6216,37 @@ snapshots:
       get-intrinsic: 1.3.0
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -6104,6 +6531,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici-types@7.18.2: {}
+
+  uniq@1.0.1: {}
 
   unique-string@3.0.0:
     dependencies:

--- a/scene-config.json
+++ b/scene-config.json
@@ -662,6 +662,15 @@
         "tags": ["csg", "procedural", "std"]
     },
     {
+        "id": 91,
+        "slug": "scene91-csg2",
+        "name": "Scene 91 — CSG2 Operations",
+        "maxMad": 1,
+        "maxRawKB": 78,
+        "description": "Box and sphere CSG2 rows showing subtract, intersect, and add/union with textured StandardMaterial meshes and canvas texture labels.",
+        "tags": ["csg", "procedural", "std"]
+    },
+    {
         "id": 110,
         "slug": "scene110-rtt-override",
         "name": "Scene 110 — RTT with material override",

--- a/scene-config.json
+++ b/scene-config.json
@@ -653,6 +653,15 @@
         "tags": ["nme", "procedural", "loop", "storage"]
     },
     {
+        "id": 90,
+        "slug": "scene90-csg",
+        "name": "Scene 90 — CSG Operations",
+        "maxMad": 1,
+        "maxRawKB": 78,
+        "description": "Box and sphere constructive solid geometry rows showing subtract, intersect, and union with textured StandardMaterial meshes and SVG texture labels.",
+        "tags": ["csg", "procedural", "std"]
+    },
+    {
         "id": 110,
         "slug": "scene110-rtt-override",
         "name": "Scene 110 — RTT with material override",

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -659,12 +659,12 @@ const ALL_SCENES = sceneConfig.map((s) => `scene${s.id}`);
 const SCENES = process.env.BUNDLE_SCENES ? process.env.BUNDLE_SCENES.split(",") : ALL_SCENES;
 const BJS_SCENES = process.env.SKIP_BJS ? [] : SCENES.map((s) => `bjs-${s}`);
 
-function getAllJsFiles(dir: string): string[] {
+function getAllBundleFiles(dir: string): string[] {
     const results: string[] = [];
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const fullPath = join(dir, entry.name);
-        if (entry.isDirectory()) results.push(...getAllJsFiles(fullPath));
-        else if (entry.name.endsWith(".js")) results.push(fullPath);
+        if (entry.isDirectory()) results.push(...getAllBundleFiles(fullPath));
+        else results.push(fullPath);
     }
     return results;
 }
@@ -762,6 +762,7 @@ export async function buildBundleScenes(): Promise<void> {
         const buildResult = await build({
             root: labDir,
             configFile: false,
+            base: "./",
             publicDir: false,
             logLevel: "warn",
             plugins: isBjs ? [bjsSideEffectsFalsePlugin()] : [wgslMinifyPlugin(), terserPropertyManglePlugin(), minimalVitePreloadPlugin()],
@@ -785,7 +786,7 @@ export async function buildBundleScenes(): Promise<void> {
                     input: { [scene]: resolve(labDir, isBjs ? `src/bjs/${scene.slice(4)}.ts` : `src/lite/${scene}.ts`) },
                     // Exclude third-party WASM runtimes from Lite bundles so the
                     // bundle-size metric reflects only first-party Lite engine code.
-                    ...(!isBjs && { external: ["@babylonjs/havok"] }),
+                    ...(!isBjs && { external: ["@babylonjs/havok", "manifold-3d"] }),
                     output: {
                         format: "es",
                         entryFileNames: "[name].js",
@@ -809,9 +810,9 @@ export async function buildBundleScenes(): Promise<void> {
         // Atomically replace this scene's files in outDir:
         // 1. Write all new files (overwriting existing ones).
         // 2. Remove any stale old chunk files that didn't appear in the new build.
-        const jsFiles = getAllJsFiles(sceneOutDir);
+        const bundleFiles = getAllBundleFiles(sceneOutDir);
         const newNames = new Set<string>();
-        for (const f of jsFiles) {
+        for (const f of bundleFiles) {
             const name = f.substring(sceneOutDir.length + 1).replace(/\\/g, "/");
             newNames.add(name);
             const dest = resolve(outDir, name);
@@ -881,6 +882,19 @@ export async function buildBundleScenes(): Promise<void> {
         }
     } catch {
         /* @babylonjs/havok not installed — skip vendor copy */
+    }
+    try {
+        const _require = createRequire(resolve(labDir, "package.json"));
+        const manifoldJsSrc = _require.resolve("manifold-3d/manifold.js");
+        const manifoldDir = resolve(vendorDir, "manifold-3d");
+        mkdirSync(manifoldDir, { recursive: true });
+        writeFileSync(resolve(manifoldDir, "manifold.js"), readFileSync(manifoldJsSrc));
+        const manifoldWasmSrc = resolve(dirname(manifoldJsSrc), "manifold.wasm");
+        if (existsSync(manifoldWasmSrc)) {
+            writeFileSync(resolve(manifoldDir, "manifold.wasm"), readFileSync(manifoldWasmSrc));
+        }
+    } catch {
+        /* manifold-3d not installed — skip vendor copy */
     }
     // ── 2. Measure real runtime sizes via headless browser ───────────────
     if (process.env.SKIP_MEASURE) {

--- a/tests/parity/scenes/scene90-csg.spec.ts
+++ b/tests/parity/scenes/scene90-csg.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import * as path from "path";
+import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
+
+const sceneConfig = getSceneConfig(90);
+const REFERENCE_DIR = path.resolve(__dirname, "../../../reference/scene90-csg");
+const GOLDEN_REF = path.join(REFERENCE_DIR, "babylon-ref-golden.png");
+
+test.skip(!!sceneConfig.skipParity, "Scene 90 skipped via skipParity in scene-config.json");
+
+test("Scene 90 — CSG operations match Babylon.js reference", async ({ page }, testInfo) => {
+    const browser = page.context().browser()!;
+    await captureGolden(browser, { sceneId: 90, timeout: 90_000, settleMs: 1000 });
+
+    await page.goto("/scene90.html");
+    await page.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 60_000 });
+    await page.waitForTimeout(500);
+
+    const screenshotPath = path.join(REFERENCE_DIR, "test-actual.png");
+    await page.locator("canvas").screenshot({ path: screenshotPath });
+
+    const full = compareImages(screenshotPath, GOLDEN_REF);
+    await attachCompareArtifacts(testInfo, screenshotPath, GOLDEN_REF, REFERENCE_DIR);
+    console.log(`Full image MAD=${full.mad.toFixed(3)}`);
+
+    expect(full.mad, `Full image MAD should be ≤ ${sceneConfig.maxMad}`).toBeLessThanOrEqual(sceneConfig.maxMad);
+});

--- a/tests/parity/scenes/scene91-csg2.spec.ts
+++ b/tests/parity/scenes/scene91-csg2.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import * as path from "path";
+import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
+
+const sceneConfig = getSceneConfig(91);
+const REFERENCE_DIR = path.resolve(__dirname, "../../../reference/scene91-csg2");
+const GOLDEN_REF = path.join(REFERENCE_DIR, "babylon-ref-golden.png");
+
+test.skip(!!sceneConfig.skipParity, "Scene 91 skipped via skipParity in scene-config.json");
+
+test("Scene 91 — CSG2 operations match Babylon.js reference", async ({ page }, testInfo) => {
+    const browser = page.context().browser()!;
+    await captureGolden(browser, { sceneId: 91, timeout: 90_000, settleMs: 1000 });
+
+    await page.goto("/scene91.html");
+    await page.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 60_000 });
+    await page.waitForTimeout(500);
+
+    const screenshotPath = path.join(REFERENCE_DIR, "test-actual.png");
+    await page.locator("canvas").screenshot({ path: screenshotPath });
+
+    const full = compareImages(screenshotPath, GOLDEN_REF);
+    await attachCompareArtifacts(testInfo, screenshotPath, GOLDEN_REF, REFERENCE_DIR);
+    console.log(`Full image MAD=${full.mad.toFixed(3)}`);
+
+    expect(full.mad, `Full image MAD should be ≤ ${sceneConfig.maxMad}`).toBeLessThanOrEqual(sceneConfig.maxMad);
+});


### PR DESCRIPTION
## Summary
- add Scene90 CSG operations and Scene91 CSG2 playground coverage
- switch Scene91 Lite to Manifold-backed CSG2 with material-slot preservation
- update bundle handling for Scene91's Manifold runtime and refreshed bundle manifest entries

## Validation
- pnpm run lint
- pnpm test
- git diff -- tests/bundle-size.test.ts
- git diff -- reference