### PR TITLE
Add API report PR validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,12 @@ commit. If a PR is labeled `breaking`, `breaking change`, `major`, or
 release-marker job has a repo-scoped `GITHUB_TOKEN` available to read PR labels.
 
 Manual patch/minor/major releases are requested by editing `config/release.json`
-and incrementing its `nonce`; weekly scheduled releases remain `auto`.
+and incrementing its `nonce`; weekly scheduled releases remain `auto`. The npm
+publish script scans commits since the previous `npm-lite-v*` release tag for
+breaking-change markers on every release mode. If breaking changes are present,
+`auto` resolves to `major`, and explicit `patch`/`minor` releases are rejected
+so a manual patch cannot hide a breaking change from the next weekly auto
+release.
 
 ### Guardrails (Non-Negotiable)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,13 @@
 # Azure Pipelines — Babylon Lite CI
 #
-# Runs on every PR targeting master. Six parallel jobs:
+# Runs on every PR targeting master. Seven parallel jobs:
 #   1. Release Markers  — breaking-change marker validation
-#   2. Unit Tests       — vitest + plumbing (Playwright)
-#   3. Bundle Size      — ceiling checks
-#   4. Perf Regression  — Lite vs Stable on BrowserStack
-#   5. Parity (Cloud)   — pixel-diff via cloud browser with real WebGPU
-#   6. Lint             — ESLint + TypeScript type-check
+#   2. API Report       — public API diff comment + breaking-change validation
+#   3. Unit Tests       — vitest + plumbing (Playwright)
+#   4. Bundle Size      — ceiling checks
+#   5. Perf Regression  — Lite vs Stable on BrowserStack
+#   6. Parity (Cloud)   — pixel-diff via cloud browser with real WebGPU
+#   7. Lint             — ESLint + TypeScript type-check
 #
 
 trigger: none
@@ -63,7 +64,47 @@ stages:
                       GITHUB_TOKEN: "$(GITHUB_TOKEN)"
 
           # ──────────────────────────────────────────────────────────────
-          # Job 1: Unit Tests
+          # Job 1: API Report
+          # ──────────────────────────────────────────────────────────────
+          - job: ApiReport
+            displayName: "API Report"
+            pool:
+                vmImage: "ubuntu-latest"
+            steps:
+                - checkout: self
+                  fetchDepth: 0
+
+                - task: UseNode@1
+                  inputs:
+                      version: $(NODE_VERSION)
+
+                - script: |
+                      corepack enable
+                      corepack prepare pnpm@$(PNPM_VERSION) --activate
+                  displayName: "Enable pnpm via corepack"
+
+                - script: pnpm install --frozen-lockfile
+                  displayName: "Install dependencies"
+
+                - script: pnpm report:api-changes
+                  displayName: "Generate API report diff"
+                  env:
+                      GITHUB_REPOSITORY: "BabylonJS/Babylon-Lite"
+                      PR_NUMBER: "$(System.PullRequest.PullRequestNumber)"
+                      GITHUB_TOKEN: "$(GITHUB_TOKEN)"
+
+                - task: GitHubComment@0
+                  condition: and(always(), eq(variables['POST_API_COMMENT'], 'true'))
+                  continueOnError: true
+                  displayName: "Post API changes to PR"
+                  inputs:
+                      gitHubConnection: "BabylonBotPAT"
+                      repositoryName: "$(Build.Repository.Name)"
+                      id: "$(System.PullRequest.PullRequestNumber)"
+                      comment: "$(API_COMMENT_BODY)"
+
+          # ──────────────────────────────────────────────────────────────
+          # Job 2: Unit Tests
           # ──────────────────────────────────────────────────────────────
           - job: UnitTests
             displayName: "Unit Tests"
@@ -119,7 +160,7 @@ stages:
                   displayName: "Report test results"
 
           # ──────────────────────────────────────────────────────────────
-          # Job 2: Bundle Size
+          # Job 3: Bundle Size
           # ──────────────────────────────────────────────────────────────
           - job: BundleSize
             displayName: "Bundle Size"
