### PR TITLE
fix(picking): thin-instance buffer storage usage + small engine exports

### DIFF
--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -148,7 +148,7 @@ export type { SceneNode } from "./scene/scene-node.js";
 export { loadBabylon } from "./loader-babylon/load-babylon.js";
 export { loadEnvironment } from "./loader-env/load-env.js";
 export { loadHdrEnvironment } from "./loader-hdr/load-hdr.js";
-export { loadTexture2D } from "./texture/texture-2d.js";
+export { loadTexture2D, cloneTexture2D } from "./texture/texture-2d.js";
 export { loadSkybox } from "./loader-skybox/load-skybox.js";
 export { loadSplat } from "./loader-splat/load-splat.js";
 export { loadSOG } from "./loader-splat/load-sog.js";
@@ -201,7 +201,8 @@ export { mat4Translation } from "./math/mat4-translation.js";
 export { mat4Identity } from "./math/mat4-identity.js";
 export { mat4Scale } from "./math/mat4-scale.js";
 export { mat4Compose } from "./math/mat4-compose.js";
-export type { Vec3, Vec3Tuple } from "./math/types.js";
+export { mat4Invert } from "./math/mat4-invert.js";
+export type { Vec3, Vec3Tuple, Mat4 } from "./math/types.js";
 
 // ─── Thin Instances ──────────────────────────────────────────────────
 export {

--- a/packages/babylon-lite/src/material/shader/shader-material.ts
+++ b/packages/babylon-lite/src/material/shader/shader-material.ts
@@ -1,6 +1,7 @@
 import type { Material } from "../material.js";
 import type { MeshGroupBuilder } from "../../render/renderable.js";
 import type { Texture2D } from "../../texture/texture-2d.js";
+import type { Mat4 } from "../../math/types.js";
 import { shaderGroupBuilder } from "./shader-group-builder.js";
 
 /** Vertex attribute names a ShaderMaterial can bind. */
@@ -331,7 +332,10 @@ export function setShaderVector3(material: ShaderMaterial, name: string, value: 
     setShaderUniform(material, name, value);
 }
 
-/** Set a declared `mat4x4<f32>` uniform. Convenience wrapper over `setShaderUniform()`. */
-export function setShaderMatrix(material: ShaderMaterial, name: string, value: Float32Array): void {
-    setShaderUniform(material, name, value);
+/** Set a declared `mat4x4<f32>` uniform. Convenience wrapper over `setShaderUniform()`.
+ *  Accepts a raw `Float32Array` or the engine's branded `Mat4` (e.g. the result of
+ *  `getViewProjectionMatrix()` / `mat4Invert()`), so camera/math matrices can be fed
+ *  straight into a matrix uniform without laundering through a typed array. */
+export function setShaderMatrix(material: ShaderMaterial, name: string, value: Float32Array | Mat4): void {
+    setShaderUniform(material, name, value instanceof Float32Array ? value : Array.from(value));
 }

--- a/packages/babylon-lite/src/mesh/thin-instance-gpu.ts
+++ b/packages/babylon-lite/src/mesh/thin-instance-gpu.ts
@@ -22,7 +22,11 @@ export function syncThinInstanceGpuData(engine: EngineContext, ti: ThinInstanceD
             ti._gpuBuffer?.destroy();
             ti._gpuBuffer = device.createBuffer({
                 size: Math.max(ti._capacity * 64, 4),
-                usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST | (needsStorage ? GPUBufferUsage.STORAGE : 0),
+                // STORAGE is always included: the GPU picker binds this matrix
+                // buffer as a read-only storage buffer for thin-instance picking,
+                // so it must be storage-capable even when compute culling is off
+                // (otherwise the whole pick pass is invalidated → nothing is pickable).
+                usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
             });
             ti._gpuBufferStorage = needsStorage;
             bufferRecreated = true;


### PR DESCRIPTION
## What & why

Three small, additive engine improvements that surfaced while building a downstream app (a cozy procedural cottage diorama) on top of `babylon-lite`.

### 1. fix(picking): thin-instance matrix buffer is always STORAGE-capable
The GPU picker binds a thin-instanced mesh's matrix buffer as a **read-only storage buffer** for per-instance picking. That buffer was only created with `STORAGE` usage when compute culling was enabled (`needsStorage`). So a scene containing **any** non-culled thin-instanced mesh produced an invalid bind group, which **discards the entire pick pass** — every pick (including unrelated, non-instanced meshes) silently misses.

Symptom in the WebGPU validation log:
> Binding usage (BufferUsage::(CopyDst|Vertex)) ... doesn't match expected usage (BufferUsage::Storage)
> [Invalid BindGroup] ... [Invalid CommandBuffer from CommandEncoder "pick"] ... Queue.Submit

Fix: always include `GPUBufferUsage.STORAGE`. It is purely a usage flag — no extra work, no perf or visual change — and makes thin-instance picking robust regardless of culling.

### 2. feat(api): export `cloneTexture2D`, `mat4Invert`, `Mat4`
Small entry-point exports needed by consumers: `cloneTexture2D` (a UV-retiled view that shares the underlying GPU texture), `mat4Invert`, and the branded `Mat4` type.

### 3. feat(shader): `setShaderMatrix` accepts a branded `Mat4`
`setShaderMatrix` now accepts either a `Float32Array` or the engine's `Mat4` (e.g. the result of `getViewProjectionMatrix()` / `mat4Invert()`), converting the latter to a plain array. Camera/math matrices can feed a `mat4x4<f32>` uniform directly. Backwards compatible — the `Float32Array` path is unchanged.

## Risk / validation
- Additive only; no breaking changes.
- Engine `tsc --noEmit` + `eslint` clean on the changed files.
- No bundle/parity-relevant code paths altered (a buffer usage flag, two re-exports, a widened parameter type). CI bundle-size + parity guardrails should be unaffected.
