### PR TITLE
Implement reverse-Z depth buffer

### DIFF
--- a/docs/architecture/08-camera.md
+++ b/docs/architecture/08-camera.md
@@ -212,7 +212,7 @@ Both cameras use the same world-matrix-to-view inversion (described above). This
 
 ### Projection Matrix
 
-Both cameras: `mat4PerspectiveLH(fov, aspectRatio, nearPlane, farPlane)` — left-handed perspective with zero-to-one depth range.
+Both cameras: `mat4PerspectiveLH(fov, aspectRatio, nearPlane, farPlane)` — left-handed perspective with reverse-Z zero-to-one depth (`nearPlane` maps to `1`, `farPlane` maps to `0`).
 
 ### View-Projection Matrix
 

--- a/docs/architecture/10-pbr-material.md
+++ b/docs/architecture/10-pbr-material.md
@@ -445,7 +445,7 @@ Base vertex buffers are defined by the template. Fragment modules add additional
 | Cull mode     | `back` (or `none` if `PBR_HAS_DOUBLE_SIDED`)                  |
 | Front face    | `ccw`                                                         |
 | Depth format  | `depth24plus-stencil8`                                        |
-| Depth compare | `less-equal`                                                  |
+| Depth compare | `greater-equal`                                               |
 | Depth write   | `true` (disabled for alpha-blend variants)                    |
 | MSAA          | `count = msaaSamples` (4)                                     |
 | Color target  | Canvas preferred format, alpha blend if `PBR_HAS_ALPHA_BLEND` |

--- a/docs/architecture/11-standard-material.md
+++ b/docs/architecture/11-standard-material.md
@@ -267,7 +267,7 @@ The `rebuildSingle` closure returned from `buildStandardMeshRenderables()` is st
 | Cull mode     | `back` (or `none` if `DOUBLE_SIDED`) |
 | Front face    | `ccw`                                |
 | Depth format  | `depth24plus-stencil8`               |
-| Depth compare | `less-equal`                         |
+| Depth compare | `greater-equal`                      |
 | Depth write   | `true`                               |
 | MSAA          | `count = msaaSamples`                |
 | Color target  | Canvas preferred format, no blend    |

