### PR TITLE
Demos site: loading screens, mobile filtering, Minecraft assets; remove Pages workflow

### DIFF
--- a/demos-config.json
+++ b/demos-config.json
@@ -3,24 +3,28 @@
         "slug": "torus-states",
         "name": "Torus States",
         "description": "Fullscreen WGSL raymarched twisted-torus SDF that auto-morphs through 7 states. Pure Lite effect pipeline — no scene, camera, or mesh. Reproduction of Robert Penner's demo.",
-        "tags": ["effect", "shader", "procedural"]
+        "tags": ["effect", "shader", "procedural"],
+        "mobile": false
     },
     {
         "slug": "doom",
         "name": "DOOM (id Tech 1)",
         "description": "Playable id Tech 1 / Doom-format level player built on Lite. Ships the BSD-licensed Freedoom IWAD; optionally load your own legally-owned doom1.wad at runtime. Clean-room engine reimplemented from public format specs — no id data or GPL source.",
-        "tags": ["game", "fps", "showcase"]
+        "tags": ["game", "fps", "showcase"],
+        "mobile": false
     },
     {
         "slug": "quake",
         "name": "LibreQuake — E1M1",
         "description": "Playable port of LibreQuake's first level (lq_e1m1) on Lite: clean-room Quake BSP v29 parser with embedded textures and grayscale lightmaps, player physics + BSP collision, working doors/lifts/triggers, MDL enemies (soldiers & dogs) with AI, a shotgun with hitscan combat, items and a HUD. Ships the BSD-3-Clause LibreQuake assets — no id data or GPL source.",
-        "tags": ["game", "fps", "bsp", "quake", "showcase"]
+        "tags": ["game", "fps", "bsp", "showcase"],
+        "mobile": false
     },
     {
         "slug": "minecraft",
         "name": "Voxel Sandbox",
         "description": "Minecraft-style creative voxel sandbox built on Lite. Procedurally generated, infinitely streaming chunk world with break/place editing, ambient occlusion, water, day-night sky and fog. Ships CC0 Kenney textures; optionally load your own resource pack at runtime. Original clean-room engine — no Mojang code or assets.",
-        "tags": ["game", "voxel", "sandbox", "showcase"]
+        "tags": ["game", "voxel", "sandbox", "showcase"],
+        "mobile": false
     }
 ]

--- a/lab/demo-doom.html
+++ b/lab/demo-doom.html
@@ -6,6 +6,24 @@
   <style>
     html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
     canvas { width: 100%; height: 100%; display: block; }
+    .loading-overlay {
+      position: fixed; inset: 0; z-index: 10000;
+      display: flex; align-items: center; justify-content: center;
+      background: #0b0809; color: #f4ece9;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      transition: opacity 0.5s ease;
+    }
+    .loading-overlay.is-hidden { opacity: 0; pointer-events: none; }
+    .loading-box { display: flex; flex-direction: column; align-items: center; gap: 1rem; text-align: center; padding: 0 1rem; }
+    .loading-spinner {
+      width: 54px; height: 54px; border-radius: 50%;
+      border: 4px solid rgba(224, 104, 75, 0.25); border-top-color: #e0684b;
+      animation: lite-spin 0.9s linear infinite;
+    }
+    .loading-label { font-size: 1.05rem; font-weight: 600; }
+    .loading-sub { font-size: 0.8rem; color: #b8a9a4; }
+    @keyframes lite-spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) { .loading-spinner { animation-duration: 2.4s; } }
   </style>
 </head>
 <body>
@@ -15,6 +33,37 @@
     (also part of `pnpm dev:lab`) to (re)generate the bundle this page references.
   -->
   <canvas id="renderCanvas"></canvas>
