### PR TITLE
Fix interactive-object depth bug in Quake demo (buttons/torches through walls)

### DIFF
--- a/lab/src/demos/quake.ts
+++ b/lab/src/demos/quake.ts
@@ -76,12 +76,19 @@ const brushNudge = (modelIndex: number): number =>
     BRUSH_BASE_NUDGE + ((modelIndex * 7) % 16) * 0.04;
 
 // Movers render solid (zero geometry nudge) and instead win coplanar depth ties
-// via a per-model clip-space depth bias (reverse-Z → larger is nearer). The base
-// keeps leaves in front of the world / func_wall backing; the per-model jitter
-// separates coplanar sibling leaves so they don't z-fight each other.
-const MOVER_BIAS_BASE = 1.2e-3;
+// via a per-model depth pull toward the camera. Unlike the geometric brushNudge,
+// the pull is applied in clip space by the quake material as `DEPTH_BIAS / w`,
+// which (see quake-material.ts) yields a CONSTANT view-space pull of
+// `DEPTH_BIAS / near` world units at every distance — so the value below is the
+// pull in world units multiplied by the camera near plane (fixed at 1 for this
+// demo). The base keeps leaves in front of the world / func_wall backing (whose
+// geometric nudge tops out at ~1 unit); the per-model jitter separates coplanar
+// sibling leaves so they don't z-fight each other. Kept comfortably below the
+// recess depth of inset buttons/torches so those stay correctly behind the wall.
+const MOVER_CAMERA_NEAR = 1; // matches cam.nearPlane; pull(world) = bias / near.
+const MOVER_PULL_BASE = 1.1; // world units of toward-camera pull for a closed leaf.
 const moverDepthBias = (modelIndex: number): number =>
-    MOVER_BIAS_BASE + ((modelIndex * 7) % 16) * 4e-5;
+    (MOVER_PULL_BASE + ((modelIndex * 7) % 16) * 0.02) * MOVER_CAMERA_NEAR;
 
 const START_SHELLS = 25;
 const START_NAILS = 0;

--- a/lab/src/demos/quake/render/quake-material.ts
+++ b/lab/src/demos/quake/render/quake-material.ts
@@ -9,10 +9,17 @@ const OVERBRIGHT = 2.5;
 
 // Movers (doors/buttons/lifts) sit coplanar with the static world and with each
 // other, so they z-fight. Rather than physically expanding the brush (which tears
-// small cuboids like buttons apart), we bias their clip-space depth toward the
+// small cuboids like buttons apart), we pull their depth a fixed amount toward the
 // camera. The engine uses reverse-Z (depthCompare "greater-equal"), so a larger
-// NDC z is nearer — we ADD the bias. A per-model jitter keeps coplanar siblings
-// (e.g. two door leaves) from fighting each other.
+// NDC z is nearer — we ADD to clip-space z.
+//
+// Crucially the term is `DEPTH_BIAS / w`, NOT `DEPTH_BIAS * w`. With reverse-Z the
+// NDC shift is `(DEPTH_BIAS / w) / w = DEPTH_BIAS / w²`, and since `w == z_view` this
+// translates to a CONSTANT view-space pull of `DEPTH_BIAS / near` world units at all
+// distances. A constant *NDC* bias (`* w`) instead pulls by `bias·z²/near`, which
+// explodes with distance (≈0.5u at z=20 but ≈190u at z=500) and yanks recessed
+// buttons/torches clean through the wall in front of them — the depth bug this fixes.
+// `DEPTH_BIAS` is therefore expressed as `pull · near` (world units × near plane).
 const vertexSource = (depthBias: number) => `struct VertexOutput {
   @builtin(position) position: vec4<f32>,
   @location(0) uv: vec2<f32>,
@@ -22,7 +29,7 @@ const DEPTH_BIAS: f32 = ${depthBias.toExponential(6)};
 @vertex fn mainVertex(input: VertexInput) -> VertexOutput {
   var out: VertexOutput;
   out.position = shaderSystem.worldViewProjection * vec4<f32>(input.position, 1.0);
-  out.position.z = out.position.z + DEPTH_BIAS * out.position.w;
+  out.position.z = out.position.z + DEPTH_BIAS / out.position.w;
   out.uv = input.uv;
   out.uv2 = input.uv2;
   return out;


### PR DESCRIPTION
## Symptom

Interactive objects in the LibreQuake E1M1 demo (recessed buttons, torch flames, movers) rendered IN FRONT OF the walls they should be occluded by, increasingly so with distance.

## Root cause

The Quake world material biases mover depth toward the camera to win coplanar z-fighting against the static world. It did so with out.position.z + DEPTH_BIAS * out.position.w — a **constant NDC** offset. Under the engine's **reverse-Z** depth, a constant NDC offset maps to a world-space pull that grows with distance (≈0.5u at z=20, but ≈190u at z=500), pulling recessed buttons/torches clean through the wall in front of them.

## Fix

- `quake-material.ts`: use `DEPTH_BIAS / out.position.w` instead of `* w`. This yields a **constant view-space pull** of `DEPTH_BIAS / near` world units at every distance.
- `quake.ts`: retune the mover bias as a ~1.1 world-unit camera pull (expressed as `pull · near`), kept below the recess depth of inset buttons/torches so they stay correctly occluded, while still beating the static world's coplanar brushes and separating sibling door leaves.

## Verification

Visual: recessed buttons/torches are now correctly occluded by walls; coplanar door leaves still don't z-fight. (Reviewer note: this only touches the Quake demo's two render files.)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>