### PR TITLE
chore(bundle): update manifest.json sizes after #131

### DIFF
--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -1,7 +1,7 @@
 {
   "scene1": {
-    "rawKB": 84.8,
-    "gzipKB": 34.4,
+    "rawKB": 85.1,
+    "gzipKB": 34.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene1-background-dds-skybox-Bl_YonQ_.js",
@@ -10,7 +10,7 @@
       "scene1-generate-mipmaps-BOz445sj.js",
       "scene1-gltf-glb-parser-BdYiApo0.js",
       "scene1-ibl-fragment-BfgmykuX.js",
-      "scene1-pbr-renderable-B1_v5lKI.js",
+      "scene1-pbr-renderable-DfDuRXJS.js",
       "scene1-rgbd-decode-O-q0NvD4.js",
       "scene1-scene-uniforms-FTYH6Ct0.js",
       "scene1-singlelight-hemispheric-wgsl-CU6xMcAz.js",
@@ -21,11 +21,11 @@
     "bjsGzipKB": 675.2
   },
   "scene2": {
-    "rawKB": 43,
-    "gzipKB": 17.1,
+    "rawKB": 43.3,
+    "gzipKB": 17.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene2-standard-renderable-CbWwZEHg.js",
+      "scene2-standard-renderable-Bes0oqLH.js",
       "scene2-wgsl-helpers-WTsokIfK.js",
       "scene2.js"
     ],
@@ -33,13 +33,13 @@
     "bjsGzipKB": 343.7
   },
   "scene3": {
-    "rawKB": 49.9,
-    "gzipKB": 19.8,
+    "rawKB": 50.2,
+    "gzipKB": 19.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene3-scene-uniforms-FTYH6Ct0.js",
       "scene3-skybox-renderable-Ch_U65dA.js",
-      "scene3-standard-renderable-C_SNgBaO.js",
+      "scene3-standard-renderable-mSDL6gNI.js",
       "scene3-wgsl-helpers-DkZw4EJ3.js",
       "scene3.js"
     ],
@@ -47,8 +47,8 @@
     "bjsGzipKB": 346
   },
   "scene4": {
-    "rawKB": 68.4,
-    "gzipKB": 26.6,
+    "rawKB": 68.7,
+    "gzipKB": 26.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene4-esm-shadow-view-7yqUFA1x.js",
@@ -56,7 +56,7 @@
       "scene4-material-view-Dua1bl7W.js",
       "scene4-no-color-view-mmRdAV3G.js",
       "scene4-shadow-task-DcO2nH-l.js",
-      "scene4-standard-renderable-Bs3-hCdj.js",
+      "scene4-standard-renderable-CR4gGgs1.js",
       "scene4-std-shadow-fragment-C4iPvy9E.js",
       "scene4-wgsl-helpers-WTsokIfK.js",
       "scene4.js"
@@ -65,8 +65,8 @@
     "bjsGzipKB": 371.2
   },
   "scene5": {
-    "rawKB": 81.4,
-    "gzipKB": 33.4,
+    "rawKB": 81.7,
+    "gzipKB": 33.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene5-create-morph-targets-DNgngg2Q.js",
@@ -76,26 +76,26 @@
       "scene5-gltf-feature-animations-MA15bz11.js",
       "scene5-gltf-feature-morph-BLItGC3N.js",
       "scene5-gltf-feature-skeleton-D3boSrwZ.js",
-      "scene5-morph-fragment-D8c9_x4u.js",
-      "scene5-pbr-renderable-CO4mrFOc.js",
+      "scene5-morph-fragment-SDmstOG0.js",
+      "scene5-pbr-renderable-BrCN0Y-z.js",
       "scene5-pbr-template-ext-B00NeHp4.js",
       "scene5-singlelight-hemispheric-wgsl-BWhSkwzq.js",
-      "scene5-skeleton-fragment-BKOBzGpw.js",
+      "scene5-skeleton-fragment-Bt78ROXB.js",
       "scene5.js"
     ],
     "bjsRawKB": 2206.6,
     "bjsGzipKB": 529.2
   },
   "scene6": {
-    "rawKB": 68.9,
-    "gzipKB": 28.3,
+    "rawKB": 69.2,
+    "gzipKB": 28.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene6-background-dds-skybox-uk0-j86J.js",
       "scene6-background-ground-BSKeIIXx.js",
       "scene6-cubemap-skybox-material-BJ3_1URU.js",
       "scene6-ibl-fragment-BfgmykuX.js",
-      "scene6-pbr-renderable-nZUEIbDl.js",
+      "scene6-pbr-renderable-DhmeEU1d.js",
       "scene6-rgbd-decode-O-q0NvD4.js",
       "scene6-scene-uniforms-FTYH6Ct0.js",
       "scene6-wgsl-helpers-BgB2AJrF.js",
@@ -105,8 +105,8 @@
     "bjsGzipKB": 549.2
   },
   "scene7": {
-    "rawKB": 95.4,
-    "gzipKB": 39.2,
+    "rawKB": 95.6,
+    "gzipKB": 39.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene7-background-ground-gf9FDfVG.js",
@@ -117,11 +117,11 @@
       "scene7-gltf-feature-animations-BeoDCmlU.js",
       "scene7-gltf-feature-skeleton-D847Sr-X.js",
       "scene7-ibl-fragment-BfgmykuX.js",
-      "scene7-pbr-renderable-ZoHk9Zne.js",
+      "scene7-pbr-renderable-B2sQ8qKr.js",
       "scene7-rgbd-decode-O-q0NvD4.js",
       "scene7-scene-uniforms-FTYH6Ct0.js",
       "scene7-singlelight-hemispheric-wgsl-Uxs3i3vt.js",
-      "scene7-skeleton-fragment-CkK8rvJn.js",
+      "scene7-skeleton-fragment-nQJn0BQk.js",
       "scene7-skybox.vertex-D1KSfOUq.js",
       "scene7-wgsl-helpers-BgB2AJrF.js",
       "scene7.js"
@@ -130,13 +130,13 @@
     "bjsGzipKB": 678.1
   },
   "scene8": {
-    "rawKB": 70,
-    "gzipKB": 27.7,
+    "rawKB": 70.3,
+    "gzipKB": 27.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene8-background-hdr-skybox-CZiKt2tJ.js",
       "scene8-ibl-fragment-BfgmykuX.js",
-      "scene8-pbr-renderable-DPymlYPz.js",
+      "scene8-pbr-renderable-BKl1eTYo.js",
       "scene8-scene-size-CBRA6KcU.js",
       "scene8-scene-uniforms-FTYH6Ct0.js",
       "scene8-singlelight-point-wgsl-dQJZ58qK.js",
@@ -146,18 +146,18 @@
     "bjsGzipKB": 410.4
   },
   "scene9": {
-    "rawKB": 55.2,
-    "gzipKB": 22.4,
+    "rawKB": 55.5,
+    "gzipKB": 22.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene9-generate-mipmaps-BADAHSqV.js",
       "scene9-normal-map-fragment-BP7duUVm.js",
-      "scene9-point-light-Dib38zhm.js",
-      "scene9-standard-renderable-PXDuUV48.js",
-      "scene9-std-ambient-fragment-D5VruGNp.js",
-      "scene9-std-opacity-fragment-DgknJ00w.js",
-      "scene9-std-reflection-fragment-Ph0flcre.js",
-      "scene9-std-specular-fragment-C0K7sjjY.js",
+      "scene9-point-light-DJ5BQy-Y.js",
+      "scene9-standard-renderable-CVCDWczQ.js",
+      "scene9-std-ambient-fragment-Cxekaaad.js",
+      "scene9-std-opacity-fragment-DvrCnTul.js",
+      "scene9-std-reflection-fragment-pSPIaLUi.js",
+      "scene9-std-specular-fragment-Dv-34Xf7.js",
       "scene9-wgsl-helpers-WTsokIfK.js",
       "scene9.js"
     ],
@@ -165,11 +165,11 @@
     "bjsGzipKB": 731.9
   },
   "scene10": {
-    "rawKB": 48.2,
-    "gzipKB": 19.5,
+    "rawKB": 48.5,
+    "gzipKB": 19.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene10-pbr-renderable-DyhvQjI3.js",
+      "scene10-pbr-renderable-Dq4bfPHJ.js",
       "scene10-singlelight-hemispheric-wgsl-ftW_j34v.js",
       "scene10.js"
     ],
@@ -177,8 +177,8 @@
     "bjsGzipKB": 397.2
   },
   "scene11": {
-    "rawKB": 77.4,
-    "gzipKB": 31.7,
+    "rawKB": 77.7,
+    "gzipKB": 31.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene11-create-skeleton-7voiszP1.js",
@@ -188,17 +188,17 @@
       "scene11-gltf-feature-animations-DGG084-L.js",
       "scene11-gltf-feature-skeleton-CZmcRqnJ.js",
       "scene11-gltf-glb-parser-BdYiApo0.js",
-      "scene11-pbr-renderable-NiRnUVvV.js",
+      "scene11-pbr-renderable-La3kekLX.js",
       "scene11-singlelight-hemispheric-wgsl-B_5gGJZS.js",
-      "scene11-skeleton-fragment-DyIAcBJE.js",
+      "scene11-skeleton-fragment-CmEeiSFR.js",
       "scene11.js"
     ],
     "bjsRawKB": 2207,
     "bjsGzipKB": 529.3
   },
   "scene12": {
-    "rawKB": 93.3,
-    "gzipKB": 37.4,
+    "rawKB": 93.6,
+    "gzipKB": 37.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene12-create-skeleton-DeoZJ7lE.js",
@@ -208,28 +208,28 @@
       "scene12-gltf-feature-skeleton-Dy2Y_IwG.js",
       "scene12-gltf-glb-parser-BdYiApo0.js",
       "scene12-ibl-fragment-BfgmykuX.js",
-      "scene12-pbr-renderable-DX-O9r1X.js",
+      "scene12-pbr-renderable-CaxcTtdP.js",
       "scene12-reflectance-fragment-DpTgZRoM.js",
       "scene12-rgbd-decode-O-q0NvD4.js",
       "scene12-scene-material-swap-D59o_FWG.js",
       "scene12-scene-uniforms-FTYH6Ct0.js",
       "scene12-singlelight-directional-wgsl-wnrNEEIR.js",
-      "scene12-skeleton-fragment-CTub8lkz.js",
+      "scene12-skeleton-fragment-Dz1yxIp_.js",
       "scene12.js"
     ],
     "bjsRawKB": 2209.2,
     "bjsGzipKB": 531.5
   },
   "scene13": {
-    "rawKB": 80.1,
-    "gzipKB": 32.1,
+    "rawKB": 80.4,
+    "gzipKB": 32.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene13-background-ground-COMVjXJq.js",
       "scene13-generate-mipmaps-CD--Ea4s.js",
       "scene13-gltf-glb-parser-BdYiApo0.js",
       "scene13-ibl-fragment-BfgmykuX.js",
-      "scene13-pbr-renderable-D8hwtUAU.js",
+      "scene13-pbr-renderable-D8vOAERb.js",
       "scene13-rgbd-decode-O-q0NvD4.js",
       "scene13-scene-uniforms-FTYH6Ct0.js",
       "scene13-singlelight-hemispheric-wgsl-Do0XQQfw.js",
@@ -240,8 +240,8 @@
     "bjsGzipKB": 674.6
   },
   "scene14": {
-    "rawKB": 85.1,
-    "gzipKB": 34.5,
+    "rawKB": 85.3,
+    "gzipKB": 34.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene14-background-dds-skybox-BcSRBQ9Z.js",
@@ -250,7 +250,7 @@
       "scene14-generate-mipmaps-ConWzwUk.js",
       "scene14-gltf-glb-parser-BdYiApo0.js",
       "scene14-ibl-fragment-BfgmykuX.js",
-      "scene14-pbr-renderable-ByRS7YlT.js",
+      "scene14-pbr-renderable-D2oVEt31.js",
       "scene14-rgbd-decode-O-q0NvD4.js",
       "scene14-scene-uniforms-FTYH6Ct0.js",
       "scene14-singlelight-hemispheric-wgsl-BnlSfsxA.js",
@@ -261,11 +261,11 @@
     "bjsGzipKB": 675.3
   },
   "scene15": {
-    "rawKB": 43.3,
-    "gzipKB": 17.2,
+    "rawKB": 43.6,
+    "gzipKB": 17.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene15-standard-renderable-C2GzXIGp.js",
+      "scene15-standard-renderable-Cj2PaNKZ.js",
       "scene15-wgsl-helpers-WTsokIfK.js",
       "scene15.js"
     ],