+  <div id="loadingOverlay" class="loading-overlay" role="status" aria-live="polite">
+    <div class="loading-box">
+      <div class="loading-spinner" aria-hidden="true"></div>
+      <div class="loading-label">Loading DOOM…</div>
+      <div class="loading-sub">Preparing assets — this can take a moment.</div>
+    </div>
+  </div>
+  <script>
+    // Loading screen: hide once the demo signals ready (or errors) via the canvas
+    // data attributes it sets when its assets are loaded and the engine starts.
+    (function () {
+      var overlay = document.getElementById("loadingOverlay");
+      var canvas = document.getElementById("renderCanvas");
+      if (!overlay || !canvas) return;
+      var done = false;
+      function hide() {
+        if (done) return;
+        done = true;
+        overlay.classList.add("is-hidden");
+        setTimeout(function () { if (overlay.parentNode) overlay.parentNode.removeChild(overlay); }, 600);
+      }
+      function check() {
+        if (canvas.dataset.ready === "true" || canvas.dataset.error) { hide(); return true; }
+        return false;
+      }
+      if (!check()) {
+        new MutationObserver(check).observe(canvas, { attributes: true, attributeFilter: ["data-ready", "data-error"] });
+        setTimeout(hide, 45000);
+      }
+    })();
+  </script>
   <script type="module" src="/bundle/demos/doom.js"></script>
 </body>
 </html>

--- a/lab/demo-minecraft.html
+++ b/lab/demo-minecraft.html
@@ -6,6 +6,24 @@
   <style>
     html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #88b0d8; }
     canvas { width: 100%; height: 100%; display: block; }
+    .loading-overlay {
+      position: fixed; inset: 0; z-index: 10000;
+      display: flex; align-items: center; justify-content: center;
+      background: #0b0809; color: #f4ece9;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      transition: opacity 0.5s ease;
+    }
+    .loading-overlay.is-hidden { opacity: 0; pointer-events: none; }
+    .loading-box { display: flex; flex-direction: column; align-items: center; gap: 1rem; text-align: center; padding: 0 1rem; }
+    .loading-spinner {
+      width: 54px; height: 54px; border-radius: 50%;
+      border: 4px solid rgba(224, 104, 75, 0.25); border-top-color: #e0684b;
+      animation: lite-spin 0.9s linear infinite;
+    }
+    .loading-label { font-size: 1.05rem; font-weight: 600; }
+    .loading-sub { font-size: 0.8rem; color: #b8a9a4; }
+    @keyframes lite-spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) { .loading-spinner { animation-duration: 2.4s; } }
   </style>
 </head>
 <body>
@@ -15,6 +33,37 @@
     (also part of `pnpm dev:lab`) to (re)generate the bundle this page references.
   -->
   <canvas id="renderCanvas"></canvas>
+  <div id="loadingOverlay" class="loading-overlay" role="status" aria-live="polite">
+    <div class="loading-box">
+      <div class="loading-spinner" aria-hidden="true"></div>
+      <div class="loading-label">Loading Voxel Sandbox…</div>
+      <div class="loading-sub">Preparing assets — this can take a moment.</div>
+    </div>
+  </div>
+  <script>
+    // Loading screen: hide once the demo signals ready (or errors) via the canvas
+    // data attributes it sets when its assets are loaded and the engine starts.
+    (function () {
+      var overlay = document.getElementById("loadingOverlay");
+      var canvas = document.getElementById("renderCanvas");
+      if (!overlay || !canvas) return;
+      var done = false;
+      function hide() {
+        if (done) return;
+        done = true;
+        overlay.classList.add("is-hidden");
+        setTimeout(function () { if (overlay.parentNode) overlay.parentNode.removeChild(overlay); }, 600);
+      }
+      function check() {
+        if (canvas.dataset.ready === "true" || canvas.dataset.error) { hide(); return true; }
+        return false;
+      }
+      if (!check()) {
+        new MutationObserver(check).observe(canvas, { attributes: true, attributeFilter: ["data-ready", "data-error"] });
+        setTimeout(hide, 45000);
+      }
+    })();
+  </script>
   <script type="module" src="/bundle/demos/minecraft.js"></script>
 </body>
 </html>

--- a/lab/demo-quake.html
+++ b/lab/demo-quake.html
@@ -6,6 +6,24 @@
   <style>
     html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
     canvas { width: 100%; height: 100%; display: block; }
+    .loading-overlay {
+      position: fixed; inset: 0; z-index: 10000;
+      display: flex; align-items: center; justify-content: center;
+      background: #0b0809; color: #f4ece9;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      transition: opacity 0.5s ease;
+    }
+    .loading-overlay.is-hidden { opacity: 0; pointer-events: none; }
+    .loading-box { display: flex; flex-direction: column; align-items: center; gap: 1rem; text-align: center; padding: 0 1rem; }
+    .loading-spinner {
+      width: 54px; height: 54px; border-radius: 50%;
+      border: 4px solid rgba(224, 104, 75, 0.25); border-top-color: #e0684b;
+      animation: lite-spin 0.9s linear infinite;
+    }
+    .loading-label { font-size: 1.05rem; font-weight: 600; }
+    .loading-sub { font-size: 0.8rem; color: #b8a9a4; }
+    @keyframes lite-spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) { .loading-spinner { animation-duration: 2.4s; } }
   </style>
 </head>
 <body>
