### PR TITLE
Add bundle size delta PR comment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,6 +131,21 @@ stages:
                       testResultsFiles: "test-results/bundle-ceiling-junit.xml"
                       testRunTitle: "Bundle Size"
 
+                # Generate bundle-size delta comment for PR
+                - script: npx tsx scripts/report-bundle-size-deltas.ts
+                  condition: always()
+                  displayName: "Generate bundle-size delta comment"
+
+                - task: GitHubComment@0
+                  condition: and(always(), eq(variables['POST_BUNDLE_COMMENT'], 'true'))
+                  continueOnError: true
+                  displayName: "Post bundle-size changes to PR"
+                  inputs:
+                      gitHubConnection: "BabylonBotPAT"
+                      repositoryName: "$(Build.Repository.Name)"
+                      id: "$(System.PullRequest.PullRequestNumber)"
+                      comment: "$(BUNDLE_COMMENT_BODY)"
+
                 - script: pnpm build:lab-site
                   displayName: "Build static lab site"
                   env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,6 +107,9 @@ stages:
                 - script: pnpm exec playwright install chromium
                   displayName: "Install Playwright browsers"
 
+                - script: git fetch origin master:refs/remotes/origin/master --depth=1
+                  displayName: "Fetch master bundle baseline"
+
                 - script: pnpm build:bundle-scenes
                   displayName: "Build bundle scenes"
                   env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,7 @@ stages:
                 vmImage: "ubuntu-latest"
             steps:
                 - checkout: self
+                  persistCredentials: true
 
                 - task: UseNode@1
                   inputs:
@@ -107,7 +108,10 @@ stages:
                 - script: pnpm exec playwright install chromium
                   displayName: "Install Playwright browsers"
 
-                - script: git fetch origin master:refs/remotes/origin/master --depth=1
+                - script: |
+                      TARGET_BRANCH="${SYSTEM_PULLREQUEST_TARGETBRANCH:-refs/heads/master}"
+                      TARGET_BRANCH="${TARGET_BRANCH#refs/heads/}"
+                      git fetch origin "$TARGET_BRANCH:refs/remotes/origin/$TARGET_BRANCH" --depth=1
                   displayName: "Fetch master bundle baseline"
 
                 - script: pnpm build:bundle-scenes

--- a/lab/src/lite/scene1.ts
+++ b/lab/src/lite/scene1.ts
@@ -1,4 +1,15 @@
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl, registerScene } from "babylon-lite";
+import {
+    addToScene,
+    startEngine,
+    createEngine,
+    createSceneContext,
+    createDefaultCamera,
+    loadEnvironment,
+    loadGltf,
+    createHemisphericLight,
+    attachControl,
+    registerScene,
+} from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();

--- a/lab/src/lite/scene1.ts
+++ b/lab/src/lite/scene1.ts
@@ -1,8 +1,29 @@
-import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl, registerScene } from "babylon-lite";
+import {
+    addToScene,
+    startEngine,
+    createEngine,
+    createSceneContext,
+    createDefaultCamera,
+    loadEnvironment,
+    loadGltf,
+    createHemisphericLight,
+    attachControl,
+    registerScene,
+} from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    // DRAFT-ONLY BUNDLE-SIZE CHECK: intentionally unnecessary scene code.
+    // Remove this before marking the PR ready; it only verifies the CI PR comment.
+    canvas.dataset.bundleSizeDraftProbe =
+        "scene1-draft-bundle-size-comment-check:" +
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" +
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" +
+        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);

--- a/lab/src/lite/scene1.ts
+++ b/lab/src/lite/scene1.ts
@@ -1,29 +1,8 @@
-import {
-    addToScene,
-    startEngine,
-    createEngine,
-    createSceneContext,
-    createDefaultCamera,
-    loadEnvironment,
-    loadGltf,
-    createHemisphericLight,
-    attachControl,
-    registerScene,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createDefaultCamera, loadEnvironment, loadGltf, createHemisphericLight, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
-
-    // DRAFT-ONLY BUNDLE-SIZE CHECK: intentionally unnecessary scene code.
-    // Remove this before marking the PR ready; it only verifies the CI PR comment.
-    canvas.dataset.bundleSizeDraftProbe =
-        "scene1-draft-bundle-size-comment-check:" +
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
-        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" +
-        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" +
-        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);