@@ -273,11 +273,11 @@
     "bjsGzipKB": 344.3
   },
   "scene16": {
-    "rawKB": 44,
-    "gzipKB": 17.5,
+    "rawKB": 44.3,
+    "gzipKB": 17.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene16-standard-renderable-BuSR5Ron.js",
+      "scene16-standard-renderable-ClKHtzi5.js",
       "scene16-thin-instance-fragment-C6G2xA6T.js",
       "scene16-thin-instance-gpu-BFOKnF2w.js",
       "scene16-wgsl-helpers-WTsokIfK.js",
@@ -287,17 +287,17 @@
     "bjsGzipKB": 341.7
   },
   "scene17": {
-    "rawKB": 79,
-    "gzipKB": 32.5,
+    "rawKB": 79.3,
+    "gzipKB": 32.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene17-generate-mipmaps-BZDsdBiu.js",
       "scene17-ibl-fragment-BfgmykuX.js",
       "scene17-mesh-features-CmiDU-Vn.js",
-      "scene17-pbr-renderable-BgoH3Zq1.js",
+      "scene17-pbr-renderable-CXJmlFlU.js",
       "scene17-rgbd-decode-Do-JwHYK.js",
       "scene17-singlelight-hemispheric-wgsl-Ck1RXlCo.js",
-      "scene17-standard-renderable-jmZ0skNn.js",
+      "scene17-standard-renderable-BGZgRsYa.js",
       "scene17-thin-instance-fragment-C6G2xA6T.js",
       "scene17-thin-instance-gpu-BFOKnF2w.js",
       "scene17-wgsl-helpers-WTsokIfK.js",
@@ -307,15 +307,15 @@
     "bjsGzipKB": 415.6
   },
   "scene18": {
-    "rawKB": 56.8,
-    "gzipKB": 22.6,
+    "rawKB": 57.1,
+    "gzipKB": 22.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene18-generate-mipmaps-BLhEcFI7.js",
       "scene18-material-view-Dua1bl7W.js",
       "scene18-no-color-view-D1zdiIgC.js",
       "scene18-shadow-task-B9rxiQQ3.js",
-      "scene18-standard-renderable-CyneooI7.js",
+      "scene18-standard-renderable-9_cN8q_x.js",
       "scene18-std-shadow-fragment-C4iPvy9E.js",
       "scene18-wgsl-helpers-WTsokIfK.js",
       "scene18.js"
@@ -324,13 +324,13 @@
     "bjsGzipKB": 358.5
   },
   "scene19": {
-    "rawKB": 64.3,
-    "gzipKB": 26.1,
+    "rawKB": 64.6,
+    "gzipKB": 26.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene19-clearcoat-fragment-CLQH7RM-.js",
       "scene19-ibl-fragment-BfgmykuX.js",
-      "scene19-pbr-renderable-qPPAkZ0Z.js",
+      "scene19-pbr-renderable-D_khwZkF.js",
       "scene19-rgbd-decode-Do-JwHYK.js",
       "scene19-singlelight-hemispheric-wgsl-C60991Md.js",
       "scene19.js"
@@ -339,8 +339,8 @@
     "bjsGzipKB": 403
   },
   "scene20": {
-    "rawKB": 73.9,
-    "gzipKB": 30.5,
+    "rawKB": 74.2,
+    "gzipKB": 30.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene20-background-dds-skybox-D2jLrf1h.js",
@@ -348,7 +348,7 @@
       "scene20-cubemap-skybox-material-D0TWWop9.js",
       "scene20-emissive-fragment-C399zhlr.js",
       "scene20-ibl-fragment-BfgmykuX.js",
-      "scene20-pbr-renderable-CTZFC3rb.js",
+      "scene20-pbr-renderable-C2Dyzblm.js",
       "scene20-rgbd-decode-O-q0NvD4.js",
       "scene20-scene-uniforms-FTYH6Ct0.js",
       "scene20-singlelight-hemispheric-wgsl-mbjPT-1V.js",
@@ -359,8 +359,8 @@
     "bjsGzipKB": 569.9
   },
   "scene21": {
-    "rawKB": 81.6,
-    "gzipKB": 32.7,
+    "rawKB": 81.9,
+    "gzipKB": 32.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene21-background-hdr-skybox-TPESZiSg.js",
@@ -368,7 +368,7 @@
       "scene21-generate-mipmaps-Ck18qOH0.js",
       "scene21-gltf-glb-parser-BdYiApo0.js",
       "scene21-ibl-fragment-BfgmykuX.js",
-      "scene21-pbr-renderable-GuIBI90E.js",
+      "scene21-pbr-renderable-DtdyrBju.js",
       "scene21-rgbd-decode-O-q0NvD4.js",
       "scene21-scene-material-swap-D59o_FWG.js",
       "scene21-scene-uniforms-FTYH6Ct0.js",
@@ -379,8 +379,8 @@
     "bjsGzipKB": 678.2
   },
   "scene22": {
-    "rawKB": 90.8,
-    "gzipKB": 36.4,
+    "rawKB": 91.1,
+    "gzipKB": 36.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene22-esm-shadow-view-DYtxGfcI.js",
@@ -389,11 +389,11 @@
       "scene22-mesh-features-CmiDU-Vn.js",
       "scene22-multilight-wgsl-B7kP3ItJ.js",
       "scene22-no-color-view-BtzQQJzb.js",
-      "scene22-pbr-renderable-C-q68Uh5.js",
+      "scene22-pbr-renderable-BMwVTYnU.js",
       "scene22-pbr-shadow-fragment-BFeG0hRF.js",
       "scene22-shadow-fragment-core-BgZG1upy.js",
       "scene22-shadow-task-BQJM9IT5.js",
-      "scene22-standard-renderable-DKcFk72c.js",
+      "scene22-standard-renderable-CwySLVsi.js",
       "scene22-wgsl-helpers-WTsokIfK.js",
       "scene22.js"
     ],
@@ -401,8 +401,8 @@
     "bjsGzipKB": 448.3
   },
   "scene23": {
-    "rawKB": 73.2,
-    "gzipKB": 29.8,
+    "rawKB": 73.5,
+    "gzipKB": 29.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene23-anisotropy-fragment-DHgVc2mJ.js",
@@ -410,7 +410,7 @@
       "scene23-background-ground-BMU6EJb1.js",
       "scene23-cubemap-skybox-material-wJgjZ2qC.js",
       "scene23-ibl-fragment-BfgmykuX.js",
-      "scene23-pbr-renderable-Cn0G75m-.js",
+      "scene23-pbr-renderable-CwOJ8oqo.js",
       "scene23-rgbd-decode-O-q0NvD4.js",
       "scene23-scene-uniforms-FTYH6Ct0.js",
       "scene23-wgsl-helpers-BgB2AJrF.js",
@@ -420,20 +420,20 @@
     "bjsGzipKB": 565.6
   },
   "scene24": {
-    "rawKB": 55.3,
-    "gzipKB": 23,
+    "rawKB": 55.6,
+    "gzipKB": 23.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene24-bake-local-matrix-67U-IT8C.js",
       "scene24-cube-texture-D6PLeF1H.js",
       "scene24-generate-mipmaps-c3ByLjV7.js",
-      "scene24-parse-camera-mciWjey_.js",
-      "scene24-point-light-ByT6ulgq.js",
-      "scene24-standard-renderable-Drg91Yf7.js",
-      "scene24-std-ambient-fragment-B71MYRoF.js",
-      "scene24-std-cube-reflection-fragment-CNI0Tp44.js",
-      "scene24-std-opacity-fragment-Cu5lXy9L.js",
-      "scene24-std-specular-fragment-Ct3Xduy6.js",
+      "scene24-parse-camera-D-kPPkqm.js",
+      "scene24-point-light-BOyMOw2t.js",
+      "scene24-standard-renderable-W2HArEdM.js",
+      "scene24-std-ambient-fragment-Pui5pJ7d.js",
+      "scene24-std-cube-reflection-fragment-CJpCTjFB.js",
+      "scene24-std-opacity-fragment-BuuLInPt.js",
+      "scene24-std-specular-fragment-3gCF3h4N.js",
       "scene24-wgsl-helpers-WTsokIfK.js",
       "scene24.js"
     ],
@@ -441,11 +441,11 @@
     "bjsGzipKB": 732.2
   },
   "scene25": {
-    "rawKB": 48.5,
-    "gzipKB": 19.1,
+    "rawKB": 48.8,
+    "gzipKB": 19.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene25-standard-renderable-Q_0KVRCj.js",
+      "scene25-standard-renderable-FzoSCuiA.js",
       "scene25-wgsl-helpers-WTsokIfK.js",
       "scene25.js"
     ],