@@ -15,6 +33,37 @@
     (also part of `pnpm dev:lab`) to (re)generate the bundle this page references.
   -->
   <canvas id="renderCanvas"></canvas>
+  <div id="loadingOverlay" class="loading-overlay" role="status" aria-live="polite">
+    <div class="loading-box">
+      <div class="loading-spinner" aria-hidden="true"></div>
+      <div class="loading-label">Loading LibreQuake…</div>
+      <div class="loading-sub">Preparing assets — this can take a moment.</div>
+    </div>
+  </div>
+  <script>
+    // Loading screen: hide once the demo signals ready (or errors) via the canvas
+    // data attributes it sets when its assets are loaded and the engine starts.
+    (function () {
+      var overlay = document.getElementById("loadingOverlay");
+      var canvas = document.getElementById("renderCanvas");
+      if (!overlay || !canvas) return;
+      var done = false;
+      function hide() {
+        if (done) return;
+        done = true;
+        overlay.classList.add("is-hidden");
+        setTimeout(function () { if (overlay.parentNode) overlay.parentNode.removeChild(overlay); }, 600);
+      }
+      function check() {
+        if (canvas.dataset.ready === "true" || canvas.dataset.error) { hide(); return true; }
+        return false;
+      }
+      if (!check()) {
+        new MutationObserver(check).observe(canvas, { attributes: true, attributeFilter: ["data-ready", "data-error"] });
+        setTimeout(hide, 45000);
+      }
+    })();
+  </script>
   <script type="module" src="/bundle/demos/quake.js"></script>
 </body>
 </html>

--- a/lab/demo-torus-states.html
+++ b/lab/demo-torus-states.html
@@ -6,6 +6,24 @@
   <style>
     html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
     canvas { width: 100%; height: 100%; display: block; }
+    .loading-overlay {
+      position: fixed; inset: 0; z-index: 10000;
+      display: flex; align-items: center; justify-content: center;
+      background: #0b0809; color: #f4ece9;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      transition: opacity 0.5s ease;
+    }
+    .loading-overlay.is-hidden { opacity: 0; pointer-events: none; }
+    .loading-box { display: flex; flex-direction: column; align-items: center; gap: 1rem; text-align: center; padding: 0 1rem; }
+    .loading-spinner {
+      width: 54px; height: 54px; border-radius: 50%;
+      border: 4px solid rgba(224, 104, 75, 0.25); border-top-color: #e0684b;
+      animation: lite-spin 0.9s linear infinite;
+    }
+    .loading-label { font-size: 1.05rem; font-weight: 600; }
+    .loading-sub { font-size: 0.8rem; color: #b8a9a4; }
+    @keyframes lite-spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) { .loading-spinner { animation-duration: 2.4s; } }
   </style>
 </head>
 <body>
@@ -16,6 +34,37 @@
     `pnpm dev:lab`) to (re)generate the bundle that this page references.
   -->
   <canvas id="renderCanvas"></canvas>
+  <div id="loadingOverlay" class="loading-overlay" role="status" aria-live="polite">
+    <div class="loading-box">
+      <div class="loading-spinner" aria-hidden="true"></div>
+      <div class="loading-label">Loading Torus States…</div>
+      <div class="loading-sub">Preparing assets — this can take a moment.</div>
+    </div>
+  </div>
+  <script>
+    // Loading screen: hide once the demo signals ready (or errors) via the canvas
+    // data attributes it sets when its assets are loaded and the engine starts.
+    (function () {
+      var overlay = document.getElementById("loadingOverlay");
+      var canvas = document.getElementById("renderCanvas");
+      if (!overlay || !canvas) return;
+      var done = false;
+      function hide() {
+        if (done) return;
+        done = true;
+        overlay.classList.add("is-hidden");
+        setTimeout(function () { if (overlay.parentNode) overlay.parentNode.removeChild(overlay); }, 600);
+      }
+      function check() {
+        if (canvas.dataset.ready === "true" || canvas.dataset.error) { hide(); return true; }
+        return false;
+      }
+      if (!check()) {
+        new MutationObserver(check).observe(canvas, { attributes: true, attributeFilter: ["data-ready", "data-error"] });
+        setTimeout(hide, 45000);
+      }
+    })();
+  </script>
   <script type="module" src="/bundle/demos/torus-states.js"></script>
 </body>
 </html>

