### PR TITLE
docs: broaden WebGPU browser support note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A WebGPU-exclusive, tree-shakable 3D engine that produces pixel-identical output
 
 - **Node.js** ≥ 18
 - **pnpm** ≥ 9 (`corepack enable` to activate the version pinned in `package.json`)
-- A browser with **WebGPU** support (Chrome 113+, Edge 113+, or Firefox Nightly)
+- A browser with **WebGPU** support (Chrome 113+, Edge 113+, or recent Firefox and Safari)
 
 ## Getting Started
 


### PR DESCRIPTION
## What

Updates the README prerequisites to reflect that **WebGPU now ships in stable Firefox and Safari**, not just Firefox Nightly.

## Change

- Before: `Chrome 113+, Edge 113+, or Firefox Nightly`n- After: `Chrome 113+, Edge 113+, or recent Firefox and Safari`

## Why

The previous note was outdated and undersold browser compatibility. This keeps the README consistent with current WebGPU availability.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>