@@ -201,7 +242,7 @@ stages:
                       siteName: "Lab"
 
           # ──────────────────────────────────────────────────────────────
-          # Job 3: Performance Regression
+          # Job 4: Performance Regression
           # ──────────────────────────────────────────────────────────────
           - job: PerfRegression
             displayName: "Performance: Lite vs Stable"
@@ -319,7 +360,7 @@ stages:
                       reportType: perf
 
           # ──────────────────────────────────────────────────────────────
-          # Job 4: Parity (Cloud Browser)
+          # Job 5: Parity (Cloud Browser)
           # ──────────────────────────────────────────────────────────────
           - job: ParityCloud
             displayName: "Parity Tests (Cloud Browser)"
@@ -378,7 +419,7 @@ stages:
                       reportType: parity
 
           # ──────────────────────────────────────────────────────────────
-          # Job 5: Lint
+          # Job 6: Lint
           # ──────────────────────────────────────────────────────────────
           - job: Lint
             displayName: "Lint & Type Check"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,6 +73,7 @@ stages:
             steps:
                 - checkout: self
                   fetchDepth: 0
+                  persistCredentials: true
 
                 - task: UseNode@1
                   inputs:

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "test:parity-cloud": "tsx scripts/run-browserstack.ts playwright test --config config/playwright.parity-cloud.config.ts",
         "test:perf-cloud": "tsx scripts/run-browserstack.ts playwright test --config config/playwright.perf-cloud.config.ts tests/lite/perf/perf-regression.spec.ts",
         "validate:release-markers": "tsx scripts/validate-pr-release-markers.ts",
+        "report:api-changes": "tsx scripts/report-api-changes.ts",
         "build:perf-baseline": "tsx scripts/build-perf-baseline.ts",
         "lint": "eslint . && tsc -p packages/babylon-lite/tsconfig.json --noEmit && tsc -p lab/tsconfig.typecheck.json --noEmit && tsc -p tests/lite/tsconfig.json --noEmit",
         "lint:fix": "eslint . --fix",
@@ -44,6 +45,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@microsoft/api-extractor": "^7.58.7",
         "@playwright/test": "^1.58.2",
         "@types/node": "^25.9.1",
         "@types/pngjs": "^6.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.1.0)
+      '@microsoft/api-extractor':
+        specifier: ^7.58.7
+        version: 7.58.7(@types/node@25.9.1)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2