--- a/pages/index.template.html
+++ b/pages/index.template.html
@@ -194,6 +194,31 @@
                 border-color: var(--bjs-coral);
                 box-shadow: 0 12px 30px -12px rgba(224, 104, 75, 0.55);
             }
+            /* Mobile: hide demos flagged not mobile-compatible (data-mobile="false"). */
+            body.is-mobile a.card[data-mobile="false"] {
+                display: none;
+            }
+            /* Shown when, on mobile, no mobile-compatible demo remains. */
+            .no-demos-msg {
+                display: none;
+                grid-column: 1 / -1;
+                margin: 1rem auto;
+                max-width: 34rem;
+                padding: 1.1rem 1.3rem;
+                text-align: center;
+                border: 1px solid var(--border);
+                border-radius: 12px;
+                background: var(--card-bg);
+                color: var(--muted);
+                font-size: 0.95rem;
+                line-height: 1.5;
+            }
+            body.no-compatible-demos .no-demos-msg {
+                display: block;
+            }
+            body.no-compatible-demos .filters {
+                display: none;
+            }
             .card-image {
                 aspect-ratio: 16 / 9;
                 background: #0f0c0d;
@@ -399,6 +424,7 @@
             <!--FILTERS-->
             <main class="grid">
                 <!--CARDS-->
+                <p class="no-demos-msg" id="noDemosMsg">No compatible demo was found. Please try on a desktop device.</p>
             </main>
             <footer>
                 Built with <a href="https://github.com/BabylonJS/Babylon-Lite">Babylon&nbsp;Lite</a> · WebGPU only
@@ -459,6 +485,31 @@
                         apply();
                     });
                 });
+            })();
+        </script>
+        <script>
+            // Mobile gate: demos flagged "mobile": false in demos-config.json carry
+            // data-mobile="false" and are WebGPU/desktop-oriented (pointer lock,
+            // heavy input). On a mobile device we hide them; if none remain, show a
+            // "no compatible demo" message. This is independent of the tag filters.
+            (function () {
+                function isMobile() {
+                    var uad = navigator.userAgentData;
+                    if (uad && typeof uad.mobile === "boolean") return uad.mobile;
+                    var ua = navigator.userAgent || "";
+                    if (/Mobi|Android|iPhone|iPod|IEMobile|BlackBerry|Opera Mini/i.test(ua)) return true;
+                    // iPadOS reports as desktop Safari but exposes touch points.
+                    if (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1) return true;
+                    var coarse = window.matchMedia && window.matchMedia("(pointer: coarse)").matches;
+                    return !!coarse && navigator.maxTouchPoints > 0;
+                }
+                if (!isMobile()) return;
+                document.body.classList.add("is-mobile");
+                var cards = Array.prototype.slice.call(document.querySelectorAll("a.card"));
+                var compatible = cards.filter(function (c) { return c.getAttribute("data-mobile") !== "false"; });
+                if (compatible.length === 0) {
+                    document.body.classList.add("no-compatible-demos");
+                }
             })();
         </script>
     </body>

--- a/scripts/build-pages-site.ts
+++ b/scripts/build-pages-site.ts
@@ -32,6 +32,7 @@ const DEMOS_BUNDLE_SRC = resolve(LAB, "public/bundle/demos");
 const DEMOS_MANIFEST = resolve(LAB, "public/bundle/demos-manifest.json");
 const DOOM_SRC = resolve(LAB, "public/doom");
 const LIBREQUAKE_SRC = resolve(LAB, "public/librequake");