@@ -453,8 +453,8 @@
     "bjsGzipKB": 335.9
   },
   "scene26": {
-    "rawKB": 83.7,
-    "gzipKB": 33.6,
+    "rawKB": 84,
+    "gzipKB": 33.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene26-emissive-fragment-D7SDxfpf.js",
@@ -463,7 +463,7 @@
       "scene26-ibl-fragment-BfgmykuX.js",
       "scene26-ibl-skybox-wgsl-63iqxPTk.js",
       "scene26-pbr-aces-wgsl-XxSkrbTG.js",
-      "scene26-pbr-renderable-Deg8Ng1r.js",
+      "scene26-pbr-renderable-DgyISHic.js",
       "scene26-rgbd-decode-Do-JwHYK.js",
       "scene26-scene-material-swap-D59o_FWG.js",
       "scene26-singlelight-point-wgsl-CZ_QkJJo.js",
@@ -474,8 +474,8 @@
     "bjsGzipKB": 620.2
   },
   "scene27": {
-    "rawKB": 73,
-    "gzipKB": 29.3,
+    "rawKB": 73.3,
+    "gzipKB": 29.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene27-generate-mipmaps-DYy_RjB2.js",
@@ -484,7 +484,7 @@
       "scene27-gltf-glb-parser-BdYiApo0.js",
       "scene27-gltf-pbr-builder-ext-Dn4nQG9B.js",
       "scene27-gltf-variants-TwEoBG2l.js",
-      "scene27-pbr-renderable-DjqQN6bJ.js",
+      "scene27-pbr-renderable-QAYggK2P.js",
       "scene27-reflectance-fragment-DGwRlQBZ.js",
       "scene27-singlelight-hemispheric-wgsl-C4eiBQd3.js",
       "scene27-texture-2d-DQo3n8D6.js",
@@ -494,15 +494,15 @@
     "bjsGzipKB": 520.6
   },
   "scene28": {
-    "rawKB": 77.9,
-    "gzipKB": 30.8,
+    "rawKB": 78.2,
+    "gzipKB": 30.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene28-clearcoat-fragment-CVbncs02.js",
+      "scene28-clearcoat-fragment-DbqDV7vD.js",
       "scene28-generate-mipmaps-D9AUse2y.js",
       "scene28-gltf-ext-clearcoat-BgaLgSgD.js",
       "scene28-ibl-fragment-BfgmykuX.js",
-      "scene28-pbr-renderable-CIX8EDI7.js",
+      "scene28-pbr-renderable-8turDo_M.js",
       "scene28-rgbd-decode-O-q0NvD4.js",
       "scene28-scene-uniforms-FTYH6Ct0.js",
       "scene28.js"
@@ -511,8 +511,8 @@
     "bjsGzipKB": 672
   },
   "scene29": {
-    "rawKB": 80.4,
-    "gzipKB": 32.5,
+    "rawKB": 80.7,
+    "gzipKB": 32.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene29-generate-mipmaps-_HVdIyD1.js",
@@ -520,11 +520,11 @@
       "scene29-gltf-ext-uv-transform-tUSEOqA7.js",
       "scene29-gltf-pbr-builder-ext-Dh5q6a0b.js",
       "scene29-ibl-fragment-BfgmykuX.js",
-      "scene29-pbr-renderable-T9F-3pKk.js",
+      "scene29-pbr-renderable-L6mpTyGZ.js",
       "scene29-pbr-template-ext-B00NeHp4.js",
       "scene29-rgbd-decode-O-q0NvD4.js",
       "scene29-scene-uniforms-FTYH6Ct0.js",
-      "scene29-sheen-fragment-CuoXaNGo.js",
+      "scene29-sheen-fragment-DLIVBjEy.js",
       "scene29-texture-2d-DQo3n8D6.js",
       "scene29-uv-transform-fragment-BJnSYzXA.js",
       "scene29.js"
@@ -533,11 +533,11 @@
     "bjsGzipKB": 672
   },
   "scene30": {
-    "rawKB": 93.6,
-    "gzipKB": 37.8,
+    "rawKB": 93.9,
+    "gzipKB": 37.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene30-alpha-test-fragment-CALi5d49.js",
+      "scene30-alpha-test-fragment-CYYy-p8Y.js",
       "scene30-generate-mipmaps-C_kZEx8C.js",
       "scene30-gltf-ext-dielectric-fB9ecuBG.js",
       "scene30-gltf-ext-uv-transform-DQN5DAiE.js",
@@ -545,10 +545,10 @@
       "scene30-gltf-glb-parser-BdYiApo0.js",
       "scene30-gltf-pbr-builder-ext-kE24Du8h.js",
       "scene30-ibl-fragment-BfgmykuX.js",
-      "scene30-pbr-refraction-D4Bs29X1.js",
-      "scene30-pbr-renderable-Ck84q-xX.js",
+      "scene30-pbr-refraction-t1KJp8i7.js",
+      "scene30-pbr-renderable-fO_CzdHk.js",
       "scene30-pbr-template-ext-B00NeHp4.js",
-      "scene30-pbr-transmission-ext-vCWSPfrq.js",
+      "scene30-pbr-transmission-ext-DD78rgq_.js",
       "scene30-rgbd-decode-O-q0NvD4.js",
       "scene30-scene-uniforms-FTYH6Ct0.js",
       "scene30-texture-2d-DQo3n8D6.js",
@@ -559,8 +559,8 @@
     "bjsGzipKB": 673.2
   },
   "scene31": {
-    "rawKB": 73.1,
-    "gzipKB": 29.2,
+    "rawKB": 73.4,
+    "gzipKB": 29.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene31-emissive-fragment-C67xzXHp.js",
@@ -568,7 +568,7 @@
       "scene31-gltf-ext-emissive-strength-CButLZnK.js",
       "scene31-gltf-glb-parser-BdYiApo0.js",
       "scene31-ibl-fragment-BfgmykuX.js",
-      "scene31-pbr-renderable-CxU9Vneq.js",
+      "scene31-pbr-renderable-BQBpxye3.js",
       "scene31-rgbd-decode-O-q0NvD4.js",
       "scene31-scene-uniforms-FTYH6Ct0.js",
       "scene31.js"
@@ -577,39 +577,39 @@
     "bjsGzipKB": 672
   },
   "scene32": {
-    "rawKB": 73,
-    "gzipKB": 29.2,
+    "rawKB": 73.3,
+    "gzipKB": 29.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene32-generate-mipmaps-CfD9ep0x.js",
       "scene32-gltf-ext-unlit-1vUYfF7v.js",
       "scene32-gltf-glb-parser-BdYiApo0.js",
       "scene32-ibl-fragment-BfgmykuX.js",
-      "scene32-pbr-renderable-DnfLCuIp.js",
+      "scene32-pbr-renderable-C0hrjrxV.js",
       "scene32-rgbd-decode-O-q0NvD4.js",
       "scene32-scene-uniforms-FTYH6Ct0.js",
-      "scene32-unlit-fragment-CHS-mFSV.js",
+      "scene32-unlit-fragment-BFCcwj1w.js",
       "scene32.js"
     ],
     "bjsRawKB": 2785.6,
     "bjsGzipKB": 672
   },
   "scene33": {
-    "rawKB": 92,
-    "gzipKB": 36.8,
+    "rawKB": 92.3,
+    "gzipKB": 37,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene33-generate-mipmaps-tahNs0PW.js",
       "scene33-gltf-ext-dielectric-fB9ecuBG.js",
-      "scene33-gltf-feature-lights-punctual-B0Df0CJ5.js",
+      "scene33-gltf-feature-lights-punctual-Bje_v2lN.js",
       "scene33-gltf-glb-parser-BdYiApo0.js",
       "scene33-ibl-fragment-BfgmykuX.js",
-      "scene33-light-base-DG8ogNVh.js",
+      "scene33-light-base-Dko_cCEY.js",
       "scene33-multilight-wgsl-D1KkFrvn.js",
-      "scene33-pbr-refraction-CHhlZONN.js",
-      "scene33-pbr-renderable-D3hD-kxl.js",
-      "scene33-pbr-transmission-ext-BEj0cH0S.js",
-      "scene33-point-light-CjMOKQQR.js",
+      "scene33-pbr-refraction-TgdbKV1u.js",
+      "scene33-pbr-renderable-p9bBZsZ4.js",
+      "scene33-pbr-transmission-ext-D-unqV_4.js",
+      "scene33-point-light-B2KwGlb8.js",
       "scene33-rgbd-decode-O-q0NvD4.js",
       "scene33-scene-uniforms-FTYH6Ct0.js",
       "scene33.js"
@@ -618,18 +618,18 @@
     "bjsGzipKB": 672
   },
   "scene34": {
-    "rawKB": 82.9,
-    "gzipKB": 33.8,
+    "rawKB": 83.2,
+    "gzipKB": 33.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene34-generate-mipmaps-Dq7lC7Fm.js",
       "scene34-gltf-animation-B-E9Gz7r.js",
       "scene34-gltf-ext-node-visibility-B4JwTDbS.js",
       "scene34-gltf-feature-animation-pointer-Cjhe50JW.js",
-      "scene34-gltf-feature-animations-BbPTKIxI.js",
+      "scene34-gltf-feature-animations-ButLUf67.js",
       "scene34-gltf-glb-parser-BdYiApo0.js",
       "scene34-ibl-fragment-BfgmykuX.js",
-      "scene34-pbr-renderable-BrhtAlim.js",
+      "scene34-pbr-renderable-Ctwz46-N.js",
       "scene34-rgbd-decode-O-q0NvD4.js",
       "scene34-scene-uniforms-FTYH6Ct0.js",
       "scene34-visibility-DOJqaQ7y.js",
@@ -639,15 +639,15 @@
     "bjsGzipKB": 675.5
   },
   "scene35": {
-    "rawKB": 75.7,
-    "gzipKB": 30.4,
+    "rawKB": 76,
+    "gzipKB": 30.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene35-generate-mipmaps-CgXGqw0s.js",
       "scene35-gltf-feature-gpu-instancing-DCcayUcD.js",
       "scene35-gltf-glb-parser-BdYiApo0.js",
       "scene35-ibl-fragment-BfgmykuX.js",
-      "scene35-pbr-renderable-DUlrYMmQ.js",
+      "scene35-pbr-renderable-CB4UbmJc.js",
       "scene35-rgbd-decode-O-q0NvD4.js",
       "scene35-scene-uniforms-FTYH6Ct0.js",
       "scene35-thin-instance-fragment-C6G2xA6T.js",
@@ -658,11 +658,11 @@
     "bjsGzipKB": 672
   },
   "scene36": {
-    "rawKB": 47.6,
-    "gzipKB": 18.6,
+    "rawKB": 47.9,
+    "gzipKB": 18.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene36-standard-renderable-B8DVzrbc.js",
+      "scene36-standard-renderable-CDtR_UF7.js",
       "scene36-std-emissive-fragment-BNJ_WIUU.js",
       "scene36-wgsl-helpers-WTsokIfK.js",
       "scene36.js"
@@ -671,8 +671,8 @@
     "bjsGzipKB": 345.5
   },
   "scene37": {
-    "rawKB": 85.8,
-    "gzipKB": 34.6,
+    "rawKB": 86.1,
+    "gzipKB": 34.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene37-generate-mipmaps-DhfusDDo.js",
@@ -682,12 +682,12 @@
       "scene37-gltf-glb-parser-BdYiApo0.js",
       "scene37-gltf-pbr-builder-ext-BsxR9Yvm.js",
       "scene37-ibl-fragment-BfgmykuX.js",
-      "scene37-pbr-renderable-BhwOtCt8.js",
+      "scene37-pbr-renderable-_jzt1usx.js",
       "scene37-pbr-template-ext-B00NeHp4.js",
-      "scene37-reflectance-fragment-7fNwrQ4G.js",
+      "scene37-reflectance-fragment-DEvCynr2.js",
       "scene37-rgbd-decode-O-q0NvD4.js",
       "scene37-scene-uniforms-FTYH6Ct0.js",
-      "scene37-sheen-fragment-Pi7VsoEt.js",
+      "scene37-sheen-fragment-sDE6jCzJ.js",
       "scene37-texture-2d-DQo3n8D6.js",
       "scene37-uv-transform-fragment-BJnSYzXA.js",
       "scene37.js"
@@ -696,11 +696,11 @@
     "bjsGzipKB": 672
   },
   "scene38": {
-    "rawKB": 57.6,
-    "gzipKB": 22.5,
+    "rawKB": 57.9,
+    "gzipKB": 22.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene38-standard-renderable-BwoUcXfy.js",
+      "scene38-standard-renderable-CfT9l_34.js",
       "scene38-wgsl-helpers-WTsokIfK.js",
       "scene38.js"
     ],
