### PR TITLE
Pages site: bundle Quake (LibreQuake) assets + drop header em dashes

### DIFF
--- a/pages/index.template.html
+++ b/pages/index.template.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Babylon.lite demos</title>
-        <meta name="description" content="Standalone showcase demos built on Babylon Lite — a WebGPU-exclusive, tree-shakable, minimal-footprint rendering engine." />
+        <meta name="description" content="Standalone showcase demos built on Babylon Lite, a WebGPU-exclusive, tree-shakable, minimal-footprint rendering engine." />
         <style>
             :root {
                 --bjs-red: #bb464b;
@@ -392,8 +392,8 @@
                 <img class="logo" src="babylon-logo.svg" alt="Babylon logo" />
                 <h1><span class="brand">Babylon</span><span class="lite">.lite</span> <span class="dot">demos</span></h1>
                 <p>
-                    Standalone showcase pages built on Babylon&nbsp;Lite — a WebGPU-exclusive, fully tree-shakable rendering engine. Each demo is production-bundled, so the size it
-                    actually ships is shown right on its card. Sizes cover the <strong>engine and demo code only</strong> — external assets (textures, game data, etc.) aren’t included.
+                    Standalone showcase pages built on Babylon&nbsp;Lite, a WebGPU-exclusive, fully tree-shakable rendering engine. Each demo is production-bundled, so the size it
+                    actually ships is shown right on its card. Sizes cover the <strong>engine and demo code only</strong>. External assets (textures, game data, etc.) aren’t included.
                 </p>
             </header>
             <!--FILTERS-->

--- a/scripts/build-pages-site.ts
+++ b/scripts/build-pages-site.ts
@@ -31,6 +31,7 @@ const DEMOS_CONFIG = resolve(ROOT, "demos-config.json");
 const DEMOS_BUNDLE_SRC = resolve(LAB, "public/bundle/demos");
 const DEMOS_MANIFEST = resolve(LAB, "public/bundle/demos-manifest.json");
 const DOOM_SRC = resolve(LAB, "public/doom");
+const LIBREQUAKE_SRC = resolve(LAB, "public/librequake");
 const THUMBS_SRC = resolve(LAB, "public/thumbnails");
 
 interface DemoConfigEntry {
@@ -89,10 +90,11 @@ function rewriteDemoHtml(html: string): string {
     return html.replace(/(["'])\/bundle\//g, "$1./bundle/");
 }
 
-/** Make a demo bundle deployable under any base path. The only root-relative
- *  reference in any demo bundle is the DOOM demo's `fetch("/doom/...")`. */
+/** Make a demo bundle deployable under any base path. Demos that fetch runtime
+ *  data use root-relative URLs (DOOM `/doom/...`, Quake `/librequake/...`); make
+ *  them relative so the site works under any Pages base path. */
 function rewriteBundle(code: string): string {
-    return code.replace(/(["'])\/doom\//g, "$1doom/");
+    return code.replace(/(["'])\/doom\//g, "$1doom/").replace(/(["'])\/librequake\//g, "$1librequake/");
 }
 
 /** Fail loudly if any root-relative URL survives in the assembled site. */
@@ -162,6 +164,14 @@ async function main(): Promise<void> {
             if (file === "freedoom2.wad") continue;
             cpSync(resolve(DOOM_SRC, file), resolve(doomOut, file));
         }
+    }
+
+    // 4b. Quake demo data (BSD-licensed LibreQuake: BSP, palette, models, sounds,
+    //     license/attribution files). Fetched at dev/build time by
+    //     `pnpm fetch:librequake` into lab/public/librequake/ (not committed). The
+    //     whole tree is copied since the demo fetches many nested assets at runtime.
+    if (demos.some((d) => d.slug === "quake") && existsSync(LIBREQUAKE_SRC)) {
+        cpSync(LIBREQUAKE_SRC, resolve(SITE, "librequake"), { recursive: true });
     }
 
     // 5. Thumbnails for the demo cards.


### PR DESCRIPTION
## Why

Adding the Quake demo to `demos-config.json` broke `pnpm build:pages-site`: the assembled site failed its no-root-relative-URL guardrail because `quake.js` fetches `/librequake/...` at runtime, and the builder only knew how to handle the DOOM demo's `/doom/` data.

## Changes

- `scripts/build-pages-site.ts`:
  - `rewriteBundle` now also rewrites `/librequake/` -> relative.
  - Copy the LibreQuake asset tree (`lab/public/librequake/`, fetched via `pnpm fetch:librequake`) into the site when the `quake` demo is present, mirroring the DOOM handling.
- `pages/index.template.html`: removed the two em dashes from the header intro paragraph and the meta description.

## Note for deploy

The Pages CI workflow (`deploy-pages.yml`) currently only runs `pnpm fetch:freedoom`. It will also need a `pnpm fetch:librequake` step so the Quake assets are present at build time. (Can add here if desired.)

## Verification

`pnpm build:pages-site` succeeds (3 demos), Quake assets land under `librequake/`, and no root-relative `/librequake/` references remain in the bundle.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>