### PR TITLE
Add static lab site CI deployment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,6 +131,17 @@ stages:
                       testResultsFiles: "test-results/bundle-ceiling-junit.xml"
                       testRunTitle: "Bundle Size"
 
+                - script: pnpm build:lab-site
+                  displayName: "Build static lab site"
+                  env:
+                      LAB_BASE_PATH: "/lite/$(Build.BuildNumber)/lab/"
+
+                - template: config/templates/upload-static-site.yml
+                  parameters:
+                      siteDir: $(System.DefaultWorkingDirectory)/lab/dist
+                      deployPath: lite/$(Build.BuildNumber)/lab
+                      siteName: "Lab"
+
           # ──────────────────────────────────────────────────────────────
           # Job 3: Performance Regression
           # ──────────────────────────────────────────────────────────────

--- a/config/templates/upload-static-site.yml
+++ b/config/templates/upload-static-site.yml
@@ -1,0 +1,60 @@
+# Reusable step template: upload a static site directory and post its link to the PR
+#
+# Parameters:
+#   siteDir     - path to the static site folder to zip and upload
+#   deployPath  - storage path where the site should be served
+#   siteName    - label used in display names and the PR comment
+#
+# Required pipeline variables:
+#   BabylonJS-Deployment variable group: DEPLOYMENT_SERVER, DEPLOY_TOKEN
+#   Report upload settings: DEPLOY_ENDPOINT_UPLOAD, STORAGE_ACCOUNT, SERVE_DOMAIN
+# Required service connection:
+#   BabylonBotPAT - GitHub PAT service connection for PR comments
+
+parameters:
+    - name: siteDir
+      type: string
+    - name: deployPath
+      type: string
+    - name: siteName
+      type: string
+
+steps:
+    - script: |
+          SITE_DIR="${{ parameters.siteDir }}"
+
+          if ! test -d "$SITE_DIR"; then
+            echo "No static site directory found at $SITE_DIR"
+            exit 1
+          fi
+
+          cd "$SITE_DIR"
+          zip -r $(Build.SourcesDirectory)/_static_site.zip *
+          cd $(Build.SourcesDirectory)
+
+          curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+            -H "Content-Type: multipart/form-data" \
+            -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
+            -F "path=${{ parameters.deployPath }}" \
+            -F "storageAccount=$(STORAGE_ACCOUNT)" \
+            -F "zip=@_static_site.zip"
+
+          rm -f _static_site.zip
+      condition: succeeded()
+      continueOnError: true
+      displayName: "Upload ${{ parameters.siteName }} static site"
+
+    - task: GitHubComment@0
+      condition: succeeded()
+      continueOnError: true
+      displayName: "Post ${{ parameters.siteName }} site link to PR"
+      inputs:
+          gitHubConnection: "BabylonBotPAT"
+          repositoryName: "$(Build.Repository.Name)"
+          id: "$(System.PullRequest.PullRequestNumber)"
+          comment: |
+              ### ${{ parameters.siteName }} - Static Site
+
+              [Open deployed site]($(SERVE_DOMAIN)/${{ parameters.deployPath }}/index.html)
+
+              <sub>Build $(Build.BuildNumber) - $(Build.SourceBranchName) @ $(Build.SourceVersion)</sub>

--- a/lab/vite.config.ts
+++ b/lab/vite.config.ts
@@ -2,6 +2,29 @@ import { defineConfig, type Plugin } from "vite";
 import { resolve } from "path";
 import { createReadStream, existsSync, readdirSync, readFileSync, statSync } from "fs";
 