@@ -708,11 +708,11 @@
     "bjsGzipKB": 344.5
   },
   "scene40": {
-    "rawKB": 44.9,
-    "gzipKB": 17.9,
+    "rawKB": 45.2,
+    "gzipKB": 18.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene40-standard-renderable-BR54sYOl.js",
+      "scene40-standard-renderable-I5lTmQmq.js",
       "scene40-wgsl-helpers-WTsokIfK.js",
       "scene40.js"
     ],
@@ -740,11 +740,11 @@
     "bjsGzipKB": 198.3
   },
   "scene52": {
-    "rawKB": 54.2,
-    "gzipKB": 21.5,
+    "rawKB": 54.5,
+    "gzipKB": 21.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene52-standard-renderable-DogeD7V6.js",
+      "scene52-standard-renderable-_as9H-jo.js",
       "scene52-wgsl-helpers-WTsokIfK.js",
       "scene52.js"
     ],
@@ -752,11 +752,11 @@
     "bjsGzipKB": 363.8
   },
   "scene53": {
-    "rawKB": 54.6,
-    "gzipKB": 21.4,
+    "rawKB": 54.9,
+    "gzipKB": 21.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene53-standard-renderable-B8sROxfa.js",
+      "scene53-standard-renderable-C48VEpuA.js",
       "scene53-wgsl-helpers-WTsokIfK.js",
       "scene53.js"
     ],
@@ -764,13 +764,13 @@
     "bjsGzipKB": 368.8
   },
   "scene54": {
-    "rawKB": 56.2,
-    "gzipKB": 22.6,
+    "rawKB": 56.5,
+    "gzipKB": 22.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene54-billboard-renderable-D-N4jiPC.js",
       "scene54-scene-uniforms-FTYH6Ct0.js",
-      "scene54-standard-renderable-BpzNIpFN.js",
+      "scene54-standard-renderable-CH3HbejA.js",
       "scene54-wgsl-helpers-WTsokIfK.js",
       "scene54.js"
     ],
@@ -778,8 +778,8 @@
     "bjsGzipKB": 368.7
   },
   "scene55": {
-    "rawKB": 29.5,
-    "gzipKB": 12,
+    "rawKB": 29.8,
+    "gzipKB": 12.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene55-billboard-renderable-XsCsM08l.js",
@@ -789,13 +789,13 @@
     "bjsGzipKB": 240.4
   },
   "scene56": {
-    "rawKB": 56.5,
-    "gzipKB": 22.7,
+    "rawKB": 56.8,
+    "gzipKB": 22.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene56-billboard-renderable-De0uMaG1.js",
       "scene56-scene-uniforms-FTYH6Ct0.js",
-      "scene56-standard-renderable-BrkJG6kQ.js",
+      "scene56-standard-renderable-DGv7eqL3.js",
       "scene56-wgsl-helpers-WTsokIfK.js",
       "scene56.js"
     ],
@@ -803,13 +803,13 @@
     "bjsGzipKB": 359.7
   },
   "scene57": {
-    "rawKB": 56.5,
-    "gzipKB": 22.6,
+    "rawKB": 56.7,
+    "gzipKB": 22.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene57-billboard-renderable-DBMt62jp.js",
       "scene57-scene-uniforms-FTYH6Ct0.js",
-      "scene57-standard-renderable-DtJ1Ijjv.js",
+      "scene57-standard-renderable-DfLqA4TH.js",
       "scene57-wgsl-helpers-WTsokIfK.js",
       "scene57.js"
     ],
