### PR TITLE
Fix arc-rotate pinch-zoom far-clip blink; drop per-frame enforce + dead RAF mode

### DIFF
--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -21,7 +21,7 @@
     "bjsGzipKB": 675.2
   },
   "scene2": {
-    "rawKB": 44.9,
+    "rawKB": 44.8,
     "gzipKB": 17.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -33,7 +33,7 @@
     "bjsGzipKB": 343.7
   },
   "scene3": {
-    "rawKB": 51.8,
+    "rawKB": 51.7,
     "gzipKB": 20.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -47,7 +47,7 @@
     "bjsGzipKB": 346
   },
   "scene4": {
-    "rawKB": 70.2,
+    "rawKB": 70.1,
     "gzipKB": 27.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -65,8 +65,8 @@
     "bjsGzipKB": 372.5
   },
   "scene5": {
-    "rawKB": 86.1,
-    "gzipKB": 35.5,
+    "rawKB": 86,
+    "gzipKB": 35.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene5-create-morph-targets-DqCohDYt.js",
@@ -88,7 +88,7 @@
     "bjsGzipKB": 529.2
   },
   "scene6": {
-    "rawKB": 70.9,
+    "rawKB": 70.8,
     "gzipKB": 29.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -132,7 +132,7 @@
     "bjsGzipKB": 678.1
   },
   "scene8": {
-    "rawKB": 72.4,
+    "rawKB": 72.3,
     "gzipKB": 28.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -179,7 +179,7 @@
     "bjsGzipKB": 397.2
   },
   "scene11": {
-    "rawKB": 82.1,
+    "rawKB": 82,
     "gzipKB": 33.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -225,7 +225,7 @@
     "bjsGzipKB": 531.5
   },
   "scene13": {
-    "rawKB": 81.7,
+    "rawKB": 81.6,
     "gzipKB": 33,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -265,7 +265,7 @@
     "bjsGzipKB": 675.3
   },
   "scene15": {
-    "rawKB": 45.2,
+    "rawKB": 45.1,
     "gzipKB": 17.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -405,7 +405,7 @@
     "bjsGzipKB": 448.3
   },
   "scene23": {
-    "rawKB": 75.3,
+    "rawKB": 75.2,
     "gzipKB": 30.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -457,7 +457,7 @@
     "bjsGzipKB": 335.9
   },
   "scene26": {
-    "rawKB": 85.4,
+    "rawKB": 85.3,
     "gzipKB": 34.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -478,7 +478,7 @@
     "bjsGzipKB": 620.2
   },
   "scene27": {
-    "rawKB": 77.3,
+    "rawKB": 77.2,
     "gzipKB": 31.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -499,7 +499,7 @@
     "bjsGzipKB": 520.6
   },
   "scene28": {
-    "rawKB": 81.5,
+    "rawKB": 81.4,
     "gzipKB": 32.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -517,8 +517,8 @@
     "bjsGzipKB": 672
   },
   "scene29": {
-    "rawKB": 84.2,
-    "gzipKB": 34.3,
+    "rawKB": 84.1,
+    "gzipKB": 34.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene29-generate-mipmaps-DsY9dhF2.js",
@@ -567,7 +567,7 @@
     "bjsGzipKB": 673.2
   },
   "scene31": {
-    "rawKB": 76.6,
+    "rawKB": 76.5,
     "gzipKB": 30.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -587,7 +587,7 @@
   },
   "scene32": {
     "rawKB": 76.4,
-    "gzipKB": 30.9,
+    "gzipKB": 30.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene32-generate-mipmaps-Buf1Fvx9.js",
@@ -651,7 +651,7 @@
     "bjsGzipKB": 675.5
   },
   "scene35": {
-    "rawKB": 79.7,
+    "rawKB": 79.6,
     "gzipKB": 32.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -671,7 +671,7 @@
     "bjsGzipKB": 672
   },
   "scene36": {
-    "rawKB": 49.5,
+    "rawKB": 49.4,
     "gzipKB": 19.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -855,7 +855,7 @@
     "bjsGzipKB": 357.7
   },
   "scene60": {
-    "rawKB": 54.5,
+    "rawKB": 54.4,
     "gzipKB": 22,
     "ignoredRawKB": 4,
     "runtimeChunks": [
@@ -872,7 +872,7 @@
     "bjsGzipKB": 525
   },
   "scene61": {
-    "rawKB": 53.4,
+    "rawKB": 53.3,
     "gzipKB": 22.5,
     "ignoredRawKB": 7.3,
     "runtimeChunks": [
@@ -891,7 +891,7 @@
     "bjsGzipKB": 525.1
   },
   "scene62": {
-    "rawKB": 59.1,
+    "rawKB": 59,
     "gzipKB": 24.6,
     "ignoredRawKB": 5.3,
     "runtimeChunks": [
@@ -910,7 +910,7 @@
     "bjsGzipKB": 525.1
   },
   "scene63": {
-    "rawKB": 57.7,
+    "rawKB": 57.6,
     "gzipKB": 23.8,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
@@ -1015,7 +1015,7 @@
     "bjsGzipKB": 551.4
   },
   "scene67": {
-    "rawKB": 75.8,
+    "rawKB": 75.7,
     "gzipKB": 31.4,
     "ignoredRawKB": 9.6,
     "runtimeChunks": [
@@ -1037,8 +1037,8 @@
     "bjsGzipKB": 564.1
   },
   "scene68": {
-    "rawKB": 90.4,
-    "gzipKB": 35.1,
+    "rawKB": 90.3,
+    "gzipKB": 35,
     "ignoredRawKB": 11.4,
     "runtimeChunks": [
       "scene68-_math-factory-DFVyS8gB.js",
@@ -1082,8 +1082,8 @@
     "bjsGzipKB": 564.4
   },
   "scene70": {
-    "rawKB": 90.2,
-    "gzipKB": 35.9,
+    "rawKB": 90.1,
+    "gzipKB": 35.8,
     "ignoredRawKB": 14.9,
     "runtimeChunks": [
       "scene70-_math-factory-DFVyS8gB.js",
@@ -1129,7 +1129,7 @@
     "bjsGzipKB": 564.4
   },
   "scene72": {
-    "rawKB": 107.5,
+    "rawKB": 107.4,
     "gzipKB": 42.9,
     "ignoredRawKB": 3.3,
     "runtimeChunks": [
@@ -1230,7 +1230,7 @@
     "bjsGzipKB": 175.4
   },
   "scene77": {
-    "rawKB": 58.6,
+    "rawKB": 58.5,
     "gzipKB": 24.8,
     "ignoredRawKB": 7,
     "runtimeChunks": [
@@ -1290,8 +1290,8 @@
     "bjsGzipKB": 525.4
   },
   "scene79": {
-    "rawKB": 60.2,
-    "gzipKB": 26.9,
+    "rawKB": 60.1,
+    "gzipKB": 26.8,
     "ignoredRawKB": 8.1,
     "runtimeChunks": [
       "scene79-_math-factory-DFVyS8gB.js",
@@ -1397,7 +1397,7 @@
     "bjsGzipKB": 525.1
   },
   "scene83": {
-    "rawKB": 69.6,
+    "rawKB": 69.5,
     "gzipKB": 32.5,
     "ignoredRawKB": 11.4,
     "runtimeChunks": [
@@ -1431,7 +1431,7 @@
   },
   "scene84": {
     "rawKB": 82.7,
-    "gzipKB": 35.1,
+    "gzipKB": 35,
     "ignoredRawKB": 5.5,
     "runtimeChunks": [
       "scene84-_math-factory-DFVyS8gB.js",
@@ -1460,7 +1460,7 @@
     "bjsGzipKB": 543.2
   },
   "scene85": {
-    "rawKB": 59.3,
+    "rawKB": 59.2,
     "gzipKB": 25.6,
     "ignoredRawKB": 6.5,
     "runtimeChunks": [
@@ -1485,7 +1485,7 @@
     "bjsGzipKB": 524.9
   },
   "scene86": {
-    "rawKB": 58.6,
+    "rawKB": 58.5,
     "gzipKB": 26.3,
     "ignoredRawKB": 8,
     "runtimeChunks": [
@@ -1513,7 +1513,7 @@
     "bjsGzipKB": 491.1
   },
   "scene87": {
-    "rawKB": 93.1,
+    "rawKB": 93,
     "gzipKB": 36.8,
     "ignoredRawKB": 12,
     "runtimeChunks": [
@@ -1537,7 +1537,7 @@
     "bjsGzipKB": 563.8
   },
   "scene88": {
-    "rawKB": 59.5,
+    "rawKB": 59.4,
     "gzipKB": 26.1,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
@@ -1566,8 +1566,8 @@
     "bjsGzipKB": 524.8
   },
   "scene89": {
-    "rawKB": 59,
-    "gzipKB": 26.3,
+    "rawKB": 58.9,
+    "gzipKB": 26.2,
     "ignoredRawKB": 7.6,
     "runtimeChunks": [
       "scene89-_math-factory-DFVyS8gB.js",
@@ -1595,7 +1595,7 @@
     "bjsGzipKB": 524.9
   },
   "scene90": {
-    "rawKB": 57.3,
+    "rawKB": 57.2,
     "gzipKB": 22.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -1608,8 +1608,8 @@
     "bjsGzipKB": 345.7
   },
   "scene91": {
-    "rawKB": 56.4,
-    "gzipKB": 22.3,
+    "rawKB": 56.3,
+    "gzipKB": 22.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene91-generate-mipmaps-DEgDnSqu.js",
@@ -1701,7 +1701,7 @@
     "bjsGzipKB": 371.7
   },
   "scene110": {
-    "rawKB": 48.7,
+    "rawKB": 48.6,
     "gzipKB": 18.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -1714,7 +1714,7 @@
   },
   "scene111": {
     "rawKB": 131.3,
-    "gzipKB": 52.7,
+    "gzipKB": 52.6,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
       "scene111-_math-factory-DFVyS8gB.js",
@@ -1827,7 +1827,7 @@
     "bjsGzipKB": 575.3
   },
   "scene116": {
-    "rawKB": 73.3,
+    "rawKB": 73.2,
     "gzipKB": 29.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -1854,7 +1854,7 @@
     "bjsGzipKB": 361.9
   },
   "scene121": {
-    "rawKB": 34.6,
+    "rawKB": 34.5,
     "gzipKB": 13.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -1874,7 +1874,7 @@
   },
   "scene123": {
     "rawKB": 43.9,
-    "gzipKB": 17.5,
+    "gzipKB": 17.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene123-gaussian-splatting-pipeline-sh-CgxdnX-t.js",
@@ -1908,7 +1908,7 @@
     ]
   },
   "scene127": {
-    "rawKB": 54.7,
+    "rawKB": 54.6,
     "gzipKB": 20.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -1937,7 +1937,7 @@
     ]
   },
   "scene140": {
-    "rawKB": 95.4,
+    "rawKB": 95.3,
     "gzipKB": 40.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2011,8 +2011,8 @@
     ]
   },
   "scene142": {
-    "rawKB": 59.6,
-    "gzipKB": 22,
+    "rawKB": 59.5,
+    "gzipKB": 21.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene142-standard-renderable-HtLJHHQD.js",
@@ -2021,7 +2021,7 @@
     ]
   },
   "scene143": {
-    "rawKB": 66.4,
+    "rawKB": 66.3,
     "gzipKB": 26,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2038,7 +2038,7 @@
     ]
   },
   "scene144": {
-    "rawKB": 105.6,
+    "rawKB": 105.5,
     "gzipKB": 41.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2071,7 +2071,7 @@
     ]
   },
   "scene151": {
-    "rawKB": 53.2,
+    "rawKB": 53.1,
     "gzipKB": 20.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2128,7 +2128,7 @@
     ]
   },
   "scene156": {
-    "rawKB": 56.6,
+    "rawKB": 56.5,
     "gzipKB": 21.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2138,7 +2138,7 @@
     ]
   },
   "scene157": {
-    "rawKB": 90.8,
+    "rawKB": 90.7,
     "gzipKB": 36.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2210,7 +2210,7 @@
     ]
   },
   "scene163": {
-    "rawKB": 33.7,
+    "rawKB": 33.8,
     "gzipKB": 13.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2220,7 +2220,7 @@
   },
   "scene164": {
     "rawKB": 93.2,
-    "gzipKB": 37.5,
+    "gzipKB": 37.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene164-create-morph-targets-DkEaLlZR.js",
@@ -2265,7 +2265,7 @@
     ]
   },
   "scene172": {
-    "rawKB": 57.8,
+    "rawKB": 57.7,
     "gzipKB": 22.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2285,7 +2285,7 @@
     ]
   },
   "scene174": {
-    "rawKB": 93.2,
+    "rawKB": 93.1,
     "gzipKB": 37.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2300,7 +2300,7 @@
     ]
   },
   "scene175": {
-    "rawKB": 91.5,
+    "rawKB": 91.4,
     "gzipKB": 36.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2315,7 +2315,7 @@
     ]
   },
   "scene176": {
-    "rawKB": 96.9,
+    "rawKB": 96.8,
     "gzipKB": 38.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2348,7 +2348,7 @@
     ]
   },
   "scene178": {
-    "rawKB": 84.3,
+    "rawKB": 84.2,
     "gzipKB": 33.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2400,7 +2400,7 @@
     ]
   },
   "scene210": {
-    "rawKB": 71.4,
+    "rawKB": 71.3,
     "gzipKB": 29,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2415,8 +2415,8 @@
     ]
   },
   "scene211": {
-    "rawKB": 83.8,
-    "gzipKB": 34.5,
+    "rawKB": 83.7,
+    "gzipKB": 34.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene211-create-skeleton-CQTZt5d-.js",
@@ -2434,8 +2434,8 @@
     ]
   },
   "scene212": {
-    "rawKB": 98.3,
-    "gzipKB": 38.8,
+    "rawKB": 98.2,
+    "gzipKB": 38.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene212-generate-mipmaps-BRsOJ5KB.js",

--- a/packages/babylon-lite/src/camera/arc-rotate-controls.ts
+++ b/packages/babylon-lite/src/camera/arc-rotate-controls.ts
@@ -52,24 +52,28 @@ function clampCameraToLimits(camera: ArcRotateCamera): void {
 
 /**
  * Configure orbit/zoom limits on an ArcRotateCamera. This is fully opt-in and
- * self-contained: it touches nothing in {@link attachControl}'s per-frame loop, so
- * cameras that never call it pay zero cost and run no clamping code.
+ * self-contained: cameras that never call it pay zero cost and bundle no clamping
+ * code (the camera's scalar setters call an undefined hook).
  *
  * What it does:
  *  1. Stores the provided bounds on the camera and clamps the current pose into
  *     range right away (inertia zeroed), so enabling limits never causes a jump.
- *  2. If a `scene` is given, registers a per-frame enforcement step that runs
- *     *after* the controls' inertia integration each frame. Because the clamp is
- *     the last mutation before the frame renders — never the first — inertia/pinch
- *     that pushed past a bound is corrected before display, with no overshoot-then
- *     -snap jiggle (the failure mode of clamping in an `onBeforeRender` callback,
- *     which prepends and therefore runs before inertia is applied).
+ *  2. Installs a self-clamp hook on the camera (`_clampToLimits`). The
+ *     alpha/beta/radius setters invoke it on every mutation, so any caller —
+ *     pinch direct-write, inertial overshoot, auto-rotate — is snapped back to
+ *     the wall in the same statement that pushed past it. The camera is therefore
+ *     never observably out of bounds at any point a per-frame callback reads it
+ *     (e.g. a camera-pinned skybox), eliminating both the overshoot-then-snap
+ *     jiggle and the one-frame clip "blink" of a deferred per-frame clamp.
  *
  * Only the fields present on `limits` are written, so calls compose; pass a field
  * as `undefined` to remove that bound. Returns a disposer that removes the
- * per-frame enforcement step (a no-op when no `scene` was supplied).
+ * self-clamp hook.
+ *
+ * The optional `_scene` parameter is accepted for backward compatibility and is
+ * unused — enforcement no longer needs a per-frame scene hook.
  */
-export function setCameraLimits(camera: ArcRotateCamera, limits: ArcRotateCameraLimits, scene?: SceneContext): () => void {
+export function setCameraLimits(camera: ArcRotateCamera, limits: ArcRotateCameraLimits, _scene?: SceneContext): () => void {
     if ("lowerAlphaLimit" in limits) {
         camera.lowerAlphaLimit = limits.lowerAlphaLimit;
     }
@@ -88,19 +92,19 @@ export function setCameraLimits(camera: ArcRotateCamera, limits: ArcRotateCamera
     if ("upperRadiusLimit" in limits) {
         camera.upperRadiusLimit = limits.upperRadiusLimit;
     }
-    clampCameraToLimits(camera);
-
-    if (!scene) {
-        return () => {};
-    }
-
-    // Append (not unshift) so this runs after attachControl's inertia step.
+    // Install the self-clamp hook the camera's setters call on every move, then
+    // clamp the current pose once. The hook reference lives only on the limits
+    // path, so cameras that never call setCameraLimits pull none of
+    // clampCameraToLimits into their bundle. Re-entrancy is bounded: clamping a
+    // value writes it to exactly the bound, and the re-triggered hook finds it
+    // already in range and stops.
     const enforce = (): void => clampCameraToLimits(camera);
-    scene._beforeRender.push(enforce);
+    camera._clampToLimits = enforce;
+    enforce();
+
     return () => {
-        const idx = scene._beforeRender.indexOf(enforce);
-        if (idx >= 0) {
-            scene._beforeRender.splice(idx, 1);
+        if (camera._clampToLimits === enforce) {
+            camera._clampToLimits = undefined;
         }
     };
 }
@@ -114,10 +118,11 @@ export function setCameraLimits(camera: ArcRotateCamera, limits: ArcRotateCamera
  * - Pinch: zoom (touch, direct — no inertia)
  *
  * Input handlers accumulate into the camera's inertial offset properties.
- * Inertia is applied each frame via scene._beforeRender (single RAF loop).
+ * Inertia is applied each frame via scene._beforeRender (the engine's render
+ * loop); a scene is required for inertia, there is no standalone rAF fallback.
  *
- * Orbit/zoom limits are entirely opt-in via {@link setCameraLimits} and add no
- * code to this loop for cameras that don't use them.
+ * Orbit/zoom limits are entirely opt-in via {@link setCameraLimits}; the camera
+ * self-clamps in its setters, so this loop carries no limit code.
  *
  * Camera stays plain data — this function reads/writes its properties.
  * Returns a cleanup function to remove all listeners and the beforeRender hook.
@@ -135,7 +140,6 @@ export function attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement
     let isPanning = false;
     let lastX = 0;
     let lastY = 0;
-    let animFrameId = 0;
 
     // Touch state for pinch-zoom
     const activeTouches = new Map<number, { x: number; y: number }>();
@@ -236,6 +240,9 @@ export function attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement
             const p1 = iter.next().value!;
             const dist = Math.hypot(p1.x - p0.x, p1.y - p0.y);
             if (pinchStartDist > 0 && dist > 0) {
+                // Direct write — the camera's radius setter self-clamps to any
+                // configured orbit limits, so no transient out-of-bounds value
+                // is ever visible to a per-frame reader.
                 camera.radius = pinchStartRadius * (pinchStartDist / dist);
                 camera.radius = Math.max(0.01, camera.radius);
             }
@@ -322,19 +329,13 @@ export function attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement
                 camera.inertialPanningY = 0;
             }
         }
-
-        // Only self-reschedule in fallback mode (own RAF loop)
-        if (!scene) {
-            animFrameId = requestAnimationFrame(applyInertia);
-        }
     }
 
+    // Inertia is integrated once per frame from the scene's render loop. Callers
+    // always supply a scene; without one the camera is simply static (no inertia),
+    // matching free-camera-controls — there is no standalone rAF fallback.
     if (scene) {
-        // Hook into the engine's render loop — single RAF chain
         scene._beforeRender.push(applyInertia);
-    } else {
-        // Fallback: own RAF loop (for callers that don't pass scene)
-        animFrameId = requestAnimationFrame(applyInertia);
     }
 
     const listeners: [string, EventListener, AddEventListenerOptions?][] = [
@@ -355,9 +356,6 @@ export function attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement
     }
 
     return () => {
-        if (animFrameId) {
-            cancelAnimationFrame(animFrameId);
-        }
         if (scene) {
             const idx = scene._beforeRender.indexOf(applyInertia);
             if (idx >= 0) {

--- a/packages/babylon-lite/src/camera/arc-rotate-controls.ts
+++ b/packages/babylon-lite/src/camera/arc-rotate-controls.ts
@@ -70,10 +70,11 @@ function clampCameraToLimits(camera: ArcRotateCamera): void {
  * as `undefined` to remove that bound. Returns a disposer that removes the
  * self-clamp hook.
  *
- * The optional `_scene` parameter is accepted for backward compatibility and is
+ * The optional `scene` parameter is accepted for backward compatibility and is
  * unused — enforcement no longer needs a per-frame scene hook.
  */
-export function setCameraLimits(camera: ArcRotateCamera, limits: ArcRotateCameraLimits, _scene?: SceneContext): () => void {
+export function setCameraLimits(camera: ArcRotateCamera, limits: ArcRotateCameraLimits, scene?: SceneContext): () => void {
+    void scene; // accepted for backward compatibility; no per-frame scene hook is needed anymore
     if ("lowerAlphaLimit" in limits) {
         camera.lowerAlphaLimit = limits.lowerAlphaLimit;
     }

--- a/packages/babylon-lite/src/camera/arc-rotate.ts
+++ b/packages/babylon-lite/src/camera/arc-rotate.ts
@@ -55,6 +55,16 @@ export interface ArcRotateCamera extends Camera, IWorldMatrixProvider, IParentab
     lowerRadiusLimit?: number;
     upperRadiusLimit?: number;
 
+    /** @internal Self-clamp hook installed by {@link setCameraLimits}. The
+     *  alpha/beta/radius setters invoke it immediately after every mutation, so
+     *  the camera is never observably out of its orbit limits — at any point a
+     *  per-frame callback (e.g. a camera-pinned skybox) reads it. This is what
+     *  makes a direct pinch write or inertial overshoot snap to the wall in the
+     *  same statement that caused it, with no one-frame "blink". Undefined until
+     *  limits are set, so cameras that never call setCameraLimits carry none of
+     *  the clamp code and the setters' `?.()` call is a single dead check. */
+    _clampToLimits?: () => void;
+
     parent: IWorldMatrixProvider | null;
     readonly worldMatrix: Mat4;
     readonly worldMatrixVersion: number;
@@ -156,6 +166,11 @@ export function createArcRotateCamera(alpha: number, beta: number, radius: numbe
                 if (scalars[key] !== v) {
                     scalars[key] = v;
                     onDirty();
+                    // Self-clamp into orbit limits the instant a value changes, so
+                    // no caller (pinch direct-write, inertia, auto-rotate) can leave
+                    // the camera transiently out of bounds for any per-frame reader.
+                    // No-op (and no clamp code bundled) until setCameraLimits runs.
+                    cam._clampToLimits?.();
                 }
             },
             configurable: true,

--- a/tests/lite/unit/arc-rotate-controls.test.ts
+++ b/tests/lite/unit/arc-rotate-controls.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { attachControl, setCameraLimits } from "../../../packages/babylon-lite/src/camera/arc-rotate-controls";
+import { createArcRotateCamera } from "../../../packages/babylon-lite/src/camera/arc-rotate";
 import type { ArcRotateCamera } from "../../../packages/babylon-lite/src/camera/arc-rotate";
 import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scene";
 
@@ -46,20 +47,9 @@ function fire(canvas: FakeCanvas, type: string, ev: unknown): void {
 }
 
 function makeCamera(radius = 10): ArcRotateCamera {
-    return {
-        alpha: 0,
-        beta: 1,
-        radius,
-        fov: 0.8,
-        inertia: 0.9,
-        panningInertia: 0.9,
-        inertialAlphaOffset: 0,
-        inertialBetaOffset: 0,
-        inertialRadiusOffset: 0,
-        inertialPanningX: 0,
-        inertialPanningY: 0,
-        target: { x: 0, y: 0, z: 0 },
-    } as unknown as ArcRotateCamera;
+    // Use the real factory so the alpha/beta/radius setters (and the
+    // setCameraLimits self-clamp hook they invoke) are exercised, not stubbed.
+    return createArcRotateCamera(0, 1, radius, { x: 0, y: 0, z: 0 });
 }
 
 function makeScene(): SceneContext {
@@ -210,8 +200,8 @@ describe("setCameraLimits + clamping", () => {
         let maxSeen = cam.radius;
         for (let i = 0; i < 60; i++) {
             beforeRender(scene);
-            // The enforcement step runs after inertia integration, so the radius
-            // the frame would render with must never exceed the wall.
+            // The camera self-clamps inside its radius setter as inertia integrates,
+            // so the radius the frame would render with never exceeds the wall.
             maxSeen = Math.max(maxSeen, cam.radius);
         }
         expect(maxSeen).toBeLessThanOrEqual(6);
@@ -232,6 +222,57 @@ describe("setCameraLimits + clamping", () => {
         // The per-frame enforcement clamps the direct radius write before render.
         beforeRender(scene);
         expect(cam.radius).toBe(6);
+    });
+
+    it("clamps the pinch radius write immediately, before any _beforeRender runs", () => {
+        // Regression: the pinch handler writes radius directly. If it leaves an
+        // out-of-limit value until the per-frame `enforce` step, other
+        // _beforeRender callbacks that read the camera earlier in the frame
+        // (e.g. a camera-pinned skybox sync) observe a transient far-flung pose
+        // for one frame — the source of the mobile pinch-zoom "blink".
+        const canvas = makeCanvas();
+        const cam = makeCamera(6);
+        const scene = makeScene();
+        attachControl(cam, canvas as unknown as HTMLCanvasElement, scene);
+        setCameraLimits(cam, { lowerRadiusLimit: 4, upperRadiusLimit: 6 }, scene);
+
+        // Pinch fingers together → radius would grow to 12 (6 * 200/100).
+        fire(canvas, "touchstart", touchEvent([touch(1, 0, 0), touch(2, 200, 0)]));
+        fire(canvas, "touchmove", touchEvent([touch(1, 50, 0), touch(2, 150, 0)]));
+        // No beforeRender yet: the radius must already be clamped to the wall.
+        expect(cam.radius).toBe(6);
+
+        // Pinch fingers apart → radius would shrink to 3 (6 * 100/200); clamp up.
+        fire(canvas, "touchstart", touchEvent([touch(1, 0, 0), touch(2, 100, 0)]));
+        fire(canvas, "touchmove", touchEvent([touch(1, 0, 0), touch(2, 200, 0)]));
+        expect(cam.radius).toBe(4);
+    });
+
+    it("does NOT clamp the pinch write when no limits were set (opt-in: zero clamp code in the gesture)", () => {
+        const canvas = makeCanvas();
+        const cam = makeCamera(6);
+        const scene = makeScene();
+        // attachControl but NO setCameraLimits → the input-time clamp hook is
+        // never installed, so the pinch writes radius freely (the per-frame
+        // enforcement that bounds it is what setCameraLimits adds, opt-in).
+        attachControl(cam, canvas as unknown as HTMLCanvasElement, scene);
+
+        fire(canvas, "touchstart", touchEvent([touch(1, 0, 0), touch(2, 200, 0)]));
+        fire(canvas, "touchmove", touchEvent([touch(1, 50, 0), touch(2, 150, 0)]));
+        expect(cam.radius).toBe(12); // 6 * 200/100, unclamped
+    });
+
+    it("stops clamping the pinch write after the limits disposer runs", () => {
+        const canvas = makeCanvas();
+        const cam = makeCamera(6);
+        const scene = makeScene();
+        attachControl(cam, canvas as unknown as HTMLCanvasElement, scene);
+        const dispose = setCameraLimits(cam, { lowerRadiusLimit: 4, upperRadiusLimit: 6 }, scene);
+        dispose();
+
+        fire(canvas, "touchstart", touchEvent([touch(1, 0, 0), touch(2, 200, 0)]));
+        fire(canvas, "touchmove", touchEvent([touch(1, 50, 0), touch(2, 150, 0)]));
+        expect(cam.radius).toBe(12); // hook cleared on dispose → unclamped again
     });
 
     it("clamps beta against an upper beta limit during inertial rotation", () => {
@@ -274,13 +315,19 @@ describe("setCameraLimits + clamping", () => {
         expect(cam.beta).toBe(0);
     });
 
-    it("disposer removes the per-frame enforcement step", () => {
+    it("installs no per-frame step and self-clamps on move; the disposer stops the clamp", () => {
         const cam = makeCamera(10);
         const scene = makeScene();
         const dispose = setCameraLimits(cam, { lowerRadiusLimit: 4, upperRadiusLimit: 6 }, scene);
-        expect((scene as unknown as { _beforeRender: unknown[] })._beforeRender.length).toBe(1);
-        dispose();
+        // Enforcement is via the camera's setters, not a scene hook — nothing pushed.
         expect((scene as unknown as { _beforeRender: unknown[] })._beforeRender.length).toBe(0);
+        // A direct move past a bound is clamped immediately by the setter.
+        cam.radius = 100;
+        expect(cam.radius).toBe(6);
+        // After dispose the hook is gone, so the camera moves freely again.
+        dispose();
+        cam.radius = 100;
+        expect(cam.radius).toBe(100);
     });
 
     it("clamps immediately even without a scene (one-shot), registering no per-frame step", () => {


### PR DESCRIPTION
## Problem

On mobile, pinch-zooming out of an ArcRotate orbit scene (e.g. the Littlest Tokyo demo) made the camera-pinned skybox **blink/clip** against the far plane — alternating clipped vs. full each frame.

### Root cause

A frame-ordering desync. `onBeforeRender` callbacks run via `_beforeRender.unshift` (skybox sync runs **first**), while the limit `enforce` installed by `setCameraLimits` was `push()`ed (runs **last**). The pinch handler wrote `camera.radius` directly and **unclamped**. A live `touchmove` landing between the previous frame's `enforce` and the current frame's skybox sync left a transient out-of-limit radius; the skybox sync pinned the camera-sized skybox far away, then `enforce` snapped radius back for the actual draw — so the blink only happened on frames where a touchmove fell in that window.

## Fix

- The camera now **self-clamps** in its `alpha`/`beta`/`radius` setters via an injected `_clampToLimits?: () => void` hook.
- `setCameraLimits` **installs the hook** (and clamps once) instead of pushing a per-frame `enforce` to `_beforeRender`. Any callback now always reads a clamped pose regardless of callback order, and the pinch handler's direct radius write is clamped immediately.
- Removed the **dead `requestAnimationFrame` fallback** in `attachControl` — every Lite caller passes a `scene`, so the RAF branch was unreachable.

### Zero-cost pillar preserved

`clampCameraToLimits` is referenced **only** by `setCameraLimits`, so scenes that don't use camera limits keep it tree-shaken; the setter only pays a cheap dead optional-chain call. Bundle sizes are **unchanged or slightly smaller** (RAF removal shrank several bundles).

## Verification

- ✅ Unit: 332 passed (`tests/lite/unit`); arc-rotate-controls suite updated with opt-in / dispose / immediate-clamp regression tests
- ✅ Bundle-size ceilings: 138/138 pass — no regression, confirming the hook keeps clamping code out of non-limit bundles
- ✅ Parity: 287/287 pass — no MAD regression
- ✅ Lint + typecheck clean; no golden reference changes, no bundle-size ceiling changes