--- a/docs/architecture/12-background-skybox.md
+++ b/docs/architecture/12-background-skybox.md
@@ -271,7 +271,7 @@ export async function loadCubeTexture(
 | Topology | `triangle-list` |
 | Cull mode | `back` |
 | Front face | `ccw` |
-| Depth compare | `less-equal` |
+| Depth compare | `greater-equal` |
 | Depth write | **`false`** |
 | MSAA | `count = msaaSamples` |
 | Blend | None |
@@ -286,7 +286,7 @@ Both DDS and HDR cubemap skyboxes use the same pipeline configuration via `creat
 | Topology | `triangle-list` |
 | Cull mode | `back` |
 | Front face | `ccw` |
-| Depth compare | `less-equal` |
+| Depth compare | `greater-equal` |
 | Depth write | **`false`** |
 | MSAA | `count = msaaSamples` |
 | Blend | None |
@@ -299,7 +299,7 @@ Both DDS and HDR cubemap skyboxes use the same pipeline configuration via `creat
 | Topology | `triangle-list` |
 | Cull mode | `back` |
 | Front face | `ccw` |
-| Depth compare | `less-equal` |
+| Depth compare | `greater-equal` |
 | Depth write | **`false`** |
 | MSAA | `count = msaaSamples` |
 | Blend | Premultiplied alpha: `src=one, dst=one-minus-src-alpha` (both color and alpha) |
@@ -312,7 +312,7 @@ Both DDS and HDR cubemap skyboxes use the same pipeline configuration via `creat
 | Topology | `triangle-list` |
 | Cull mode | **`none`** (sees inside of box) |
 | Front face | `ccw` |
-| Depth compare | `less-equal` |
+| Depth compare | `greater-equal` |
 | Depth write | `true` |
 | MSAA | `count = msaaSamples` |
 | Blend | None |

--- a/docs/architecture/18-picking.md
+++ b/docs/architecture/18-picking.md
@@ -138,7 +138,7 @@ Used for normals (`getPickedNormal`) and UVs (`getPickedUV`).
 
 ### Depth / Stencil
 - Format: `depth32float`
-- Compare: `less`
+- Compare: `greater`
 - Write: enabled
 - No stencil
 

--- a/docs/architecture/26-sprites.md
+++ b/docs/architecture/26-sprites.md
@@ -589,8 +589,8 @@ export interface Sprite2DLayerOptions {
     /**
      * Depth participation:
      *  - "none"        (default) → drawn by a `SpriteRenderer` registered on the engine. Pipeline has no depth attachment; the per-instance layout has no Z slot. HUD overlays must use this mode and live on a `SpriteRenderer` (not on `addDepthHostedSpriteLayer`).
-     *  - "test"                  → drawn inside the scene's 3D pass via `addDepthHostedSpriteLayer` with `depthCompare: "less-equal"`, `depthWrite: false`. Sprites occlude behind 3D geometry but do not write depth.
-     *  - "test-write"            → drawn inside the scene's 3D pass via `addDepthHostedSpriteLayer` with `depthCompare: "less-equal"`, `depthWrite: true`. Sprites direct-draw after cached opaque meshes and before transparent renderables.
+     *  - "test"                  → drawn inside the scene's 3D pass via `addDepthHostedSpriteLayer` with `depthCompare: "greater-equal"`, `depthWrite: false`. Sprites occlude behind 3D geometry but do not write depth.
+     *  - "test-write"            → drawn inside the scene's 3D pass via `addDepthHostedSpriteLayer` with `depthCompare: "greater-equal"`, `depthWrite: true`. Sprites direct-draw after cached opaque meshes and before transparent renderables.
      *  Each value is a pipeline-cache key bit, baked at composition time. No runtime branch.
      *  Pure-2D engines (no scene) can only use `"none"` — they have no depth attachment.
      */
@@ -1031,9 +1031,9 @@ sample count, `_orientation`, blend mode, `_depthMode`, and depth format. The
 shader module cache also keys by `_depthMode`: transparent shaders have no
 discard path, while cutout shaders sample texture alpha, discard below
 `billboards.axisAndCutoff.w`, and return the sampled color multiplied by tint and
-`opacityMul`. The `"transparent"` depth mode uses depth compare `less-equal`,
+`opacityMul`. The `"transparent"` depth mode uses depth compare `greater-equal`,
 depth write off, no culling, and alpha or premultiplied blending. The
-`"cutout"` depth mode uses depth compare `less-equal`, depth write on, no
+`"cutout"` depth mode uses depth compare `greater-equal`, depth write on, no
 blend state, and no culling. Unsupported `additive` and `multiply` blend modes
 throw during system creation.
 
@@ -1294,8 +1294,8 @@ loses one tick of animation in the captured image. All sprite families
 | Layer `depth`  | Drawn via                                                                       | Depth attachment        | Depth compare | Depth write | Instance layout / Z                  | Render order                                                |
 | -------------- | ------------------------------------------------------------------------------- | ----------------------- | ------------- | ----------- | ------------------------------------ | ----------------------------------------------------------- |
 | `"none"`       | A `SpriteRenderer` registered on the engine                                     | none                    | none          | `false`     | 52 B / 13 floats; no slot [13]       | engine registration order; layer order within the renderer  |
-| `"test"`       | `addDepthHostedSpriteLayer` → `sprite-renderable.ts` (renderable `order = 200`) | engine depth attachment | `less-equal`  | `false`     | 56 B / 14 floats; slot [13] consumed | scene transparent queue (after opaque meshes)               |
-| `"test-write"` | `addDepthHostedSpriteLayer` → `sprite-renderable.ts` (renderable `order = 100`) | engine depth attachment | `less-equal`  | `true`      | 56 B / 14 floats; slot [13] consumed | direct-drawn after cached opaque meshes, before transparent |
+| `"test"`       | `addDepthHostedSpriteLayer` → `sprite-renderable.ts` (renderable `order = 200`) | engine depth attachment | `greater-equal` | `false`   | 56 B / 14 floats; slot [13] consumed | scene transparent queue (after opaque meshes)               |
+| `"test-write"` | `addDepthHostedSpriteLayer` → `sprite-renderable.ts` (renderable `order = 100`) | engine depth attachment | `greater-equal` | `true`    | 56 B / 14 floats; slot [13] consumed | direct-drawn after cached opaque meshes, before transparent |
 
 The sprite pipeline cache key includes `(format, sampleCount, blendMode, hasDepth, depthWrite, depthStencilFormat)`. `SpriteRenderer`
 layers always request `hasDepth = false` and `sampleCount = 1`, so their pipelines are built without a depth-stencil descriptor. Depth-hosted layers request `hasDepth = true`, use the target depth-stencil format provided by the frame graph, and set `depthWrite` from the layer's `depth` mode.
@@ -1522,7 +1522,7 @@ IDs `1..M`), ends that pass, then opens a second render pass that loads
 the same color/depth attachments and dispatches each registered
 contributor with the next free pick ID. Each contributor returns the next
 free ID after its draws; the picker accumulates and uses the result to
-bound mesh-vs-contributor ID dispatch. The depth-test contract (`less`)
+bound mesh-vs-contributor ID dispatch. The depth-test contract (`greater`)
 carries across the pass boundary because the second pass loads the
 previous depth, so closest-hit semantics are preserved across mesh +
 contributor draws.

--- a/docs/architecture/29-shader-material.md
+++ b/docs/architecture/29-shader-material.md
@@ -322,7 +322,7 @@ primitive.topology = "triangle-list";
 primitive.frontFace = target.flipY ? "cw" : "ccw";
 primitive.cullMode = options.backFaceCulling === false ? "none" : "back";
 depthStencil.format = target.depthStencilFormat ?? "depth24plus-stencil8";
-depthStencil.depthCompare = options.depthCompare ?? "less-equal";
+depthStencil.depthCompare = options.depthCompare ?? "greater-equal";
 depthStencil.depthWriteEnabled = options.needAlphaBlending ? false : (options.depthWrite ?? true);
 multisample.count = target.sampleCount;
 ```

--- a/packages/babylon-lite/src/effect/effect-renderer.ts
+++ b/packages/babylon-lite/src/effect/effect-renderer.ts
@@ -175,8 +175,8 @@ export function createEffectRenderTask(config: EffectRenderTaskConfig, engine: E
     config.clearColor ??= { r: 0, g: 0, b: 0, a: 1 };
     const sampleCount = rt._descriptor.sampleCount ?? 1;
     const targetSignature: RenderTargetSignature = {
-        colorFormat: rt._descriptor.colorFormat,
-        sampleCount,
+        _colorFormat: rt._descriptor.colorFormat,
+        _sampleCount: sampleCount,
     };
     const colorAttachment = { loadOp: "clear", storeOp: "store" } as GPURenderPassColorAttachment;
     const task: EffectRenderTaskInternal = {
@@ -262,8 +262,8 @@ export function createEffectRenderer(engine: EngineContext, effect: EffectWrappe
     });
 
     const targetSignature: RenderTargetSignature = {
-        colorFormat: rt._descriptor.colorFormat,
-        sampleCount: rt._descriptor.sampleCount ?? 1,
+        _colorFormat: rt._descriptor.colorFormat,
+        _sampleCount: rt._descriptor.sampleCount ?? 1,
     };
 
     const colorAttachment: GPURenderPassColorAttachment = {
@@ -410,10 +410,10 @@ function getEffectPipeline(wrapper: EffectWrapperInternal, targetSignature: Rend
         fragment: {
             module: getShaderModule(wrapper),
             entryPoint: "effectFragment",
-            targets: [{ format: targetSignature.colorFormat!, blend: wrapper.options.blend }],
+            targets: [{ format: targetSignature._colorFormat!, blend: wrapper.options.blend }],
         },
         primitive: { topology: "triangle-list" },
-        multisample: { count: targetSignature.sampleCount },
+        multisample: { count: targetSignature._sampleCount },
     });
     wrapper._pipelines.set(key, pipeline);
     return pipeline;

--- a/packages/babylon-lite/src/engine/render-target.ts
+++ b/packages/babylon-lite/src/engine/render-target.ts
@@ -15,21 +15,29 @@ import type { Texture2D } from "../texture/texture-2d.js";
 
 /** Signature of a render target's attachment set — enough to key a GPURenderPipeline. */
 export interface RenderTargetSignature {
-    readonly colorFormat?: GPUTextureFormat;
-    readonly depthStencilFormat?: GPUTextureFormat;
-    readonly sampleCount: number;
+    readonly _colorFormat?: GPUTextureFormat;
+    readonly _depthStencilFormat?: GPUTextureFormat;
+    /** Depth compare for this target. Defaults to reverse-Z `"greater-equal"`. Shadow-map targets use standard-Z `"less-equal"`. */
+    readonly _depthCompare?: GPUCompareFunction;
+    readonly _sampleCount: number;
     /** When true, the projection matrix's Y is flipped (offscreen RTT — see writePassSceneUBO).
      *  Pipelines must invert frontFace to keep back-face culling correct. */
-    readonly flipY?: boolean;
+    readonly _flipY?: boolean;
     /** Internal per-task refraction texture shared by transmissive material bindings. */
     readonly _transmissionTexture?: Texture2D | null;
 }
 
 /** Description of a render target — what to create, not the GPU objects themselves. */
+export const REVERSE_DEPTH_COMPARE = "greater-equal" as GPUCompareFunction;
+
 export interface RenderTargetDescriptor {
     label?: string;
     colorFormat?: GPUTextureFormat;
     depthStencilFormat?: GPUTextureFormat;
+    /** Depth clear value. Defaults to reverse-Z far depth `0`. Shadow-map targets use standard-Z far depth `1`. */
+    _depthClearValue?: number;
+    /** Depth compare for pipelines targeting this RT. Defaults to reverse-Z `"greater-equal"`. */
+    _depthCompare?: GPUCompareFunction;
     sampleCount: number;
     /** 'canvas' means match the canvas pixel size. Otherwise explicit pixels. */
     size: "canvas" | { width: number; height: number };
@@ -45,7 +53,7 @@ export interface RenderTargetDescriptor {
 
 /** Stringified signature used to key pipelines against a render target's attachment set. */
 export function targetSignatureKey(desc: RenderTargetSignature): string {
-    return `${desc.colorFormat ?? "-"}|${desc.depthStencilFormat ?? "-"}|${desc.sampleCount}|${desc.flipY ? "flipY" : ""}`;
+    return `${desc._colorFormat ?? "-"}|${desc._depthStencilFormat ?? "-"}|${desc._depthCompare ?? ""}|${desc._sampleCount}|${desc._flipY ? "y" : ""}`;
 }
 
 /** Allocated GPU state for a render target. */

--- a/packages/babylon-lite/src/frame-graph/render-pass.ts
+++ b/packages/babylon-lite/src/frame-graph/render-pass.ts
@@ -102,7 +102,7 @@ export function createRenderPass(name: string, task: Task): RenderPass {
             if (depthView) {
                 depthAttachment = {
                     view: depthView,
-                    depthClearValue: 1.0,
+                    depthClearValue: depthRt._descriptor._depthClearValue ?? 0,
                     depthLoadOp: "clear",
                     depthStoreOp: "store",
                     ...(hasStencil ? { stencilClearValue: 0, stencilLoadOp: "clear" as const, stencilStoreOp: "store" as const } : {}),

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -127,10 +127,11 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
     // samples upright when sourced by a downstream pass. Depth-only shadow maps
     // can override this to preserve shadow-sampler UV conventions.
     const targetSignature = {
-        colorFormat: desc.colorFormat,
-        depthStencilFormat: desc.depthStencilFormat,
-        sampleCount: desc.sampleCount ?? 1,
-        flipY: desc.flipY ?? desc.resolveToSwapchain !== true,
+        _colorFormat: desc.colorFormat,
+        _depthStencilFormat: desc.depthStencilFormat,
+        _depthCompare: desc._depthCompare,
+        _sampleCount: desc.sampleCount ?? 1,
+        _flipY: desc.flipY ?? desc.resolveToSwapchain !== true,
     };
 
     const sceneBGL = getSceneBindGroupLayout(eng);
@@ -298,7 +299,7 @@ function buildRenderPassDescriptor(task: RenderTask, rt: RenderTarget): void {
     if (depthView) {
         depthAttachment = {
             view: depthView,
-            depthClearValue: 1.0,
+            depthClearValue: rt._descriptor._depthClearValue ?? 0,
             depthLoadOp: "clear",
             depthStoreOp: "store",
         };
@@ -327,7 +328,7 @@ function prepareRenderTaskPass(task: RenderTask, eng: EngineContextInternal, tar
     // extension raises MAX_LIGHTS after this task was first recorded).
     refreshTaskSceneBindGroup(task, eng);
     const camera = task._config.cam ?? sc.camera;
-    writePassSceneUBO(task, eng, sc, camera, targetSignature.flipY === true);
+    writePassSceneUBO(task, eng, sc, camera, targetSignature._flipY);
     refreshSceneLightsUBO(eng, sc);
     // Expose the active camera to per-binding `update()` calls. Some renderables
     // (e.g. transparent billboard systems) need it to compute view-space sort
@@ -344,7 +345,7 @@ function prepareRenderTaskPass(task: RenderTask, eng: EngineContextInternal, tar
 
 function executePass(task: RenderTask, eng: EngineContextInternal, targetSignature: RenderTargetSignature, context: DrawUpdateContext): number {
     const sc = task.scene;
-    const sampleCount = targetSignature.sampleCount;
+    const sampleCount = targetSignature._sampleCount;
     prepareRenderTaskPass(task, eng, targetSignature, context);
     const att = task._colorAttachment;
     const cfg = task._config;
@@ -441,7 +442,7 @@ function refreshTaskSceneBindGroup(task: RenderTask, eng: EngineContextInternal)
 
 /** Write the canonical SceneUniforms struct to the task-owned scene UBO.
  *  Bails before touching scratch/GPU when all inputs are unchanged. */
-function writePassSceneUBO(task: RenderTask, eng: EngineContextInternal, scene: SceneContextInternal, camera: Camera | null, flipY: boolean): void {
+function writePassSceneUBO(task: RenderTask, eng: EngineContextInternal, scene: SceneContextInternal, camera: Camera | null, flipY?: boolean): void {
     if (!camera) {
         return;
     }

--- a/packages/babylon-lite/src/frame-graph/transmission.ts
+++ b/packages/babylon-lite/src/frame-graph/transmission.ts
@@ -91,11 +91,18 @@ function retargetRenderTaskToLinearOffscreen(task: RenderTask, engine: EngineCon
         desc.colorFormat = "rgba16float";
     }
     desc.sampleCount = engine.msaaSamples;
-    const sig = task._targetSignature as { colorFormat?: GPUTextureFormat; depthStencilFormat?: GPUTextureFormat; sampleCount: number; flipY?: boolean };
-    sig.colorFormat = desc.colorFormat;
-    sig.depthStencilFormat = desc.depthStencilFormat;
-    sig.sampleCount = desc.sampleCount;
-    sig.flipY = desc.flipY ?? true;
+    const sig = task._targetSignature as {
+        _colorFormat?: GPUTextureFormat;
+        _depthStencilFormat?: GPUTextureFormat;
+        _depthCompare?: GPUCompareFunction;
+        _sampleCount: number;
+        _flipY?: boolean;
+    };
+    sig._colorFormat = desc.colorFormat;
+    sig._depthStencilFormat = desc.depthStencilFormat;
+    sig._depthCompare = desc._depthCompare;
+    sig._sampleCount = desc.sampleCount;
+    sig._flipY = desc.flipY ?? true;
 }
 
 function executeRenderTaskLinear(scene: SceneContextInternal, execute: () => number): number {
@@ -202,7 +209,7 @@ function configureTransmissionSource(state: RenderTaskTransmissionState, task: R
     state._sourceWidth = rt._width;
     state._sourceHeight = rt._height;
     state._sourceTexture = rt._colorTexture;
-    const sampleCount = task._targetSignature.sampleCount;
+    const sampleCount = task._targetSignature._sampleCount;
     if (!state._sourceTexture) {
         return;
     }

--- a/packages/babylon-lite/src/material/node/blocks/frag-coord-block.ts
+++ b/packages/babylon-lite/src/material/node/blocks/frag-coord-block.ts
@@ -24,6 +24,6 @@ export const emitter: BlockEmitter = {
         if (!out) {
             throw new Error(`NodeMaterial: FragCoordBlock has no output "${outputName}"`);
         }
-        return { expr: `vec4<f32>(_NME_FRAG_COORD_.x, _NME_SCREEN_SIZE_.y - _NME_FRAG_COORD_.y, _NME_FRAG_COORD_.z, _NME_FRAG_COORD_.w)${out.swizzle}`, type: out.type };
+        return { expr: `vec4<f32>(_NME_FRAG_COORD_.x, _NME_SCREEN_SIZE_.y - _NME_FRAG_COORD_.y, 1.0 - _NME_FRAG_COORD_.z, _NME_FRAG_COORD_.w)${out.swizzle}`, type: out.type };
     },
 };

--- a/packages/babylon-lite/src/material/node/blocks/frag-depth-block.ts
+++ b/packages/babylon-lite/src/material/node/blocks/frag-depth-block.ts
@@ -16,7 +16,7 @@ export const emitter: BlockEmitter = {
         const depthConn = block.inputs.get("depth");
         if (depthConn?.source) {
             const depth = ctx.cast(ctx.resolve(block, "depth", stage, state), "f32");
-            state.fragment.body.push(`_NME_FRAG_DEPTH_ = ${depth.expr};`);
+            state.fragment.body.push(`_NME_FRAG_DEPTH_ = 1.0 - (${depth.expr});`);
         } else if (block.inputs.get("worldPos")?.source && block.inputs.get("viewProjection")?.source) {
             const worldPos = ctx.cast(ctx.resolve(block, "worldPos", stage, state), "vec4f");
             const viewProjection = ctx.cast(ctx.resolve(block, "viewProjection", stage, state), "mat4f");

--- a/packages/babylon-lite/src/material/node/node-pipeline.ts
+++ b/packages/babylon-lite/src/material/node/node-pipeline.ts
@@ -13,6 +13,7 @@
  */
 
 import type { EngineContextInternal } from "../../engine/engine.js";
+import { REVERSE_DEPTH_COMPARE } from "../../engine/render-target.js";
 import { getSceneBindGroupLayout } from "../../render/scene-helpers.js";
 import { createDefaultPipelineDescriptor } from "../../render/scene-helpers.js";
 import { SCENE_UBO_WGSL } from "../../shader/scene-uniforms.js";
@@ -130,6 +131,7 @@ export interface CompileOpts {
     readonly _engine: EngineContextInternal;
     readonly _format: GPUTextureFormat;
     readonly _depthStencilFormat?: GPUTextureFormat;
+    readonly _depthCompare?: GPUCompareFunction;
     readonly _msaaSamples: number;
     readonly _backFaceCulling?: boolean;
     readonly _noColorOutput?: boolean;
@@ -415,7 +417,7 @@ struct lightsUniforms { count: u32, _p0: u32, _p1: u32, _p2: u32, lights: array<
                   layout: device.createPipelineLayout({ bindGroupLayouts: [sceneBGL, _meshBGL] }),
                   vertex: { module: shaderModule, entryPoint: "vs_main", buffers: _vertexBuffers },
                   fragment: { module: shaderModule, entryPoint: "fs_main", targets: [] },
-                  depthStencil: { format: depthFormat, depthCompare: "less-equal", depthWriteEnabled: true },
+                  depthStencil: { format: depthFormat, depthCompare: opts._depthCompare ?? REVERSE_DEPTH_COMPARE, depthWriteEnabled: true },
                   multisample: { count: _msaaSamples },
                   primitive: { topology: "triangle-list", cullMode: opts._backFaceCulling !== false ? "back" : "none" },
               }
@@ -429,6 +431,7 @@ struct lightsUniforms { count: u32, _p0: u32, _p1: u32, _p2: u32, lights: array<
                       _vertexBuffers,
                       _format,
                       _depthStencilFormat: opts._depthStencilFormat,
+                      _depthCompare: opts._depthCompare,
                       _msaaSamples,
                       _cullMode: opts._backFaceCulling !== false ? "back" : "none",
                       _blend: esmShadowOutput ? undefined : blend,

--- a/packages/babylon-lite/src/material/node/node-renderable.ts
+++ b/packages/babylon-lite/src/material/node/node-renderable.ts
@@ -92,6 +92,7 @@ export function buildNodeMeshRenderables(scene: SceneContext, meshes: Mesh[], ma
                   _engine: engine,
                   _format: esmShadowOutput ? "rgba16float" : engine.format,
                   _depthStencilFormat: "depth32float",
+                  _depthCompare: "less-equal",
                   _msaaSamples: 1,
                   _backFaceCulling: material._graph.backFaceCulling,
                   _noColorOutput: noColorOutput,

--- a/packages/babylon-lite/src/material/pbr/background-ground.ts
+++ b/packages/babylon-lite/src/material/pbr/background-ground.ts
@@ -164,7 +164,7 @@ function createGroundMaterial(enableNoise: boolean, fragCode: string): GroundMat
                     entryPoint: "main",
                     targets: [
                         {
-                            format: sig.colorFormat!,
+                            format: sig._colorFormat!,
                             blend: {
                                 color: { srcFactor: "one", dstFactor: "one-minus-src-alpha", operation: "add" },
                                 alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha", operation: "add" },
@@ -173,12 +173,12 @@ function createGroundMaterial(enableNoise: boolean, fragCode: string): GroundMat
                     ],
                 },
                 depthStencil: {
-                    format: sig.depthStencilFormat ?? "depth24plus-stencil8",
-                    depthCompare: "less-equal",
+                    format: sig._depthStencilFormat ?? "depth24plus-stencil8",
+                    depthCompare: sig._depthCompare ?? "greater-equal",
                     depthWriteEnabled: false,
                 },
-                multisample: { count: sig.sampleCount },
-                primitive: { topology: "triangle-list", cullMode: "back", frontFace: sig.flipY ? "cw" : "ccw" },
+                multisample: { count: sig._sampleCount },
+                primitive: { topology: "triangle-list", cullMode: "back", frontFace: sig._flipY ? "cw" : "ccw" },
             });
             _gndPipelines.set(key, pipeline);
             return pipeline;

--- a/packages/babylon-lite/src/material/pbr/background-solid-skybox.ts
+++ b/packages/babylon-lite/src/material/pbr/background-solid-skybox.ts
@@ -104,11 +104,12 @@ function createSkyboxMaterial(): SkyboxMaterial {
                     _vertModule,
                     _fragModule,
                     _vertexBuffers: SKYBOX_POS_BUFFER,
-                    _format: sig.colorFormat!,
-                    _depthStencilFormat: sig.depthStencilFormat,
-                    _msaaSamples: sig.sampleCount,
+                    _format: sig._colorFormat!,
+                    _depthStencilFormat: sig._depthStencilFormat,
+                    _depthCompare: sig._depthCompare,
+                    _msaaSamples: sig._sampleCount,
                     _depthWriteEnabled: false,
-                    _flipY: sig.flipY,
+                    _flipY: sig._flipY,
                 })
             );
             _skyPipelines.set(key, pipeline);

--- a/packages/babylon-lite/src/material/pbr/cubemap-skybox-material.ts
+++ b/packages/babylon-lite/src/material/pbr/cubemap-skybox-material.ts
@@ -67,11 +67,12 @@ export function createCubemapSkyboxMaterial(label: string, vertCode: string, fra
                     _vertModule,
                     _fragModule,
                     _vertexBuffers: SKYBOX_POS_BUFFER,
-                    _format: sig.colorFormat!,
-                    _depthStencilFormat: sig.depthStencilFormat,
-                    _msaaSamples: sig.sampleCount,
+                    _format: sig._colorFormat!,
+                    _depthStencilFormat: sig._depthStencilFormat,
+                    _depthCompare: sig._depthCompare,
+                    _msaaSamples: sig._sampleCount,
                     _depthWriteEnabled: false,
-                    _flipY: sig.flipY,
+                    _flipY: sig._flipY,
                 })
             );
             _cmPipelines.set(key, pipeline);

--- a/packages/babylon-lite/src/material/pbr/pbr-pipeline.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-pipeline.ts
@@ -17,7 +17,7 @@ import type { _PbrBindCtx, PbrExt } from "./pbr-flags.js";
 import { _getPbrExtsSorted, PBR2_ESM_SHADOW_OUTPUT, PBR2_NO_COLOR_OUTPUT, PBR2_HAS_UV2 } from "./pbr-flags.js";
 import { PBR_HAS_NORMAL_MAP, PBR_HAS_EMISSIVE, PBR_HAS_SPEC_GLOSS, PBR_HAS_DOUBLE_SIDED, PBR_HAS_ALPHA_BLEND } from "./pbr-flags.js";
 import { MSH_HAS_TANGENTS, MSH_HAS_UV2 } from "../mesh-features.js";
-import { targetSignatureKey } from "../../engine/render-target.js";
+import { REVERSE_DEPTH_COMPARE, targetSignatureKey } from "../../engine/render-target.js";
 import { getSceneBindGroupLayout } from "../../render/scene-helpers.js";
 
 // ─── Shader Bindings (sig-independent) ──────────────────────────────
@@ -108,9 +108,9 @@ export function getOrCreatePbrPipeline(engine: EngineContextInternal, sig: Rende
 
     const vertModule = device.createShaderModule({ code: composed._vertexWGSL });
     const noColorOutput = (features2 & PBR2_NO_COLOR_OUTPUT) !== 0;
-    const fragModule = !sig.colorFormat && !noColorOutput ? null : device.createShaderModule({ code: composed._fragmentWGSL });
+    const fragModule = !sig._colorFormat && !noColorOutput ? null : device.createShaderModule({ code: composed._fragmentWGSL });
 
-    const fragTarget: GPUColorTargetState | null = noColorOutput ? null : { format: sig.colorFormat!, writeMask: GPUColorWrite.ALL };
+    const fragTarget: GPUColorTargetState | null = noColorOutput ? null : { format: sig._colorFormat!, writeMask: GPUColorWrite.ALL };
     if (hasAlpha && fragTarget) {
         fragTarget.blend = {
             color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha", operation: "add" },
@@ -122,17 +122,17 @@ export function getOrCreatePbrPipeline(engine: EngineContextInternal, sig: Rende
         layout: device.createPipelineLayout({ bindGroupLayouts: bgls }),
         vertex: { module: vertModule, entryPoint: "main", buffers: composed._vertexBufferLayouts },
         ...(fragModule ? { fragment: { module: fragModule, entryPoint: "main", targets: fragTarget ? [fragTarget] : [] } } : {}),
-        ...(sig.depthStencilFormat
+        ...(sig._depthStencilFormat
             ? {
                   depthStencil: {
-                      format: sig.depthStencilFormat,
-                      depthCompare: "less-equal" as GPUCompareFunction,
+                      format: sig._depthStencilFormat,
+                      depthCompare: sig._depthCompare ?? REVERSE_DEPTH_COMPARE,
                       depthWriteEnabled: noColorOutput || esmShadowOutput || !hasAlpha,
                   },
               }
             : {}),
-        multisample: { count: sig.sampleCount },
-        primitive: { topology: "triangle-list", cullMode: hasDoubleSided ? ("none" as GPUCullMode) : "back", frontFace: sig.flipY ? "cw" : "ccw" },
+        multisample: { count: sig._sampleCount },
+        primitive: { topology: "triangle-list", cullMode: hasDoubleSided ? ("none" as GPUCullMode) : "back", frontFace: sig._flipY ? "cw" : "ccw" },
     });
     bindings._pipelines.set(key, pipeline);
     return pipeline;

--- a/packages/babylon-lite/src/material/shader/shader-material.ts
+++ b/packages/babylon-lite/src/material/shader/shader-material.ts
@@ -181,7 +181,7 @@ export function createShaderMaterial(options: ShaderMaterialOptions): ShaderMate
         needAlphaTesting: options.needAlphaTesting ?? false,
         backFaceCulling: options.backFaceCulling ?? true,
         depthWrite: options.depthWrite ?? true,
-        depthCompare: options.depthCompare ?? "less-equal",
+        depthCompare: options.depthCompare ?? "greater-equal",
         _buildGroup: shaderGroupBuilder as MeshGroupBuilder,
         _uboVersion: 0,
         _uniformValues: uniformValues,

--- a/packages/babylon-lite/src/material/shader/shader-pipeline.ts
+++ b/packages/babylon-lite/src/material/shader/shader-pipeline.ts
@@ -71,10 +71,10 @@ export function getOrCreateShaderPipeline(
     const device = engine.device;
     const prelude = buildShaderPrelude(material, bindings.systemSpec, bindings.customSpec);
     const vertModule = device.createShaderModule({ label: `${material.name ?? "shader"}-vertex`, code: `${prelude}\n${material.vertexSource}` });
-    const fragModule = sig.colorFormat ? device.createShaderModule({ label: `${material.name ?? "shader"}-fragment`, code: `${prelude}\n${material.fragmentSource}` }) : null;
-    const colorTarget: GPUColorTargetState | null = sig.colorFormat
+    const fragModule = sig._colorFormat ? device.createShaderModule({ label: `${material.name ?? "shader"}-fragment`, code: `${prelude}\n${material.fragmentSource}` }) : null;
+    const colorTarget: GPUColorTargetState | null = sig._colorFormat
         ? {
-              format: sig.colorFormat,
+              format: sig._colorFormat,
               ...(material.needAlphaBlending
                   ? {
                         blend: {
@@ -91,17 +91,17 @@ export function getOrCreateShaderPipeline(
         layout: device.createPipelineLayout({ bindGroupLayouts: [getSceneBindGroupLayout(engine), bindings.group1BGL] }),
         vertex: { module: vertModule, entryPoint: "mainVertex", buffers: bindings.vertexBuffers },
         ...(fragModule && colorTarget ? { fragment: { module: fragModule, entryPoint: "mainFragment", targets: [colorTarget] } } : {}),
-        ...(sig.depthStencilFormat
+        ...(sig._depthStencilFormat
             ? {
                   depthStencil: {
-                      format: sig.depthStencilFormat,
+                      format: sig._depthStencilFormat,
                       depthCompare: material.depthCompare,
                       depthWriteEnabled: material.needAlphaBlending ? false : material.depthWrite,
                   },
               }
             : {}),
-        multisample: { count: sig.sampleCount },
-        primitive: { topology: "triangle-list", cullMode: material.backFaceCulling ? "back" : "none", frontFace: sig.flipY ? "cw" : "ccw" },
+        multisample: { count: sig._sampleCount },
+        primitive: { topology: "triangle-list", cullMode: material.backFaceCulling ? "back" : "none", frontFace: sig._flipY ? "cw" : "ccw" },
     });
     bindings.pipelines.set(key, pipeline);
     return pipeline;

--- a/packages/babylon-lite/src/material/standard/skybox-cubemap.ts
+++ b/packages/babylon-lite/src/material/standard/skybox-cubemap.ts
@@ -77,11 +77,12 @@ export function buildSkyboxCubeMapGPU(engine: EngineContextInternal, worldMatrix
                         { arrayStride: 12, attributes: [{ shaderLocation: 0, offset: 0, format: "float32x3" as GPUVertexFormat }] },
                         { arrayStride: 12, attributes: [{ shaderLocation: 1, offset: 0, format: "float32x3" as GPUVertexFormat }] },
                     ],
-                    _format: sig.colorFormat!,
-                    _depthStencilFormat: sig.depthStencilFormat,
-                    _msaaSamples: sig.sampleCount,
+                    _format: sig._colorFormat!,
+                    _depthStencilFormat: sig._depthStencilFormat,
+                    _depthCompare: sig._depthCompare,
+                    _msaaSamples: sig._sampleCount,
                     _cullMode: "none",
-                    _flipY: sig.flipY,
+                    _flipY: sig._flipY,
                 })
             );
             gpu.pipelines.set(key, pipeline);

--- a/packages/babylon-lite/src/material/standard/standard-pipeline.ts
+++ b/packages/babylon-lite/src/material/standard/standard-pipeline.ts
@@ -19,7 +19,7 @@ import { createStandardTemplate } from "./standard-template.js";
 import { composeShader } from "../../shader/shader-composer.js";
 import type { ComposedShader, ShaderFragment } from "../../shader/fragment-types.js";
 import { createUniformBuffer } from "../../resource/gpu-buffers.js";
-import { targetSignatureKey } from "../../engine/render-target.js";
+import { REVERSE_DEPTH_COMPARE, targetSignatureKey } from "../../engine/render-target.js";
 import {
     DIFFUSE_USES_UV2,
     DISABLE_LIGHTING,
@@ -168,36 +168,36 @@ export function getOrCreateStandardPipeline(engine: EngineContextInternal, sig: 
     const vertModule = device.createShaderModule({ code: composed._vertexWGSL });
     const noColorOutput = (features & NO_COLOR_OUTPUT) !== 0;
     const esmShadowOutput = (features & ESM_SHADOW_OUTPUT) !== 0;
-    const fragModule = !sig.colorFormat && !noColorOutput ? null : device.createShaderModule({ code: composed._fragmentWGSL });
+    const fragModule = !sig._colorFormat && !noColorOutput ? null : device.createShaderModule({ code: composed._fragmentWGSL });
 
     const needsBlend = !esmShadowOutput && ((features & HAS_OPACITY_TEXTURE) !== 0 || (features & MATERIAL_ALPHA_BLEND) !== 0);
     const colorTarget: GPUColorTargetState | null = noColorOutput
         ? null
         : needsBlend
           ? {
-                format: sig.colorFormat!,
+                format: sig._colorFormat!,
                 blend: {
                     color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha" },
                     alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha" },
                 },
             }
-          : { format: sig.colorFormat! };
+          : { format: sig._colorFormat! };
 
     const pipeline = device.createRenderPipeline({
         layout: device.createPipelineLayout({ bindGroupLayouts: bgls }),
         vertex: { module: vertModule, entryPoint: "main", buffers: composed._vertexBufferLayouts },
         ...(fragModule ? { fragment: { module: fragModule, entryPoint: "main", targets: colorTarget ? [colorTarget] : [] } } : {}),
-        ...(sig.depthStencilFormat
+        ...(sig._depthStencilFormat
             ? {
                   depthStencil: {
-                      format: sig.depthStencilFormat,
-                      depthCompare: "less-equal" as GPUCompareFunction,
+                      format: sig._depthStencilFormat,
+                      depthCompare: sig._depthCompare ?? REVERSE_DEPTH_COMPARE,
                       depthWriteEnabled: noColorOutput || esmShadowOutput || !needsBlend,
                   },
               }
             : {}),
-        multisample: { count: sig.sampleCount },
-        primitive: { topology: "triangle-list", cullMode: features & DOUBLE_SIDED ? "none" : "back", frontFace: sig.flipY ? "cw" : "ccw" },
+        multisample: { count: sig._sampleCount },
+        primitive: { topology: "triangle-list", cullMode: features & DOUBLE_SIDED ? "none" : "back", frontFace: sig._flipY ? "cw" : "ccw" },
     });
 
     bindings._pipelines.set(key, pipeline);

--- a/packages/babylon-lite/src/math/mat4-perspective-lh-to-ref.ts
+++ b/packages/babylon-lite/src/math/mat4-perspective-lh-to-ref.ts
@@ -1,10 +1,11 @@
-/** Write a perspective projection into `out` without allocating. */
+/** Write a reverse-Z perspective projection into `out` without allocating.
+ *  WebGPU clip-space depth is [0, 1]; this maps near -> 1 and far -> 0. */
 export function mat4PerspectiveLHToRef(out: Float32Array, fov: number, aspect: number, near: number, far: number): void {
     const tan = 1 / Math.tan(fov * 0.5);
     const range = far - near;
     out[0] = tan / aspect;
     out[5] = tan;
-    out[10] = far / range;
+    out[10] = -near / range;
     out[11] = 1;
-    out[14] = -(far * near) / range;
+    out[14] = (far * near) / range;
 }

--- a/packages/babylon-lite/src/math/mat4-perspective-lh.ts
+++ b/packages/babylon-lite/src/math/mat4-perspective-lh.ts
@@ -1,7 +1,7 @@
 import type { Mat4 } from "./types.js";
 import { mat4PerspectiveLHToRef } from "./mat4-perspective-lh-to-ref.js";
 
-/** Perspective projection (left-handed, zero-to-one depth). Matches Babylon.js. */
+/** Reverse-Z perspective projection (left-handed, zero-to-one depth). */
 export function mat4PerspectiveLH(fov: number, aspect: number, near: number, far: number): Mat4 {
     const out = new Float32Array(16) as Mat4;
     mat4PerspectiveLHToRef(out, fov, aspect, near, far);

--- a/packages/babylon-lite/src/mesh/GaussianSplatting/gaussian-splatting-pipeline-sh.ts
+++ b/packages/babylon-lite/src/mesh/GaussianSplatting/gaussian-splatting-pipeline-sh.ts
@@ -337,7 +337,7 @@ function getOrCreateShPipeline(engine: EngineContextInternal, sig: RenderTargetS
             entryPoint: "fs",
             targets: [
                 {
-                    format: sig.colorFormat!,
+                    format: sig._colorFormat!,
                     blend: {
                         color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha", operation: "add" },
                         alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha", operation: "add" },
@@ -348,11 +348,11 @@ function getOrCreateShPipeline(engine: EngineContextInternal, sig: RenderTargetS
         },
         primitive: { topology: "triangle-list", cullMode: "none" },
         depthStencil: {
-            format: sig.depthStencilFormat ?? "depth24plus-stencil8",
-            depthCompare: "less-equal",
+            format: sig._depthStencilFormat ?? "depth24plus-stencil8",
+            depthCompare: sig._depthCompare ?? "greater-equal",
             depthWriteEnabled: false,
         },
-        multisample: { count: sig.sampleCount },
+        multisample: { count: sig._sampleCount },
     });
     entry = { pipeline, meshBindGroupLayout, shTextureCount };
     _cache.entries.set(key, entry);

--- a/packages/babylon-lite/src/mesh/GaussianSplatting/gaussian-splatting-pipeline.ts
+++ b/packages/babylon-lite/src/mesh/GaussianSplatting/gaussian-splatting-pipeline.ts
@@ -98,7 +98,7 @@ function getOrCreatePipeline(engine: EngineContextInternal, sig: RenderTargetSig
             entryPoint: "fs",
             targets: [
                 {
-                    format: sig.colorFormat!,
+                    format: sig._colorFormat!,
                     blend: {
                         // BJS GS material uses ALPHA_COMBINE: src*srcAlpha + dst*(1-srcAlpha)
                         color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha", operation: "add" },
@@ -110,11 +110,11 @@ function getOrCreatePipeline(engine: EngineContextInternal, sig: RenderTargetSig
         },
         primitive: { topology: "triangle-list", cullMode: "none" },
         depthStencil: {
-            format: sig.depthStencilFormat ?? "depth24plus-stencil8",
-            depthCompare: "less-equal",
+            format: sig._depthStencilFormat ?? "depth24plus-stencil8",
+            depthCompare: sig._depthCompare ?? "greater-equal",
             depthWriteEnabled: false,
         },
-        multisample: { count: sig.sampleCount },
+        multisample: { count: sig._sampleCount },
     });
     entry = { pipeline, meshBindGroupLayout };
     _cache.entries.set(key, entry);

--- a/packages/babylon-lite/src/picking/gpu-picker.ts
+++ b/packages/babylon-lite/src/picking/gpu-picker.ts
@@ -170,7 +170,7 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number): Promis
             { view: rt.colorView, clearValue: { r: 0, g: 0, b: 0, a: 0 }, loadOp: "clear", storeOp: "store" },
             { view: rt.depthColorView, clearValue: { r: 1, g: 0, b: 0, a: 0 }, loadOp: "clear", storeOp: "store" },
         ],
-        depthStencilAttachment: { view: rt.depthView, depthClearValue: 1.0, depthLoadOp: "clear", depthStoreOp: "discard" },
+        depthStencilAttachment: { view: rt.depthView, depthClearValue: 0, depthLoadOp: "clear", depthStoreOp: "discard" },
     });
 
     const regularPipeline = getPickingPipeline(engine);

--- a/packages/babylon-lite/src/picking/picking-pipeline.ts
+++ b/packages/babylon-lite/src/picking/picking-pipeline.ts
@@ -104,7 +104,7 @@ function createPickingPipelineInternal(engine: EngineContextInternal, opts: Pick
         },
         depthStencil: {
             format: "depth24plus",
-            depthCompare: "less",
+            depthCompare: "greater",
             depthWriteEnabled: true,
         },
         primitive: {

--- a/packages/babylon-lite/src/picking/ray.ts
+++ b/packages/babylon-lite/src/picking/ray.ts
@@ -10,7 +10,7 @@ export interface Ray {
 
 /**
  * Create a picking ray from screen coordinates.
- * Uses left-handed coordinates with WebGPU 0-to-1 depth range.
+ * Uses left-handed coordinates with WebGPU reverse-Z 0-to-1 depth range.
  */
 export function createPickingRay(x: number, y: number, vpMatrix: Mat4, width: number, height: number): Ray | null {
     const invVP = mat4Invert(vpMatrix);
@@ -22,10 +22,9 @@ export function createPickingRay(x: number, y: number, vpMatrix: Mat4, width: nu
     const ndcX = (2 * x) / width - 1;
     const ndcY = 1 - (2 * y) / height;
 
-    // Unproject near point (depth = 0 for WebGPU 0-to-1 range)
-    const near = unprojectPoint(invVP, ndcX, ndcY, 0);
-    // Unproject far point (depth = 1)
-    const far = unprojectPoint(invVP, ndcX, ndcY, 1);
+    // Reverse-Z maps near to 1 and far to 0.
+    const near = unprojectPoint(invVP, ndcX, ndcY, 1);
+    const far = unprojectPoint(invVP, ndcX, ndcY, 0);
 
     const dx = far[0] - near[0];
     const dy = far[1] - near[1];

--- a/packages/babylon-lite/src/render/scene-helpers.ts
+++ b/packages/babylon-lite/src/render/scene-helpers.ts
@@ -5,6 +5,7 @@
 
 import type { EngineContextInternal } from "../engine/engine.js";
 import type { Mesh } from "../mesh/mesh.js";
+import { REVERSE_DEPTH_COMPARE } from "../engine/render-target.js";
 
 // ── Scene bind group layout (group 0) ────────────────────────────
 
@@ -69,6 +70,8 @@ export interface PipelineDescriptorOpts {
     _format: GPUTextureFormat;
     /** Depth-stencil format. Default: `"depth24plus-stencil8"` (matches the engine's default RT). */
     _depthStencilFormat?: GPUTextureFormat;
+    /** Depth compare. Default: reverse-Z `"greater-equal"`. */
+    _depthCompare?: GPUCompareFunction;
     _msaaSamples: number;
     _depthWriteEnabled?: boolean;
     _cullMode?: GPUCullMode;
@@ -77,8 +80,8 @@ export interface PipelineDescriptorOpts {
     _flipY?: boolean;
 }
 
-/** Build a render pipeline descriptor with the engine's default state:
- *  depth24plus-stencil8, less-equal, triangle-list, ccw front face (cw if flipY). */
+/** Build a render pipeline descriptor with the engine's default reverse-Z state:
+ *  depth24plus-stencil8, greater-equal, triangle-list, ccw front face (cw if flipY). */
 export function createDefaultPipelineDescriptor(opts: PipelineDescriptorOpts): GPURenderPipelineDescriptor {
     const target: GPUColorTargetState = opts._blend ? { format: opts._format, blend: opts._blend } : { format: opts._format };
     return {
@@ -86,7 +89,11 @@ export function createDefaultPipelineDescriptor(opts: PipelineDescriptorOpts): G
         layout: opts._engine.device.createPipelineLayout({ bindGroupLayouts: opts._bgls }),
         vertex: { module: opts._vertModule, entryPoint: "main", buffers: opts._vertexBuffers },
         fragment: { module: opts._fragModule, entryPoint: "main", targets: [target] },
-        depthStencil: { format: opts._depthStencilFormat ?? "depth24plus-stencil8", depthCompare: "less-equal", depthWriteEnabled: opts._depthWriteEnabled ?? true },
+        depthStencil: {
+            format: opts._depthStencilFormat ?? "depth24plus-stencil8",
+            depthCompare: opts._depthCompare ?? REVERSE_DEPTH_COMPARE,
+            depthWriteEnabled: opts._depthWriteEnabled ?? true,
+        },
         multisample: { count: opts._msaaSamples },
         primitive: { topology: "triangle-list", cullMode: opts._cullMode ?? "back", frontFace: opts._flipY ? "cw" : "ccw" },
     };

--- a/packages/babylon-lite/src/shadow/shadow-base.ts
+++ b/packages/babylon-lite/src/shadow/shadow-base.ts
@@ -90,6 +90,8 @@ export function createShadowRenderTarget(sg: ShadowGenerator, colorTexture: GPUT
             size: { width: mapSize, height: mapSize },
             colorFormat: colorTexture ? "rgba16float" : undefined,
             depthStencilFormat: "depth32float",
+            _depthClearValue: 1,
+            _depthCompare: "less-equal",
             sampleCount: 1,
             flipY: false,
         },

--- a/packages/babylon-lite/src/sprite/billboard-pipeline.ts
+++ b/packages/babylon-lite/src/sprite/billboard-pipeline.ts
@@ -33,9 +33,9 @@ const BLEND_MODE_TABLE: Readonly<Record<BillboardBlendMode, { index: number; des
     },
 };
 
-const DEPTH_MODE_TABLE: Readonly<Record<BillboardDepthMode, { index: number; compare: GPUCompareFunction; writeEnabled: boolean }>> = {
-    transparent: { index: 0, compare: "less-equal", writeEnabled: false },
-    cutout: { index: 1, compare: "less-equal", writeEnabled: true },
+const DEPTH_MODE_TABLE: Readonly<Record<BillboardDepthMode, { index: number; writeEnabled: boolean }>> = {
+    transparent: { index: 0, writeEnabled: false },
+    cutout: { index: 1, writeEnabled: true },
 };
 
 const BILLBOARD_POSITION_OFFSET_BYTES = 0;
@@ -412,7 +412,7 @@ function buildBillboardPipeline(
             targets: [blendEntry.descriptor ? { format, blend: blendEntry.descriptor, writeMask: GPUColorWrite.ALL } : { format, writeMask: GPUColorWrite.ALL }],
         },
         primitive: { topology: "triangle-list", cullMode: "none" },
-        depthStencil: { format: depthStencilFormat, depthCompare: depthEntry.compare, depthWriteEnabled: depthEntry.writeEnabled },
+        depthStencil: { format: depthStencilFormat, depthCompare: "greater-equal", depthWriteEnabled: depthEntry.writeEnabled },
         multisample: { count: sampleCount },
     });
 }

--- a/packages/babylon-lite/src/sprite/billboard-renderable.ts
+++ b/packages/babylon-lite/src/sprite/billboard-renderable.ts
@@ -108,17 +108,17 @@ export function buildBillboardRenderable(engine: EngineContextInternal, system: 
 }
 
 function bindSystem(renderable: BillboardRenderableInternal, engine: EngineContextInternal, target: RenderTargetSignature): DrawBinding {
-    if (!target.depthStencilFormat) {
+    if (!target._depthStencilFormat) {
         throw new Error("BillboardSpriteSystem requires a depth-stencil render target.");
     }
-    const sampleCount = target.sampleCount === 1 ? 1 : 4;
+    const sampleCount = target._sampleCount === 1 ? 1 : 4;
     const pipeline = getOrCreateBillboardPipeline(
         engine,
         renderable._pipelineCache,
-        target.colorFormat!,
+        target._colorFormat!,
         sampleCount,
         renderable._system,
-        target.depthStencilFormat,
+        target._depthStencilFormat,
         getSceneBindGroupLayout(engine)
     );
     let bindGroup = renderable._bindGroups.get(pipeline);

--- a/packages/babylon-lite/src/sprite/sprite-pipeline.ts
+++ b/packages/babylon-lite/src/sprite/sprite-pipeline.ts
@@ -24,7 +24,7 @@ const SPRITE_DEPTH_OFFSET_BYTES = 52;
 function makeSpriteWgsl(hasDepth: boolean, spriteGroupIndex: 0 | 1): string {
     const group = `@group(${spriteGroupIndex})`;
     const zAttribute = hasDepth ? `,\n@location(6) iZ: f32` : "";
-    const zPosition = hasDepth ? "in.iZ" : "0.0";
+    const zPosition = hasDepth ? "1.0 - in.iZ" : "0.0";
     return `struct Layer {
 viewPos: vec2<f32>,
 viewScale: f32,
@@ -267,7 +267,7 @@ function buildSpritePipeline(
     if (hasDepth) {
         descriptor.depthStencil = {
             format: depthStencilFormat!,
-            depthCompare: "less-equal",
+            depthCompare: "greater-equal",
             depthWriteEnabled: depthWrite,
         };
     }

--- a/packages/babylon-lite/src/sprite/sprite-renderable.ts
+++ b/packages/babylon-lite/src/sprite/sprite-renderable.ts
@@ -138,20 +138,20 @@ export function buildSpriteRenderable(engine: EngineContextInternal, layer: Spri
 
 /** Resolve this sprite layer against a render-pass target and return the per-frame draw binding. */
 function bindLayer(r: SpriteRenderableInternal, engine: EngineContextInternal, target: RenderTargetSignature): DrawBinding {
-    if (!target.depthStencilFormat) {
+    if (!target._depthStencilFormat) {
         throw new Error("Depth-hosted Sprite2DLayer requires a depth-stencil render target.");
     }
-    const sampleCount = target.sampleCount === 1 ? 1 : 4;
+    const sampleCount = target._sampleCount === 1 ? 1 : 4;
     const depthWrite = r._layer.depth === "test-write";
     const pipeline = getOrCreateSpritePipeline(
         engine,
         r._pipelineCache,
-        target.colorFormat!,
+        target._colorFormat!,
         sampleCount,
         r._layer.blendMode,
         true,
         depthWrite,
-        target.depthStencilFormat,
+        target._depthStencilFormat,
         getSceneBindGroupLayout(engine)
     );
     let bindGroup = r._bindGroups.get(pipeline);

--- a/tests/unit/billboard-sprite.test.ts
+++ b/tests/unit/billboard-sprite.test.ts
@@ -313,12 +313,12 @@ describe("addFacingBillboardSystem", () => {
             queue: { writeBuffer: ReturnType<typeof vi.fn> };
         };
         device.createRenderPipeline.mockClear();
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
 
         expect(device.createRenderPipeline).toHaveBeenCalledTimes(1);
         const descriptor = device.createRenderPipeline.mock.calls[0]![0] as GPURenderPipelineDescriptor;
         expect(descriptor.depthStencil?.format).toBe("depth32float");
-        expect(descriptor.depthStencil?.depthCompare).toBe("less-equal");
+        expect(descriptor.depthStencil?.depthCompare).toBe("greater-equal");
         expect(descriptor.depthStencil?.depthWriteEnabled).toBe(false);
         expect(descriptor.label).toBe("facing-billboard-sprite-pipeline");
         const vertexBuffer = (descriptor.vertex.buffers as GPUVertexBufferLayout[])[0]!;
@@ -352,11 +352,11 @@ describe("addFacingBillboardSystem", () => {
             queue: { writeBuffer: ReturnType<typeof vi.fn> };
         };
         device.createRenderPipeline.mockClear();
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
 
         expect(device.createRenderPipeline).toHaveBeenCalledTimes(1);
         const descriptor = device.createRenderPipeline.mock.calls[0]![0] as GPURenderPipelineDescriptor;
-        expect(descriptor.depthStencil?.depthCompare).toBe("less-equal");
+        expect(descriptor.depthStencil?.depthCompare).toBe("greater-equal");
         expect(descriptor.depthStencil?.depthWriteEnabled).toBe(true);
         const vertexBuffer = descriptor.vertex.buffers![0]!;
         expect(vertexBuffer.arrayStride).toBe(BILLBOARD_INSTANCE_STRIDE_BYTES);
@@ -389,7 +389,7 @@ describe("addFacingBillboardSystem", () => {
         await registerScene(engine, scene);
 
         const device = engine.device as unknown as { queue: { writeBuffer: ReturnType<typeof vi.fn> } };
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
         device.queue.writeBuffer.mockClear();
 
         const camera = makeIdentityCamera();
@@ -422,7 +422,7 @@ describe("addFacingBillboardSystem", () => {
         addFacingBillboardSystem(scene, system);
         await registerScene(engine, scene);
 
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
         const camera = makeIdentityCamera();
         binding.update?.({ targetWidth: 512, targetHeight: 256, _camera: camera });
         expect(scene._renderables[0]!._worldCenter).toEqual([1, 2, 3]);
@@ -451,7 +451,7 @@ describe("addFacingBillboardSystem", () => {
         await registerScene(engine, scene);
 
         const device = engine.device as unknown as { queue: { writeBuffer: ReturnType<typeof vi.fn> } };
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
         device.queue.writeBuffer.mockClear();
 
         binding.update?.({ targetWidth: 512, targetHeight: 256 });
@@ -471,7 +471,7 @@ describe("addFacingBillboardSystem", () => {
         await registerScene(engine, scene);
 
         const device = engine.device as unknown as { queue: { writeBuffer: ReturnType<typeof vi.fn> } };
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
         device.queue.writeBuffer.mockClear();
 
         const camera = makeIdentityCamera();
@@ -489,7 +489,7 @@ describe("addFacingBillboardSystem", () => {
         addFacingBillboardSystem(scene, system);
         await registerScene(engine, scene);
 
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth24plus-stencil8", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth24plus-stencil8", _sampleCount: 1 });
         const pass = makeDrawPassMock();
         expect(binding.draw(pass, engine)).toBe(1);
         expect(pass.setBindGroup).toHaveBeenCalledWith(1, expect.anything());
@@ -553,7 +553,7 @@ describe("AxisLockedBillboardSpriteSystem", () => {
             createShaderModule: ReturnType<typeof vi.fn>;
         };
         device.createRenderPipeline.mockClear();
-        scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
+        scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
 
         expect(device.createRenderPipeline).toHaveBeenCalledTimes(1);
         const descriptor = device.createRenderPipeline.mock.calls[0]![0] as GPURenderPipelineDescriptor;
@@ -577,7 +577,7 @@ describe("AxisLockedBillboardSpriteSystem", () => {
         await registerScene(engine, scene);
 
         const device = engine.device as unknown as { queue: { writeBuffer: ReturnType<typeof vi.fn> } };
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
         device.queue.writeBuffer.mockClear();
 
         binding.update?.({ targetWidth: 512, targetHeight: 256 });

--- a/tests/unit/node-emitter.test.ts
+++ b/tests/unit/node-emitter.test.ts
@@ -141,4 +141,67 @@ describe("NodeMaterial emitter core", () => {
         const result = emitGraph(graph, emitters, fragRoot.id, null);
         expect(result.fragmentWgsl).toMatch(/\(nodeU\.color\)\.xyz/);
     });
+
+    it("exposes NodeMaterial fragment coordinate depth in logical standard-Z space", async () => {
+        const graph = parseNodeMaterialSource({
+            blocks: [
+                {
+                    customType: "BABYLON.FragCoordBlock",
+                    id: 1,
+                    name: "FragCoord",
+                    inputs: [],
+                    outputs: [{ name: "z" }],
+                },
+                {
+                    customType: "BABYLON.FragmentOutputBlock",
+                    id: 2,
+                    name: "out",
+                    inputs: [{ name: "rgb", targetBlockId: 1, targetConnectionName: "z" }],
+                    outputs: [],
+                },
+            ],
+            outputNodes: [2],
+        });
+        const emitters = await loadGraphEmitters(graph);
+        const result = emitGraph(graph, emitters, 2, null);
+
+        expect(result.fragmentWgsl).toContain("1.0 - _NME_FRAG_COORD_.z");
+    });
+
+    it("converts direct NodeMaterial FragDepthBlock depth inputs to reverse-Z writes", async () => {
+        const graph = parseNodeMaterialSource({
+            blocks: [
+                {
+                    customType: "BABYLON.InputBlock",
+                    id: 1,
+                    name: "depth",
+                    mode: 0,
+                    type: 0x1,
+                    value: 0.5,
+                    inputs: [],
+                    outputs: [{ name: "output" }],
+                },
+                {
+                    customType: "BABYLON.FragDepthBlock",
+                    id: 2,
+                    name: "FragDepth",
+                    inputs: [{ name: "depth", targetBlockId: 1, targetConnectionName: "output" }],
+                    outputs: [],
+                },
+                {
+                    customType: "BABYLON.FragmentOutputBlock",
+                    id: 3,
+                    name: "out",
+                    inputs: [],
+                    outputs: [],
+                },
+            ],
+            outputNodes: [2, 3],
+        });
+        const emitters = await loadGraphEmitters(graph);
+        const result = emitGraph(graph, emitters, 3, null);
+
+        expect(result.state.usesFragDepth).toBe(true);
+        expect(result.fragmentWgsl).toContain("_NME_FRAG_DEPTH_ = 1.0 - (nodeU.depth);");
+    });
 });

--- a/tests/unit/render-pass-task.test.ts
+++ b/tests/unit/render-pass-task.test.ts
@@ -6,7 +6,9 @@ import type { Mat4 } from "../../packages/babylon-lite/src/math/types";
 import type { DrawBinding, DrawUpdateContext, Renderable } from "../../packages/babylon-lite/src/render/renderable";
 import { createSceneContext, registerScene } from "../../packages/babylon-lite/src/scene/scene";
 import type { SceneContextInternal } from "../../packages/babylon-lite/src/scene/scene-core";
-import { enableSceneTransmission } from "../../packages/babylon-lite/src/frame-graph/transmission";
+import { createRenderTarget } from "../../packages/babylon-lite/src/engine/render-target";
+import { createRenderTask } from "../../packages/babylon-lite/src/frame-graph/render-task";
+import { enableRenderTaskTransmission, enableSceneTransmission } from "../../packages/babylon-lite/src/frame-graph/transmission";
 
 const gpuGlobals = globalThis as typeof globalThis & {
     GPUBufferUsage?: { UNIFORM: number; COPY_DST: number };
@@ -168,6 +170,23 @@ function makeDrawOrderRenderable(id: string, flags: Partial<Pick<Renderable, "or
 }
 
 describe("RenderPassTask transparent sorting", () => {
+    it("preserves custom depth compare when transmission retargets a render task", () => {
+        const engine = makeMockEngine();
+        const scene = createSceneContext(engine) as SceneContextInternal;
+        const rt = createRenderTarget({
+            colorFormat: "bgra8unorm",
+            depthStencilFormat: "depth32float",
+            _depthCompare: "less-equal",
+            sampleCount: 1,
+            size: { width: 16, height: 16 },
+        });
+        const task = createRenderTask({ name: "standard-z-offscreen", rt }, engine, scene);
+
+        enableRenderTaskTransmission(task, engine);
+
+        expect(task._targetSignature._depthCompare).toBe("less-equal");
+    });
+
     it("uses world centers refreshed by binding updates before sorting transparent draws", async () => {
         const engine = makeMockEngine();
         const scene = createSceneContext(engine) as SceneContextInternal;

--- a/tests/unit/reverse-z-depth.test.ts
+++ b/tests/unit/reverse-z-depth.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { createRenderTarget, targetSignatureKey } from "../../packages/babylon-lite/src/engine/render-target";
+import { createRenderPass, setRenderPassRenderTarget } from "../../packages/babylon-lite/src/frame-graph/render-pass";
+import type { Task } from "../../packages/babylon-lite/src/frame-graph/task";
+import { mat4PerspectiveLH } from "../../packages/babylon-lite/src/math/mat4-perspective-lh";
+import { createPickingRay } from "../../packages/babylon-lite/src/picking/ray";
+
+function projectDepth(matrix: Float32Array, z: number): number {
+    const clipZ = matrix[10]! * z + matrix[14]!;
+    const clipW = matrix[11]! * z + matrix[15]!;
+    return clipZ / clipW;
+}
+
+function makeTask(): Task {
+    return {
+        name: "reverse-z-test-task",
+        engine: {} as Task["engine"],
+        scene: {} as Task["scene"],
+        _passes: [],
+        record(): void {
+            return;
+        },
+        dispose(): void {
+            return;
+        },
+    };
+}
+
+describe("reverse-Z depth", () => {
+    it("maps perspective near depth to 1 and far depth to 0", () => {
+        const near = 0.25;
+        const far = 1000;
+        const projection = mat4PerspectiveLH(Math.PI / 3, 16 / 9, near, far);
+
+        expect(projectDepth(projection, near)).toBeCloseTo(1, 6);
+        expect(projectDepth(projection, far)).toBeCloseTo(0, 6);
+        expect(projectDepth(projection, 10)).toBeGreaterThan(projectDepth(projection, 100));
+    });
+
+    it("defaults render targets and pipeline signatures to reverse-Z", () => {
+        const rt = createRenderTarget({
+            colorFormat: "bgra8unorm",
+            depthStencilFormat: "depth24plus-stencil8",
+            sampleCount: 1,
+            size: { width: 1, height: 1 },
+        });
+
+        expect(rt._descriptor._depthClearValue).toBeUndefined();
+        expect(rt._descriptor._depthCompare).toBeUndefined();
+        expect(targetSignatureKey({ _colorFormat: "bgra8unorm", _depthStencilFormat: "depth24plus-stencil8", _sampleCount: 1 })).toBe("bgra8unorm|depth24plus-stencil8||1|");
+    });
+
+    it("allows internal shadow targets to keep standard-Z depth maps", () => {
+        const rt = createRenderTarget({
+            depthStencilFormat: "depth32float",
+            _depthClearValue: 1,
+            _depthCompare: "less-equal",
+            sampleCount: 1,
+            size: { width: 1, height: 1 },
+        });
+
+        expect(rt._descriptor._depthClearValue).toBe(1);
+        expect(rt._descriptor._depthCompare).toBe("less-equal");
+        expect(targetSignatureKey({ _depthStencilFormat: "depth32float", _depthCompare: "less-equal", _sampleCount: 1 })).toContain("less-equal");
+    });
+
+    it("initializes render-pass depth attachments with reverse-Z clear by default", () => {
+        const rt = createRenderTarget({
+            colorFormat: "bgra8unorm",
+            depthStencilFormat: "depth24plus-stencil8",
+            sampleCount: 1,
+            size: { width: 1, height: 1 },
+        });
+        rt._colorView = {} as GPUTextureView;
+        rt._depthView = {} as GPUTextureView;
+
+        const pass = createRenderPass("reverse-z-pass", makeTask());
+        setRenderPassRenderTarget(pass, rt);
+        pass._initialize();
+
+        expect(pass._depthAttachment?.depthClearValue).toBe(0);
+    });
+
+    it("unprojects picking rays from reverse-Z near and far depths", () => {
+        const near = 0.25;
+        const far = 1000;
+        const projection = mat4PerspectiveLH(Math.PI / 3, 1, near, far);
+
+        const ray = createPickingRay(50, 50, projection, 100, 100);
+
+        expect(ray).not.toBeNull();
+        expect(ray!.origin[0]).toBeCloseTo(0, 6);
+        expect(ray!.origin[1]).toBeCloseTo(0, 6);
+        expect(ray!.origin[2]).toBeCloseTo(near, 6);
+        expect(ray!.direction[0]).toBeCloseTo(0, 6);
+        expect(ray!.direction[1]).toBeCloseTo(0, 6);
+        expect(ray!.direction[2]).toBeCloseTo(1, 6);
+        expect(ray!.length).toBeCloseTo(far - near, 3);
+    });
+});

--- a/tests/unit/sprite-depth-hosted-routing.test.ts
+++ b/tests/unit/sprite-depth-hosted-routing.test.ts
@@ -166,11 +166,11 @@ describe("addDepthHostedSpriteLayer", () => {
         const depthShaderDescriptor = device.createShaderModule.mock.calls
             .map((call) => call[0] as GPUShaderModuleDescriptor)
             .find((descriptor) => descriptor.code.includes("@location(6) iZ: f32"));
-        expect(depthShaderDescriptor?.code).toContain("vec4<f32>(ndc, in.iZ, 1.0)");
+        expect(depthShaderDescriptor?.code).toContain("vec4<f32>(ndc, 1.0 - in.iZ, 1.0)");
         device.createRenderPipeline.mockClear();
         const renderable = scene._renderables[0]!;
 
-        const first = renderable.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
+        const first = renderable.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
         expect(device.createRenderPipeline).toHaveBeenCalledTimes(1);
         let descriptor = device.createRenderPipeline.mock.calls[0]![0] as GPURenderPipelineDescriptor;
         expect(descriptor.depthStencil?.format).toBe("depth32float");
@@ -178,7 +178,7 @@ describe("addDepthHostedSpriteLayer", () => {
         expect(vertexBuffer.arrayStride).toBe(DEPTH_INSTANCE_STRIDE_BYTES);
         expect(vertexBuffer.attributes.map((attr) => attr.shaderLocation)).toEqual([0, 1, 2, 3, 4, 5, 6]);
 
-        const second = renderable.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth24plus-stencil8", sampleCount: 1 });
+        const second = renderable.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth24plus-stencil8", _sampleCount: 1 });
         expect(second.pipeline).not.toBe(first.pipeline);
         expect(device.createRenderPipeline).toHaveBeenCalledTimes(2);
         descriptor = device.createRenderPipeline.mock.calls[1]![0] as GPURenderPipelineDescriptor;
@@ -200,7 +200,7 @@ describe("addDepthHostedSpriteLayer", () => {
         const instanceBufferCreate = device.createBuffer.mock.calls.find((call) => (call[0] as GPUBufferDescriptor).label === "sprite-depth-hosted-instances");
         expect((instanceBufferCreate![0] as GPUBufferDescriptor).size).toBe(DEPTH_INSTANCE_STRIDE_BYTES);
 
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth24plus-stencil8", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth24plus-stencil8", _sampleCount: 1 });
         device.queue.writeBuffer.mockClear();
         binding.update?.({ targetWidth: 512, targetHeight: 256 });
 
@@ -215,7 +215,7 @@ describe("addDepthHostedSpriteLayer", () => {
         addDepthHostedSpriteLayer(scene, layer);
         await registerScene(engine, scene);
 
-        const binding = scene._renderables[0]!.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth24plus-stencil8", sampleCount: 1 });
+        const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth24plus-stencil8", _sampleCount: 1 });
         const queue = (engine.device as unknown as { queue: { writeBuffer: ReturnType<typeof vi.fn> } }).queue;
         queue.writeBuffer.mockClear();
         binding.update?.({ targetWidth: 512, targetHeight: 256 });
@@ -241,8 +241,8 @@ describe("addDepthHostedSpriteLayer", () => {
         device.createBindGroup.mockClear();
 
         const renderable = scene._renderables[0]!;
-        const first = renderable.bind(engine, { colorFormat: "bgra8unorm", depthStencilFormat: "depth32float", sampleCount: 1 });
-        const second = renderable.bind(engine, { colorFormat: "rgba16float", depthStencilFormat: "depth32float", sampleCount: 1 });
+        const first = renderable.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth32float", _sampleCount: 1 });
+        const second = renderable.bind(engine, { _colorFormat: "rgba16float", _depthStencilFormat: "depth32float", _sampleCount: 1 });
 
         expect(second.pipeline).not.toBe(first.pipeline);
         expect(device.createBindGroup).toHaveBeenCalledTimes(2);

--- a/tests/unit/sprite-renderer.test.ts
+++ b/tests/unit/sprite-renderer.test.ts
@@ -35,6 +35,7 @@ import {
     disposeSpriteRenderer,
     _spriteRendererPipelineCacheSize,
 } from "../../packages/babylon-lite/src/sprite/sprite-renderer";
+import { createSpritePipelineCache, getOrCreateSpritePipeline } from "../../packages/babylon-lite/src/sprite/sprite-pipeline";
 import type { SpriteAtlas } from "../../packages/babylon-lite/src/sprite/shared/sprite-atlas";
 import type { Texture2D } from "../../packages/babylon-lite/src/texture/texture-2d";
 import type { EngineContext, EngineContextInternal } from "../../packages/babylon-lite/src/engine/engine";
@@ -179,6 +180,20 @@ describe("createSpriteRenderer", () => {
         const shaderDescriptor = device.createShaderModule.mock.calls[0]![0] as GPUShaderModuleDescriptor;
         expect(shaderDescriptor.code).not.toContain("iZ");
         expect(shaderDescriptor.code).toContain("vec4<f32>(ndc, 0.0, 1.0)");
+    });
+
+    it("converts depth-hosted sprite NDC Z to reverse-Z clip depth", () => {
+        const { engine } = makeMockEngine();
+        const cache = createSpritePipelineCache();
+        const sceneBGL = {} as GPUBindGroupLayout;
+
+        getOrCreateSpritePipeline(engine as EngineContextInternal, cache, "bgra8unorm", 4, "alpha", true, false, "depth24plus-stencil8", sceneBGL);
+
+        const device = engine.device as unknown as { createRenderPipeline: ReturnType<typeof vi.fn>; createShaderModule: ReturnType<typeof vi.fn> };
+        const shaderDescriptor = device.createShaderModule.mock.calls[0]![0] as GPUShaderModuleDescriptor;
+        const descriptor = device.createRenderPipeline.mock.calls[0]![0] as GPURenderPipelineDescriptor;
+        expect(shaderDescriptor.code).toContain("vec4<f32>(ndc, 1.0 - in.iZ, 1.0)");
+        expect(descriptor.depthStencil?.depthCompare).toBe("greater-equal");
     });
 });
 


### PR DESCRIPTION
## Summary
- Replace normal rendering with reverse-Z depth (clear 0, greater-equal compare) while preserving standard-Z shadow map targets
- Update picking, sprites/billboards, NodeMaterial FragCoord/FragDepth semantics, transmission retargeting, and render target signatures
- Add focused reverse-Z/unit coverage and update architecture docs

## Validation
- pnpm exec vitest run tests/unit/reverse-z-depth.test.ts tests/unit/billboard-sprite.test.ts tests/unit/sprite-renderer.test.ts tests/unit/sprite-depth-hosted-routing.test.ts tests/unit/render-pass-task.test.ts
- pnpm run lint
- pnpm build:bundle-scenes
- pnpm test:parity
- git diff --check

Note: lab/public/bundle/manifest.json and the pre-existing golden image diffs are intentionally not included in this PR.