@@ -817,15 +817,15 @@
     "bjsGzipKB": 348.6
   },
   "scene60": {
-    "rawKB": 53.8,
-    "gzipKB": 21.5,
+    "rawKB": 54,
+    "gzipKB": 21.6,
     "ignoredRawKB": 4,
     "runtimeChunks": [
       "scene60-_math-factory-DFVyS8gB.js",
       "scene60-fragment-output-CfRmfbPv.js",
       "scene60-input-block-Dx-s01X8.js",
       "scene60-node-registry-BBic-RVv.js",
-      "scene60-node-renderable-g4X-16Pa.js",
+      "scene60-node-renderable-7W85qjFc.js",
       "scene60-transform-block-CTO4A4d-.js",
       "scene60-vertex-output-C7G5u6Y0.js",
       "scene60.js"
@@ -834,8 +834,8 @@
     "bjsGzipKB": 525
   },
   "scene61": {
-    "rawKB": 52.6,
-    "gzipKB": 21.9,
+    "rawKB": 52.9,
+    "gzipKB": 22,
     "ignoredRawKB": 7.3,
     "runtimeChunks": [
       "scene61-_math-factory-DFVyS8gB.js",
@@ -843,7 +843,7 @@
       "scene61-fragment-output-CfRmfbPv.js",
       "scene61-input-block-DpRZ-Ft1.js",
       "scene61-node-registry-BN8St9FB.js",
-      "scene61-node-renderable-DWKiic8z.js",
+      "scene61-node-renderable-t-SdwYPn.js",
       "scene61-scale-block-6qtIvFiz.js",
       "scene61-transform-block-CNLo7x5_.js",
       "scene61-vertex-output-C7G5u6Y0.js",
@@ -853,8 +853,8 @@
     "bjsGzipKB": 525.1
   },
   "scene62": {
-    "rawKB": 58.3,
-    "gzipKB": 24,
+    "rawKB": 58.6,
+    "gzipKB": 24.1,
     "ignoredRawKB": 5.3,
     "runtimeChunks": [
       "scene62-_math-factory-DFVyS8gB.js",
@@ -862,7 +862,7 @@
       "scene62-generate-mipmaps-a3cRDC9n.js",
       "scene62-input-block-BgDpnyI_.js",
       "scene62-node-registry-Bnb6aYuw.js",
-      "scene62-node-renderable-CFJVit0w.js",
+      "scene62-node-renderable-CgWQy9Ne.js",
       "scene62-texture-block-qpJiHpPr.js",
       "scene62-transform-block-BSlYzxBO.js",
       "scene62-vertex-output-C7G5u6Y0.js",
@@ -872,8 +872,8 @@
     "bjsGzipKB": 525.1
   },
   "scene63": {
-    "rawKB": 56.6,
-    "gzipKB": 23.2,
+    "rawKB": 56.9,
+    "gzipKB": 23.4,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
       "scene63-_math-factory-DFVyS8gB.js",
@@ -881,7 +881,7 @@
       "scene63-input-block-DtZeDmLA.js",
       "scene63-light-block-CCEnsdUz.js",
       "scene63-node-registry-CwcwrT_u.js",
-      "scene63-node-renderable-DlbMHgL5.js",
+      "scene63-node-renderable-sYcX3ngD.js",
       "scene63-transform-block-CvEP0L-h.js",
       "scene63-vertex-output-C7G5u6Y0.js",
       "scene63.js"
@@ -890,8 +890,8 @@
     "bjsGzipKB": 525.9
   },
   "scene64": {
-    "rawKB": 55.2,
-    "gzipKB": 22.3,
+    "rawKB": 55.5,
+    "gzipKB": 22.4,
     "ignoredRawKB": 4.3,
     "runtimeChunks": [
       "scene64-_math-factory-DFVyS8gB.js",
@@ -899,7 +899,7 @@
       "scene64-input-block-CmvPVsv0.js",
       "scene64-morph-targets-CsnL5CDS.js",
       "scene64-node-registry-BoQd61A8.js",
-      "scene64-node-renderable-CzsRy2_8.js",
+      "scene64-node-renderable-AWdV2b_Q.js",
       "scene64-transform-block-C-HoggRW.js",
       "scene64-vertex-output-C7G5u6Y0.js",
       "scene64.js"
@@ -908,8 +908,8 @@
     "bjsGzipKB": 528
   },
   "scene65": {
-    "rawKB": 72.6,
-    "gzipKB": 29.3,
+    "rawKB": 72.9,
+    "gzipKB": 29.4,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
       "scene65-_math-factory-DFVyS8gB.js",
@@ -920,7 +920,7 @@
       "scene65-material-view-Dua1bl7W.js",
       "scene65-node-flags-3CD_c1Kp.js",
       "scene65-node-registry-CMsydnt5.js",
-      "scene65-node-renderable-CbN8h4rA.js",
+      "scene65-node-renderable-B7XtBVmu.js",
       "scene65-node-shadow-DGK1QqE_.js",
       "scene65-shadow-task-Ciyy4_Zw.js",
       "scene65-transform-block-DDRhlmcT.js",
@@ -931,8 +931,8 @@
     "bjsGzipKB": 545.8
   },
   "scene66": {
-    "rawKB": 87.2,
-    "gzipKB": 39.7,
+    "rawKB": 87.5,
+    "gzipKB": 39.8,
     "ignoredRawKB": 5.5,
     "runtimeChunks": [
       "scene66-_math-factory-DFVyS8gB.js",
@@ -958,7 +958,7 @@
       "scene66-no-color-view-CIGis567.js",
       "scene66-node-flags-3CD_c1Kp.js",
       "scene66-node-registry-BfOHl4m_.js",
-      "scene66-node-renderable-BXjCrOmV.js",
+      "scene66-node-renderable-sXEQRui6.js",
       "scene66-node-shadow-fpSaAatb.js",
       "scene66-normalize-block-i-7IPb6A.js",
       "scene66-oneminus-block-C_JubHUo.js",
@@ -977,8 +977,8 @@
     "bjsGzipKB": 551.4
   },
   "scene67": {
-    "rawKB": 74.3,
-    "gzipKB": 30.7,
+    "rawKB": 74.5,
+    "gzipKB": 30.8,
     "ignoredRawKB": 9.6,
     "runtimeChunks": [
       "scene67-_math-factory-DFVyS8gB.js",
@@ -986,7 +986,7 @@
       "scene67-input-block-C3R5NLd7.js",
       "scene67-node-env-9-digQG0.js",
       "scene67-node-registry-BPX1_QaQ.js",
-      "scene67-node-renderable-BRjRhRSY.js",
+      "scene67-node-renderable-B0Mxlp9T.js",
       "scene67-pbr-metallic-roughness-block-DO8GQS6Y.js",
       "scene67-pbr-mr-helper-core-CEFScavi.js",
       "scene67-reflection-block-CIXuH-z0.js",
@@ -999,8 +999,8 @@
     "bjsGzipKB": 564.1
   },
   "scene68": {
-    "rawKB": 84.8,
-    "gzipKB": 34.1,
+    "rawKB": 85.1,
+    "gzipKB": 34.2,
     "ignoredRawKB": 11.4,
     "runtimeChunks": [
       "scene68-_math-factory-DFVyS8gB.js",
@@ -1009,7 +1009,7 @@
       "scene68-input-block-CMznN6K7.js",
       "scene68-node-env-9-digQG0.js",
       "scene68-node-registry-CuMa-7kS.js",
-      "scene68-node-renderable-CLpEJWDe.js",
+      "scene68-node-renderable-BN_SRGDf.js",
       "scene68-pbr-metallic-roughness-block-full-Bq-STqpa.js",
       "scene68-reflection-block-CIXuH-z0.js",
       "scene68-rgbd-decode-O-q0NvD4.js",
@@ -1021,8 +1021,8 @@
     "bjsGzipKB": 564.3
   },
   "scene69": {
-    "rawKB": 84.3,
-    "gzipKB": 34.4,
+    "rawKB": 84.6,
+    "gzipKB": 34.5,
     "ignoredRawKB": 13.3,
     "runtimeChunks": [
       "scene69-_math-factory-DFVyS8gB.js",
@@ -1031,7 +1031,7 @@
       "scene69-input-block-DlAP62bA.js",
       "scene69-node-env-9-digQG0.js",
       "scene69-node-registry-C-vHYr7j.js",
-      "scene69-node-renderable-C-ozXQmU.js",
+      "scene69-node-renderable-S2BlLqmo.js",
       "scene69-pbr-metallic-roughness-block-full-BlMpwh9g.js",
       "scene69-reflection-block-CIXuH-z0.js",
       "scene69-rgbd-decode-O-q0NvD4.js",
@@ -1044,8 +1044,8 @@
     "bjsGzipKB": 564.4
   },
   "scene70": {
-    "rawKB": 84.6,
-    "gzipKB": 35,
+    "rawKB": 84.9,
+    "gzipKB": 35.1,
     "ignoredRawKB": 14.9,
     "runtimeChunks": [
       "scene70-_math-factory-DFVyS8gB.js",
@@ -1055,7 +1055,7 @@
       "scene70-input-block-Db0MJXes.js",
       "scene70-node-env-9-digQG0.js",
       "scene70-node-registry-flVpSMAc.js",
-      "scene70-node-renderable-CSCq8JMz.js",
+      "scene70-node-renderable-Sl--_r22.js",
       "scene70-pbr-metallic-roughness-block-full-X6czlPGi.js",
       "scene70-perturb-normal-B_Pe7L6w.js",
       "scene70-reflection-block-CIXuH-z0.js",
@@ -1068,8 +1068,8 @@
     "bjsGzipKB": 564.5
   },
   "scene71": {
-    "rawKB": 84.5,
-    "gzipKB": 34.4,
+    "rawKB": 84.8,
+    "gzipKB": 34.5,
     "ignoredRawKB": 12.9,
     "runtimeChunks": [
       "scene71-_math-factory-DFVyS8gB.js",
@@ -1077,7 +1077,7 @@
       "scene71-input-block-DDVjNkyD.js",
       "scene71-node-env-9-digQG0.js",
       "scene71-node-registry-0D8Eo2f0.js",
-      "scene71-node-renderable-LPEigsQV.js",
+      "scene71-node-renderable-CZg0Jldn.js",
       "scene71-pbr-metallic-roughness-block-full-BRMnoU1Z.js",
       "scene71-reflection-block-CIXuH-z0.js",
       "scene71-refraction-block-CNhcdLis.js",
@@ -1091,8 +1091,8 @@
     "bjsGzipKB": 564.4
   },
   "scene72": {
-    "rawKB": 101.5,
-    "gzipKB": 41.9,
+    "rawKB": 101.8,
+    "gzipKB": 42,
     "ignoredRawKB": 3.3,
     "runtimeChunks": [
       "scene72-_math-factory-DFVyS8gB.js",
@@ -1108,7 +1108,7 @@
       "scene72-no-color-view-BDusEge-.js",
       "scene72-node-env-9-digQG0.js",
       "scene72-node-flags-3CD_c1Kp.js",
-      "scene72-node-renderable-COQXo5Dz.js",
+      "scene72-node-renderable-B50K5sFO.js",
       "scene72-pbr-metallic-roughness-block-full-DIs9uv_5.js",
       "scene72-perturb-normal-B_Pe7L6w.js",
       "scene72-reflection-block-CIXuH-z0.js",
@@ -1128,13 +1128,13 @@
     "bjsGzipKB": 585.1
   },
   "scene73": {
-    "rawKB": 131.6,
-    "gzipKB": 53.4,
+    "rawKB": 131.9,
+    "gzipKB": 53.5,
     "ignoredRawKB": 3.3,
     "runtimeChunks": [
       "scene73-_math-factory-DFVyS8gB.js",
       "scene73-clearcoat-block-BPLkmxQ1.js",
-      "scene73-clearcoat-fragment-wLNHNf1b.js",
+      "scene73-clearcoat-fragment-DDfasba4.js",
       "scene73-color-splitter-BK-XgtrJ.js",
       "scene73-fragment-output-CfRmfbPv.js",
       "scene73-generate-mipmaps-CdxUfH0k.js",
@@ -1143,9 +1143,9 @@
       "scene73-ibl-fragment-BfgmykuX.js",
       "scene73-input-block-lrbZBZJO.js",
       "scene73-node-env-9-digQG0.js",
-      "scene73-node-renderable-CF8rhALg.js",
+      "scene73-node-renderable-DzDo0DdU.js",
       "scene73-pbr-metallic-roughness-block-full-B-j3l0PP.js",
-      "scene73-pbr-renderable-BdaUywuU.js",
+      "scene73-pbr-renderable-BGa8kL0O.js",
       "scene73-perturb-normal-B_Pe7L6w.js",
       "scene73-reflection-block-CIXuH-z0.js",
       "scene73-rgbd-decode-O-q0NvD4.js",
@@ -1169,11 +1169,11 @@
     "bjsGzipKB": 175
   },
   "scene75": {
-    "rawKB": 46.6,
-    "gzipKB": 18.4,
+    "rawKB": 46.9,
+    "gzipKB": 18.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene75-standard-renderable-CPq5O3Bu.js",
+      "scene75-standard-renderable-orwFstem.js",
       "scene75-wgsl-helpers-WTsokIfK.js",
       "scene75.js"
     ],
@@ -1191,8 +1191,8 @@
     "bjsGzipKB": 175.4
   },
   "scene77": {
-    "rawKB": 58.1,
-    "gzipKB": 24.2,
+    "rawKB": 58.4,
+    "gzipKB": 24.3,
     "ignoredRawKB": 7,
     "runtimeChunks": [
       "scene77-_math-factory-DFVyS8gB.js",
@@ -1203,7 +1203,7 @@
       "scene77-node-registry-1XJ5C-2Q.js",
       "scene77-node-registry-extra-compat-WJskWIWa.js",
       "scene77-node-registry-extra-math-BDZZMEV4.js",
-      "scene77-node-renderable-DsMJ6-M4.js",
+      "scene77-node-renderable-C72dRiRk.js",
       "scene77-opposite-block-DWEPm0Z5.js",
       "scene77-teleport-in-block-DJKPTgKE.js",
       "scene77-teleport-out-block-C2Djod45.js",
@@ -1217,8 +1217,8 @@
     "bjsGzipKB": 524.3
   },
   "scene78": {
-    "rawKB": 56.1,
-    "gzipKB": 26,
+    "rawKB": 56.4,
+    "gzipKB": 26.2,
     "ignoredRawKB": 9.7,
     "runtimeChunks": [
       "scene78-_math-factory-DFVyS8gB.js",
@@ -1235,7 +1235,7 @@
       "scene78-multiply-block-DKKfQJFj.js",
       "scene78-node-registry-DWelkacs.js",
       "scene78-node-registry-extra-math-CKvWkhfv.js",
-      "scene78-node-renderable-DDuPCoup.js",
+      "scene78-node-renderable-BI1gDAZD.js",
       "scene78-normalize-block-BUk4O2XX.js",
       "scene78-reciprocal-block-DilmIM2-.js",
       "scene78-reflect-block-CSAIYNw5.js",
@@ -1251,8 +1251,8 @@
     "bjsGzipKB": 525.4
   },
   "scene79": {
-    "rawKB": 59.7,
-    "gzipKB": 26.3,
+    "rawKB": 59.9,
+    "gzipKB": 26.4,
     "ignoredRawKB": 8.1,
     "runtimeChunks": [
       "scene79-_math-factory-DFVyS8gB.js",
@@ -1266,7 +1266,7 @@
       "scene79-nlerp-block-DCTQwLVE.js",
       "scene79-node-registry-DEzJEjn-.js",
       "scene79-node-registry-extra-math-Dw_l0pN0.js",
-      "scene79-node-renderable-CxgXkg0f.js",
+      "scene79-node-renderable-D_odP4Qh.js",
       "scene79-random-number-block-Cc5cHymD.js",
       "scene79-transform-block-Dt_QHxTW.js",
       "scene79-vector-merger-YcC3xFyg.js",
@@ -1279,8 +1279,8 @@
     "bjsGzipKB": 525.1
   },
   "scene80": {
-    "rawKB": 59.1,
-    "gzipKB": 25.3,
+    "rawKB": 59.3,
+    "gzipKB": 25.5,
     "ignoredRawKB": 6,
     "runtimeChunks": [
       "scene80-_math-factory-DFVyS8gB.js",
@@ -1292,7 +1292,7 @@
       "scene80-input-block-CRfb77r9.js",
       "scene80-node-registry-Cc2H8p48.js",
       "scene80-node-registry-extra-procedural-CIYNG1uF.js",
-      "scene80-node-renderable-DUHOG4Gz.js",
+      "scene80-node-renderable-7iW-GLO1.js",
       "scene80-posterize-block-PW8UWjyJ.js",
       "scene80-replace-color-block-jNV1Iu7G.js",
       "scene80-transform-block-DM6P_1Fx.js",
@@ -1304,8 +1304,8 @@
     "bjsGzipKB": 524.8
   },
   "scene81": {
-    "rawKB": 65,
-    "gzipKB": 28.4,
+    "rawKB": 65.3,
+    "gzipKB": 28.5,
     "ignoredRawKB": 7,
     "runtimeChunks": [
       "scene81-_math-factory-DFVyS8gB.js",
@@ -1315,7 +1315,7 @@
       "scene81-input-block-DjQ0htzg.js",
       "scene81-node-registry-BEtJM2Mj.js",
       "scene81-node-registry-extra-procedural-DVqOq6t1.js",
-      "scene81-node-renderable-C0OukXII.js",
+      "scene81-node-renderable-D5vlTNKK.js",
       "scene81-panner-block-fcbonbH6.js",
       "scene81-rotate2d-block-PoTUVgvt.js",
       "scene81-scale-block-6qtIvFiz.js",
@@ -1329,8 +1329,8 @@
     "bjsGzipKB": 525.9
   },
   "scene82": {
-    "rawKB": 64.9,
-    "gzipKB": 28.4,
+    "rawKB": 65.2,
+    "gzipKB": 28.5,
     "ignoredRawKB": 8.4,
     "runtimeChunks": [
       "scene82-_math-factory-DFVyS8gB.js",
@@ -1343,7 +1343,7 @@
       "scene82-node-registry-C2rWM8VN.js",
       "scene82-node-registry-extra-math-B_9Eknx7.js",
       "scene82-node-registry-extra-procedural-Bmt_Y40q.js",
-      "scene82-node-renderable-sfZ99mLt.js",
+      "scene82-node-renderable-C0F_sEuP.js",
       "scene82-scale-block-6qtIvFiz.js",
       "scene82-simplex-perlin-3d-block-Cfood6_x.js",
       "scene82-transform-block-Dmzn7Riu.js",
@@ -1358,8 +1358,8 @@
     "bjsGzipKB": 525.1
   },
   "scene83": {
-    "rawKB": 68,
-    "gzipKB": 31.8,
+    "rawKB": 68.2,
+    "gzipKB": 32,
     "ignoredRawKB": 11.4,
     "runtimeChunks": [
       "scene83-_math-factory-DFVyS8gB.js",
@@ -1374,7 +1374,7 @@
       "scene83-input-block-PzznsC_q.js",
       "scene83-light-block-B2q9pooY.js",
       "scene83-multiply-block-G4bDy_QN.js",
-      "scene83-node-renderable-qnaO5Rne.js",
+      "scene83-node-renderable-dAeUFU-X.js",
       "scene83-normal-blend-block-BVPL4brK.js",
       "scene83-perturb-normal-B_Pe7L6w.js",
       "scene83-scale-block-6qtIvFiz.js",
@@ -1391,8 +1391,8 @@
     "bjsGzipKB": 527.2
   },
   "scene84": {
-    "rawKB": 81.6,
-    "gzipKB": 34.3,
+    "rawKB": 81.9,
+    "gzipKB": 34.4,
     "ignoredRawKB": 5.5,
     "runtimeChunks": [
       "scene84-_math-factory-DFVyS8gB.js",
@@ -1406,10 +1406,10 @@
       "scene84-node-registry-extra-advanced-CSoT_N1X.js",
       "scene84-node-registry-extra-math-DQQRybe0.js",
       "scene84-node-registry-extra-procedural-D8ozSQZ9.js",
-      "scene84-node-renderable-BFD3u07O.js",
+      "scene84-node-renderable--Ndxl9ad.js",
       "scene84-screen-size-block-yVY2pHhh.js",
       "scene84-screen-space-block-Cfi3u-na.js",
-      "scene84-standard-renderable-4kycMMM9.js",
+      "scene84-standard-renderable-DbKzKtHM.js",
       "scene84-transform-block-PEh7VaCZ.js",
       "scene84-twirl-block-tQLhuAc6.js",
       "scene84-vector-splitter-BMf4DQi8.js",
@@ -1421,8 +1421,8 @@
     "bjsGzipKB": 543.2
   },
   "scene85": {
-    "rawKB": 58.8,
-    "gzipKB": 25.1,
+    "rawKB": 59.1,
+    "gzipKB": 25.2,
     "ignoredRawKB": 6.5,
     "runtimeChunks": [
       "scene85-_math-factory-DFVyS8gB.js",
@@ -1435,7 +1435,7 @@
       "scene85-node-registry-BRMAEAaV.js",
       "scene85-node-registry-extra-advanced-BHEcVu1g.js",
       "scene85-node-registry-extra-procedural-CIRC8AQw.js",
-      "scene85-node-renderable-DDpe3oVi.js",
+      "scene85-node-renderable-DoXkJ7q-.js",
       "scene85-scale-block-6qtIvFiz.js",
       "scene85-transform-block-DDhnh2Z5.js",
       "scene85-vector-merger-YcC3xFyg.js",
@@ -1446,8 +1446,8 @@
     "bjsGzipKB": 524.9
   },
   "scene86": {
-    "rawKB": 58.1,
-    "gzipKB": 25.7,
+    "rawKB": 58.4,
+    "gzipKB": 25.9,
     "ignoredRawKB": 8,
     "runtimeChunks": [
       "scene86-_math-factory-DFVyS8gB.js",
@@ -1462,7 +1462,7 @@
       "scene86-node-registry-Dq8w67K7.js",
       "scene86-node-registry-extra-compat-BySiaXlE.js",
       "scene86-node-registry-extra-procedural-B0-_-3_0.js",
-      "scene86-node-renderable-UHamvJn3.js",
+      "scene86-node-renderable-AHI4QIPs.js",
       "scene86-reflection-texture-base-block-CklyAZSo.js",
       "scene86-scale-block-6qtIvFiz.js",
       "scene86-transform-block-Cf9qywIP.js",
@@ -1474,8 +1474,8 @@
     "bjsGzipKB": 491.1
   },
   "scene87": {
-    "rawKB": 87.7,
-    "gzipKB": 35.9,
+    "rawKB": 88,
+    "gzipKB": 36,
     "ignoredRawKB": 12,
     "runtimeChunks": [
       "scene87-_math-factory-DFVyS8gB.js",
@@ -1486,7 +1486,7 @@
       "scene87-node-env-9-digQG0.js",
       "scene87-node-registry-B_n5cam4.js",
       "scene87-node-registry-extra-compat-DA2oTCsk.js",
-      "scene87-node-renderable-BeGifjE7.js",
+      "scene87-node-renderable-DF8NEAvB.js",
       "scene87-pbr-metallic-roughness-block-full-B_axejY0.js",
       "scene87-reflection-block-CIXuH-z0.js",
       "scene87-rgbd-decode-O-q0NvD4.js",
@@ -1498,8 +1498,8 @@
     "bjsGzipKB": 563.8
   },
   "scene88": {
-    "rawKB": 59.1,
-    "gzipKB": 25.6,
+    "rawKB": 59.3,
+    "gzipKB": 25.7,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
       "scene88-_math-factory-DFVyS8gB.js",
@@ -1512,7 +1512,7 @@
       "scene88-node-registry-3f7XgrR-.js",
       "scene88-node-registry-extra-compat-NqgyiD-S.js",
       "scene88-node-registry-extra-math-BzNJZp4Y.js",
-      "scene88-node-renderable-D_U-9hD8.js",
+      "scene88-node-renderable-OaKV6yoA.js",
       "scene88-step-block-sbiWJXfG.js",
       "scene88-storage-read-block-DkBAxglb.js",
       "scene88-storage-write-block-BSqc-AKf.js",
@@ -1527,8 +1527,8 @@
     "bjsGzipKB": 524.8
   },
   "scene89": {
-    "rawKB": 58.6,
-    "gzipKB": 25.7,
+    "rawKB": 58.8,
+    "gzipKB": 25.8,
     "ignoredRawKB": 7.6,
     "runtimeChunks": [
       "scene89-_math-factory-DFVyS8gB.js",
@@ -1541,7 +1541,7 @@
       "scene89-node-registry-BKQ-FlYE.js",
       "scene89-node-registry-extra-compat-DjvO4Ffj.js",
       "scene89-node-registry-extra-math-BaLrv1wL.js",
-      "scene89-node-renderable-CK2KgJjR.js",
+      "scene89-node-renderable-B6YVWVxx.js",
       "scene89-step-block-sbiWJXfG.js",
       "scene89-storage-read-block-DkBAxglb.js",
       "scene89-storage-write-block-BSqc-AKf.js",
@@ -1556,12 +1556,12 @@
     "bjsGzipKB": 524.9
   },
   "scene90": {
-    "rawKB": 55.5,
-    "gzipKB": 21.7,
+    "rawKB": 55.8,
+    "gzipKB": 21.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene90-generate-mipmaps-DW5J86gX.js",
-      "scene90-standard-renderable-DUcOKb_o.js",
+      "scene90-standard-renderable-C8kdkkst.js",
       "scene90-wgsl-helpers-WTsokIfK.js",
       "scene90.js"
     ],
@@ -1569,12 +1569,12 @@
     "bjsGzipKB": 345.7
   },
   "scene91": {
-    "rawKB": 54.6,
-    "gzipKB": 21.6,
+    "rawKB": 54.9,
+    "gzipKB": 21.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene91-generate-mipmaps-D34sKB5R.js",
-      "scene91-standard-renderable-BtP9yaNf.js",
+      "scene91-standard-renderable-B1x3KTWN.js",
       "scene91-wgsl-helpers-WTsokIfK.js",
       "scene91.js"
     ],
@@ -1582,11 +1582,11 @@
     "bjsGzipKB": 345.2
   },
   "scene110": {
-    "rawKB": 46.7,
-    "gzipKB": 18.2,
+    "rawKB": 47,
+    "gzipKB": 18.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene110-standard-renderable-Bp6jjJ9o.js",
+      "scene110-standard-renderable-CFRXEUlU.js",
       "scene110-wgsl-helpers-WTsokIfK.js",
       "scene110.js"
     ],
@@ -1594,8 +1594,8 @@
     "bjsGzipKB": 345.6
   },
   "scene111": {
-    "rawKB": 128,
-    "gzipKB": 51.3,
+    "rawKB": 128.3,
+    "gzipKB": 51.4,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
       "scene111-_math-factory-DFVyS8gB.js",
@@ -1612,13 +1612,13 @@
       "scene111-no-color-view-DvvwhelJ.js",
       "scene111-node-flags-3CD_c1Kp.js",
       "scene111-node-registry-BEF7pDW0.js",
-      "scene111-node-renderable-DplC-ob7.js",
+      "scene111-node-renderable-BPwnVi_Y.js",
       "scene111-node-shadow-CMDpglyc.js",
-      "scene111-pbr-renderable-C1IhuG6V.js",
+      "scene111-pbr-renderable-CLO0MEbu.js",
       "scene111-pbr-shadow-fragment-D_IVR4A_.js",
       "scene111-shadow-fragment-core-BgZG1upy.js",
       "scene111-shadow-task-WuuxPmuL.js",
-      "scene111-standard-renderable-w8hDG65S.js",
+      "scene111-standard-renderable-BwHUG0Lp.js",
       "scene111-std-shadow-fragment-H0IlS3xP.js",
       "scene111-transform-block-xSHzJVmq.js",
       "scene111-vertex-output-C7G5u6Y0.js",
@@ -1629,8 +1629,8 @@
     "bjsGzipKB": 598.7
   },
   "scene112": {
-    "rawKB": 109.4,
-    "gzipKB": 43.3,
+    "rawKB": 109.7,
+    "gzipKB": 43.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene112-background-dds-skybox-Bbwg9yD_.js",
@@ -1641,7 +1641,7 @@
       "scene112-gltf-ext-dielectric-fB9ecuBG.js",
       "scene112-ibl-fragment-BfgmykuX.js",
       "scene112-pbr-refraction-B3LVuLW7.js",
-      "scene112-pbr-renderable-NBnhnILS.js",
+      "scene112-pbr-renderable-_df7dD8-.js",
       "scene112-pbr-transmission-ext-CbWXBJ-l.js",
       "scene112-rgbd-decode-O-q0NvD4.js",
       "scene112-scene-uniforms-FTYH6Ct0.js",
@@ -1653,11 +1653,11 @@
     "bjsGzipKB": 676.1
   },
   "scene113": {
-    "rawKB": 58.2,
-    "gzipKB": 22.2,
+    "rawKB": 58.5,
+    "gzipKB": 22.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene113-standard-renderable-Q8kJxnIB.js",
+      "scene113-standard-renderable-BOijwZQL.js",
       "scene113-wgsl-helpers-WTsokIfK.js",
       "scene113.js"
     ],
@@ -1665,15 +1665,15 @@
     "bjsGzipKB": 343.8
   },
   "scene114": {
-    "rawKB": 75.6,
+    "rawKB": 75.8,
     "gzipKB": 28.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene114-morph-fragment-DI5AIR1s.js",
-      "scene114-pbr-renderable-BwQ_QJQ0.js",
+      "scene114-morph-fragment-Bm16mHC_.js",
+      "scene114-pbr-renderable-D68fP0hp.js",
       "scene114-pbr-template-ext-B00NeHp4.js",
       "scene114-singlelight-hemispheric-wgsl-BSjAY3sb.js",
-      "scene114-skeleton-fragment-FCkz2clD.js",
+      "scene114-skeleton-fragment-D6fOEzqE.js",
       "scene114-unlit-fragment-C0-vFiaY.js",
       "scene114.js"
     ],
@@ -1681,8 +1681,8 @@
     "bjsGzipKB": 432.8
   },
   "scene115": {
-    "rawKB": 113.6,
-    "gzipKB": 45.5,
+    "rawKB": 113.9,
+    "gzipKB": 45.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene115-create-morph-targets-Q2UNbVM8.js",
@@ -1694,11 +1694,11 @@
       "scene115-gltf-feature-skeleton-BXYoKcjo.js",
       "scene115-mesh-features-GJGfSdO-.js",
       "scene115-morph-fragment-t6RXXXtF.js",
-      "scene115-pbr-renderable-D7C0nBqY.js",
+      "scene115-pbr-renderable-QaOMo9qK.js",
       "scene115-pbr-template-ext-B00NeHp4.js",
       "scene115-singlelight-hemispheric-wgsl-BQTWI-6s.js",
       "scene115-skeleton-fragment-Sa2bymIR.js",
-      "scene115-standard-renderable-GT3tLp1o.js",
+      "scene115-standard-renderable-D3Aj8ZEM.js",
       "scene115-wgsl-helpers-WTsokIfK.js",
       "scene115.js"
     ],
@@ -1706,14 +1706,14 @@
     "bjsGzipKB": 575.3
   },
   "scene116": {
-    "rawKB": 70.2,
-    "gzipKB": 28.6,
+    "rawKB": 70.5,
+    "gzipKB": 28.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene116-mesh-features-CmiDU-Vn.js",
-      "scene116-pbr-renderable-Bn-UFW7R.js",
+      "scene116-pbr-renderable-mPtvhWp_.js",
       "scene116-singlelight-hemispheric-wgsl-DhG_VRRW.js",
-      "scene116-standard-renderable-BZq7RJne.js",
+      "scene116-standard-renderable-E-LYPdV0.js",
       "scene116-std-emissive-fragment-Dbkg8I5G.js",
       "scene116-unlit-fragment-XtoycUlq.js",
       "scene116-wgsl-helpers-WTsokIfK.js",
@@ -1723,8 +1723,8 @@
     "bjsGzipKB": 421.1
   },
   "scene120": {
-    "rawKB": 33.3,
-    "gzipKB": 12.8,
+    "rawKB": 33.6,
+    "gzipKB": 12.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene120.js"
@@ -1733,8 +1733,8 @@
     "bjsGzipKB": 361.9
   },
   "scene121": {
-    "rawKB": 33.5,
-    "gzipKB": 12.9,
+    "rawKB": 33.8,
+    "gzipKB": 13,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene121.js"
@@ -1743,8 +1743,8 @@
     "bjsGzipKB": 361.9
   },
   "scene122": {
-    "rawKB": 46.1,
-    "gzipKB": 18,
+    "rawKB": 46.4,
+    "gzipKB": 18.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene122-gaussian-splatting-pipeline-sh-6Rc9set5.js",
@@ -1752,8 +1752,8 @@
     ]
   },
   "scene123": {
-    "rawKB": 42.8,
-    "gzipKB": 17,
+    "rawKB": 43.1,
+    "gzipKB": 17.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene123-gaussian-splatting-pipeline-sh-66O4ouNL.js",
@@ -1761,8 +1761,8 @@
     ]
   },
   "scene124": {
-    "rawKB": 48.8,
-    "gzipKB": 19,
+    "rawKB": 49.1,
+    "gzipKB": 19.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene124-gaussian-splatting-pipeline-sh-xZRorqzG.js",
@@ -1771,11 +1771,11 @@
     ]
   },
   "scene150": {
-    "rawKB": 51,
-    "gzipKB": 19.8,
+    "rawKB": 51.3,
+    "gzipKB": 19.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene150-standard-renderable-DyfXhx-C.js",
+      "scene150-standard-renderable-WY7KgOxC.js",
       "scene150-wgsl-helpers-WTsokIfK.js",
       "scene150.js"
     ],
@@ -1783,11 +1783,11 @@
     "bjsGzipKB": 350.8
   },
   "scene151": {
-    "rawKB": 51.2,
-    "gzipKB": 19.9,
+    "rawKB": 51.5,
+    "gzipKB": 20,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene151-standard-renderable-C0D-MA6U.js",
+      "scene151-standard-renderable-DCBcoGGn.js",
       "scene151-wgsl-helpers-WTsokIfK.js",
       "scene151.js"
     ],
@@ -1795,8 +1795,8 @@
     "bjsGzipKB": 350.9
   },
   "scene152": {
-    "rawKB": 82.5,
-    "gzipKB": 33.3,
+    "rawKB": 82.8,
+    "gzipKB": 33.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene152-create-skeleton-Bwh5ukeN.js",
@@ -1806,9 +1806,9 @@
       "scene152-gltf-feature-animations-DGH-Mypu.js",
       "scene152-gltf-feature-skeleton-CxBRKCXA.js",
       "scene152-gltf-glb-parser-BdYiApo0.js",
-      "scene152-pbr-renderable-BMjOAjc4.js",
+      "scene152-pbr-renderable-CNWaDqeN.js",
       "scene152-singlelight-hemispheric-wgsl-DHul_Jju.js",
-      "scene152-skeleton-fragment-D9msbUqS.js",
+      "scene152-skeleton-fragment-BXgDwh2H.js",
       "scene152.js"
     ],
     "bjsRawKB": 2315.7,
@@ -1825,11 +1825,11 @@
     "bjsGzipKB": 138.8
   },
   "scene154": {
-    "rawKB": 51.4,
-    "gzipKB": 19.9,
+    "rawKB": 51.7,
+    "gzipKB": 20,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene154-standard-renderable-CNwa78-P.js",
+      "scene154-standard-renderable-DR6kSI_n.js",
       "scene154-wgsl-helpers-WTsokIfK.js",
       "scene154.js"
     ],
@@ -1837,11 +1837,11 @@
     "bjsGzipKB": 350.9
   },
   "scene155": {
-    "rawKB": 53.8,
-    "gzipKB": 20.7,
+    "rawKB": 54.1,
+    "gzipKB": 20.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene155-standard-renderable-DSfjA8jW.js",
+      "scene155-standard-renderable-BpUOExyD.js",
       "scene155-wgsl-helpers-WTsokIfK.js",
       "scene155.js"
     ],
@@ -1849,11 +1849,11 @@
     "bjsGzipKB": 353.8
   },
   "scene156": {
-    "rawKB": 54.6,
-    "gzipKB": 21,
+    "rawKB": 54.9,
+    "gzipKB": 21.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene156-standard-renderable-BJz1N5b5.js",
+      "scene156-standard-renderable-C64io-pT.js",
       "scene156-wgsl-helpers-WTsokIfK.js",
       "scene156.js"
     ],
@@ -1861,8 +1861,8 @@
     "bjsGzipKB": 353.9
   },
   "scene157": {
-    "rawKB": 87.4,
-    "gzipKB": 34.7,
+    "rawKB": 87.7,
+    "gzipKB": 34.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene157-create-skeleton-BqYvWhLW.js",
@@ -1872,16 +1872,16 @@
       "scene157-gltf-feature-skeleton-BNeFHqif.js",
       "scene157-gltf-glb-parser-BdYiApo0.js",
       "scene157-multilight-wgsl-BnheuIew.js",
-      "scene157-pbr-renderable-Bol3szzK.js",
-      "scene157-skeleton-fragment-C5vRpmWE.js",
+      "scene157-pbr-renderable-CSS0V_tB.js",
+      "scene157-skeleton-fragment-Cw3MT5qT.js",
       "scene157.js"
     ],
     "bjsRawKB": 2180.1,
     "bjsGzipKB": 512.1
   },
   "scene158": {
-    "rawKB": 87.9,
-    "gzipKB": 34.8,
+    "rawKB": 88.2,
+    "gzipKB": 34.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene158-create-skeleton-CYCJVpYI.js",
@@ -1891,16 +1891,16 @@
       "scene158-gltf-feature-skeleton-D6-d-IKZ.js",
       "scene158-gltf-glb-parser-BdYiApo0.js",
       "scene158-multilight-wgsl-BQmC2qph.js",
-      "scene158-pbr-renderable-BaLPdCM4.js",
-      "scene158-skeleton-fragment-1U3keThF.js",
+      "scene158-pbr-renderable-D3i8QnX_.js",
+      "scene158-skeleton-fragment-DfGnKw2Q.js",
       "scene158.js"
     ],
     "bjsRawKB": 2180.4,
     "bjsGzipKB": 510.7
   },
   "scene159": {
-    "rawKB": 33.2,
-    "gzipKB": 13,
+    "rawKB": 33.5,
+    "gzipKB": 13.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene159-shader-renderable-DCL-Ogx0.js",
@@ -1910,8 +1910,8 @@
     "bjsGzipKB": 293.9
   },
   "scene160": {
-    "rawKB": 35.3,
-    "gzipKB": 13.7,
+    "rawKB": 35.6,
+    "gzipKB": 13.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene160-shader-renderable-CvAyQXvx.js",
@@ -1921,8 +1921,8 @@
     "bjsGzipKB": 294
   },
   "scene161": {
-    "rawKB": 33.6,
-    "gzipKB": 13.1,
+    "rawKB": 33.8,
+    "gzipKB": 13.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene161-shader-renderable-BhTOUT2M.js",
@@ -1932,8 +1932,8 @@
     "bjsGzipKB": 293.9
   },
   "scene162": {
-    "rawKB": 33.3,
-    "gzipKB": 13,
+    "rawKB": 33.5,
+    "gzipKB": 13.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene162-shader-renderable-enek5GMN.js",
@@ -1943,8 +1943,8 @@
     "bjsGzipKB": 293.9
   },
   "scene163": {
-    "rawKB": 33,
-    "gzipKB": 12.9,
+    "rawKB": 33.3,
+    "gzipKB": 13,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene163-shader-renderable-DqJ_peWv.js",
@@ -1954,24 +1954,24 @@
     "bjsGzipKB": 294
   },
   "scene125": {
-    "rawKB": 35.2,
-    "gzipKB": 13.6,
+    "rawKB": 35.5,
+    "gzipKB": 13.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene125.js"
     ]
   },
   "scene126": {
-    "rawKB": 33.6,
-    "gzipKB": 12.9,
+    "rawKB": 33.8,
+    "gzipKB": 13.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene126.js"
     ]
   },
   "scene127": {
-    "rawKB": 53.6,
-    "gzipKB": 20,
+    "rawKB": 53.9,
+    "gzipKB": 20.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene127-shader-renderable-DZaxW6LF.js",
@@ -1979,8 +1979,8 @@
     ]
   },
   "scene128": {
-    "rawKB": 53.5,
-    "gzipKB": 20,
+    "rawKB": 53.8,
+    "gzipKB": 20.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene128-shader-renderable-C8hk6Vfv.js",
@@ -1988,19 +1988,19 @@
     ]
   },
   "scene129": {
-    "rawKB": 78.1,
-    "gzipKB": 29.3,
+    "rawKB": 78.4,
+    "gzipKB": 29.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene129-gs-picking-pipeline-C1yljf5N.js",
-      "scene129-standard-renderable-Djh5drsG.js",
+      "scene129-standard-renderable-0oDTXXRe.js",
       "scene129-wgsl-helpers-WTsokIfK.js",
       "scene129.js"
     ]
   },
   "scene164": {
-    "rawKB": 88.5,
-    "gzipKB": 35.4,
+    "rawKB": 88.8,
+    "gzipKB": 35.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene164-create-morph-targets-CoqAeTwl.js",
@@ -2010,20 +2010,20 @@
       "scene164-gltf-feature-animations---DwAZyx.js",
       "scene164-gltf-feature-morph-Cikejl12.js",
       "scene164-gltf-feature-skeleton-Bcx2IF9F.js",
-      "scene164-morph-fragment-FoZSnxd9.js",
-      "scene164-pbr-renderable-B_aS9o8k.js",
+      "scene164-morph-fragment-Cyz3PbEA.js",
+      "scene164-pbr-renderable-PPO4Pono.js",
       "scene164-pbr-template-ext-B00NeHp4.js",
       "scene164-singlelight-hemispheric-wgsl-B1doqVvb.js",
-      "scene164-skeleton-fragment-C6GPN9KB.js",
+      "scene164-skeleton-fragment-BpgNyItp.js",
       "scene164.js"
     ]
   },
   "scene170": {
-    "rawKB": 48,
-    "gzipKB": 18.9,
+    "rawKB": 48.3,
+    "gzipKB": 19,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene170-standard-renderable-BHwDriJN.js",
+      "scene170-standard-renderable-CJQIuJ8-.js",
       "scene170-wgsl-helpers-WTsokIfK.js",
       "scene170.js"
     ],
