### PR TITLE
fix(demos): add tetris loading progress bar, make all demo progress bars monotonic

### DIFF
--- a/lab/lite/demo-tetris.html
+++ b/lab/lite/demo-tetris.html
@@ -22,8 +22,19 @@
     }
     .loading-label { font-size: 1.05rem; font-weight: 600; }
     .loading-sub { font-size: 0.8rem; color: #b8a9a4; }
+    .loading-size { font-size: 0.78rem; color: #d8c9c4; margin-top: 0.4rem; min-height: 1em; letter-spacing: 0.01em; }
     @keyframes lite-spin { to { transform: rotate(360deg); } }
     @media (prefers-reduced-motion: reduce) { .loading-spinner { animation-duration: 2.4s; } }
+      .loading-bar {
+        width: 240px; max-width: 62vw; height: 4px; margin-top: 0.55rem;
+        border-radius: 999px; overflow: hidden; background: rgba(255, 255, 255, 0.14);
+        opacity: 0; transition: opacity 0.25s ease;
+      }
+      .loading-overlay.has-progress .loading-bar { opacity: 1; }
+      .loading-bar-fill {
+        width: 0%; height: 100%; border-radius: inherit; background: #e0684b;
+        transition: width 0.25s ease;
+      }
   </style>
 </head>
 <body>
@@ -39,6 +50,8 @@
       <div class="loading-spinner" aria-hidden="true"></div>
       <div class="loading-label">Loading 3D Tetris…</div>
       <div class="loading-sub">Spinning up WebGPU…</div>
+      <div class="loading-bar" aria-hidden="true"><div id="loadingBarFill" class="loading-bar-fill"></div></div>
+      <div class="loading-size" aria-hidden="true">Estimated demo assets: 1.0 MB</div>
     </div>
   </div>
   <script>
@@ -61,6 +74,34 @@
         new MutationObserver(check).observe(canvas, { attributes: true, attributeFilter: ["data-ready", "data-error"] });
         setTimeout(hide, 45000);
       }
+    })();
+  </script>
+  <script>
+    // Determinate progress + asset-amount detail: mirror canvas data-progress /
+    // data-loading-detail (set by installFetchProgress) into the overlay. Runs
+    // independently of the data-ready/data-error hide logic above.
+    (function () {
+      var canvas = document.getElementById("renderCanvas");
+      var overlay = document.getElementById("loadingOverlay");
+      if (!canvas || !overlay) return;
+      var fill = document.getElementById("loadingBarFill");
+      var sub = overlay.querySelector(".loading-sub");
+      var size = overlay.querySelector(".loading-size");
+      function sync() {
+        var p = canvas.dataset.progress;
+        if (p !== undefined && p !== "") {
+          overlay.classList.add("has-progress");
+          if (fill) fill.style.width = Math.max(0, Math.min(100, +p)) + "%";
+        } else {
+          overlay.classList.remove("has-progress");
+        }
+        var d = canvas.dataset.loadingDetail;
+        if (d !== undefined && d !== "" && sub) sub.textContent = d;
+        var sz = canvas.dataset.loadingSize;
+        if (sz !== undefined && sz !== "" && size) size.textContent = sz;
+      }
+      sync();
+      new MutationObserver(sync).observe(canvas, { attributes: true, attributeFilter: ["data-progress", "data-loading-detail", "data-loading-size"] });
     })();
   </script>
   <script type="module" src="/lite/bundle/demos/tetris.js"></script>

