### PR TITLE
test: run Playwright on an isolated dev-server port

### DIFF
--- a/lab/vite.config.ts
+++ b/lab/vite.config.ts
@@ -550,7 +550,13 @@ export default defineConfig({
         },
     },
     server: {
-        port: 5174,
+        // Default interactive port is 5174. Playwright test runs pass LAB_DEV_PORT
+        // to spin up an ISOLATED server on a dedicated port (so test traffic never
+        // competes with the interactive lab). strictPort is enabled only for that
+        // test server so the exact port Playwright waits on is guaranteed; the
+        // interactive dev server keeps Vite's default auto-increment behavior.
+        port: Number(process.env.LAB_DEV_PORT) || 5174,
+        strictPort: !!process.env.LAB_DEV_PORT,
         watch: {
             // On-demand tab generation writes many files under the Vite root that
             // would otherwise churn the single-threaded dev server (stalling the

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,12 @@ const screenX = process.env.SCREEN_X;
 const headless = process.env.HEADLESS === "true";
 const isCI = !!process.env.CI;
 
+// Tests run their OWN isolated Vite dev server on a dedicated port — NOT the
+// interactive lab (5174). Sharing that server made the lab unresponsive during
+// test runs (its single Node event loop was busy transforming/serving scene
+// modules to the headless test browsers). Override with LAB_TEST_PORT if needed.
+const labTestPort = Number(process.env.LAB_TEST_PORT ?? 5179);
+
 // SwiftShader flags — only in CI (locally we use the real GPU)
 const swiftShaderArgs = isCI
     ? ["--enable-features=Vulkan", "--use-vulkan=swiftshader", "--use-angle=swiftshader", "--disable-vulkan-fallback-to-gl-for-testing", "--ignore-gpu-blocklist"]
@@ -38,8 +44,9 @@ export default defineConfig({
     },
     webServer: {
         command: "pnpm --filter @babylon-lite/lab dev",
-        port: 5174,
+        port: labTestPort,
+        env: { LAB_DEV_PORT: String(labTestPort) },
         reuseExistingServer: true,
-        timeout: 15_000,
+        timeout: 30_000,
     },
 });

--- a/playwright.perf.config.ts
+++ b/playwright.perf.config.ts
@@ -17,6 +17,11 @@ const screenX = process.env.SCREEN_X;
 const headless = process.env.HEADLESS === "true";
 const isCI = !!process.env.CI;
 
+// Tests run their OWN isolated Vite dev server on a dedicated port — NOT the
+// interactive lab (5174). Sharing that server made the lab unresponsive during
+// test runs. Override with LAB_TEST_PORT if needed.
+const labTestPort = Number(process.env.LAB_TEST_PORT ?? 5179);
+
 const swiftShaderArgs = isCI
     ? ["--enable-features=Vulkan", "--use-vulkan=swiftshader", "--use-angle=swiftshader", "--disable-vulkan-fallback-to-gl-for-testing", "--ignore-gpu-blocklist"]
     : [];
@@ -41,8 +46,9 @@ export default defineConfig({
     },
     webServer: {
         command: "pnpm --filter @babylon-lite/lab dev",
-        port: 5174,
+        port: labTestPort,
+        env: { LAB_DEV_PORT: String(labTestPort) },
         reuseExistingServer: true,
-        timeout: 15_000,
+        timeout: 30_000,
     },
 });


### PR DESCRIPTION
## Problem

Running visual/perf tests (or bundling) made the interactive lab unresponsive — images took forever to load.

**Root cause:** playwright.config.ts and playwright.perf.config.ts used `reuseExistingServer: true` on port **5174**, the same Vite server as the interactive lab. Each parity run drives ~250 scene loads across multiple workers, every one triggering on-the-fly TS+WGSL transforms through Vite's single Node event loop. That starved the lab's HTTP responses.

(The file-watcher `ignored` globs were audited and found complete — not the cause. Static-serving offload wouldn't help either, since the load is Vite's transform pipeline, not static I/O.)

## Fix

Tests now spin up their **own isolated Vite server on a dedicated port** so test traffic never competes with the interactive lab:

- playwright.config.ts / playwright.perf.config.ts: webServer targets `LAB_TEST_PORT` (default **5179**), passed to the dev server via Playwright `webServer.env` as `LAB_DEV_PORT`. Timeout 15s→30s.
- lab/vite.config.ts: `server.port` reads `LAB_DEV_PORT` (default **5174** unchanged for interactive use); `strictPort` enabled **only** when that env is set, so the test server binds the exact port Playwright waits on while interactive dev keeps auto-increment.

Port is passed via `env` rather than CLI args because under `cmd /c` (Windows Playwright spawn) pnpm forwards a literal `--` to Vite, which then ignores `--port`.

## Validation

- `scene1-boombox` parity spec passes end-to-end through the new isolated server (MAD 0.02, server started on 5179 while 5174 stayed free).
- Interactive default port (5174) and watcher ignore list unchanged.

Cloud configs (`config/playwright.*-cloud.config.ts`) intentionally left on 5174 — they run in CI with BrowserStack tunneling and no interactive lab.