+function hasBuildableRootScripts(htmlFile: string): boolean {
+    const html = readFileSync(resolve(__dirname, htmlFile), "utf-8");
+    for (const match of html.matchAll(/<script\b[^>]*\bsrc=["']\/([^"']+)["']/g)) {
+        const scriptPath = match[1];
+        if (!scriptPath) {
+            continue;
+        }
+        if (!existsSync(resolve(__dirname, scriptPath)) && !existsSync(resolve(__dirname, "public", scriptPath))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function getHtmlInputs(): Record<string, string> {
+    return Object.fromEntries([
+        ["main", resolve(__dirname, "index.html")],
+        ...readdirSync(__dirname)
+            .filter((f) => f.endsWith(".html") && f !== "index.html" && hasBuildableRootScripts(f))
+            .map((f) => [f.replace(".html", ""), resolve(__dirname, f)]),
+    ]);
+}
+
 /** Serve reference images from the repo-root reference/ directory */
 function serveReferenceImages(): Plugin {
     return {
@@ -94,12 +117,7 @@ export default defineConfig({
     },
     build: {
         rollupOptions: {
-            input: Object.fromEntries([
-                ["main", resolve(__dirname, "index.html")],
-                ...readdirSync(__dirname)
-                    .filter((f) => f.endsWith(".html") && f !== "index.html")
-                    .map((f) => [f.replace(".html", ""), resolve(__dirname, f)]),
-            ]),
+            input: getHtmlInputs(),
         },
     },
 });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "dev:lab": "tsx scripts/build-bundle-scenes.ts && pnpm --filter @babylon-lite/lab dev",
         "build": "pnpm --filter babylon-lite build",
         "build:prod": "pnpm --filter babylon-lite build:prod",
+        "build:lab-site": "tsx scripts/build-lab-site.ts",
         "build:bundle-scenes": "tsx scripts/build-bundle-scenes.ts",
         "test": "pnpm build:bundle-scenes && pnpm test:parity",
         "test:watch": "vitest",

--- a/scripts/build-lab-site.ts
+++ b/scripts/build-lab-site.ts
@@ -1,0 +1,113 @@
+/**
+ * Build Lab Site - creates a deployable static version of the lab website.
+ *
+ * The dev server serves a few repo-root files (/scene-config.json and
+ * /reference/*) through middleware. This script runs the normal Vite build,
+ * copies those files into lab/dist, and optionally rewrites root-relative URLs
+ * for deployment under a build-specific subpath.
+ *
+ * Env: LAB_BASE_PATH - public base path for the deployed site, e.g.
+ *      /lite/$(Build.BuildNumber)/lab/
+ */
+import { spawnSync } from "child_process";
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { extname, resolve } from "path";
+
+const ROOT = resolve(__dirname, "..");
+const LAB_DIR = resolve(ROOT, "lab");
+const DIST_DIR = resolve(LAB_DIR, "dist");
+const SCENE_CONFIG = resolve(ROOT, "scene-config.json");
+const REFERENCE_DIR = resolve(ROOT, "reference");
+
+const ROOT_RELATIVE_PREFIXES = [
+    "HavokPhysics.wasm",
+    "babylon-ref-scene",
+    "brdf-lut.png",
+    "bundle",
+    "bundle-baseline",
+    "bundle-baseline-scene",
+    "bundle-bjs-scene",
+    "bundle-scene",
+    "draco_decoder.js",
+    "draco_decoder.wasm",
+    "lab-api",
+    "loader.js",
+    "models",
+    "perf-manifest.json",
+    "perf-regression-manifest.json",
+    "reference",
+    "scene",
+    "scene-config.json",
+    "textures",
+    "thumbnails",
+    "vendor",
+];
+
+function normalizeBasePath(value: string | undefined): string {
+    if (!value) {
+        return "/";
+    }
+    const withLeading = value.startsWith("/") ? value : `/${value}`;
+    return withLeading.endsWith("/") ? withLeading : `${withLeading}/`;
+}
+
+function runViteBuild(basePath: string): void {
+    const result = spawnSync("pnpm", ["--filter", "@babylon-lite/lab", "exec", "vite", "build", "--base", basePath], {
+        cwd: ROOT,
+        stdio: "inherit",
+        env: process.env,
+    });
+    if (result.status !== 0) {
+        process.exit(result.status ?? 1);
+    }
+}
+
+function copyStaticRuntimeData(): void {
+    mkdirSync(DIST_DIR, { recursive: true });
+    cpSync(SCENE_CONFIG, resolve(DIST_DIR, "scene-config.json"));
+    if (existsSync(REFERENCE_DIR)) {
+        const target = resolve(DIST_DIR, "reference");
+        rmSync(target, { recursive: true, force: true });
+        cpSync(REFERENCE_DIR, target, { recursive: true });
+    }
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function rewriteRootRelativeUrls(text: string, basePath: string): string {
+    const prefixes = ROOT_RELATIVE_PREFIXES.map(escapeRegExp).join("|");
+    return text.replace(new RegExp(`(["'=(:\\s])/((${prefixes})(?=[/"'.?#)\\s]|[0-9A-Za-z_-]))`, "g"), `$1${basePath}$2`);
+}
+
+function rewriteFilesForBasePath(dir: string, basePath: string): void {
+    for (const entry of readdirSync(dir)) {
+        const path = resolve(dir, entry);
+        const stat = statSync(path);
+        if (stat.isDirectory()) {
+            rewriteFilesForBasePath(path, basePath);
+            continue;
+        }
+
+        if (![".css", ".html", ".js", ".json"].includes(extname(path))) {
+            continue;
+        }
+
+        const before = readFileSync(path, "utf-8");
+        const after = rewriteRootRelativeUrls(before, basePath);
+        if (after !== before) {
+            writeFileSync(path, after);
+        }
+    }
+}
+
+const basePath = normalizeBasePath(process.env.LAB_BASE_PATH);
+runViteBuild(basePath);
+copyStaticRuntimeData();
+
+if (basePath !== "/") {
+    rewriteFilesForBasePath(DIST_DIR, basePath);
+}
+
+console.log(`Lab static site built to ${DIST_DIR}`);


### PR DESCRIPTION
## Summary

This adds a deployable static build for the lab website and wires it into the Bundle Size CI job.

- Adds `pnpm build:lab-site`, which runs the lab Vite build, copies static runtime data (`scene-config.json` and `reference/`) into `lab/dist`, and rewrites root-relative URLs for deployment under `/lite/$(Build.BuildNumber)/lab/`.
- Adds a reusable `upload-static-site.yml` pipeline template that zips a static directory, uploads it through the existing deployment endpoint, and comments the deployed URL on the PR.
- Updates the Bundle Size job to build and upload the lab site to `lite/$(Build.BuildNumber)/lab`.
- Filters lab Vite HTML inputs so static builds skip generated pages whose root-relative script files were not produced.

## Validation

- `LAB_BASE_PATH=/lite/test-build/lab/ pnpm build:lab-site` passed.
- Static output contains `lab/dist/index.html`, `lab/dist/scene-config.json`, and `lab/dist/reference`.
- Checked generated `lab/dist` files for unreplaced root-relative lab asset paths.
- `pnpm lint` passed.
- `pnpm exec prettier --check scripts/build-lab-site.ts config/templates/upload-static-site.yml` passed.
- `git diff -- tests/bundle-size.test.ts reference` is empty.

`pnpm test` ran through `pnpm build:bundle-scenes` and the bundle-size checks, but `pnpm test:parity` failed in existing visual parity scenes unrelated to this CI/static-site change:

- Scene 22 PBR Shadows: MAD `0.7517`, threshold `0.07`
- Scene 25 KTX Texture: MAD `7.9407`, threshold `0.5`
- Scene 4 Shadows: MAD `1.1557`, threshold `0.08`