### PR TITLE
perf(scene): push world-matrix dirty to children for O(1) version reads

### DIFF
--- a/packages/babylon-lite/src/camera/arc-rotate.ts
+++ b/packages/babylon-lite/src/camera/arc-rotate.ts
@@ -3,7 +3,7 @@ import type { Vec3, Mat4 } from "../math/types.js";
 import { mat4LookAtLH } from "../math/mat4-look-at-lh.js";
 import { Vec3Up } from "../math/vec3-up.js";
 import type { IWorldMatrixProvider, IParentable } from "../scene/parentable.js";
-import { createWorldMatrixState } from "../scene/world-matrix-state.js";
+import { createWorldMatrixState, attachWorldMatrixState } from "../scene/world-matrix-state.js";
 import { ObservableVec3 } from "../math/observable-vec3.js";
 import type { SceneNode } from "../scene/scene-node.js";
 
@@ -120,6 +120,9 @@ export function createArcRotateCamera(alpha: number, beta: number, radius: numbe
             enumerable: true,
         });
     }
+
+    // Tag so children parented to this camera get push invalidation (O(1) reads).
+    attachWorldMatrixState(cam, wm);
 
     return cam;
 }

--- a/packages/babylon-lite/src/camera/free-camera.ts
+++ b/packages/babylon-lite/src/camera/free-camera.ts
@@ -3,7 +3,7 @@ import type { Vec3, Mat4 } from "../math/types.js";
 import { mat4LookAtLH } from "../math/mat4-look-at-lh.js";
 import { Vec3Up } from "../math/vec3-up.js";
 import type { IWorldMatrixProvider, IParentable } from "../scene/parentable.js";
-import { createWorldMatrixState } from "../scene/world-matrix-state.js";
+import { createWorldMatrixState, attachWorldMatrixState } from "../scene/world-matrix-state.js";
 import { ObservableVec3 } from "../math/observable-vec3.js";
 import type { SceneNode } from "../scene/scene-node.js";
 
@@ -122,6 +122,9 @@ export function createFreeCamera(position: Vec3, target: Vec3): FreeCamera {
         configurable: true,
         enumerable: true,
     });
+
+    // Tag so children parented to this camera get push invalidation (O(1) reads).
+    attachWorldMatrixState(cam, wm);
 
     return cam;
 }

--- a/packages/babylon-lite/src/light/light-base.ts
+++ b/packages/babylon-lite/src/light/light-base.ts
@@ -3,7 +3,7 @@
 
 import type { Mat4 } from "../math/types.js";
 import type { IWorldMatrixProvider } from "../scene/parentable.js";
-import { createWorldMatrixState, type WorldMatrixAccessors } from "../scene/world-matrix-state.js";
+import { createWorldMatrixState, attachWorldMatrixState, type WorldMatrixAccessors } from "../scene/world-matrix-state.js";
 
 export { ObservableVec3 } from "../math/observable-vec3.js";
 
@@ -71,5 +71,7 @@ export function applyWorldMatrixAccessors<R>(target: object, wm: WorldMatrixAcce
             configurable: true,
         });
     }
+    // Tag so children parented to this light get push invalidation (O(1) reads).
+    attachWorldMatrixState(target, wm);
     return target as R;
 }

--- a/packages/babylon-lite/src/mesh/GaussianSplatting/gaussian-splatting-mesh.ts
+++ b/packages/babylon-lite/src/mesh/GaussianSplatting/gaussian-splatting-mesh.ts
@@ -15,7 +15,7 @@ import type { Mat4 } from "../../math/types.js";
 import { mat4Identity, mat4Compose } from "../../math/mat4.js";
 import { ObservableVec3 } from "../../math/observable-vec3.js";
 import { ObservableQuat } from "../../math/observable-quat.js";
-import { createWorldMatrixState } from "../../scene/world-matrix-state.js";
+import { createWorldMatrixState, attachWorldMatrixState } from "../../scene/world-matrix-state.js";
 import { eulerToQuat, createEulerProxy } from "../../scene/scene-node.js";
 import { buildSplatGeometry, type SplatGeometry, type ParsedSplat } from "../../loader-splat/splat-data.js";
 