@@ -2031,8 +2031,8 @@
     "bjsGzipKB": 326
   },
   "scene140": {
-    "rawKB": 94.3,
-    "gzipKB": 40.2,
+    "rawKB": 94.6,
+    "gzipKB": 40.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene140-_math-factory-DFVyS8gB.js",
@@ -2058,7 +2058,7 @@
       "scene140-no-color-view-Bf6EFWnB.js",
       "scene140-node-flags-3CD_c1Kp.js",
       "scene140-node-registry-DOfRjTX1.js",
-      "scene140-node-renderable-EJ3oOTgh.js",
+      "scene140-node-renderable-qM7pyFC7.js",
       "scene140-node-shadow-BujSPIa0.js",
       "scene140-normalize-block-DF8IC9k_.js",
       "scene140-oneminus-block-CS0SK7Sc.js",
@@ -2075,8 +2075,8 @@
     ]
   },
   "scene141": {
-    "rawKB": 124,
-    "gzipKB": 48.1,
+    "rawKB": 124.2,
+    "gzipKB": 48.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene141-_math-factory-DFVyS8gB.js",
@@ -2090,14 +2090,14 @@
       "scene141-mesh-features-Cd5ILGnU.js",
       "scene141-node-flags-3CD_c1Kp.js",
       "scene141-node-registry-5pEZzMsT.js",
-      "scene141-node-renderable-DiwoJW7a.js",
+      "scene141-node-renderable-DhZnj_ET.js",
       "scene141-node-shadow-DlFYdcs3.js",
-      "scene141-pbr-renderable-jJ5ffOr7.js",
+      "scene141-pbr-renderable-RxSviRFN.js",
       "scene141-pbr-shadow-fragment-D9r-Jru6.js",
       "scene141-shadow-fragment-core-BgZG1upy.js",
       "scene141-shadow-task-hy2qkhnM.js",
       "scene141-singlelight-directional-wgsl-l_YMnTTP.js",
-      "scene141-standard-renderable-BpY4V5YM.js",
+      "scene141-standard-renderable-DyKV6dLR.js",
       "scene141-transform-block-DWUOQ_Fz.js",
       "scene141-vertex-output-C7G5u6Y0.js",
       "scene141-wgsl-helpers-WTsokIfK.js",
@@ -2105,16 +2105,16 @@
     ]
   },
   "scene171": {
-    "rawKB": 90.5,
-    "gzipKB": 36.1,
+    "rawKB": 90.8,
+    "gzipKB": 36.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene171-generate-mipmaps-Uy5fTPh7.js",
       "scene171-gltf-glb-parser-BdYiApo0.js",
       "scene171-mesh-features-GJGfSdO-.js",
-      "scene171-pbr-renderable-CUGBbbZ2.js",
+      "scene171-pbr-renderable-DcS5QAD4.js",
       "scene171-singlelight-hemispheric-wgsl-fdOH0N74.js",
-      "scene171-standard-renderable-BxzaquFU.js",
+      "scene171-standard-renderable-RS9qu5Qa.js",
       "scene171-wgsl-helpers-WTsokIfK.js",
       "scene171.js"
     ],
