### PR TITLE
fix(lab): resolve 39 lab typecheck errors (freeciv demo + scene59)

### DIFF
--- a/lab/src/bjs/scene59.ts
+++ b/lab/src/bjs/scene59.ts
@@ -79,7 +79,7 @@ async function main(): Promise<void> {
     await scene.whenReadyAsync();
     engine.runRenderLoop(() => scene.render());
     window.addEventListener("resize", () => engine.resize());
-    await new Promise<void>((resolve) => scene.onAfterRenderObservable.addOnce(resolve));
+    await new Promise<void>((resolve) => scene.onAfterRenderObservable.addOnce(() => resolve()));
     canvas.dataset.initMs = String(performance.now() - initStart);
     canvas.dataset.ready = "true";
 }

--- a/lab/src/demos/freeciv.ts
+++ b/lab/src/demos/freeciv.ts
@@ -270,7 +270,8 @@ function createCityLabels(cities: readonly { x: number; y: number; name: string;
 
     return {
         update(view: View, engine: EngineContext): void {
-            const dpr = (engine.canvas.width || 1) / (engine.canvas.clientWidth || 1);
+            const cv = engine.canvas as HTMLCanvasElement;
+            const dpr = (cv.width || 1) / (cv.clientWidth || 1);
             // Match the snapped transform the tiles render with so labels don't
             // drift off their tiles by a fraction of a pixel.
             const z = snapZoom(view.zoom);
@@ -443,8 +444,8 @@ function findPath(world: GameMap, sx: number, sy: number, gx: number, gy: number
         let u = -1;
         let best = Infinity;
         for (let i = 0; i < N; i++) {
-            if (!done[i] && dist[i] < best) {
-                best = dist[i];
+            if (!done[i] && dist[i]! < best) {
+                best = dist[i]!;
                 u = i;
             }
         }
@@ -463,8 +464,8 @@ function findPath(world: GameMap, sx: number, sy: number, gx: number, gy: number
             if (done[v]) continue;
             const onRoadStep = onRoad && world.hasRoad(nx, ny);
             const cost = onRoadStep ? ROAD_DISCOUNT : 1;
-            const nd = dist[u] + cost;
-            if (nd < dist[v]) {
+            const nd = dist[u]! + cost;
+            if (nd < dist[v]!) {
                 dist[v] = nd;
                 prev[v] = u;
             }
@@ -472,7 +473,7 @@ function findPath(world: GameMap, sx: number, sy: number, gx: number, gy: number
     }
     if (dist[goal] === Infinity) return null;
     const path: Array<[number, number]> = [];
-    for (let cur = goal; cur !== start && cur !== -1; cur = prev[cur]) {
+    for (let cur = goal; cur !== start && cur !== -1; cur = prev[cur]!) {
         const cx = cur % W;
         path.push([cx, (cur - cx) / W]);
     }
@@ -490,7 +491,7 @@ function installControls(
     onHover?: HoverFn,
     onClick?: (tileX: number, tileY: number) => void,
 ): void {
-    const canvas = engine.canvas;
+    const canvas = engine.canvas as HTMLCanvasElement;
     const dpr = (): number => (canvas.width || 1) / (canvas.clientWidth || 1);
     let dragging = false;
     let lastX = 0;

--- a/lab/src/demos/freeciv/minimap.ts
+++ b/lab/src/demos/freeciv/minimap.ts
@@ -150,7 +150,7 @@ export function createMinimap(engine: EngineContext, sr: SpriteRenderer, world: 
 
     /** Current minimap rectangle in DEVICE pixels (bottom-right anchored). */
     function rect(): { x0: number; y0: number; w: number; h: number; dpr: number } {
-        const canvas = engine.canvas;
+        const canvas = engine.canvas as HTMLCanvasElement;
         const dpr = (canvas.width || 1) / (canvas.clientWidth || 1);
         const aspect = tw / th;
         const cssW = aspect >= 1 ? MINIMAP_MAX : Math.round(MINIMAP_MAX * aspect);

--- a/lab/src/demos/freeciv/spec-parser.ts
+++ b/lab/src/demos/freeciv/spec-parser.ts
@@ -53,7 +53,7 @@ function stripComment(line: string): string {
 function matchAssign(line: string, key: string): string | null {
     const m = line.match(new RegExp(`^${key}\\s*=\\s*(.+)$`));
     if (!m) return null;
-    return m[1].trim().replace(/^"(.*)"$/, "$1");
+    return m[1]!.trim().replace(/^"(.*)"$/, "$1");
 }
 
 interface GridDraft {
@@ -93,15 +93,15 @@ export function parseSpec(text: string): ParsedSpec {
             if (!m || !current) continue;
             const row = Number(m[1]);
             const col = Number(m[2]);
-            for (const q of m[3].matchAll(/"([^"]+)"/g)) {
-                current.tags.set(q[1], { row, col });
+            for (const q of m[3]!.matchAll(/"([^"]+)"/g)) {
+                current.tags.set(q[1]!, { row, col });
             }
             continue;
         }
 
         const sectionMatch = line.match(/^\[(\w+)\]$/);
         if (sectionMatch) {
-            section = sectionMatch[1];
+            section = sectionMatch[1]!;
             continue;
         }
 


### PR DESCRIPTION
## Problem
`pnpm lint` (which runs `eslint .` + engine `tsc` + `tsc -p lab/tsconfig.typecheck.json`) was **red on master**. ESLint and the engine typecheck were clean, but the **lab typecheck** reported **39 errors** introduced by recently merged PRs:

- **#133** (freeciv rework) → `lab/src/demos/freeciv.ts` (33), `freeciv/spec-parser.ts` (4), `freeciv/minimap.ts` (1)
- **#102** (sprite animation) → `lab/src/bjs/scene59.ts` (1)

These are demo/bjs files (not the engine), which is why parity/bundle CI didn't catch them.

## Fixes
- **DOM access on `engine.canvas`** (`RenderCanvas = HTMLCanvasElement | OffscreenCanvas`): the freeciv interaction/label/minimap code uses DOM-only members (`clientWidth`, `getBoundingClientRect`, `setPointerCapture`, pointer/wheel event fields). Cast to `HTMLCanvasElement` — this also narrows the `addEventListener` callbacks to `PointerEvent`/`WheelEvent`, clearing the bulk of the errors.
- **`noUncheckedIndexedAccess`**: `findPath` typed-array reads (`dist[i]`/`prev[cur]`) and `spec-parser` regex capture groups (`m[1]`, `m[3]`, `q[1]`, `sectionMatch[1]`) are `T | undefined`. Added non-null assertions — indices are provably in-bounds and the capture groups are guaranteed by the matching regex.
- **`scene59`**: `addOnce(resolve)` passed a `Scene` arg into `Promise<void>`'s resolve; wrapped as `() => resolve()`.

## Testing
- `pnpm lint` → **green** (eslint + engine tsc + lab tsc all pass).
- Demo/bjs-only changes — no engine/runtime code touched, so no parity or bundle-size impact (per `GUIDANCE.md` § line 140).
