### PR TITLE
Add Scene 170 parity spec

### DIFF
--- a/tests/parity/scenes/scene170-navigation-basic.spec.ts
+++ b/tests/parity/scenes/scene170-navigation-basic.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Scene 170 - Navigation Basic Parity Test
+ */
+import { test, expect } from "@playwright/test";
+import * as path from "path";
+import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
+
+const sceneConfig = getSceneConfig(170);
+const REFERENCE_DIR = path.resolve(__dirname, "../../../reference/scene170-navigation-basic");
+const GOLDEN_REF = path.join(REFERENCE_DIR, "babylon-ref-golden.png");
+
+test.skip(!!sceneConfig.skipParity, "Scene 170 skipped via skipParity in scene-config.json");
+
+test("Scene 170 - Navigation Basic matches Babylon.js reference", async ({ page }, testInfo) => {
+    test.setTimeout(180_000);
+
+    const browser = page.context().browser()!;
+    await captureGolden(browser, { sceneId: 170, timeout: 180_000 });
+
+    await page.goto("/scene170.html");
+    await page.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 60_000 });
+    await page.waitForTimeout(500);
+
+    const screenshotPath = path.join(REFERENCE_DIR, "test-actual.png");
+    await page.locator("canvas").screenshot({ path: screenshotPath });
+
+    const full = compareImages(screenshotPath, GOLDEN_REF);
+    await attachCompareArtifacts(testInfo, screenshotPath, GOLDEN_REF, REFERENCE_DIR);
+    console.log(`Full image (${full.totalPixels} px): MAD=${full.mad.toFixed(3)}, within-5=${((100 * full.within5) / full.totalPixels).toFixed(1)}%`);
+
+    expect(full.mad, `Full image MAD should be <= ${sceneConfig.maxMad}`).toBeLessThanOrEqual(sceneConfig.maxMad);
+});


### PR DESCRIPTION
## Summary
- Add a Scene 170 navigation-basic parity spec
- Capture the Babylon.js golden via captureGolden before comparing Lite output

## Validation
- pnpm run lint
- npx playwright test tests/parity --grep "Scene 170 - Navigation Basic matches Babylon.js reference"