@@ -2122,11 +2122,11 @@
     "bjsGzipKB": 961.4
   },
   "scene172": {
-    "rawKB": 55.9,
-    "gzipKB": 21.7,
+    "rawKB": 56.2,
+    "gzipKB": 21.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene172-standard-renderable-CGWGkx4d.js",
+      "scene172-standard-renderable-2QMES1nB.js",
       "scene172-wgsl-helpers-WTsokIfK.js",
       "scene172.js"
     ],
@@ -2134,11 +2134,11 @@
     "bjsGzipKB": 576.8
   },
   "scene173": {
-    "rawKB": 57.8,
-    "gzipKB": 22.4,
+    "rawKB": 58.1,
+    "gzipKB": 22.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene173-standard-renderable-BOXM0czM.js",
+      "scene173-standard-renderable-BrJAN-mx.js",
       "scene173-wgsl-helpers-WTsokIfK.js",
       "scene173.js"
     ],
@@ -2146,16 +2146,16 @@
     "bjsGzipKB": 576.9
   },
   "scene174": {
-    "rawKB": 91.1,
-    "gzipKB": 36.5,
+    "rawKB": 91.4,
+    "gzipKB": 36.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene174-generate-mipmaps-B38bkebo.js",
       "scene174-gltf-glb-parser-BdYiApo0.js",
       "scene174-mesh-features-GJGfSdO-.js",
-      "scene174-pbr-renderable-BKJxSvzr.js",
+      "scene174-pbr-renderable-tCCJRoBG.js",
       "scene174-singlelight-hemispheric-wgsl--TtdjZvs.js",
-      "scene174-standard-renderable-Dpq93EQp.js",
+      "scene174-standard-renderable-Dv-X0veU.js",
       "scene174-wgsl-helpers-WTsokIfK.js",
       "scene174.js"
     ],