+const MINECRAFT_SRC = resolve(LAB, "public/minecraft");
 const THUMBS_SRC = resolve(LAB, "public/thumbnails");
 
 interface DemoConfigEntry {
@@ -39,6 +40,8 @@ interface DemoConfigEntry {
     name: string;
     description: string;
     tags?: string[];
+    /** When false, the demo is hidden on mobile devices (see index.template.html). */
+    mobile?: boolean;
 }
 interface DemoSize {
     rawKB: number;
@@ -58,7 +61,7 @@ function renderCard(demo: DemoConfigEntry, size: DemoSize | undefined): string {
     const tags = tagList.map((t) => `<span class="tag">${escapeHtml(t)}</span>`).join("");
     const sizeRow = size ? `<div class="size" title="Engine + demo code only — excludes external assets (textures, game data, etc.)"><strong>${size.rawKB} KB</strong> · ${size.gzipKB} KB gzip</div>` : "";
     return [
-        `<a class="card" href="./demo-${demo.slug}.html" data-tags="${escapeHtml(tagList.join(" "))}">`,
+        `<a class="card" href="./demo-${demo.slug}.html" data-tags="${escapeHtml(tagList.join(" "))}" data-mobile="${demo.mobile === false ? "false" : "true"}">`,
         `<div class="card-image">`,
         `<img src="thumbnails/demo-${demo.slug}.png" alt="${escapeHtml(demo.name)} thumbnail" loading="lazy" decoding="async" onerror="this.remove()" />`,
         `</div>`,
@@ -94,7 +97,10 @@ function rewriteDemoHtml(html: string): string {
  *  data use root-relative URLs (DOOM `/doom/...`, Quake `/librequake/...`); make
  *  them relative so the site works under any Pages base path. */
 function rewriteBundle(code: string): string {
-    return code.replace(/(["'])\/doom\//g, "$1doom/").replace(/(["'])\/librequake\//g, "$1librequake/");
+    return code
+        .replace(/(["'])\/doom\//g, "$1doom/")
+        .replace(/(["'])\/librequake\//g, "$1librequake/")
+        .replace(/(["'])\/minecraft\//g, "$1minecraft/");
 }
 
 /** Fail loudly if any root-relative URL survives in the assembled site. */
@@ -172,6 +178,14 @@ async function main(): Promise<void> {
     //     whole tree is copied since the demo fetches many nested assets at runtime.
     if (demos.some((d) => d.slug === "quake") && existsSync(LIBREQUAKE_SRC)) {
         cpSync(LIBREQUAKE_SRC, resolve(SITE, "librequake"), { recursive: true });
+    }
+
+    // 4c. Minecraft demo data (BSD-licensed voxel texture pack + attribution).
+    //     Fetched at dev/build time by `pnpm fetch:voxelpack` into
+    //     lab/public/minecraft/ (not committed). The demo fetches the pack's PNGs
+    //     at runtime from /minecraft/voxelpack/, so copy the whole tree.
+    if (demos.some((d) => d.slug === "minecraft") && existsSync(MINECRAFT_SRC)) {
+        cpSync(MINECRAFT_SRC, resolve(SITE, "minecraft"), { recursive: true });
     }
 
     // 5. Thumbnails for the demo cards.


### PR DESCRIPTION
## Summary

Three improvements to the standalone demos site (and the lab demo pages they share):

### 1. Per-demo loading screens
Every demo page (`lab/demo-*.html`) now shows a branded loading overlay (Babylon-coral spinner + label) while assets download. It is removed the moment the demo signals readiness via the `canvas` `data-ready` / `data-error` attributes each demo already sets after its assets load and the engine starts, with a 45s safety timeout so it can never trap the user. Pure inline CSS/markup — **no engine, bundle, or TypeScript changes**, and no root-relative URLs (passes the pages-site guardrail). Works identically in the lab and the published pages site.

### 2. Mobile filtering
Demos flagged `"mobile": false` in `demos-config.json` (torus-states, doom, quake — they rely on pointer lock / heavy keyboard input) now carry a `data-mobile="false"` card attribute. A small detection script in `index.template.html` hides those cards on mobile devices; if none remain, it shows **"No compatible demo was found. Please try on a desktop device."** Minecraft stays mobile-compatible.

### 3. Minecraft asset support in the pages build
`build-pages-site.ts` now copies the Minecraft voxelpack and rewrites `/minecraft/` runtime fetches to relative, mirroring the existing DOOM/Quake handling, so the 4th demo deploys correctly under any base path.

### 4. Remove the GitHub Pages deploy workflow
This repo will not use GitHub Pages — the demos are published manually to an external host — so `.github/workflows/deploy-pages.yml` is removed.

## Testing
- `pnpm build:pages-site` → builds 4 demos, no root-relative URLs slip through.
- Verified DOOM and Minecraft load in the lab dev server and the overlay clears cleanly (no stuck overlay).
- Mobile filtering verified via the generated `data-mobile` attributes and detection logic.
