### PR TITLE
feat(shadow): add onCsmReceiverUpdate so custom CSM receivers avoid a one-frame shadow lag

### DIFF
--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -172,6 +172,7 @@ export { createEsmDirectionalShadowGenerator } from "./shadow/esm-directional-sh
 export { createPcfSpotlightShadowGenerator } from "./shadow/pcf-spotlight-shadow-generator.js";
 export { createPcfDirectionalShadowGenerator } from "./shadow/pcf-directional-shadow-generator.js";
 export { createCsmDirectionalShadowGenerator } from "./shadow/csm-directional-shadow-generator.js";
+export { onCsmReceiverUpdate } from "./shadow/csm-directional-shadow-generator.js";
 export { setShadowTaskCasterMeshes } from "./frame-graph/shadow-inputs.js";
 
 // ─── Animation ───────────────────────────────────────────────────────

--- a/packages/babylon-lite/src/shadow/csm-directional-shadow-generator.ts
+++ b/packages/babylon-lite/src/shadow/csm-directional-shadow-generator.ts
@@ -124,3 +124,36 @@ export function createCsmDirectionalShadowGenerator(engine: EngineContext, _ligh
     sg._renderShadowMap = (eng, state) => renderCsmShadowMap(eng, sg, state as CsmTaskState, csmCfg);
     return sg;
 }
+
+/**
+ * Register a callback fired each frame the CSM cascades are recomputed, right after the receiver
+ * UBO is updated and uploaded — and before the shadow map and main pass are rendered.
+ *
+ * Custom `ShaderMaterial` receivers that mirror the cascade transforms into their own uniforms
+ * (rather than binding the generator's receiver UBO directly, as the built-in standard/PBR/node
+ * receivers do) MUST sync from inside this callback. Syncing from an `onBeforeRender` callback
+ * reads the *previous* frame's transforms — a one-frame lag that makes those shadows visibly swim
+ * while the camera moves (the cascade window can slide many texels per frame during a zoom).
+ *
+ * Multiple receivers may register on the same generator; every registered callback is invoked each
+ * frame. The callback receives the 80-float receiver UBO (layout: four `mat4x4` cascade transforms,
+ * `viewFrustumZ`, `frustumLengths`, `shadowsInfo`, `csmParams` — see the cascaded-shadow
+ * architecture doc). The array is reused each frame; copy what you need.
+ *
+ * @param sg - A cascaded-shadow generator from {@link createCsmDirectionalShadowGenerator}.
+ * @param cb - Receiver-sync callback.
+ * @returns A disposer that unregisters this callback.
+ */
+export function onCsmReceiverUpdate(sg: ShadowGenerator, cb: (data: Float32Array) => void): () => void {
+    (sg._onReceiverData ??= []).push(cb);
+    return () => {
+        const list = sg._onReceiverData;
+        if (!list) {
+            return;
+        }
+        const i = list.indexOf(cb);
+        if (i >= 0) {
+            list.splice(i, 1);
+        }
+    };
+}

--- a/packages/babylon-lite/src/shadow/csm-shadow-task-hooks.ts
+++ b/packages/babylon-lite/src/shadow/csm-shadow-task-hooks.ts
@@ -177,6 +177,20 @@ export function renderCsmShadowMap(engine: EngineContext, sg: ShadowGenerator, s
     sg._version++;
     engine._device.queue.writeBuffer(sg._shadowUBO, 0, state._uboData as Float32Array<ArrayBuffer>);
 
+    // Notify custom receivers (e.g. a ShaderMaterial that mirrors the cascade transforms into
+    // its own uniforms) with this frame's freshly-computed receiver UBO. This fires inside the
+    // shadow task — after the transforms are finalized but before the shadow map and main pass
+    // render — so such receivers stay in lock-step with the depth map. Syncing from a
+    // `onBeforeRender` callback instead would read the previous frame's transforms (a one-frame
+    // lag that makes those shadows swim while the camera moves). The built-in standard/PBR/node
+    // receivers don't need this: they bind `sg._shadowUBO` directly.
+    const receiverCbs = sg._onReceiverData;
+    if (receiverCbs) {
+        for (let i = 0; i < receiverCbs.length; i++) {
+            receiverCbs[i]!(state._uboData);
+        }
+    }
+
     state._cameraVersion++;
     for (let i = 0; i < cascades._transforms.length; i++) {
         const cam = state._cameras[i]!;

--- a/packages/babylon-lite/src/shadow/shadow-generator.ts
+++ b/packages/babylon-lite/src/shadow/shadow-generator.ts
@@ -47,6 +47,11 @@ export interface ShadowGenerator {
     _version: number;
     /** @internal */
     _shadowTaskState?: ShadowTaskInternalState;
+    /** @internal Optional callbacks invoked each frame the receiver UBO is (re)written, after the
+     *  GPU upload and before the shadow map / main pass render. Used by custom ShaderMaterial
+     *  receivers (e.g. CSM) to mirror the fresh transforms into their own uniforms without a
+     *  one-frame lag. Registered via the public `onCsmReceiverUpdate()`. */
+    _onReceiverData?: ((data: Float32Array) => void)[];
     /** @internal Dynamically imports and prepares the shadow-map render task for the given caster meshes. */
     _preloadShadowTask?(casterMeshes: readonly import("../mesh/mesh.js").Mesh[]): Promise<void>;
     /** @internal Lazily creates (or returns the cached) shadow-task state for rendering the shadow map this frame. */


### PR DESCRIPTION
## Problem

CSM shadows visibly **jumped/swam when the camera zoomed** for receivers implemented as custom `ShaderMaterial`s (e.g. a ground/grass material that mirrors the cascade transforms into its own uniforms).

The built-in standard/PBR/node receivers bind the generator's receiver UBO (`sg._shadowUBO`) directly, so the `writeBuffer` the shadow task issues in `scene._record()` is seen by the same frame's main pass — no lag.

A custom receiver instead has to **snapshot** the cascade transforms CPU-side. Doing so from an `onBeforeRender` callback runs during `scene._update()` — *before* the shadow task recomputes the cascades in `scene._record()`. So the receiver sampled **this** frame's depth map using **last** frame's transforms: a one-frame lag. During a zoom the cascade window slides up to **~100 texels/frame**, so those shadows jumped while the built-in receivers stayed put.

## Fix

Add a small public hook:

`onCsmReceiverUpdate(sg, cb): () => void`

The generator invokes every registered callback each frame **right after it rewrites the receiver UBO and before the shadow map / main pass render**, so custom receivers stay in lock-step with the depth map. Multiple receivers may register on one generator; the function returns a disposer.

## Notes

- **No behavior change** for scenes that don't register a callback — `sg._onReceiverData` is `undefined` and the new loop is skipped. Parity scenes 214/215 are unaffected.
- Verified the fix end-to-end in a downstream consumer (custom ground + grass CSM receivers): the zoom swim is gone.

## Validation

- `pnpm run lint` (ESLint + tsc) ✓
- `pnpm build:bundle-scenes` ✓
- `pnpm test:parity` → bundle-size (140 tests) ✓; scene214 63.5 KB / 67 KB, scene215 74.5 KB / 78 KB
- Scene 214 & 215 CSM parity specs ✓ (MAD unchanged)