### PR TITLE
Minecraft demo: indestructible bedrock + step-by-step water

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default tseslint.config(
         ignores: [
             "dist/**",
             "**/dist/**",
+            "pages-dist/**",
             "node_modules/**",
             "**/node_modules/**",
             "reference/**",

--- a/lab/src/demos/minecraft.ts
+++ b/lab/src/demos/minecraft.ts
@@ -89,7 +89,7 @@ async function main(): Promise<void> {
     const water = new WaterSim(world, renderer);
     // Flood connected sub-sea-level air (caves opening into the seafloor) from the
     // ocean as each chunk activates, so there are never dry pockets under water.
-    renderer.onChunkActivated = (cx, cz) => water.seedChunk(cx, cz);
+    renderer.onChunkActivated = (cx, cz) => water.settleChunk(cx, cz);
     const player = new PlayerController(scene, world, renderer, highlight, hud, canvas, particles, falling, water);
 
     const mobs = new Mobs(engine, scene, world, { fogStart: FOG_START, fogEnd: FOG_END, fogColor: FOG_COLOR });
@@ -176,7 +176,7 @@ async function main(): Promise<void> {
 
         player.update(dt);
         falling.update(dt);
-        water.update();
+        water.update(dt);
         renderer.processQueue();
         renderer.setTime(time);
         renderer.setCameraPos([player.camera.position.x, player.camera.position.y, player.camera.position.z]);

--- a/lab/src/demos/minecraft/blocks.ts
+++ b/lab/src/demos/minecraft/blocks.ts
@@ -49,6 +49,8 @@ export interface BlockDef {
     sway: boolean;
     /** Light emitted by this block, 0..15 (0 = not a light source). */
     light: number;
+    /** Cannot be broken or replaced by the player (e.g. bedrock world floor). */
+    indestructible: boolean;
 }
 
 function def(id: Block, name: string, faces: Partial<BlockDef["faces"]> & { all?: string }, opts: Partial<BlockDef> = {}): BlockDef {
@@ -64,6 +66,7 @@ function def(id: Block, name: string, faces: Partial<BlockDef["faces"]> & { all?
         fluid: opts.fluid ?? false,
         sway: opts.sway ?? false,
         light: opts.light ?? 0,
+        indestructible: opts.indestructible ?? false,
     };
 }
 
@@ -86,7 +89,7 @@ const DEFS: Record<number, BlockDef> = {
     [Block.GRAVEL]: def(Block.GRAVEL, "Gravel", { all: "gravel_stone" }),
     [Block.ICE]: def(Block.ICE, "Ice", { all: "ice" }, { renderMode: "blend", hidesNeighborFaces: false, castsAO: false }),
     [Block.CACTUS]: def(Block.CACTUS, "Cactus", { top: "cactus_top", side: "cactus_side", bottom: "cactus_top" }, { renderMode: "cutout", hidesNeighborFaces: false }),
-    [Block.BEDROCK]: def(Block.BEDROCK, "Bedrock", { all: "greystone" }),
+    [Block.BEDROCK]: def(Block.BEDROCK, "Bedrock", { all: "greystone" }, { indestructible: true }),
     [Block.WOOL_RED]: def(Block.WOOL_RED, "Red Wool", { all: "cotton_red" }),
     [Block.WOOL_GREEN]: def(Block.WOOL_GREEN, "Green Wool", { all: "cotton_green" }),
     [Block.WOOL_BLUE]: def(Block.WOOL_BLUE, "Blue Wool", { all: "cotton_blue" }),
@@ -133,6 +136,11 @@ export function isAir(id: number): boolean {
     return id === Block.AIR;
 }
 
+/** True if a block cannot be broken or replaced by the player (e.g. bedrock). */
+export function isIndestructible(id: number): boolean {
+    return DEFS[id]?.indestructible === true;
+}
+
 /** Light emitted by a block (0..15). Air and non-source blocks emit 0. */
 export function blockLight(id: number): number {
     return DEFS[id]?.light ?? 0;
@@ -149,6 +157,7 @@ export function allReferencedTiles(): string[] {
     const set = new Set<string>();
     for (const id of Object.keys(DEFS)) {
         const d = DEFS[Number(id)];
+        if (!d) continue;
         set.add(d.faces.top);
         set.add(d.faces.side);
         set.add(d.faces.bottom);

--- a/lab/src/demos/minecraft/chunk-renderer.ts
+++ b/lab/src/demos/minecraft/chunk-renderer.ts
@@ -104,7 +104,9 @@ export class ChunkRenderer {
 
         // Unload chunks beyond the keep radius.
         for (const [key, cm] of this.active) {
-            const [cx, cz] = key.split(",").map(Number);
+            const parts = key.split(",");
+            const cx = Number(parts[0]);
+            const cz = Number(parts[1]);
             if (Math.abs(cx - ccx) > keep || Math.abs(cz - ccz) > keep) {
                 this.retire(cm.meshes);
                 this.active.delete(key);

--- a/lab/src/demos/minecraft/controls.ts
+++ b/lab/src/demos/minecraft/controls.ts
@@ -6,7 +6,7 @@
 
 import { createFreeCamera, type FreeCamera, type SceneContext } from "babylon-lite";
 
-import { Block, HOTBAR, blockDef, blockColor } from "./blocks.js";
+import { Block, HOTBAR, blockDef, blockColor, isIndestructible } from "./blocks.js";
 import { CHUNK_SX, CHUNK_SZ, WORLD_H } from "./constants.js";
 import type { World } from "./world.js";
 import type { ChunkRenderer } from "./chunk-renderer.js";
@@ -164,6 +164,7 @@ export class PlayerController {
         if (!this.target) return;
         const { bx, by, bz } = this.target;
         const removed = this.world.getBlock(bx, by, bz);
+        if (isIndestructible(removed)) return; // bedrock and other world-floor blocks can't be mined
         const aff = this.world.setBlock(bx, by, bz, Block.AIR);
         if (aff) {
             this.particles.burst(bx + 0.5, by + 0.5, bz + 0.5, blockColor(removed));

--- a/lab/src/demos/minecraft/mesher.ts
+++ b/lab/src/demos/minecraft/mesher.ts
@@ -60,19 +60,19 @@ class Batch {
         // Vertex colour packs four baked terms: r = ambient-occlusion multiplier,
         // g = skylight (0..1), b = blocklight (0..1), a = fluid flag (1 = animated
         // water surface, 0 = static). The shader combines them.
-        const aoMul = [AO_LUT[ao[0]], AO_LUT[ao[1]], AO_LUT[ao[2]], AO_LUT[ao[3]]];
+        const aoMul = [AO_LUT[ao[0]!]!, AO_LUT[ao[1]!]!, AO_LUT[ao[2]!]!, AO_LUT[ao[3]!]!];
         const fluidFlag = fluid ? 1 : 0;
         // (cu,cv): (0,0),(1,0),(1,1),(0,1) -> atlas corners.
         const uvU = [rect.u0, rect.u1, rect.u1, rect.u0];
         const uvV = [rect.v1, rect.v1, rect.v0, rect.v0];
         for (let i = 0; i < 4; i++) {
-            this.pos.push(corners[i][0], corners[i][1], corners[i][2]);
+            this.pos.push(corners[i]![0], corners[i]![1], corners[i]![2]);
             this.nrm.push(normal[0], normal[1], normal[2]);
-            this.uv.push(uvU[i], uvV[i]);
+            this.uv.push(uvU[i]!, uvV[i]!);
             this.col.push(aoMul[i]!, sky[i]!, blk[i]!, fluidFlag);
         }
         // Flip the triangulation diagonal toward the brighter pair to avoid AO seams.
-        if (ao[0] + ao[2] > ao[1] + ao[3]) {
+        if (ao[0]! + ao[2]! > ao[1]! + ao[3]!) {
             this.idx.push(base, base + 1, base + 2, base, base + 2, base + 3);
         } else {
             this.idx.push(base + 1, base + 2, base + 3, base + 1, base + 3, base);

--- a/lab/src/demos/minecraft/water-sim.ts
+++ b/lab/src/demos/minecraft/water-sim.ts
@@ -4,15 +4,19 @@
 // makes the water pour in and flood the opening. Placed water (creative) streams
 // downward like a waterfall until it lands.
 //
-// The simulation is event-driven and bounded, mirroring the falling-block system:
+// The simulation is event-driven, generational and bounded, mirroring the
+// falling-block system:
 //   - Edits (break/place) enqueue the affected cell and its six neighbours.
-//   - Each frame a capped number of cells are evaluated; an AIR cell that is fed
-//     from a water source (from above always, or from the side only below sea
-//     level) becomes water and enqueues its neighbours, so a flood spreads over a
-//     few frames — which reads naturally as the water flowing in.
+//   - Flow advances on fixed timed STEPS (not per frame): each step evaluates one
+//     generation of cells, and the cells it produces are deferred to the NEXT step.
+//     So an AIR cell fed from a water source (from above always, or from the side
+//     only below sea level) turns to water, and its neighbours flow one step later
+//     — the flood visibly creeps in one block-ring at a time, like Minecraft.
 //   - Horizontal spread is gated to below sea level, so flooding is always bounded
 //     by solid walls and the sea surface and never runs away across the world.
 //   - Touched chunks are coalesced and each remeshed at most once per frame.
+//   - Startup (prefill) drains every generation to a fixpoint instantly, so the
+//     initial world loads with its oceans already settled (no step-in delay).
 //
 // Pure public-API: only world block access and the renderer's remesh entry point.
 
@@ -21,13 +25,20 @@ import { CHUNK_SX, CHUNK_SZ, SEA_LEVEL, WORLD_H } from "./constants.js";
 import type { World } from "./world.js";
 import type { ChunkRenderer } from "./chunk-renderer.js";
 
-const MAX_CELLS_PER_FRAME = 768;
+// Water advances one "ring" of cells per fixed step, so a flood visibly creeps in
+// block by block (à la Minecraft) instead of filling instantly. Cells produced by a
+// step are deferred to the NEXT step, so each generation is one block farther out.
+const WATER_STEP = 0.2; // seconds between flow steps
+const MAX_STEPS_PER_FRAME = 4; // catch-up cap so a long stall can't spiral
+const MAX_CELLS_PER_STEP = 8192; // safety bound on a single (huge) generation
 
 export class WaterSim {
     private readonly world: World;
     private readonly renderer: ChunkRenderer;
-    private queue: number[] = []; // flat triples [x,y,z, x,y,z, ...]
-    private head = 0; // read cursor into queue
+    private current: number[] = []; // generation being evaluated this step
+    private next: number[] = []; // cells produced this step, evaluated next step
+    private head = 0; // read cursor into `current`
+    private accum = 0; // seconds accumulated toward the next step
     private readonly pending = new Set<string>();
 
     constructor(world: World, renderer: ChunkRenderer) {
@@ -43,8 +54,10 @@ export class WaterSim {
     /** Clear all pending flow work (used when reloading the world). Flooding then
      *  re-seeds deterministically as chunks reactivate. */
     reset(): void {
-        this.queue = [];
+        this.current = [];
+        this.next = [];
         this.head = 0;
+        this.accum = 0;
         this.pending.clear();
     }
 
@@ -54,14 +67,13 @@ export class WaterSim {
         this.enqueueNeighborhood(x, y, z);
     }
 
-    /** Seed flooding for a freshly generated/activated chunk. Worldgen fills the
+    /** Visit every sub-sea-level air cell in a chunk that already touches water —
+     *  the flood front a freshly generated chunk introduces. Worldgen fills the
      *  ocean body straight down per column, but a cave that opens into the seafloor
-     *  has lateral air the column fill can't reach — leaving a "wall of water" with
-     *  a dry pocket beside it. We enqueue every sub-sea-level air cell that already
-     *  touches water (the flood front); evaluate() then pours water through the
-     *  connected cavity (across chunk borders) until the cave is full. Sealed
-     *  pockets with no air path to the ocean stay dry. */
-    seedChunk(cx: number, cz: number): void {
+     *  has lateral air the column fill can't reach (a "wall of water" beside a dry
+     *  pocket); these are the cells from which water must pour through the connected
+     *  cavity. */
+    private forEachFloodSeed(cx: number, cz: number, visit: (x: number, y: number, z: number) => void): void {
         const baseX = cx * CHUNK_SX;
         const baseZ = cz * CHUNK_SZ;
         for (let lx = 0; lx < CHUNK_SX; lx++) {
@@ -77,11 +89,59 @@ export class WaterSim {
                         this.world.getBlock(wx, y, wz + 1) === Block.WATER ||
                         this.world.getBlock(wx, y, wz - 1) === Block.WATER
                     ) {
-                        this.enqueue(wx, y, wz);
+                        visit(wx, y, wz);
                     }
                 }
             }
         }
+    }
+
+    /** Seed flooding for a chunk into the live stepwise generations (used only by
+     *  prefill, which then drains them instantly). */
+    seedChunk(cx: number, cz: number): void {
+        this.forEachFloodSeed(cx, cz, (x, y, z) => this.enqueue(x, y, z));
+    }
+
+    /** Instantly settle the flooding a freshly activated chunk introduces, with one
+     *  remesh per touched chunk. World-gen oceans thus never visibly "creep" in as
+     *  you explore — only player edits flow step by step. Self-contained: it runs
+     *  its own flood and does NOT touch the live stepwise generations. */
+    settleChunk(cx: number, cz: number): void {
+        const q: number[] = [];
+        const seen = new Set<string>();
+        const push = (x: number, y: number, z: number): void => {
+            if (y < 0 || y >= WORLD_H) return;
+            if (!this.world.hasChunk(Math.floor(x / CHUNK_SX), Math.floor(z / CHUNK_SZ))) return;
+            const k = x + "," + y + "," + z;
+            if (seen.has(k)) return;
+            seen.add(k);
+            q.push(x, y, z);
+        };
+        this.forEachFloodSeed(cx, cz, push);
+        if (q.length === 0) return;
+        const dirty = new Set<string>();
+        let i = 0;
+        let guard = 0;
+        const MAX = 4_000_000;
+        while (i < q.length && guard++ < MAX) {
+            const x = q[i]!;
+            const y = q[i + 1]!;
+            const z = q[i + 2]!;
+            i += 3;
+            // Allow a cell to be reconsidered if a later fill reaches it (a cell
+            // popped before its feeder fills would otherwise be lost).
+            seen.delete(x + "," + y + "," + z);
+            if (this.feeds(x, y, z)) {
+                this.world.setBlock(x, y, z, Block.WATER, false);
+                this.markDirty(x, z, dirty);
+                push(x, y - 1, z);
+                push(x + 1, y, z);
+                push(x - 1, y, z);
+                push(x, y, z + 1);
+                push(x, y, z - 1);
+            }
+        }
+        this.flush(dirty);
     }
 
     private enqueueNeighborhood(x: number, y: number, z: number): void {
@@ -104,7 +164,7 @@ export class WaterSim {
         const k = x + "," + y + "," + z;
         if (this.pending.has(k)) return;
         this.pending.add(k);
-        this.queue.push(x, y, z);
+        this.next.push(x, y, z);
     }
 
     /** One-shot, data-only flood for startup. Seeds the given chunks then pours
@@ -116,75 +176,134 @@ export class WaterSim {
         const sink = new Set<string>(); // discarded: no remesh during warm-up
         let guard = 0;
         const MAX = 4_000_000;
-        while (this.head < this.queue.length && guard++ < MAX) {
-            const x = this.queue[this.head]!;
-            const y = this.queue[this.head + 1]!;
-            const z = this.queue[this.head + 2]!;
+        // Drain BOTH generations to a fixpoint with no step delay: startup water is
+        // already settled before the first frame is meshed.
+        while ((this.head < this.current.length || this.next.length > 0) && guard++ < MAX) {
+            if (this.head >= this.current.length) this.promote();
+            const x = this.current[this.head]!;
+            const y = this.current[this.head + 1]!;
+            const z = this.current[this.head + 2]!;
             this.head += 3;
             this.pending.delete(x + "," + y + "," + z);
             this.evaluate(x, y, z, sink);
         }
-        // Reset so the live per-frame loop starts from a clean queue.
-        this.queue.length = 0;
+        // Reset so the live per-step loop starts clean.
+        this.current.length = 0;
+        this.next.length = 0;
         this.head = 0;
+        this.accum = 0;
         this.pending.clear();
     }
 
-    /** Advance the flood a bounded amount; the remainder carries to later frames. */
-    update(): void {
-        if (this.head >= this.queue.length) {
-            if (this.queue.length > 0) {
-                this.queue.length = 0;
-                this.head = 0;
-            }
+    /** True when no flow work remains in either generation. */
+    private idle(): boolean {
+        return this.head >= this.current.length && this.next.length === 0;
+    }
+
+    /** Swap the produced `next` generation into `current` and clear `next`. */
+    private promote(): void {
+        this.head = 0;
+        const tmp = this.current;
+        this.current = this.next;
+        this.next = tmp;
+        this.next.length = 0;
+    }
+
+    /** Advance the flood on fixed steps so it creeps one block-ring at a time. The
+     *  per-frame delta only triggers a whole number of steps; the remainder carries
+     *  over, keeping the flow rate independent of frame rate. */
+    update(dt: number): void {
+        if (this.idle()) {
+            this.accum = 0;
             return;
         }
+        this.accum += dt;
         const dirty = new Set<string>();
-        let processed = 0;
-        while (this.head < this.queue.length && processed < MAX_CELLS_PER_FRAME) {
-            const x = this.queue[this.head]!;
-            const y = this.queue[this.head + 1]!;
-            const z = this.queue[this.head + 2]!;
-            this.head += 3;
-            this.pending.delete(x + "," + y + "," + z);
-            processed++;
-            this.evaluate(x, y, z, dirty);
-        }
-        // Compact the consumed prefix so the backing array can't grow unbounded.
-        if (this.head >= this.queue.length) {
-            this.queue.length = 0;
-            this.head = 0;
-        } else if (this.head > 4096) {
-            this.queue = this.queue.slice(this.head);
-            this.head = 0;
+        let steps = 0;
+        while (this.accum >= WATER_STEP && steps < MAX_STEPS_PER_FRAME) {
+            this.accum -= WATER_STEP;
+            steps++;
+            this.step(dirty);
+            if (this.idle()) {
+                this.accum = 0;
+                break;
+            }
         }
         this.flush(dirty);
     }
 
-    private evaluate(x: number, y: number, z: number, dirty: Set<string>): void {
-        if (this.world.getBlock(x, y, z) !== Block.AIR) return;
+    /** Evaluate exactly one generation: every cell currently in `current`. This is
+     *  TWO-PHASE so the spread is strictly one block-ring per step: we first decide
+     *  which cells fill — reading the world as it was at the start of the generation
+     *  — and only THEN apply the water and enqueue neighbours (into `next`). Applying
+     *  mid-scan would let a cell filled earlier in the generation feed its sibling,
+     *  collapsing several rings into one step. A single enormous generation is
+     *  bounded by MAX_CELLS_PER_STEP and carries its tail to the next step. */
+    private step(dirty: Set<string>): void {
+        if (this.head >= this.current.length) {
+            if (this.next.length === 0) return;
+            this.promote();
+        }
+        // Phase 1: collect cells that fill this generation (no world mutation yet).
+        const fills: number[] = [];
+        let processed = 0;
+        while (this.head < this.current.length && processed < MAX_CELLS_PER_STEP) {
+            const x = this.current[this.head]!;
+            const y = this.current[this.head + 1]!;
+            const z = this.current[this.head + 2]!;
+            this.head += 3;
+            this.pending.delete(x + "," + y + "," + z);
+            processed++;
+            if (this.feeds(x, y, z)) fills.push(x, y, z);
+        }
+        // Compact the consumed prefix so a carried-over generation can't grow the
+        // backing array unbounded.
+        if (this.head >= this.current.length) {
+            this.current.length = 0;
+            this.head = 0;
+        } else if (this.head > 4096) {
+            this.current = this.current.slice(this.head);
+            this.head = 0;
+        }
+        // Phase 2: apply the fills and schedule their neighbours for the next step.
+        for (let i = 0; i < fills.length; i += 3) {
+            this.fill(fills[i]!, fills[i + 1]!, fills[i + 2]!, dirty);
+        }
+    }
 
-        // Fed from above (water always falls) or, below sea level, from any side.
-        const fedAbove = this.world.getBlock(x, y + 1, z) === Block.WATER;
-        let fedSide = false;
+    /** True if the AIR cell at (x,y,z) is currently fed by water: from above always
+     *  (water falls), or — only below sea level — from any of the four sides. Pure:
+     *  it reads the world but never mutates it. */
+    private feeds(x: number, y: number, z: number): boolean {
+        if (this.world.getBlock(x, y, z) !== Block.AIR) return false;
+        if (this.world.getBlock(x, y + 1, z) === Block.WATER) return true;
         if (y < SEA_LEVEL) {
-            fedSide =
+            return (
                 this.world.getBlock(x + 1, y, z) === Block.WATER ||
                 this.world.getBlock(x - 1, y, z) === Block.WATER ||
                 this.world.getBlock(x, y, z + 1) === Block.WATER ||
-                this.world.getBlock(x, y, z - 1) === Block.WATER;
+                this.world.getBlock(x, y, z - 1) === Block.WATER
+            );
         }
-        if (!fedAbove && !fedSide) return;
+        return false;
+    }
 
+    /** Turn a fed cell into water, mark its chunk(s) dirty, and enqueue its down +
+     *  four lateral neighbours so the flood continues. */
+    private fill(x: number, y: number, z: number, dirty: Set<string>): void {
         this.world.setBlock(x, y, z, Block.WATER, false);
         this.markDirty(x, z, dirty);
-
-        // Propagate: down first (fall), then outward.
         this.enqueue(x, y - 1, z);
         this.enqueue(x + 1, y, z);
         this.enqueue(x - 1, y, z);
         this.enqueue(x, y, z + 1);
         this.enqueue(x, y, z - 1);
+    }
+
+    /** Immediate evaluate-and-apply for the instant warm-up paths (prefill /
+     *  settleChunk), where there is no per-step delay. */
+    private evaluate(x: number, y: number, z: number, dirty: Set<string>): void {
+        if (this.feeds(x, y, z)) this.fill(x, y, z, dirty);
     }
 
     /** Mark the edited cell's chunk dirty, plus a neighbour chunk only when the


### PR DESCRIPTION
## Summary
- **Indestructible bedrock**: `BEDROCK` (the single y=0 layer) can no longer be mined/broken, matching real Minecraft. Implemented via an `indestructible` flag on the block def and an `isIndestructible` guard in `breakBlock()`.
- **Step-by-step water**: water now propagates gradually (generational two-phase stepping, ~1 block per 0.2s) instead of filling instantly. World-gen chunks still settle instantly on activation, so only player-caused flows creep visibly.
- **Cleanup**: fixed pre-existing `noUncheckedIndexedAccess` strict-index errors in `blocks.ts`/`chunk-renderer.ts`/`mesher.ts` and added `pages-dist/**` to the eslint ignores.

## Scope
Demo-only changes under `lab/src/demos/minecraft/` — no engine or scene code touched, so visual parity is unaffected.

## Testing
- `pnpm lint` (eslint + both tsc typecheck projects) green.
- Verified in-browser: bedrock unbreakable at y=0, textures load, water flows step-by-step.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>