--- a/lab/src/lite/scene2.ts
+++ b/lab/src/lite/scene2.ts
@@ -1,10 +1,31 @@
 // Scene 2: Sphere + DirectionalLight — matches Babylon #20OAV9#1
 
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createDirectionalLight, createSphere, createStandardMaterial, attachControl, registerScene } from "babylon-lite";
+import {
+    addToScene,
+    startEngine,
+    createEngine,
+    createSceneContext,
+    createArcRotateCamera,
+    createDirectionalLight,
+    createSphere,
+    createStandardMaterial,
+    attachControl,
+    registerScene,
+} from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    // DRAFT-ONLY BUNDLE-SIZE CHECK: intentionally unnecessary scene code.
+    // Remove this before marking the PR ready; it only verifies the CI PR comment.
+    canvas.dataset.bundleSizeDraftProbe =
+        "scene2-draft-bundle-size-comment-check:" +
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+        "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg" +
+        "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh" +
+        "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii" +
+        "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj";
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);
 

--- a/lab/src/lite/scene2.ts
+++ b/lab/src/lite/scene2.ts
@@ -1,6 +1,17 @@
 // Scene 2: Sphere + DirectionalLight — matches Babylon #20OAV9#1
 
-import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createDirectionalLight, createSphere, createStandardMaterial, attachControl, registerScene } from "babylon-lite";
+import {
+    addToScene,
+    startEngine,
+    createEngine,
+    createSceneContext,
+    createArcRotateCamera,
+    createDirectionalLight,
+    createSphere,
+    createStandardMaterial,
+    attachControl,
+    registerScene,
+} from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();

--- a/lab/src/lite/scene2.ts
+++ b/lab/src/lite/scene2.ts
@@ -1,31 +1,10 @@
 // Scene 2: Sphere + DirectionalLight — matches Babylon #20OAV9#1
 
