### PR TITLE
Fix demo asset URLs for subpath deployment

### DIFF
--- a/lab/lite/src/demos/demo-asset-url.ts
+++ b/lab/lite/src/demos/demo-asset-url.ts
@@ -1,0 +1,10 @@
+export function demoAssetUrl(path: string, moduleUrl: string): string {
+    const url = new URL(path, moduleUrl);
+    url.pathname = url.pathname.replace("/lite/bundle/demos/", "/bundle/demos/");
+    return url.href;
+}
+
+export async function configureDemoDracoBase(moduleUrl: string): Promise<void> {
+    const { setDracoBaseUrl } = await import("babylon-lite/loader-gltf/draco-decode.js");
+    setDracoBaseUrl(demoAssetUrl("./", moduleUrl));
+}

--- a/lab/lite/src/demos/doom.ts
+++ b/lab/lite/src/demos/doom.ts
@@ -11,9 +11,10 @@
  */
 
 import { createEngine, createSceneContext, registerScene, startEngine } from "babylon-lite";
+import { demoAssetUrl } from "./demo-asset-url.js";
 import { buildDoomLevel } from "./doom/doom-level.js";
 
-const WAD_URL = "/doom/freedoom1.wad";
+const WAD_URL = demoAssetUrl("./doom/freedoom1.wad", import.meta.url);
 const MAP_NAME = "E1M1";
 
 async function main(): Promise<void> {

--- a/lab/lite/src/demos/freeciv.ts
+++ b/lab/lite/src/demos/freeciv.ts
@@ -13,15 +13,7 @@
  * and no tileset bytes are committed to this repo.
  */
 
-import {
-    createEngine,
-    createSprite2DLayer,
-    createSpriteRenderer,
-    registerSpriteRenderer,
-    startEngine,
-    type EngineContext,
-    type Sprite2DLayer,
-} from "babylon-lite";
+import { createEngine, createSprite2DLayer, createSpriteRenderer, registerSpriteRenderer, startEngine, type EngineContext, type Sprite2DLayer } from "babylon-lite";
 import { loadFreecivSheet } from "./freeciv/atlas.js";
 import { createAtmosphere } from "./freeciv/atmosphere.js";
 import { createBackdrop } from "./freeciv/backdrop.js";
@@ -33,12 +25,9 @@ import { createLiveSim } from "./freeciv/live.js";
 import { createPicker } from "./freeciv/pick.js";
 import { createMinimap } from "./freeciv/minimap.js";
 import { DIR8, DIR_DELTA, TILE_H, TILE_W, isoCentre, worldToTile } from "./freeciv/iso.js";
+import { demoAssetUrl } from "./demo-asset-url.js";
 
-// Relative (no leading slash) so the tileset resolves against the page URL —
-// works both on the dev server (root) and when the demo is published under a
-// sub-path (e.g. GitHub Pages project page). An absolute "/freeciv" would 404
-// on a sub-path deployment. Mirrors the minecraft/doom demos.
-const BASE_URL = "freeciv";
+const BASE_URL = demoAssetUrl("./freeciv", import.meta.url);
 
 async function main(): Promise<void> {
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
@@ -282,14 +271,13 @@ function createCityLabels(cities: readonly { x: number; y: number; name: string;
             const vx = Math.round(view.x * z) / z;
             const vy = Math.round(view.y * z) / z;
             for (const a of anchors) {
-                const sx = (a.wx - vx) * z / dpr;
-                const sy = (a.wy - vy) * z / dpr;
+                const sx = ((a.wx - vx) * z) / dpr;
+                const sy = ((a.wy - vy) * z) / dpr;
                 a.el.style.transform = `translate(${sx}px, ${sy}px) translate(-50%, -100%)`;
             }
         },
     };
 }
-
 
 interface View {
     x: number;
@@ -488,13 +476,7 @@ function findPath(world: GameMap, sx: number, sy: number, gx: number, gy: number
 /** Callback fired as the cursor moves over the map; `tileX = null` clears hover. */
 type HoverFn = (tileX: number | null, tileY: number | null, cssX: number, cssY: number) => void;
 
-function installControls(
-    engine: EngineContext,
-    view: View,
-    layers: readonly Sprite2DLayer[],
-    onHover?: HoverFn,
-    onClick?: (tileX: number, tileY: number) => void,
-): void {
+function installControls(engine: EngineContext, view: View, layers: readonly Sprite2DLayer[], onHover?: HoverFn, onClick?: (tileX: number, tileY: number) => void): void {
     const canvas = engine.canvas as HTMLCanvasElement;
     const dpr = (): number => (canvas.width || 1) / (canvas.clientWidth || 1);
     let dragging = false;
@@ -585,7 +567,7 @@ function installControls(
             view.userMoved = true;
             applyView(view, layers);
         },
-        { passive: false },
+        { passive: false }
     );
 }
 

--- a/lab/lite/src/demos/minecraft.ts
+++ b/lab/lite/src/demos/minecraft.ts
@@ -30,8 +30,9 @@ import { FallingBlocks } from "./minecraft/falling-blocks.js";
 import { WaterSim } from "./minecraft/water-sim.js";
 import { Mobs } from "./minecraft/mobs.js";
 import { saveToFile, loadFromFile, type SaveData } from "./minecraft/save-load.js";
+import { demoAssetUrl } from "./demo-asset-url.js";
 
-const PACK_URL = "/minecraft/voxelpack";
+const PACK_URL = demoAssetUrl("./minecraft/voxelpack", import.meta.url);
 const SEED = 1337;
 const RENDER_RADIUS = 6;
 
@@ -184,12 +185,7 @@ async function main(): Promise<void> {
         particles.update(dt);
 
         // Underwater tint when the camera (eye) is inside a water voxel.
-        const submerged =
-            world.getBlock(
-                Math.floor(player.camera.position.x),
-                Math.floor(player.camera.position.y),
-                Math.floor(player.camera.position.z)
-            ) === Block.WATER;
+        const submerged = world.getBlock(Math.floor(player.camera.position.x), Math.floor(player.camera.position.y), Math.floor(player.camera.position.z)) === Block.WATER;
         underwater.style.opacity = submerged ? "1" : "0";
 
         // Advance the day-night cycle and push lighting to sky + materials.

--- a/lab/lite/src/demos/mosquito-amber.ts
+++ b/lab/lite/src/demos/mosquito-amber.ts
@@ -5,11 +5,23 @@
 // Static camera (no auto-rotation) for a deterministic golden.
 
 import {
-    addToScene, attachControl, createArcRotateCamera, createBox, createEngine, createPbrMaterial,
-    createSceneContext, createSolidTexture2D, getFrameGraph, loadEnvironment, loadGltf,
-    onBeforeRender, registerScene, startEngine,
+    addToScene,
+    attachControl,
+    createArcRotateCamera,
+    createBox,
+    createEngine,
+    createPbrMaterial,
+    createSceneContext,
+    createSolidTexture2D,
+    getFrameGraph,
+    loadEnvironment,
+    loadGltf,
+    onBeforeRender,
+    registerScene,
+    startEngine,
     type RenderTask,
 } from "babylon-lite";
+import { configureDemoDracoBase, demoAssetUrl } from "./demo-asset-url.js";
 
 const MODEL_URL = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/MosquitoInAmber.gltf";
 const ENV_URL = "https://assets.babylonjs.com/environments/studio.env";
@@ -42,6 +54,8 @@ async function main(): Promise<void> {
     scene.camera = cam;
     attachControl(cam, canvas, scene);
 
+    await configureDemoDracoBase(import.meta.url);
+
     await Promise.all([
         loadGltf(engine, MODEL_URL).then((asset) => addToScene(scene, asset)),
         loadEnvironment(scene, ENV_URL, {
@@ -49,7 +63,7 @@ async function main(): Promise<void> {
             // (mirrors BJS createDefaultSkybox(env, true, scale, 0.3) = microSurface 0.7).
             skipSkybox: true,
             skipGround: true,
-            brdfUrl: "/brdf-lut.png",
+            brdfUrl: demoAssetUrl("./brdf-lut.png", import.meta.url),
         }),
     ]);
 

--- a/lab/lite/src/demos/offscreen-scene.ts
+++ b/lab/lite/src/demos/offscreen-scene.ts
@@ -30,6 +30,7 @@ import {
     type EngineContext,
     type RenderCanvas,
 } from "babylon-lite";
+import { configureDemoDracoBase, demoAssetUrl } from "./demo-asset-url.js";
 
 // Same CDN assets used by the existing Flight Helmet scene (lab scene 14):
 // PBR model, .env IBL, DDS skybox and a reflective ground texture.
@@ -37,12 +38,7 @@ const MODEL_URL = "https://assets.babylonjs.com/meshes/flightHelmet.glb";
 const ENV_URL = "https://assets.babylonjs.com/core/environments/environmentSpecular.env";
 const SKYBOX_URL = "https://assets.babylonjs.com/core/environments/backgroundSkybox.dds";
 const GROUND_URL = "https://assets.babylonjs.com/core/environments/backgroundGround.png";
-// Served locally by the lab from lab/public/brdf-lut.png. The bundled Pages build
-// rewrites this to a page-relative path, which a Web Worker would otherwise
-// resolve against its own script URL (…/bundle/demos/) instead of the page. The
-// caller therefore resolves it to an absolute URL (against document.baseURI) on
-// the main thread and passes it in via `brdfUrl` so it loads identically in both.
-export const BRDF_ASSET = "/brdf-lut.png";
+export const BRDF_ASSET = demoAssetUrl("./brdf-lut.png", import.meta.url);
 
 /**
  * Build, register and start the Offscreen demo scene on the given canvas/offscreen.
@@ -53,6 +49,8 @@ export const BRDF_ASSET = "/brdf-lut.png";
  *   (resolved against the document) so it loads correctly inside a worker.
  */
 export async function startOffscreenScene(canvas: RenderCanvas, brdfUrl: string = BRDF_ASSET): Promise<EngineContext> {
+    await configureDemoDracoBase(import.meta.url);
+
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);
 

--- a/lab/lite/src/demos/offscreen.ts
+++ b/lab/lite/src/demos/offscreen.ts
@@ -18,10 +18,7 @@ import { BRDF_ASSET, startOffscreenScene } from "./offscreen-scene";
 
 const DPR = (): number => globalThis.devicePixelRatio || 1;
 
-// Resolve the local BRDF LUT to an absolute URL against the document base so it
-// loads identically on the main thread and inside the worker (a worker would
-// otherwise resolve a relative path against its own /bundle/demos/ script URL).
-const BRDF_URL = new URL(BRDF_ASSET, document.baseURI).href;
+const BRDF_URL = BRDF_ASSET;
 
 function deviceSize(canvas: HTMLCanvasElement): { w: number; h: number } {
     const dpr = DPR();

--- a/lab/lite/src/demos/quake.ts
+++ b/lab/lite/src/demos/quake.ts
@@ -48,9 +48,10 @@ import { WEAPONS, WEAPON_ORDER, WEAPON_PICKUPS, type WeaponId, type AmmoType } f
 import { spawnItemModels, type SpawnedItem } from "./quake/render/items.js";
 import { QuakeSound } from "./quake/audio/sound.js";
 import { SbarHud } from "./quake/hud/sbar.js";
+import { demoAssetUrl } from "./demo-asset-url.js";
 
-const BSP_URL = "/librequake/lq_e1m1.bsp";
-const PALETTE_URL = "/librequake/palette.lmp";
+const BSP_URL = demoAssetUrl("./librequake/lq_e1m1.bsp", import.meta.url);
+const PALETTE_URL = demoAssetUrl("./librequake/palette.lmp", import.meta.url);
 const MOVE_SPEED = 320; // Quake units / second
 const LOOK_SENS = 0.0022;
 const MAX_FRAME = 0.05;
@@ -72,8 +73,7 @@ const MOVER_KINDS = new Set(["door", "secret", "button", "plat"]);
 // All offsets are a couple of units at most — sub-pixel at gameplay distances and
 // well inside the door's own thickness, so collision (BSP hulls) is unaffected.
 const BRUSH_BASE_NUDGE = 0.4;
-const brushNudge = (modelIndex: number): number =>
-    BRUSH_BASE_NUDGE + ((modelIndex * 7) % 16) * 0.04;
+const brushNudge = (modelIndex: number): number => BRUSH_BASE_NUDGE + ((modelIndex * 7) % 16) * 0.04;
 
 // Movers render solid (zero geometry nudge) and instead win coplanar depth ties
 // via a per-model depth pull toward the camera. Unlike the geometric brushNudge,
@@ -87,8 +87,7 @@ const brushNudge = (modelIndex: number): number =>
 // recess depth of inset buttons/torches so those stay correctly behind the wall.
 const MOVER_CAMERA_NEAR = 1; // matches cam.nearPlane; pull(world) = bias / near.
 const MOVER_PULL_BASE = 1.1; // world units of toward-camera pull for a closed leaf.
-const moverDepthBias = (modelIndex: number): number =>
-    (MOVER_PULL_BASE + ((modelIndex * 7) % 16) * 0.02) * MOVER_CAMERA_NEAR;
+const moverDepthBias = (modelIndex: number): number => (MOVER_PULL_BASE + ((modelIndex * 7) % 16) * 0.02) * MOVER_CAMERA_NEAR;
 
 const START_SHELLS = 25;
 const START_NAILS = 0;
@@ -192,7 +191,20 @@ async function main(): Promise<void> {
 
     const hud = await createHud(palette);
     const sound = new QuakeSound();
-    sound.preload(["weapons/guncock.wav", "weapons/shotgn2.wav", "weapons/grenade.wav", "weapons/bounce.wav", "weapons/r_exp3.wav", "weapons/lock4.wav", "weapons/pkup.wav", "items/health1.wav", "items/armor1.wav", "player/pain1.wav", "player/pain2.wav", "soldier/sight1.wav"]);
+    sound.preload([
+        "weapons/guncock.wav",
+        "weapons/shotgn2.wav",
+        "weapons/grenade.wav",
+        "weapons/bounce.wav",
+        "weapons/r_exp3.wav",
+        "weapons/lock4.wav",
+        "weapons/pkup.wav",
+        "items/health1.wav",
+        "items/armor1.wav",
+        "player/pain1.wav",
+        "player/pain2.wav",
+        "soldier/sight1.wav",
+    ]);
     // Brush entities removed via killtarget (forcefields, hidden walls) must be
     // hideable, so collect every killtarget name up-front and render those brush
     // models as their own meshes instead of baking them into the static world.
@@ -296,7 +308,18 @@ async function main(): Promise<void> {
 
     // Enemies + combat.
     const godmode = params.get("godmode") !== null && params.get("godmode") !== "0";
-    const player: Player = { health: START_HEALTH, armor: 0, shells: START_SHELLS, nails: START_NAILS, rockets: START_ROCKETS, weapon: "shotgun", owned: new Set<WeaponId>(["shotgun"]), dead: false, godmode, suitTime: 0 };
+    const player: Player = {
+        health: START_HEALTH,
+        armor: 0,
+        shells: START_SHELLS,
+        nails: START_NAILS,
+        rockets: START_ROCKETS,
+        weapon: "shotgun",
+        owned: new Set<WeaponId>(["shotgun"]),
+        dead: false,
+        godmode,
+        suitTime: 0,
+    };
     const monsters = new MonsterSystem(engine, scene, physics, lightTex, atlas.whiteUV, palette, {
         damage: (amount) => {
             hurtPlayer(player, amount, hud, sound);
@@ -593,14 +616,14 @@ function installPlayerControls(
             e.preventDefault();
             cycleWeapon(e.deltaY > 0 ? 1 : -1);
         },
-        { passive: false },
+        { passive: false }
     );
     // Fire on the rising edge of the left button; grab/release the mouse (pointer
     // lock) on the rising/falling edge of the right button so look is free-cursor.
     const handleButtons = (buttons: number): void => {
-        if ((buttons & LEFT_BUTTON) && !(prevButtons & LEFT_BUTTON)) fire();
-        if ((buttons & RIGHT_BUTTON) && !(prevButtons & RIGHT_BUTTON)) requestLock();
-        if (!(buttons & RIGHT_BUTTON) && (prevButtons & RIGHT_BUTTON)) exitLock();
+        if (buttons & LEFT_BUTTON && !(prevButtons & LEFT_BUTTON)) fire();
+        if (buttons & RIGHT_BUTTON && !(prevButtons & RIGHT_BUTTON)) requestLock();
+        if (!(buttons & RIGHT_BUTTON) && prevButtons & RIGHT_BUTTON) exitLock();
         prevButtons = buttons;
     };
     canvas.addEventListener("pointerdown", (e) => {
@@ -954,8 +977,12 @@ class Particles {
             m.scaling.set(0, 0, 0);
             addToScene(scene, m);
             this.mesh.push(m);
-            this.px.push(0); this.py.push(0); this.pz.push(0);
-            this.vx.push(0); this.vy.push(0); this.vz.push(0);
+            this.px.push(0);
+            this.py.push(0);
+            this.pz.push(0);
+            this.vx.push(0);
+            this.vy.push(0);
+            this.vz.push(0);
             this.life.push(-1);
         }
     }
@@ -970,7 +997,9 @@ class Particles {
             const cosP = 2 * Math.random() - 1;
             const sinP = Math.sqrt(1 - cosP * cosP);
             const spd = this.speedBase + Math.random() * this.speedRand;
-            this.px[i] = x; this.py[i] = y; this.pz[i] = z;
+            this.px[i] = x;
+            this.py[i] = y;
+            this.pz[i] = z;
             this.vx[i] = Math.cos(theta) * sinP * spd;
             this.vy[i] = cosP * spd * 0.6 + this.upBias;
             this.vz[i] = Math.sin(theta) * sinP * spd;
@@ -1126,7 +1155,7 @@ async function createHud(palette: Palette): Promise<Hud> {
                 requestAnimationFrame(() => {
                     damage.style.transition = "opacity .5s ease-out";
                     damage.style.opacity = "0";
-                }),
+                })
             );
         },
         underwater(contents: number) {

--- a/lab/lite/src/demos/quake/audio/sound.ts
+++ b/lab/lite/src/demos/quake/audio/sound.ts
@@ -7,9 +7,11 @@
 // distance and panned left/right relative to the listener's facing, mirroring
 // Quake's ATTN_NORM falloff without copying any game code.
 
+import { demoAssetUrl } from "../../demo-asset-url.js";
+
 type V3 = [number, number, number];
 
-const SND_BASE = "/librequake/sound/";
+const SND_BASE = demoAssetUrl("./librequake/sound/", import.meta.url);
 /** Distance (Quake units) past which a positional sound is inaudible. */
 const ATTN_RANGE = 1400;
 /** Minimum gap between two plays of the same sound, in seconds. */

--- a/lab/lite/src/demos/quake/combat/grenades.ts
+++ b/lab/lite/src/demos/quake/combat/grenades.ts
@@ -12,10 +12,11 @@ import { quakeToEngine } from "../geometry/build-geometry.js";
 import type { QuakePhysics } from "../physics/collision.js";
 import type { MonsterSystem } from "./monsters.js";
 import type { Palette } from "../palette.js";
+import { demoAssetUrl } from "../../demo-asset-url.js";
 
 type V3 = [number, number, number];
 
-const MODEL_URL = "/librequake/progs/grenade.mdl";
+const MODEL_URL = demoAssetUrl("./librequake/progs/grenade.mdl", import.meta.url);
 const POOL = 8;
 const GRAVITY = 800; // Quake sv_gravity (units/s²)
 const LAUNCH_SPEED = 600; // forward muzzle velocity
@@ -62,7 +63,10 @@ const dot = (a: V3, b: V3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 export class GrenadeSystem {
     private readonly grenades: Grenade[] = [];
 
-    constructor(private readonly deps: GrenadeDeps, private readonly hooks: GrenadeHooks) {}
+    constructor(
+        private readonly deps: GrenadeDeps,
+        private readonly hooks: GrenadeHooks
+    ) {}
 
     async load(): Promise<void> {
         const res = await fetch(MODEL_URL);

--- a/lab/lite/src/demos/quake/combat/monsters.ts
+++ b/lab/lite/src/demos/quake/combat/monsters.ts
@@ -7,20 +7,12 @@
 // Vertex animation is done by streaming each keyframe's positions into the mesh's
 // GPU vertex buffer (the Quake world material is unlit, so normals are ignored).
 
-import {
-    addToScene,
-    createMeshFromData,
-    createTexture2DFromPixels,
-    updateMeshPositions,
-    type EngineContext,
-    type Mesh,
-    type SceneContext,
-    type Texture2D,
-} from "babylon-lite";
+import { addToScene, createMeshFromData, createTexture2DFromPixels, updateMeshPositions, type EngineContext, type Mesh, type SceneContext, type Texture2D } from "babylon-lite";
 
 import { parseMdl, expandFrame, type MdlModel } from "../render/mdl.js";
 import { createQuakeMaterial } from "../render/quake-material.js";
 import { quakeToEngine } from "../geometry/build-geometry.js";
+import { demoAssetUrl } from "../../demo-asset-url.js";
 import type { QuakePhysics } from "../physics/collision.js";
 import type { Palette } from "../palette.js";
 
@@ -53,8 +45,50 @@ interface MonsterDef {
 //   soldier: stand 0-7, deathc 18-28, run 73-80, shoot 81-89 (flash ~85)
 //   dog:     attack 0-7, death 8-16, run 48-59, stand 69-77
 const DEFS: Record<string, MonsterDef> = {
-    monster_army: { classname: "monster_army", url: "/librequake/progs/soldier.mdl", health: 30, speed: 70, sightRange: 1200, attackRange: 600, attackDamage: 5, attackInterval: 1.0, stand: [0, 7], run: [73, 80], attack: [81, 89], death: [18, 28], standFps: 5, runFps: 10, attackFps: 10, deathFps: 8, sightSnd: "soldier/sight1.wav", attackSnd: "soldier/sattck1.wav", painSnds: ["soldier/pain1.wav", "soldier/pain2.wav"], deathSnd: "soldier/death1.wav" },
-    monster_dog: { classname: "monster_dog", url: "/librequake/progs/dog.mdl", health: 25, speed: 150, sightRange: 1000, attackRange: 80, attackDamage: 6, attackInterval: 0.6, stand: [69, 77], run: [48, 59], attack: [0, 7], death: [8, 16], standFps: 6, runFps: 14, attackFps: 12, deathFps: 10, sightSnd: "dog/dsight.wav", attackSnd: "dog/dattack1.wav", painSnds: ["dog/dpain1.wav"], deathSnd: "dog/ddeath.wav" },
+    monster_army: {
+        classname: "monster_army",
+        url: demoAssetUrl("./librequake/progs/soldier.mdl", import.meta.url),
+        health: 30,
+        speed: 70,
+        sightRange: 1200,
+        attackRange: 600,
+        attackDamage: 5,
+        attackInterval: 1.0,
+        stand: [0, 7],
+        run: [73, 80],
+        attack: [81, 89],
+        death: [18, 28],
+        standFps: 5,
+        runFps: 10,
+        attackFps: 10,
+        deathFps: 8,
+        sightSnd: "soldier/sight1.wav",
+        attackSnd: "soldier/sattck1.wav",
+        painSnds: ["soldier/pain1.wav", "soldier/pain2.wav"],
+        deathSnd: "soldier/death1.wav",
+    },
+    monster_dog: {
+        classname: "monster_dog",
+        url: demoAssetUrl("./librequake/progs/dog.mdl", import.meta.url),
+        health: 25,
+        speed: 150,
+        sightRange: 1000,
+        attackRange: 80,
+        attackDamage: 6,
+        attackInterval: 0.6,
+        stand: [69, 77],
+        run: [48, 59],
+        attack: [0, 7],
+        death: [8, 16],
+        standFps: 6,
+        runFps: 14,
+        attackFps: 12,
+        deathFps: 10,
+        sightSnd: "dog/dsight.wav",
+        attackSnd: "dog/dattack1.wav",
+        painSnds: ["dog/dpain1.wav"],
+        deathSnd: "dog/ddeath.wav",
+    },
 };
 
 const MON_MINS: V3 = [-16, -16, -24];
@@ -103,8 +137,7 @@ export class MonsterSystem {
         private readonly whiteUV: [number, number],
         private readonly palette: Palette,
         private readonly hooks: MonsterHooks
-    ) {
-    }
+    ) {}
 
     /** Fetch + parse the MDL models needed for the given entity classes. */
     async load(classes: Iterable<string>): Promise<void> {
@@ -161,7 +194,15 @@ export class MonsterSystem {
             uv2[i * 2] = this.whiteUV[0];
             uv2[i * 2 + 1] = this.whiteUV[1];
         }
-        const mesh = createMeshFromData(this.engine, `mon_${def.classname}_${this.total}`, scratch.slice(), new Float32Array(corners * 3), model.indices.slice(), model.uvs.slice(), uv2);
+        const mesh = createMeshFromData(
+            this.engine,
+            `mon_${def.classname}_${this.total}`,
+            scratch.slice(),
+            new Float32Array(corners * 3),
+            model.indices.slice(),
+            model.uvs.slice(),
+            uv2
+        );
         const skinTex = createTexture2DFromPixels(this.engine, model.skinRgba, model.skinWidth, model.skinHeight, {
             addressModeU: "clamp-to-edge",
             addressModeV: "clamp-to-edge",
@@ -171,7 +212,21 @@ export class MonsterSystem {
         mesh.material = createQuakeMaterial(`monMat_${def.classname}_${this.total}`, skinTex, this.lightTex);
         addToScene(this.scene, mesh);
 
-        const m: Monster = { def, model, mesh, scratch, origin: [origin[0], origin[1], origin[2]], yaw, health: def.health, state: "idle", anim: "stand", frame: def.stand[0], animTime: Math.random() * 2, attackTimer: 0, deathDone: false };
+        const m: Monster = {
+            def,
+            model,
+            mesh,
+            scratch,
+            origin: [origin[0], origin[1], origin[2]],
+            yaw,
+            health: def.health,
+            state: "idle",
+            anim: "stand",
+            frame: def.stand[0],
+            animTime: Math.random() * 2,
+            attackTimer: 0,
+            deathDone: false,
+        };
         this.dropToFloor(m);
         this.placeMesh(m);
         return m;
@@ -307,7 +362,12 @@ export class MonsterSystem {
         let bestT = range;
         for (const m of this.monsters) {
             if (m.state === "dead") continue;
-            const t = rayAabb(origin, dir, [m.origin[0] + MON_MINS[0], m.origin[1] + MON_MINS[1], m.origin[2] + MON_MINS[2]], [m.origin[0] + MON_MAXS[0], m.origin[1] + MON_MAXS[1], m.origin[2] + MON_MAXS[2]]);
+            const t = rayAabb(
+                origin,
+                dir,
+                [m.origin[0] + MON_MINS[0], m.origin[1] + MON_MINS[1], m.origin[2] + MON_MINS[2]],
+                [m.origin[0] + MON_MAXS[0], m.origin[1] + MON_MAXS[1], m.origin[2] + MON_MAXS[2]]
+            );
             if (t !== null && t < bestT) {
                 const hit: V3 = [origin[0] + dir[0] * t, origin[1] + dir[1] * t, origin[2] + dir[2] * t];
                 if (this.physics.visible(origin, hit)) {

--- a/lab/lite/src/demos/quake/hud/sbar.ts
+++ b/lab/lite/src/demos/quake/hud/sbar.ts
@@ -10,6 +10,7 @@
 
 import { indicesToRgba, type Palette } from "../palette.js";
 import { parseWad2, readQpic, TYP_QPIC, type Wad2 } from "../render/wad2.js";
+import { demoAssetUrl } from "../../demo-asset-url.js";
 
 const BAR_W = 320;
 const BAR_H = 24;
@@ -46,7 +47,10 @@ export class SbarHud {
     private painUntil = 0;
     private painTimer = 0;
 
-    private constructor(private readonly wad: Wad2, private readonly palette: Palette) {
+    private constructor(
+        private readonly wad: Wad2,
+        private readonly palette: Palette
+    ) {
         const canvas = document.createElement("canvas");
         canvas.style.cssText = "position:fixed;inset:0;pointer-events:none;z-index:9998;image-rendering:pixelated;";
         document.body.appendChild(canvas);
@@ -59,7 +63,7 @@ export class SbarHud {
     /** Load gfx.wad and build the overlay; resolves null if the asset is missing. */
     static async create(palette: Palette): Promise<SbarHud | null> {
         try {
-            const res = await fetch("/librequake/gfx.wad");
+            const res = await fetch(demoAssetUrl("./librequake/gfx.wad", import.meta.url));
             if (!res.ok) return null;
             const wad = parseWad2(await res.arrayBuffer());
             return new SbarHud(wad, palette);

--- a/lab/lite/src/demos/quake/render/items.ts
+++ b/lab/lite/src/demos/quake/render/items.ts
@@ -21,10 +21,11 @@ import { quakeToEngine } from "../geometry/build-geometry.js";
 import type { QuakePhysics } from "../physics/collision.js";
 import type { Palette } from "../palette.js";
 import type { WorldEnt } from "../entities/mover-system.js";
+import { demoAssetUrl } from "../../demo-asset-url.js";
 
 type V3 = [number, number, number];
 
-const ASSET_BASE = "/librequake";
+const ASSET_BASE = demoAssetUrl("./librequake", import.meta.url);
 
 /** Brush-model faces with these textures are clip/skip surfaces — never drawn. */
 const SKIP_TEXTURES = new Set(["skip", "clip", "trigger", "hint", "hintskip", "waterskip"]);

--- a/lab/lite/src/demos/quake/render/viewmodel.ts
+++ b/lab/lite/src/demos/quake/render/viewmodel.ts
@@ -5,12 +5,23 @@
 // the mesh GPU buffer, mirroring the monster animation path. Inactive weapons
 // are toggled off with setMeshVisible. No GPL code copied.
 
-import { addToScene, createMeshFromData, createTexture2DFromPixels, setMeshVisible, updateMeshPositions, type EngineContext, type Mesh, type SceneContext, type Texture2D } from "babylon-lite";
+import {
+    addToScene,
+    createMeshFromData,
+    createTexture2DFromPixels,
+    setMeshVisible,
+    updateMeshPositions,
+    type EngineContext,
+    type Mesh,
+    type SceneContext,
+    type Texture2D,
+} from "babylon-lite";
 
 import { parseMdl, expandFrame, type MdlModel } from "./mdl.js";
 import { createQuakeMaterial } from "./quake-material.js";
 import type { Palette } from "../palette.js";
 import type { WeaponId, WeaponDef } from "../combat/weapons.js";
+import { demoAssetUrl } from "../../demo-asset-url.js";
 
 // Placement relative to the camera basis (engine units). The view models are
 // authored at the eye (barrel +X forward, body hanging below), so only small
@@ -32,7 +43,12 @@ function quat(ax: number, ay: number, az: number, angle: number): V4 {
 }
 
 function qmul(a: V4, b: V4): V4 {
-    return [a[3] * b[0] + a[0] * b[3] + a[1] * b[2] - a[2] * b[1], a[3] * b[1] - a[0] * b[2] + a[1] * b[3] + a[2] * b[0], a[3] * b[2] + a[0] * b[1] - a[1] * b[0] + a[2] * b[3], a[3] * b[3] - a[0] * b[0] - a[1] * b[1] - a[2] * b[2]];
+    return [
+        a[3] * b[0] + a[0] * b[3] + a[1] * b[2] - a[2] * b[1],
+        a[3] * b[1] - a[0] * b[2] + a[1] * b[3] + a[2] * b[0],
+        a[3] * b[2] + a[0] * b[1] - a[1] * b[0] + a[2] * b[3],
+        a[3] * b[3] - a[0] * b[0] - a[1] * b[1] - a[2] * b[2],
+    ];
 }
 
 interface WeaponEntry {
@@ -54,13 +70,12 @@ export class Viewmodel {
         private readonly lightTex: Texture2D,
         private readonly palette: Palette,
         private readonly whiteUV: [number, number]
-    ) {
-    }
+    ) {}
 
     /** Load every weapon's viewmodel. The first def becomes the active weapon. */
     async load(defs: WeaponDef[]): Promise<void> {
         for (const def of defs) {
-            const url = `/librequake/${def.viewModel.file}`;
+            const url = demoAssetUrl(`./librequake/${def.viewModel.file}`, import.meta.url);
             const res = await fetch(url);
             if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
             const model = parseMdl(await res.arrayBuffer(), this.palette);

--- a/lab/public/bundle/demos-manifest.json
+++ b/lab/public/bundle/demos-manifest.json
@@ -4,27 +4,27 @@
     "gzipKB": 8.4
   },
   "doom": {
-    "rawKB": 106.6,
-    "gzipKB": 36.3
+    "rawKB": 97.1,
+    "gzipKB": 32.5
   },
   "quake": {
-    "rawKB": 122.8,
-    "gzipKB": 44.1
+    "rawKB": 123.1,
+    "gzipKB": 44.2
   },
   "minecraft": {
-    "rawKB": 102.7,
-    "gzipKB": 36.6
+    "rawKB": 102.8,
+    "gzipKB": 36.7
   },
   "offscreen": {
-    "rawKB": 169.9,
-    "gzipKB": 69.2
+    "rawKB": 173.7,
+    "gzipKB": 71.2
   },
   "freeciv": {
-    "rawKB": 49.1,
-    "gzipKB": 19
+    "rawKB": 49.2,
+    "gzipKB": 19.1
   },
   "mosquito-amber": {
-    "rawKB": 94.7,
-    "gzipKB": 36.7
+    "rawKB": 96.6,
+    "gzipKB": 37.6
   }
 }


### PR DESCRIPTION
## Summary
- Resolve demo runtime assets from each demo module URL instead of root-relative paths
- Add a small demo-local helper for copied assets and Draco decoder base URLs
- Update Doom, Quake, Minecraft, Freeciv, Offscreen, and Mosquito Amber asset loading so deployed demos work under `/lite-demos/`
- Refresh the demo bundle manifest after rebuilding

## Validation
- `pnpm build:bundle-demos`
- generated bundle scan: `remainingRootAssetRefs=0`
- `pnpm run lint`
- local subdirectory smoke test under `http://localhost:8089/lite-demos/` showed demo assets resolving from `/lite-demos/...`