@@ -323,4 +323,6 @@ function initSplatTransform(node: GaussianSplattingMesh): void {
         configurable: true,
         enumerable: false,
     });
+    // Tag so children parented to this splat mesh get push invalidation.
+    attachWorldMatrixState(node, wm);
 }

--- a/packages/babylon-lite/src/scene/scene-remove.ts
+++ b/packages/babylon-lite/src/scene/scene-remove.ts
@@ -57,6 +57,11 @@ export function removeFromScene(scene: SceneContext, mesh: Mesh): void {
         sc._materialSwapQueue.splice(qi, 1);
     }
     (mesh as MeshInternal)._materialDirty = false;
+    // Deregister from the world-matrix push registry so a long-lived parent stops
+    // retaining/traversing this disposed child on every invalidation. (The parent→
+    // child reference is new with the push model; reparent already deregisters, but
+    // removal does not go through the parent setter otherwise.)
+    mesh.parent = null;
     // Frame-graph eviction: the scene always has a frame graph (created in
     // createSceneContext). Walk its render-pass tasks and drop any binding whose
     // source mesh matches. Tasks identified by having a `_config` field

--- a/packages/babylon-lite/src/scene/world-matrix-state.ts
+++ b/packages/babylon-lite/src/scene/world-matrix-state.ts
@@ -2,19 +2,25 @@
  *
  *  Each entity provides only getLocalMatrix(). This module handles:
  *  - version tracking (_worldVersion bumped by own TRS changes and ancestor motion)
- *  - parent chain validation (version-only walk via detectParentChange)
  *  - caching and staleness detection (_cachedWorld nulled on any change)
+ *  - PUSH dirty propagation: a transform write invalidates the node AND all of its
+ *    descendants up front, so per-frame consumers can read worldMatrixVersion in
+ *    O(1) (a plain field read) instead of walking the parent chain.
  *
  *  Ancestor-only motion (e.g. animating a parent transform node) must bump a
  *  descendant's worldMatrixVersion so per-frame consumers re-upload its UBO.