-import {
-    addToScene,
-    startEngine,
-    createEngine,
-    createSceneContext,
-    createArcRotateCamera,
-    createDirectionalLight,
-    createSphere,
-    createStandardMaterial,
-    attachControl,
-    registerScene,
-} from "babylon-lite";
+import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, createDirectionalLight, createSphere, createStandardMaterial, attachControl, registerScene } from "babylon-lite";
 
 async function main(): Promise<void> {
     const __initStart = performance.now();
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
-
-    // DRAFT-ONLY BUNDLE-SIZE CHECK: intentionally unnecessary scene code.
-    // Remove this before marking the PR ready; it only verifies the CI PR comment.
-    canvas.dataset.bundleSizeDraftProbe =
-        "scene2-draft-bundle-size-comment-check:" +
-        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
-        "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg" +
-        "hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh" +
-        "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii" +
-        "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj";
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);
 

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -1,0 +1,163 @@
+/// <reference types="node" />
+
+/**
+ * Compare current bundle sizes vs master baseline and generate a GitHub PR comment.
+ *
+ * Reads:
+ *  - lab/public/bundle/manifest.json (current)
+ *  - lab/public/bundle/master-manifest.json (baseline)
+ *  - scene-config.json (scene metadata)
+ *
+ * Outputs:
+ *  - Markdown comment listing all changes rounded to nearest whole KB
+ *  - Azure DevOps variables for conditional GitHubComment@0 posting
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+
+interface ManifestEntry {
+    rawKB?: number;
+    gzipKB?: number;
+}
+
+type Manifest = Record<string, ManifestEntry>;
+
+interface SceneConfig {
+    id: number;
+    slug: string;
+    name: string;
+}
+
+interface BundleDelta {
+    key: string;
+    name: string;
+    currentKB: number;
+    masterKB: number;
+    deltaKB: number;
+}
+
+export function loadManifest(path: string): Manifest | null {
+    if (!existsSync(path)) {
+        return null;
+    }
+    return JSON.parse(readFileSync(path, "utf-8")) as Manifest;
+}
+
+export function loadSceneConfig(path: string): SceneConfig[] {
+    return JSON.parse(readFileSync(path, "utf-8")) as SceneConfig[];
+}
+
+export function roundToWholeKB(kb: number): number {
+    return Math.round(kb);
+}
+
+export function escapeAzureVariableValue(value: string): string {
+    return value.replace(/%/g, "%AZP25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+export function computeDeltas(current: Manifest, master: Manifest, sceneConfigs: SceneConfig[]): BundleDelta[] {
+    const sceneNameMap = new Map(sceneConfigs.map((s) => [`scene${s.id}`, s.name]));
+    const allKeys = new Set([...Object.keys(current), ...Object.keys(master)]);
+    const deltas: BundleDelta[] = [];
+
+    for (const key of allKeys) {
+        const currentEntry = current[key];
+        const masterEntry = master[key];
+
+        if (currentEntry?.rawKB == null || masterEntry?.rawKB == null) {
+            continue;
+        }
+
+        const currentKB = roundToWholeKB(currentEntry.rawKB);
+        const masterKB = roundToWholeKB(masterEntry.rawKB);
+        const deltaKB = currentKB - masterKB;
+
+        if (deltaKB !== 0) {
+            const name = sceneNameMap.get(key) ?? key;
+            deltas.push({ key, name, currentKB, masterKB, deltaKB });
+        }
+    }
+
+    return deltas.sort((a, b) => Math.abs(b.deltaKB) - Math.abs(a.deltaKB));
+}
+
+export function formatComment(deltas: BundleDelta[]): string {
+    if (deltas.length === 0) {
+        return "**Bundle Size**: No changes detected.";
+    }
+
+    const lines = ["## Bundle Size Changes", ""];
+    const increases = deltas.filter((d) => d.deltaKB > 0);
+    const decreases = deltas.filter((d) => d.deltaKB < 0);
+
+    if (increases.length > 0) {
+        lines.push("### Increases");
+        lines.push("");
+        lines.push("| Package | Current | Master | Change |");
+        lines.push("|---------|---------|--------|--------|");
+        for (const { name, key, currentKB, masterKB, deltaKB } of increases) {
+            lines.push(`| ${name}<br/>\`${key}\` | ${currentKB} KB | ${masterKB} KB | **+${deltaKB} KB** |`);
+        }
+        lines.push("");
+    }
+
+    if (decreases.length > 0) {
+        lines.push("### Decreases");
+        lines.push("");
+        lines.push("| Package | Current | Master | Change |");
+        lines.push("|---------|---------|--------|--------|");
+        for (const { name, key, currentKB, masterKB, deltaKB } of decreases) {
+            lines.push(`| ${name}<br/>\`${key}\` | ${currentKB} KB | ${masterKB} KB | ${deltaKB} KB |`);
+        }
+        lines.push("");
+    }
+
+    lines.push("*Sizes rounded to nearest KB. Run `pnpm build:bundle-scenes` locally to verify.*");
+
+    return lines.join("\n");
+}
+
+function main(): void {
+    const rootDir = resolve(__dirname, "..");
+    const currentPath = process.env.BUNDLE_SIZE_CURRENT_MANIFEST ?? resolve(rootDir, "lab/public/bundle/manifest.json");
+    const masterPath = process.env.BUNDLE_SIZE_MASTER_MANIFEST ?? resolve(rootDir, "lab/public/bundle/master-manifest.json");
+    const sceneConfigPath = process.env.BUNDLE_SIZE_SCENE_CONFIG ?? resolve(rootDir, "scene-config.json");
+    const outputPath = process.env.BUNDLE_SIZE_COMMENT_PATH ?? resolve(rootDir, "test-results/bundle-size-comment.md");
+
+    const current = loadManifest(currentPath);
+    const master = loadManifest(masterPath);
+
+    if (!current) {
+        console.error(`Error: Current manifest not found at ${currentPath}`);
+        process.exit(1);
+    }
+
+    if (!master) {
+        console.log("Master manifest not found; skipping delta report.");
+        console.log("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
+        return;
+    }
+
+    const sceneConfigs = loadSceneConfig(sceneConfigPath);
+    const deltas = computeDeltas(current, master, sceneConfigs);
+    const comment = formatComment(deltas);
+
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, comment, "utf-8");
+    console.log(`Bundle size comment written to ${outputPath}`);
+    console.log("");
+    console.log(comment);
+
+    if (deltas.length > 0) {
+        console.log("");
+        console.log("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
+        const escapedComment = escapeAzureVariableValue(comment);
+        console.log(`##vso[task.setvariable variable=BUNDLE_COMMENT_BODY]${escapedComment}`);
+    } else {
+        console.log("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
+    }
+}
+
+if (require.main === module) {
+    main();
+}

--- a/tests/unit/report-bundle-size-deltas.test.ts
+++ b/tests/unit/report-bundle-size-deltas.test.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from "child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const ROOT = resolve(__dirname, "../..");
+const SCRIPT = resolve(ROOT, "scripts/report-bundle-size-deltas.ts");
+
+const tempDirs: string[] = [];
+
+interface RunReporterOptions {
+    current?: unknown;
+    master?: unknown;
+    scenes?: unknown;
+}
+
+function runReporter(options: RunReporterOptions): { stdout: string; comment: string | null } {
+    const dir = mkdtempSync(resolve(tmpdir(), "bundle-size-deltas-"));
+    tempDirs.push(dir);
+
+    const currentPath = resolve(dir, "manifest.json");
+    const masterPath = resolve(dir, "master-manifest.json");
+    const sceneConfigPath = resolve(dir, "scene-config.json");
+    const outputPath = resolve(dir, "comment.md");
+
+    if (options.current !== undefined) {
+        writeFileSync(currentPath, JSON.stringify(options.current), "utf-8");
+    }
+    if (options.master !== undefined) {
+        writeFileSync(masterPath, JSON.stringify(options.master), "utf-8");
+    }
+    writeFileSync(sceneConfigPath, JSON.stringify(options.scenes ?? []), "utf-8");
+
+    const stdout = execFileSync("npx", ["tsx", SCRIPT], {
+        cwd: ROOT,
+        encoding: "utf-8",
+        env: {
+            ...process.env,
+            BUNDLE_SIZE_CURRENT_MANIFEST: currentPath,
+            BUNDLE_SIZE_MASTER_MANIFEST: masterPath,
+            BUNDLE_SIZE_SCENE_CONFIG: sceneConfigPath,
+            BUNDLE_SIZE_COMMENT_PATH: outputPath,
+        },
+    });
+
+    return {
+        stdout,
+        comment: existsSync(outputPath) ? readFileSync(outputPath, "utf-8") : null,
+    };
+}
+
+afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+describe("report-bundle-size-deltas", () => {
+    it("writes no comment variable when rounded sizes do not change", () => {
+        const result = runReporter({
+            current: { scene1: { rawKB: 93.4 } },
+            master: { scene1: { rawKB: 93.0 } },
+            scenes: [{ id: 1, slug: "scene1", name: "Scene 1" }],
+        });
+
+        expect(result.comment).toContain("No changes detected");
+        expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
+    });
+
+    it("reports all nonzero rounded size changes with whole KB values", () => {
+        const result = runReporter({
+            current: {
+                scene1: { rawKB: 95.4 },
+                scene2: { rawKB: 40.4 },
+                scene3: { rawKB: 12.4 },
+                scene4: {},
+            },
+            master: {
+                scene1: { rawKB: 93.0 },
+                scene2: { rawKB: 46.4 },
+                scene3: { rawKB: 12.0 },
+                scene4: { rawKB: 8.0 },
+            },
+            scenes: [
+                { id: 1, slug: "scene1", name: "Scene 1 - BoomBox PBR" },
+                { id: 2, slug: "scene2", name: "Scene 2 - Sphere" },
+            ],
+        });
+
+        expect(result.comment).toContain("| Package | Current | Master | Change |");
+        expect(result.comment).toContain("Scene 1 - BoomBox PBR<br/>`scene1` | 95 KB | 93 KB | **+2 KB**");
+        expect(result.comment).toContain("Scene 2 - Sphere<br/>`scene2` | 40 KB | 46 KB | -6 KB");
+        expect(result.comment).not.toContain("scene3");
+        expect(result.comment).not.toContain("scene4");
+        expect(result.comment).not.toMatch(/\d+\.\d+ KB/);
+        expect(result.comment).not.toMatch(/bytes?/i);
+        expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
+        expect(result.stdout).toContain("%0A");
+    });
+
+    it("skips reporting when the master manifest is unavailable", () => {
+        const result = runReporter({
+            current: { scene1: { rawKB: 95.0 } },
+            scenes: [{ id: 1, slug: "scene1", name: "Scene 1" }],
+        });
+
+        expect(result.comment).toBeNull();
+        expect(result.stdout).toContain("Master manifest not found; skipping delta report.");
+        expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
+    });
+});


### PR DESCRIPTION
## Summary

Adds a Bundle Size CI follow-up that posts a GitHub PR comment when the current bundle manifest differs from the target-branch baseline after rounding to the nearest KB.

## What changed

- Added `scripts/report-bundle-size-deltas.ts` to compare `lab/public/bundle/manifest.json` with `lab/public/bundle/master-manifest.json`.
- Added Azure Pipelines wiring in the Bundle Size job to fetch the authenticated target-branch baseline and post a GitHub comment only when one or more rounded package/scene sizes changed.
- Added unit coverage for the reporter CLI using temporary manifests.

## Validation

- `npx vitest run tests/unit/report-bundle-size-deltas.test.ts` passed locally.
- `npx vitest run` passed locally: 125 tests.
- `pnpm test` / `pnpm build:bundle-scenes` was previously blocked locally before parity by an unrelated Vite resolution error for `manifold-3d/manifold.wasm?url` from `packages/babylon-lite/src/mesh/csg2.ts`.
