### PR TITLE
Fix moving vertical seam in landing-bg background effect

### DIFF
--- a/lab/src/demos/landing-bg.ts
+++ b/lab/src/demos/landing-bg.ts
@@ -22,12 +22,15 @@ const CORAL = vec3f(0.878, 0.408, 0.294); // #e0684b
 const LIGHT = vec3f(0.878, 0.871, 0.847); // #e0ded8
 const DARK  = vec3f(0.040, 0.026, 0.032);
 
-// Palette ramp across the ribbons: red -> coral -> light -> coral.
+// Cyclic palette ramp across the ribbons: red -> coral -> light -> red.
+// Must close the loop (x=1 maps back to RED) so the fract() wrap is seamless;
+// otherwise the wrap creates a hard colour jump that appears as a vertical bar
+// drifting horizontally with p.x / time.
 fn palette(h: f32) -> vec3f {
 let x = fract(h);
 if (x < 0.4) { return mix(RED, CORAL, x / 0.4); }
 if (x < 0.7) { return mix(CORAL, LIGHT, (x - 0.4) / 0.3); }
-return mix(LIGHT, CORAL, (x - 0.7) / 0.3);
+return mix(LIGHT, RED, (x - 0.7) / 0.3);
 }
 
 @fragment fn effectFragment(@location(0) uv: vec2f) -> @location(0) vec4f {


### PR DESCRIPTION
## Problem

The demos landing-page background effect (`lab/src/demos/landing-bg.ts`) showed a vertical bar drifting left and right across the screen.

## Cause

`palette()` was a non-cyclic ramp (RED -> CORAL -> LIGHT -> CORAL) but is sampled through `fract()`. At every `x=1` wrap the colour jumped hard from CORAL back to RED. Since `hue` depends on `p.x` (horizontal position) and time, that discontinuity rendered as a moving vertical seam.

## Fix

Close the palette loop (RED -> CORAL -> LIGHT -> **RED**) so the `fract()` wrap is seamless. Verified visually via WebGPU capture over several frames — ribbons now flow continuously with no seam.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>