### PR TITLE
Block native pinch-zoom on mobile demo pages so pinch drives the camera

### DIFF
--- a/lab/lite/demo-bath-day.html
+++ b/lab/lite/demo-bath-day.html
@@ -2,10 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <!-- Disable the browser's pinch-to-zoom so two-finger gestures drive the camera (pinch zoom) instead. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>Babylon Lite — Demo: Bath Day</title>
   <style>
     html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
-    canvas { width: 100%; height: 100%; display: block; }
+    /* touch-action: none lets the canvas receive raw touch gestures (pinch/drag) for camera control
+       instead of the browser consuming them for page scroll/zoom. */
+    canvas { width: 100%; height: 100%; display: block; touch-action: none; }
     .loading-overlay {
       position: fixed; inset: 0; z-index: 10000;
       display: flex; align-items: center; justify-content: center;

--- a/lab/lite/demo-littlest-tokyo.html
+++ b/lab/lite/demo-littlest-tokyo.html
@@ -2,10 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <!-- Disable the browser's pinch-to-zoom so two-finger gestures drive the camera (pinch zoom) instead. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>Babylon Lite — Demo: Littlest Tokyo</title>
   <style>
     html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
-    canvas { width: 100%; height: 100%; display: block; }
+    /* touch-action: none lets the canvas receive raw touch gestures (pinch/drag) for camera control
+       instead of the browser consuming them for page scroll/zoom. */
+    canvas { width: 100%; height: 100%; display: block; touch-action: none; }
     .loading-overlay {
       position: fixed; inset: 0; z-index: 10000;
       display: flex; align-items: center; justify-content: center;

--- a/lab/lite/demo-mosquito-amber.html
+++ b/lab/lite/demo-mosquito-amber.html
@@ -2,10 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <!-- Disable the browser's pinch-to-zoom so two-finger gestures drive the camera (pinch zoom) instead. -->
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>Babylon Lite — Demo: Mosquito in Amber</title>
   <style>
     html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
-    canvas { width: 100%; height: 100%; display: block; }
+    /* touch-action: none lets the canvas receive raw touch gestures (pinch/drag) for camera control
+       instead of the browser consuming them for page scroll/zoom. */
+    canvas { width: 100%; height: 100%; display: block; touch-action: none; }
     .loading-overlay {
       position: fixed; inset: 0; z-index: 10000;
       display: flex; align-items: center; justify-content: center;

--- a/lab/lite/demo-offscreen.html
+++ b/lab/lite/demo-offscreen.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>Babylon Lite — Demo: Offscreen (Worker)</title>
   <style>
     html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #0b0809; }


### PR DESCRIPTION
## What

Demos flagged `mobile: true` in `demos-config.json` (bath-day, littlest-tokyo, mosquito-amber, offscreen) now suppress the browser's native pinch-to-zoom so two-finger gestures drive the camera instead.

## Changes

- Added `touch-action: none` to the fullscreen `canvas` (the three camera demos; offscreen already had it).
- Added/hardened the viewport meta to `maximum-scale=1, user-scalable=no`.

## Why

The ArcRotate `attachControl` already reads two-finger `touchmove` to set `camera.radius` (pinch zoom), but its touch listeners are `passive` and never `preventDefault`. Without `touch-action: none` the browser claimed the gesture as page zoom and fired `pointercancel` mid-drag. `touch-action: none` hands raw touch/pointer gestures to the canvas for camera control while suppressing the browser's own pinch-to-zoom — it does not block the DOM events.

## Scope

Only demo HTML (`lab/lite/demo-*.html`), the source `writeDemoHtml` copies to the published demos dir. These demos are outside `scene-config.json`, so parity / bundle-size guardrails do not apply (no TS or shader changes).