--- a/scripts/prepare-npm-release.ts
+++ b/scripts/prepare-npm-release.ts
@@ -150,6 +150,14 @@ if (currentBuildId && latestPublishedBuildId === currentBuildId) {
 
 const previousReleaseTag = getPreviousReleaseTag(latestPublishedVersion);
 const breakingChangesDetected = hasBreakingChanges(previousReleaseTag);
+
+if (breakingChangesDetected && requestedReleaseType !== "auto" && requestedReleaseType !== "major") {
+    throw new Error(
+        `Breaking changes were detected since ${previousReleaseTag || "the start of history"}. ` +
+            `A ${requestedReleaseType} release would hide those changes from the next auto release; request a major release or remove the breaking-change marker if it is incorrect.`
+    );
+}
+
 const resolvedReleaseType: ResolvedReleaseType = requestedReleaseType === "auto" ? (breakingChangesDetected ? "major" : "minor") : requestedReleaseType;
 const nextVersion = bumpVersion(latestPublishedVersion, resolvedReleaseType);
 

--- a/scripts/report-api-changes.ts
+++ b/scripts/report-api-changes.ts
@@ -1,0 +1,454 @@
+/// <reference types="node" />
+
+import { execFileSync } from "child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, resolve } from "path";
+import { Extractor, ExtractorConfig, ExtractorLogLevel } from "@microsoft/api-extractor";
+
+type PullRequestInfo = {
+    title: string;
+    body: string;
+};
+
+type CallableSignature = {
+    prefix: string;
+    parameters: string[];
+    suffix: string;
+};
+
+const PACKAGE_NAME = "@babylonjs/lite";
+const API_REPORT_FILE_NAME = "babylon-lite.api.md";
+const BREAKING_MARKER = /^(?:BREAKING[ -]CHANGE:|[a-z][a-z0-9-]*(?:\([^)]+\))?!:)/m;
+const COMMENT_MAX_DIFF_LENGTH = 30_000;
+
+function run(command: string, args: string[], cwd: string, options: { allowFailure?: boolean; inheritStdio?: boolean } = {}): string {
+    try {
+        return (
+            execFileSync(command, args, {
+                cwd,
+                encoding: "utf-8",
+                stdio: options.inheritStdio ? "inherit" : ["ignore", "pipe", "pipe"],
+            })?.trim() ?? ""
+        );
+    } catch (error) {
+        if (options.allowFailure) {
+            const output = error instanceof Error && "stdout" in error ? String((error as { stdout?: unknown }).stdout ?? "") : "";
+            return output.trim();
+        }
+        throw error;
+    }
+}
+
+function normalizeBranchRef(value: string | undefined): string {
+    const branch = value?.replace(/^refs\/heads\//, "").trim();
+    return branch || "master";
+}
+
+function escapeAzureVariableValue(value: string): string {
+    return value.replace(/%/g, "%AZP25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+function packageDir(projectRoot: string): string {
+    return resolve(projectRoot, "packages/babylon-lite");
+}
+
+function generateApiReport(projectRoot: string, outputDir: string): string {
+    const currentPackageDir = packageDir(projectRoot);
+    const entryPoint = resolve(currentPackageDir, "dist/index.d.ts");
+    const reportFolder = resolve(outputDir, "approved");
+    const reportTempFolder = resolve(outputDir, "temp");
+
+    if (!existsSync(entryPoint)) {
+        throw new Error(`Cannot generate API report because ${entryPoint} does not exist.`);
+    }
+
+    mkdirSync(reportFolder, { recursive: true });
+    mkdirSync(reportTempFolder, { recursive: true });
+
+    const config = ExtractorConfig.prepare({
+        configObject: {
+            projectFolder: currentPackageDir,
+            mainEntryPointFilePath: entryPoint,
+            compiler: {
+                overrideTsconfig: {
+                    compilerOptions: {
+                        target: "es2022",
+                        module: "esnext",
+                        moduleResolution: "bundler",
+                        lib: ["es2022", "dom", "dom.iterable"],
+                        types: ["@webgpu/types"],
+                        strict: true,
+                        declaration: true,
+                        skipLibCheck: true,
+                    },
+                    include: [entryPoint],
+                },
+            },
+            apiReport: {
+                enabled: true,
+                reportFileName: "babylon-lite",
+                reportFolder,
+                reportTempFolder,
+            },
+            docModel: { enabled: false },
+            tsdocMetadata: { enabled: false },
+            dtsRollup: { enabled: false },
+            messages: {
+                compilerMessageReporting: {
+                    default: { logLevel: ExtractorLogLevel.Warning },
+                },
+                extractorMessageReporting: {
+                    default: { logLevel: ExtractorLogLevel.Warning },
+                    "ae-missing-release-tag": { logLevel: ExtractorLogLevel.None },
+                    "ae-undocumented": { logLevel: ExtractorLogLevel.None },
+                    "ae-forgotten-export": { logLevel: ExtractorLogLevel.None },
+                    "ae-unresolved-link": { logLevel: ExtractorLogLevel.None },
+                    "ae-internal-missing-underscore": { logLevel: ExtractorLogLevel.Error },
+                },
+                tsdocMessageReporting: {
+                    default: { logLevel: ExtractorLogLevel.None },
+                },
+            },
+        },
+        configObjectFullPath: undefined,
+        packageJsonFullPath: resolve(currentPackageDir, "package.json"),
+    });
+
+    const result = Extractor.invoke(config, {
+        localBuild: true,
+        showVerboseMessages: false,
+        messageCallback: (message) => {
+            if (String(message.messageId).startsWith("console-api-report-")) {
+                message.handled = true;
+            }
+        },
+    });
+    if (!result.succeeded) {
+        throw new Error(`API Extractor failed: ${result.errorCount} errors, ${result.warningCount} warnings`);
+    }
+
+    const reportPath = resolve(reportTempFolder, API_REPORT_FILE_NAME);
+    if (!existsSync(reportPath)) {
+        throw new Error(`API Extractor did not write the expected report at ${reportPath}.`);
+    }
+
+    return reportPath;
+}
+
+function createTargetWorktree(rootDir: string, targetRef: string): string {
+    const worktreeDir = mkdtempSync(resolve(tmpdir(), "babylon-lite-api-baseline-"));
+    run("git", ["fetch", "origin", `${targetRef}:refs/remotes/origin/${targetRef}`], rootDir, { inheritStdio: true });
+    run("git", ["worktree", "add", "--detach", worktreeDir, `origin/${targetRef}`], rootDir, { inheritStdio: true });
+    return worktreeDir;
+}
+
+function removeTargetWorktree(rootDir: string, worktreeDir: string): void {
+    run("git", ["worktree", "remove", "--force", worktreeDir], rootDir, { allowFailure: true, inheritStdio: true });
+    rmSync(worktreeDir, { recursive: true, force: true });
+}
+
+function buildPackage(projectRoot: string, options: { installDependencies: boolean }): void {
+    if (options.installDependencies) {
+        run("pnpm", ["install", "--frozen-lockfile"], projectRoot, { inheritStdio: true });
+    }
+    run("pnpm", ["--filter", "babylon-lite", "exec", "vite", "build", "--logLevel", "warn"], projectRoot, { inheritStdio: true });
+}
+
+function diffReports(rootDir: string, targetReport: string, currentReport: string): string {
+    return run("git", ["diff", "--no-index", "--unified=3", "--", targetReport, currentReport], rootDir, { allowFailure: true });
+}
+
+function normalizeApiLine(line: string): string {
+    return line.trim().replace(/\s+/g, " ");
+}
+
+function isIgnorableApiLine(content: string): boolean {
+    return !content || content === "}" || content.startsWith("//") || content.startsWith("/*") || content.startsWith("*");
+}
+
+function collectChangedApiLines(diff: string, marker: "+" | "-"): string[] {
+    const changedLines: string[] = [];
+
+    for (const line of diff.split(/\r?\n/)) {
+        if (!line.startsWith(marker) || line.startsWith(`${marker}${marker}${marker}`)) {
+            continue;
+        }
+
+        const content = normalizeApiLine(line.slice(1));
+        if (isIgnorableApiLine(content)) {
+            continue;
+        }
+
+        changedLines.push(content);
+    }
+
+    return changedLines;
+}
+
+function updateDepth(character: string, depth: { angle: number; square: number; curly: number }): void {
+    if (character === "<") {
+        depth.angle += 1;
+    } else if (character === ">" && depth.angle > 0) {
+        depth.angle -= 1;
+    } else if (character === "[") {
+        depth.square += 1;
+    } else if (character === "]" && depth.square > 0) {
+        depth.square -= 1;
+    } else if (character === "{") {
+        depth.curly += 1;
+    } else if (character === "}" && depth.curly > 0) {
+        depth.curly -= 1;
+    }
+}
+
+function findParameterStart(line: string): number {
+    const depth = { angle: 0, square: 0, curly: 0 };
+
+    for (let index = 0; index < line.length; index += 1) {
+        const character = line[index]!;
+        if (character === "(" && depth.angle === 0 && depth.square === 0 && depth.curly === 0) {
+            return index;
+        }
+        updateDepth(character, depth);
+    }
+
+    return -1;
+}
+
+function findParameterEnd(line: string, parameterStart: number): number {
+    const depth = { angle: 0, square: 0, curly: 0 };
+    let parenDepth = 0;
+
+    for (let index = parameterStart; index < line.length; index += 1) {
+        const character = line[index]!;
+        if (character === "(" && depth.angle === 0 && depth.square === 0 && depth.curly === 0) {
+            parenDepth += 1;
+        } else if (character === ")" && depth.angle === 0 && depth.square === 0 && depth.curly === 0) {
+            parenDepth -= 1;
+            if (parenDepth === 0) {
+                return index;
+            }
+        } else {
+            updateDepth(character, depth);
+        }
+    }
+
+    return -1;
+}
+
+function splitParameters(parametersText: string): string[] {
+    const parameters: string[] = [];
+    const depth = { angle: 0, square: 0, curly: 0 };
+    let parenDepth = 0;
+    let segmentStart = 0;
+
+    for (let index = 0; index < parametersText.length; index += 1) {
+        const character = parametersText[index]!;
+
+        if (character === "(" && depth.angle === 0 && depth.square === 0 && depth.curly === 0) {
+            parenDepth += 1;
+        } else if (character === ")" && depth.angle === 0 && depth.square === 0 && depth.curly === 0 && parenDepth > 0) {
+            parenDepth -= 1;
+        } else if (character === "," && depth.angle === 0 && depth.square === 0 && depth.curly === 0 && parenDepth === 0) {
+            parameters.push(normalizeApiLine(parametersText.slice(segmentStart, index)));
+            segmentStart = index + 1;
+        } else {
+            updateDepth(character, depth);
+        }
+    }
+
+    const finalParameter = normalizeApiLine(parametersText.slice(segmentStart));
+    if (finalParameter) {
+        parameters.push(finalParameter);
+    }
+
+    return parameters;
+}
+
+function parseCallableSignature(line: string): CallableSignature | undefined {
+    const parameterStart = findParameterStart(line);
+    if (parameterStart === -1) {
+        return undefined;
+    }
+
+    const parameterEnd = findParameterEnd(line, parameterStart);
+    if (parameterEnd === -1) {
+        return undefined;
+    }
+
+    return {
+        prefix: normalizeApiLine(line.slice(0, parameterStart)),
+        parameters: splitParameters(line.slice(parameterStart + 1, parameterEnd)),
+        suffix: normalizeApiLine(line.slice(parameterEnd + 1)),
+    };
+}
+
+function isOptionalParameter(parameter: string): boolean {
+    return parameter.startsWith("...") || /^[A-Za-z_$][\w$]*\s*\?:/.test(parameter);
+}
+
+function isNonBreakingOptionalParameterExpansion(removedLine: string, addedLine: string): boolean {
+    const removedSignature = parseCallableSignature(removedLine);
+    const addedSignature = parseCallableSignature(addedLine);
+
+    if (!removedSignature || !addedSignature) {
+        return false;
+    }
+
+    if (removedSignature.prefix !== addedSignature.prefix || removedSignature.suffix !== addedSignature.suffix) {
+        return false;
+    }
+
+    if (addedSignature.parameters.length <= removedSignature.parameters.length) {
+        return false;
+    }
+
+    for (let index = 0; index < removedSignature.parameters.length; index += 1) {
+        if (removedSignature.parameters[index] !== addedSignature.parameters[index]) {
+            return false;
+        }
+    }
+
+    return addedSignature.parameters.slice(removedSignature.parameters.length).every(isOptionalParameter);
+}
+
+export function breakingApiLines(diff: string): string[] {
+    const removedLines = collectChangedApiLines(diff, "-");
+    const addedLines = collectChangedApiLines(diff, "+");
+
+    return removedLines.filter((removedLine) => !addedLines.some((addedLine) => isNonBreakingOptionalParameterExpansion(removedLine, addedLine)));
+}
+
+function truncateDiff(diff: string): string {
+    if (diff.length <= COMMENT_MAX_DIFF_LENGTH) {
+        return diff;
+    }
+
+    return `${diff.slice(0, COMMENT_MAX_DIFF_LENGTH)}\n\n... diff truncated for GitHub comment length ...`;
+}
+
+function formatComment(diff: string, breakingLines: string[]): string {
+    if (!diff) {
+        return "**API Report**: No public API changes detected.";
+    }
+
+    const lines = ["## API Changes", "", `API Extractor detected public API changes for \`${PACKAGE_NAME}\`.`];
+
+    if (breakingLines.length > 0) {
+        lines.push("", "**Potentially breaking changes detected.** Removed or changed public API lines:", "");
+        for (const line of breakingLines.slice(0, 20)) {
+            lines.push(`- \`${line.replace(/`/g, "\\`")}\``);
+        }
+        if (breakingLines.length > 20) {
+            lines.push(`- ...and ${breakingLines.length - 20} more removed/changed lines.`);
+        }
+    } else {
+        lines.push("", "No removed public API lines were detected; this appears to be additive.");
+    }
+
+    lines.push("", "<details>", "<summary>API Extractor diff</summary>", "", "```diff", truncateDiff(diff), "```", "", "</details>");
+
+    return lines.join("\n");
+}
+
+function getPullRequestFromEnv(): PullRequestInfo | undefined {
+    if (!process.env.PR_TITLE && !process.env.PR_BODY) {
+        return undefined;
+    }
+
+    return {
+        title: process.env.PR_TITLE ?? "",
+        body: process.env.PR_BODY ?? "",
+    };
+}
+
+async function getPullRequestFromGitHub(): Promise<PullRequestInfo | undefined> {
+    const repository = process.env.GITHUB_REPOSITORY;
+    const pullRequestNumber = process.env.PR_NUMBER;
+    const token = process.env.GITHUB_TOKEN;
+
+    if (!repository || !pullRequestNumber || !token) {
+        return undefined;
+    }
+
+    const response = await fetch(`https://api.github.com/repos/${repository}/pulls/${pullRequestNumber}`, {
+        headers: {
+            accept: "application/vnd.github+json",
+            authorization: `Bearer ${token}`,
+            "user-agent": "babylon-lite-api-report-check",
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to read PR metadata from GitHub: ${response.status} ${response.statusText}`);
+    }
+
+    const pullRequest = (await response.json()) as { title?: unknown; body?: unknown };
+    return {
+        title: typeof pullRequest.title === "string" ? pullRequest.title : "",
+        body: typeof pullRequest.body === "string" ? pullRequest.body : "",
+    };
+}
+
+async function hasBreakingMarkerInPullRequest(): Promise<boolean> {
+    const pullRequest = getPullRequestFromEnv() ?? (await getPullRequestFromGitHub());
+    if (!pullRequest) {
+        return false;
+    }
+
+    return BREAKING_MARKER.test(`${pullRequest.title}\n\n${pullRequest.body}`);
+}
+
+async function main(): Promise<void> {
+    const rootDir = resolve(__dirname, "..");
+    const targetBranch = normalizeBranchRef(process.env.SYSTEM_PULLREQUEST_TARGETBRANCH ?? process.env.API_REPORT_TARGET_BRANCH);
+    const outputDir = resolve(rootDir, "test-results/api-report");
+    const currentOutputDir = resolve(outputDir, "current");
+    const targetOutputDir = resolve(outputDir, "target");
+    const commentPath = process.env.API_REPORT_COMMENT_PATH ?? resolve(outputDir, "api-report-comment.md");
+    let targetWorktree = "";
+
+    console.log(`Generating API report comparison against ${targetBranch}.`);
+    rmSync(outputDir, { recursive: true, force: true });
+    mkdirSync(outputDir, { recursive: true });
+
+    try {
+        console.log("Building current branch package...");
+        buildPackage(rootDir, { installDependencies: false });
+        const currentReport = generateApiReport(rootDir, currentOutputDir);
+
+        console.log(`Building target branch package from origin/${targetBranch}...`);
+        targetWorktree = createTargetWorktree(rootDir, targetBranch);
+        buildPackage(targetWorktree, { installDependencies: true });
+        const targetReport = generateApiReport(targetWorktree, targetOutputDir);
+
+        const diff = diffReports(rootDir, targetReport, currentReport);
+        const breakingLines = breakingApiLines(diff);
+        const comment = formatComment(diff, breakingLines);
+
+        mkdirSync(dirname(commentPath), { recursive: true });
+        writeFileSync(commentPath, comment, "utf-8");
+        console.log(comment);
+
+        const hasApiChanges = diff.length > 0;
+        console.log(`##vso[task.setvariable variable=POST_API_COMMENT]${hasApiChanges ? "true" : "false"}`);
+        console.log(`##vso[task.setvariable variable=API_COMMENT_BODY]${escapeAzureVariableValue(comment)}`);
+
+        if (breakingLines.length > 0 && !(await hasBreakingMarkerInPullRequest())) {
+            console.error(
+                "API Extractor detected removed or changed public API lines, but the PR title or description does not contain a breaking-change marker. " +
+                    "Add a Conventional Commit breaking marker such as 'feat!: ...' or a 'BREAKING CHANGE:' footer."
+            );
+            process.exitCode = 1;
+        }
+    } finally {
+        if (targetWorktree) {
+            removeTargetWorktree(rootDir, targetWorktree);
+        }
+    }
+}
+
+if (require.main === module) {
+    void main();
+}

--- a/tests/lite/unit/report-api-changes.test.ts
+++ b/tests/lite/unit/report-api-changes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { breakingApiLines } from "../../../scripts/report-api-changes";
+
+function apiDiff(removed: string, added: string): string {
+    return ["diff --git a/target.api.md b/current.api.md", "--- a/target.api.md", "+++ b/current.api.md", "@@", `-${removed}`, `+${added}`].join("\n");
+}
+
+describe("API report breaking-change classifier", () => {
+    it("treats trailing optional function parameters as additive", () => {
+        const diff = apiDiff("export declare function createMesh(name: string): Mesh;", "export declare function createMesh(name: string, options?: MeshOptions): Mesh;");
+
+        expect(breakingApiLines(diff)).toEqual([]);
+    });
+
+    it("treats trailing rest parameters as additive", () => {
+        const diff = apiDiff("export declare function setDefines(name: string): void;", "export declare function setDefines(name: string, ...defines: string[]): void;");
+
+        expect(breakingApiLines(diff)).toEqual([]);
+    });
+
+    it("flags added required function parameters as breaking", () => {
+        const diff = apiDiff("export declare function createMesh(name: string): Mesh;", "export declare function createMesh(name: string, options: MeshOptions): Mesh;");
+
+        expect(breakingApiLines(diff)).toEqual(["export declare function createMesh(name: string): Mesh;"]);
+    });
+
+    it("flags parameter type changes as breaking", () => {
+        const diff = apiDiff("export declare function setColor(color: string): void;", "export declare function setColor(color: Color3): void;");
+
+        expect(breakingApiLines(diff)).toEqual(["export declare function setColor(color: string): void;"]);
+    });
+
+    it("flags return type changes as breaking", () => {
+        const diff = apiDiff("export declare function createMesh(name: string): Mesh;", "export declare function createMesh(name: string): Promise<Mesh>;");
+
+        expect(breakingApiLines(diff)).toEqual(["export declare function createMesh(name: string): Mesh;"]);
+    });
+
+    it("does not flag purely added API lines", () => {
+        const diff = [
+            "diff --git a/target.api.md b/current.api.md",
+            "--- a/target.api.md",
+            "+++ b/current.api.md",
+            "@@",
+            "+export declare function createMesh(name: string): Mesh;",
+        ].join("\n");
+
+        expect(breakingApiLines(diff)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Adds PR automation that compares the public `@babylonjs/lite` API surface with the target branch using API Extractor and posts a GitHub comment when the API changes.

## Details

- Adds an `ApiReport` Azure Pipelines job that generates an API Extractor report diff for PRs.
- Posts an API changes comment through the existing `GitHubComment@0` flow when public API changes are detected.
- Fails the PR when potentially breaking API changes are detected without a breaking-change marker in the PR title or body.
- Treats additive API changes, including trailing optional function/rest parameters, as non-breaking.
- Adds unit tests for the API change classifier.
- Tightens npm publish release prep so explicit patch/minor releases cannot hide breaking-change markers from the next auto release.
- Documents the release marker behavior in `AGENTS.md`.

## Validation

- `npx vitest run --project unit tests/lite/unit/report-api-changes.test.ts`
- `API_REPORT_TARGET_BRANCH=master pnpm report:api-changes`
- `pnpm run lint`

Parity was not run because these changes are CI/release automation only and do not modify the Lite runtime source.