- *  Because this module holds no child references, that detection is a PULL walk
- *  up the parent chain. To keep it cheap in deep hierarchies it is gated by a
- *  global "transform write epoch": every local TRS change (markLocalDirty) and
- *  reparent bumps the epoch, so a node need re-walk its ancestors only when
- *  something, somewhere, has changed since it last validated. Within a stable
- *  period (e.g. the render phase, after all animation writes) repeated reads of
- *  the same node are O(1). The walk also calls the parent's accessor closure
- *  directly (via the attached _parentState) to skip the host's property getter.
+ *  Rather than have each node PULL up its parent chain on every read, this module
+ *  keeps its own child registry (driven by the reliably-called `parent` setter, NOT
+ *  the host's `children` array which loaders/setParent maintain inconsistently) and
+ *  PUSHES invalidation down on every local change or reparent. Reads are O(1) (a
+ *  plain field read); writers pay an O(subtree) push. This is a clear win for the
+ *  common case (few movers, many readers) and never worse than the old pull walk.
+ *
+ *  Foreign parents — an IWorldMatrixProvider that is not tagged with our state
+ *  symbol (e.g. a user-supplied object) — cannot be pushed to because we never see
+ *  their writes. For those we keep a cheap PULL fallback that polls the parent's
+ *  public version on read. All in-engine hosts (mesh, scene node, camera, light,
+ *  Gaussian-splatting mesh) ARE tagged, so engine hierarchies are pure push.
  *
  *  Zero entity imports — depends only on Mat4 and mat4Multiply. */
 
@@ -27,32 +33,39 @@ export interface WorldMatrixAccessors {
     getWorldMatrix(): Mat4;
     /** Getter — returns current version. */
     getWorldMatrixVersion(): number;
-    /** Call when own TRS changes. Invalidates cache, forces recompute on next read. */
+    /** Call when own TRS changes. Invalidates cache + subtree, forces recompute. */
     markLocalDirty(): void;
     /** Reference to parent — set directly. */
     parent: IWorldMatrixProvider | null;
 }
 
-/** Monotonic counter bumped whenever ANY node's local transform changes or a
- *  reparent happens. Lets descendants skip re-walking their parent chain when
- *  nothing has changed globally since they last validated. */
-let _globalTransformEpoch = 1;
+/** Internal contract exposed via the state symbol so a parent can push invalidation
+ *  into a child's closure and a child can (de)register itself in its parent's list,
+ *  all without going through the host's public property getters. */
+interface WorldMatrixStateInternal extends WorldMatrixAccessors {
+    /** Push: mark this node and its whole subtree dirty (clean-guarded). */
+    _invalidate(): void;
+    /** Register a same-module child so future invalidations reach it. */
+    _addChild(child: WorldMatrixStateInternal): void;
+    /** Deregister a child (reparent away). */
+    _removeChild(child: WorldMatrixStateInternal): void;
+}
 
 const WM_STATE = Symbol("wmState");
 
-/** Tag a host object (mesh, scene node, light, …) with its world-matrix state so
- *  children can call the parent's accessor closure directly, bypassing the host's
- *  property getter on the hot parent-chain walk. */
+/** Tag a host object (mesh, scene node, camera, light, …) with its world-matrix
+ *  state so children can register for push invalidation and call its accessor
+ *  closures directly, bypassing the host's property getters. */
 export function attachWorldMatrixState(host: object, state: WorldMatrixAccessors): void {
-    (host as Record<symbol, unknown>)[WM_STATE] = state;
+    (host as unknown as Record<symbol, unknown>)[WM_STATE] = state;
 }
 
-function peekWorldMatrixState(p: IWorldMatrixProvider | null): WorldMatrixAccessors | null {
+function peekWorldMatrixState(p: IWorldMatrixProvider | null): WorldMatrixStateInternal | null {
     if (p === null) {
         return null;
     }
     const s = (p as unknown as Record<symbol, unknown>)[WM_STATE];
-    return (s as WorldMatrixAccessors | undefined) ?? null;
+    return (s as WorldMatrixStateInternal | undefined) ?? null;
 }
 
 /**
@@ -67,68 +80,63 @@ export function createWorldMatrixState(getLocalMatrix: () => Mat4): WorldMatrixA
     let _cachedWorld: Mat4 | null = null;
     const _ownedWorld = new Float32Array(16) as Mat4;
     let _parent: IWorldMatrixProvider | null = null;
-    let _parentState: WorldMatrixAccessors | null = null;
-    let _validatedEpoch = 0;
+    let _parentState: WorldMatrixStateInternal | null = null;
+    const _children: WorldMatrixStateInternal[] = [];
 
-    // Detect whether an ancestor moved since we last looked. This bumps our own
-    // version and invalidates our cached matrix when a parent's version changed.
-    // Both getWorldMatrix and getWorldMatrixVersion run it so that ancestor-only
-    // changes (e.g. animating a parent transform node) are observed even when
-    // nothing reads this node's world matrix directly.
-    //
-    // For same-module parents (_parentState !== null) the walk is gated by the
-    // global transform epoch: any local change anywhere bumps the epoch, so when
-    // our _validatedEpoch is current nothing in the chain can have moved and we
-    // skip the walk. Reading the parent's version via its accessor closure
-    // synchronously validates the parent first, so the chain stays consistent
-    // regardless of read order. Foreign parents (e.g. a camera with its own
-    // accessor implementation) may change without bumping our epoch, so for them
-    // we always poll the public version.
-    function detectParentChange(): void {
-        if (_parent === null) {
-            return;
-        }
-        let pv: number;
-        if (_parentState !== null) {
-            if (_validatedEpoch === _globalTransformEpoch) {
-                return;
-            }
-            _validatedEpoch = _globalTransformEpoch;
-            pv = _parentState.getWorldMatrixVersion();
-        } else {
-            pv = _parent.worldMatrixVersion;
-        }
-        if (pv !== _lastSeenParentVersion) {
-            _lastSeenParentVersion = pv;
-            _worldVersion++;
-            _cachedWorld = null;
+    // Mark this node — and, transitively, its whole subtree — dirty, bumping the
+    // version so per-frame consumers (which gate UBO uploads on worldMatrixVersion)
+    // re-upload. Propagation is eager and unconditional: consumers may never read a
+    // pure transform node's world matrix, so a "skip if already dirty" guard would
+    // strand its descendants on a stale version when an ancestor moves every frame.
+    // Caching is still lazy — getWorldMatrix recomputes only when _cachedWorld is
+    // null — so reads stay cheap; only writers pay the O(subtree) push.
+    function invalidate(): void {
+        _cachedWorld = null;
+        _worldVersion++;
+        for (const child of _children) {
+            child._invalidate();
         }
     }
 
-    return {
+    // Foreign parent (not tagged with our symbol): we never observe its writes, so
+    // poll its public version on read and push a subtree invalidation when it moved.
+    function pollForeignParent(): void {
+        const pv = (_parent as IWorldMatrixProvider).worldMatrixVersion;
+        if (pv !== _lastSeenParentVersion) {
+            _lastSeenParentVersion = pv;
+            invalidate();
+        }
+    }
+
+    const state: WorldMatrixStateInternal = {
         get parent(): IWorldMatrixProvider | null {
             return _parent;
         },
         set parent(p: IWorldMatrixProvider | null) {
-            if (p !== _parent) {
-                _parent = p;
-                _parentState = peekWorldMatrixState(p);
-                _lastSeenParentVersion = -1;
-                _validatedEpoch = 0;
-                _worldVersion++;
-                _cachedWorld = null;
-                _globalTransformEpoch++;
+            if (p === _parent) {
+                return;
             }
+            if (_parentState !== null) {
+                _parentState._removeChild(state);
+            }
+            _parent = p;
+            _parentState = peekWorldMatrixState(p);
+            if (_parentState !== null) {
+                _parentState._addChild(state);
+            }
+            _lastSeenParentVersion = -1;
+            // Reparenting changes our world transform → dirty us and the subtree.
+            invalidate();
         },
 
         markLocalDirty(): void {
-            _worldVersion++;
-            _cachedWorld = null;
-            _globalTransformEpoch++;
+            invalidate();
         },
 
         getWorldMatrix(): Mat4 {
-            detectParentChange();
+            if (_parentState === null && _parent !== null) {
+                pollForeignParent();
+            }
             if (_cachedWorld !== null) {
                 return _cachedWorld;
             }
@@ -144,8 +152,27 @@ export function createWorldMatrixState(getLocalMatrix: () => Mat4): WorldMatrixA
         },
 
         getWorldMatrixVersion(): number {
-            detectParentChange();
+            if (_parentState === null && _parent !== null) {
+                pollForeignParent();
+            }
             return _worldVersion;
         },
+
+        _invalidate(): void {
+            invalidate();
+        },
+
+        _addChild(child: WorldMatrixStateInternal): void {
+            _children.push(child);
+        },
+
+        _removeChild(child: WorldMatrixStateInternal): void {
+            const i = _children.indexOf(child);
+            if (i >= 0) {
+                _children.splice(i, 1);
+            }
+        },
     };
+
+    return state;
 }

--- a/tests/unit/world-matrix-parent-propagation.test.ts
+++ b/tests/unit/world-matrix-parent-propagation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import { createSceneNode } from "../../packages/babylon-lite/src/scene/scene-node";
+import { createFreeCamera } from "../../packages/babylon-lite/src/camera/free-camera";
 
 describe("world matrix parent propagation", () => {
     it("bumps a child's worldMatrixVersion when an ancestor's transform changes", () => {
@@ -67,6 +68,59 @@ describe("world matrix parent propagation", () => {
         root.rotation.y = 1.0;
 
         expect(mid.worldMatrixVersion).not.toBe(midV0);
+        expect(leaf.worldMatrixVersion).not.toBe(leafV0);
+    });
+
+    it("bumps the leaf version on EVERY ancestor move (no stale skips)", () => {
+        // A consumer that only reads versions (never worldMatrix) must observe a
+        // fresh version on each successive ancestor move, frame after frame.
+        const root = createSceneNode("root");
+        const leaf = createSceneNode("leaf");
+        leaf.parent = root;
+
+        let prev = leaf.worldMatrixVersion;
+        for (let i = 1; i <= 5; i++) {
+            root.position.set(i, 0, 0);
+            const next = leaf.worldMatrixVersion;
+            expect(next).not.toBe(prev);
+            prev = next;
+        }
+    });
+
+    it("reparenting bumps the version and reflects the new parent transform", () => {
+        const a = createSceneNode("a");
+        const b = createSceneNode("b");
+        const child = createSceneNode("child");
+        a.position.set(10, 0, 0);
+        b.position.set(0, 20, 0);
+
+        child.parent = a;
+        expect(child.worldMatrix[12]).toBeCloseTo(10);
+        const vA = child.worldMatrixVersion;
+
+        child.parent = b;
+        expect(child.worldMatrixVersion).not.toBe(vA);
+        expect(child.worldMatrix[12]).toBeCloseTo(0);
+        expect(child.worldMatrix[13]).toBeCloseTo(20);
+
+        // After detaching, a former parent's motion no longer affects the child.
+        child.parent = null;
+        const vDetached = child.worldMatrixVersion;
+        b.position.set(0, 99, 0);
+        expect(child.worldMatrixVersion).toBe(vDetached);
+    });
+
+    it("propagates a camera-parented chain to a leaf with no per-frame reader", () => {
+        // camera → mid (pure transform, never read) → leaf. Moving the camera must
+        // surface on the leaf even though nothing reads the intermediate node.
+        const camera = createFreeCamera({ x: 0, y: 0, z: -10 } as never, { x: 0, y: 0, z: 0 } as never);
+        const mid = createSceneNode("mid");
+        const leaf = createSceneNode("leaf");
+        mid.parent = camera;
+        leaf.parent = mid;
+
+        const leafV0 = leaf.worldMatrixVersion;
+        camera.position.set(5, 0, -10);
         expect(leaf.worldMatrixVersion).not.toBe(leafV0);
     });
 });


### PR DESCRIPTION
## Summary

Follow-up perf optimization to #129. That PR fixed parent-transform animation propagating to children, but did so with an O(depth) **PULL** parent-chain walk gated by a global transform epoch (+3.0% on the Scene 20 perf gate).

This PR replaces it with a **PUSH** model: each `createWorldMatrixState` closure keeps its own child registry (maintained by the reliably-called `parent` setter — *not* the host `children` array, which loaders/`setParent` maintain inconsistently) and propagates invalidation **down** the subtree on every local transform write or reparent. `worldMatrixVersion` reads become O(1) plain field reads again; writers pay an O(subtree) push.

## Why no clean-guard early-out

Babylon.js can early-out invalidation on already-dirty nodes because it computes the whole tree every frame. Here, consumers gate UBO uploads on `worldMatrixVersion` and a pure transform node may **never** be read — so it stays perpetually dirty, and a "skip if already dirty" guard would strand its descendants on a stale version when an ancestor moves every frame. Invalidation therefore always bumps + recurses (caching on reads is preserved, so reads stay cheap).

## Foreign parents

A parent is "tagged" via a symbol (`attachWorldMatrixState`). All in-engine hosts are now tagged — **mesh, scene node, free + arc camera, lights, Gaussian-splat mesh** — so engine hierarchies are pure push. A cheap PULL fallback (`pollForeignParent`) remains only for untagged external `IWorldMatrixProvider` parents. Tagging cameras is required to avoid regressing #129's `camera → transformNode → mesh` behavior (the old leaf read pulled up through the chain; pure push needs the camera to push down).

## Dispose

`removeFromScene` now nulls `mesh.parent`, deregistering it from the parent's child list so a long-lived parent no longer retains/traverses disposed children (the parent→child reference is new with push).

## Tests

- Added regression tests: every-frame ancestor propagation (no stale skips), reparenting (version bump + detach), camera-parented chain with an unread intermediate node.
- ✅ `npx tsc --noEmit` clean
- ✅ 197/197 unit tests
- ✅ 119/119 bundle-size (only +~0.3 KB, all under ceilings)
- ✅ 247/248 parity locally; the 1 failure is **scene50 (pure-2D sprite grid)** — a local sub-pixel AA artifact on thin sprite edges, sharing **zero** bundle code with this change.

Perf gate (Scene 20 / Sponza) is CI-only; expectation is the +3% from #129 shrinks or reverses since the hot path (one parent animating many children) goes from O(N·depth) pulled reads to O(N) pushed writes + O(1) reads.