@@ -2163,16 +2163,16 @@
     "bjsGzipKB": 785.8
   },
   "scene175": {
-    "rawKB": 89.4,
-    "gzipKB": 35.8,
+    "rawKB": 89.7,
+    "gzipKB": 36,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene175-generate-mipmaps-CspFjsVd.js",
       "scene175-gltf-glb-parser-BdYiApo0.js",
       "scene175-mesh-features-GJGfSdO-.js",
-      "scene175-pbr-renderable-aF7s1rXU.js",
+      "scene175-pbr-renderable-DS_ExY1R.js",
       "scene175-singlelight-hemispheric-wgsl-mcWzrVrn.js",
-      "scene175-standard-renderable-DZemtgji.js",
+      "scene175-standard-renderable-CLwFRwYM.js",
       "scene175-wgsl-helpers-WTsokIfK.js",
       "scene175.js"
     ],
@@ -2180,50 +2180,50 @@
     "bjsGzipKB": 785.3
   },
   "scene142": {
-    "rawKB": 57.7,
-    "gzipKB": 21.2,
+    "rawKB": 58,
+    "gzipKB": 21.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene142-standard-renderable-UM4kvAiW.js",
+      "scene142-standard-renderable-yzv6GHgP.js",
       "scene142-wgsl-helpers-WTsokIfK.js",
       "scene142.js"
     ]
   },
   "scene143": {
-    "rawKB": 64.1,
-    "gzipKB": 25.1,
+    "rawKB": 64.4,
+    "gzipKB": 25.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene143-generate-mipmaps-_Whbkd0I.js",
+      "scene143-generate-mipmaps-Dnq3Mlrz.js",
       "scene143-normal-map-fragment-CCP8Y4uo.js",
-      "scene143-point-light-DpSFO6R_.js",
-      "scene143-standard-renderable-CeUXvm_r.js",
-      "scene143-std-ambient-fragment-65_opBrB.js",
-      "scene143-std-opacity-fragment-D47_PwBC.js",
-      "scene143-std-reflection-fragment-DHpbIjwh.js",
-      "scene143-std-specular-fragment-CzoSBW1t.js",
+      "scene143-point-light-9Uu6yB0O.js",
+      "scene143-standard-renderable-BM1lQy9L.js",
+      "scene143-std-ambient-fragment-POJhHsBY.js",
+      "scene143-std-opacity-fragment-BFyJ36CD.js",
+      "scene143-std-reflection-fragment-vFkMAjIt.js",
+      "scene143-std-specular-fragment-70jyLqRF.js",
       "scene143-wgsl-helpers-WTsokIfK.js",
       "scene143.js"
     ]
   },
   "scene144": {
-    "rawKB": 100.8,
-    "gzipKB": 39.6,
+    "rawKB": 101,
+    "gzipKB": 39.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene144-create-skeleton-umNIYXa_.js",
       "scene144-generate-mipmaps-C-W9GOTI.js",
       "scene144-gltf-animation-7h-pEKpD.js",
       "scene144-gltf-ext-spec-gloss-D60sFZYX.js",
-      "scene144-gltf-feature-animations-C401eVe8.js",
+      "scene144-gltf-feature-animations-BAa1aSey.js",
       "scene144-gltf-feature-skeleton-BPzh9oD-.js",
       "scene144-gltf-glb-parser-BdYiApo0.js",
       "scene144-gltf-pbr-builder-ext-CXw28sRk.js",
       "scene144-ibl-fragment-BfgmykuX.js",
-      "scene144-pbr-renderable-CVISIdqy.js",
+      "scene144-pbr-renderable-BdoThQ6S.js",
       "scene144-rgbd-decode-O-q0NvD4.js",
       "scene144-scene-uniforms-FTYH6Ct0.js",
-      "scene144-skeleton-fragment-B3UqQRAN.js",
+      "scene144-skeleton-fragment-MX9hAkDu.js",
       "scene144-texture-2d-DQo3n8D6.js",
       "scene144.js"
     ]


### PR DESCRIPTION
Regenerate the tracked lab/public/bundle/manifest.json so the master baseline reflects the post-#131 bundle sizes (+~0.3 KB/scene) and updated renderable chunk hashes. This was missing from #131 (the manifest was reverted during local parity runs), and an accurate master manifest is needed so future PRs can compare bundle sizes against it.

Manifest-only change; no source/runtime code touched.