### PR TITLE
fix(freeciv demo): use relative tileset base path so it loads under a published sub-path

### DIFF
--- a/lab/src/demos/freeciv.ts
+++ b/lab/src/demos/freeciv.ts
@@ -30,7 +30,11 @@ import { createPicker } from "./freeciv/pick.js";
 import { createMinimap } from "./freeciv/minimap.js";
 import { DIR8, DIR_DELTA, TILE_H, TILE_W, isoCentre, worldToTile } from "./freeciv/iso.js";
 
-const BASE_URL = "/freeciv";
+// Relative (no leading slash) so the tileset resolves against the page URL —
+// works both on the dev server (root) and when the demo is published under a
+// sub-path (e.g. GitHub Pages project page). An absolute "/freeciv" would 404
+// on a sub-path deployment. Mirrors the minecraft/doom demos.
+const BASE_URL = "freeciv";
 
 async function main(): Promise<void> {
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;


### PR DESCRIPTION
## Problem
The published freeciv demo renders a blank map. Its tileset loader used an **absolute** base path:

`const BASE_URL = "/freeciv";`

In the browser, `/freeciv/...` resolves against the **origin root**. When the demo is published under a sub-path (the catuhe.com GitHub Pages project page is served at `/catuhe.com/`), the requests go to `deltakosh.github.io/freeciv/...` and **404**, even though the assets exist at `/catuhe.com/freeciv/...`.

The `minecraft` (`"minecraft/voxelpack"`) and `doom` (`"doom/..."`) demos already use **relative** asset bases and work correctly under the sub-path.

## Fix
Switch the freeciv `BASE_URL` to a relative `"freeciv"` so the tileset resolves against the demo **page URL**. This works in both environments:
- **Dev server** — `lab/demo-freeciv.html` is served at root, so `freeciv/...` → `/freeciv/...` (assets in `lab/public/freeciv`).
- **Published sub-path** — `freeciv/...` → `/catuhe.com/freeciv/...` (assets present, verified 200).

## Scope / testing
- Change is confined to `lab/src/demos/freeciv.ts` (a demo). Per `GUIDANCE.md` (§ line 140), demo-only changes can't affect engine parity and don't require the parity/bundle-size suites.
- Pre-existing `typecheck:lab` errors in the freeciv demo (DOM `PointerEvent` typing, `spec-parser` undefined-narrowing) are unrelated to this one-line constant and are not introduced here.

## Note
`minecraft` and `doom` source still use absolute asset bases; they happen to work in the currently-published bundles but carry the same latent bug. Worth a follow-up to make them relative too.