--- a/lab/lite/src/demos/loading-progress.ts
+++ b/lab/lite/src/demos/loading-progress.ts
@@ -68,6 +68,10 @@ export function installFetchProgress(canvas: HTMLElement, options: InstallFetchP
     let raf = 0;
     let idleTimer: ReturnType<typeof setTimeout> | 0 = 0;
     let preparing = false;
+    // Highest percentage shown so far. The bar is strictly monotonic — it only
+    // ever moves forward — so multi-wave loads (download → CPU prep → download)
+    // never visibly restart.
+    let shownPct = 0;
 
     const render = (): void => {
         raf = 0;
@@ -88,18 +92,27 @@ export function installFetchProgress(canvas: HTMLElement, options: InstallFetchP
         const displayTotal = Math.max(estimate, knownTotal, totalLoaded);
         const haveSize = displayTotal > 0 && (estimate > 0 || knownTotal > 0);
 
-        if (preparing) {
-            canvas.dataset.progress = "100";
-            canvas.dataset.loadingDetail = "Preparing scene…";
-            return;
-        }
-
         if (haveSize) {
-            const pct = Math.min(99, Math.round((totalLoaded / displayTotal) * 100));
-            canvas.dataset.progress = String(pct);
-            if (started > 0) {
+            const raw = Math.min(99, Math.round((totalLoaded / displayTotal) * 100));
+            // Monotonic clamp: a later download wave grows the known total (which
+            // would otherwise drop the ratio) and CPU-bound "preparing" gaps
+            // interleave with streaming. Without this the bar slides backwards and
+            // visibly restarts between phases. The label may toggle between
+            // "Downloading" and "Preparing", but the bar itself only advances and
+            // never jumps to 100% until loading is actually finished (see done()).
+            if (raw > shownPct) {
+                shownPct = raw;
+            }
+            canvas.dataset.progress = String(shownPct);
+            if (preparing) {
+                canvas.dataset.loadingDetail = "Preparing scene…";
+            } else if (started > 0) {
                 canvas.dataset.loadingDetail = "Downloading assets…";
             }
+        } else if (preparing) {
+            // Quiet CPU-bound phase before any sized download (e.g. world gen):
+            // keep the spinner indeterminate but describe the phase.
+            canvas.dataset.loadingDetail = "Preparing scene…";
         } else if (started > 0) {
             // No size headers and no estimate: at least state how many assets are loading.
             delete canvas.dataset.progress;

--- a/lab/lite/src/demos/tetris.ts
+++ b/lab/lite/src/demos/tetris.ts
@@ -23,6 +23,7 @@ import { createGame, hardDrop, moveLeft, moveRight, restartGame, rotateCCW, rota
 import { createTetrisRenderer } from "./tetris/renderer.js";
 import { createTetrisHud } from "./tetris/hud.js";
 import { createTetrisAudio } from "./tetris/sound.js";
+import { installFetchProgress } from "./loading-progress.js";
 import { demoAssetUrl } from "./demo-asset-url.js";
 
 // A studio HDR environment drives the IBL — reflections + ambient on every PBR
@@ -47,6 +48,10 @@ interface RepeatState {
 async function main(): Promise<void> {
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
 
+    // Instrument asset downloads (HDR environment, BRDF LUT, frame geometry +
+    // colormap, pet geometries ≈ 1 MB) so the loading overlay shows a determinate
+    // progress bar. Restored via progress.done() once everything is fetched.
+    const progress = installFetchProgress(canvas, { estimatedBytes: 1_050_000 });
     // 2× supersample for crisp edges. The engine sizes its swapchain to
     // `clientWidth * devicePixelRatio`, so doubling the reported DPR causes
     // the scene to render at 4× the pixel count and the browser does the
@@ -243,6 +248,7 @@ async function main(): Promise<void> {
         hud.render(game);
     });
 
+    progress.done();
     await registerScene(engine, scene);
     await startEngine(engine);
     canvas.dataset.ready = "true";


### PR DESCRIPTION
## What

Two demo/lab-layer changes (no engine/package code touched):

1. **Tetris download progress bar.** The Tetris demo previously showed only an indeterminate spinner. It now wires installFetchProgress (estimated ~1 MB: HDR environment + BRDF LUT + frame geometry/colormap + pet geometries) and demo-tetris.html is upgraded to the shared determinate-bar overlay used by every other demo.

2. **Monotonic progress bars (fixes restart/flicker).** Multi-wave demos like **quake** and **freeciv** interleave download bursts with CPU-bound prep gaps (e.g. per-sheet spec→png→decode). Each new wave grew the known byte total or flipped the overlay to a transient 100% `Preparing scene…`, so the bar jumped to 100% and then **restarted** lower. The displayed percentage is now strictly **monotonic** — it only advances and only reaches 100% when loading actually finishes (`done()`). The detail label still alternates between `Downloading assets…` and `Preparing scene…` to reflect the real phase, but the bar no longer slides backwards.

## Scope / testing

- Changes are confined to `lab/lite/src/demos/**` and a demo HTML file. Per repo guidance, demos-only changes can't move engine parity or bundle ceilings, so the parity/bundle suites are not required.
- `pnpm run lint` (eslint) and the lab typecheck pass.
- `pnpm build:bundle-demos` builds all demos cleanly (tetris bundles at 66.8 KB raw / 24.1 KB gzip).
- Verified the Tetris, Quake, and FreeCiv demo pages locally via the lab dev server.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
