### PR TITLE
fix(loader): generate smooth normals for glTF primitives missing NORMAL

### DIFF
--- a/packages/babylon-lite/src/loader-gltf/gltf-normals.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-normals.ts
@@ -18,18 +18,38 @@ export function computeSmoothNormals(positions: Float32Array, indices: Uint16Arr
         const ia = indexed ? indices[f * 3]! : f * 3;
         const ib = indexed ? indices[f * 3 + 1]! : f * 3 + 1;
         const ic = indexed ? indices[f * 3 + 2]! : f * 3 + 2;
-        const ax = positions[ia * 3]!, ay = positions[ia * 3 + 1]!, az = positions[ia * 3 + 2]!;
-        const bx = positions[ib * 3]!, by = positions[ib * 3 + 1]!, bz = positions[ib * 3 + 2]!;
-        const cx = positions[ic * 3]!, cy = positions[ic * 3 + 1]!, cz = positions[ic * 3 + 2]!;
-        const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
-        const e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
-        const nx = e1y * e2z - e1z * e2y, ny = e1z * e2x - e1x * e2z, nz = e1x * e2y - e1y * e2x;
-        normals[ia * 3]! += nx; normals[ia * 3 + 1]! += ny; normals[ia * 3 + 2]! += nz;
-        normals[ib * 3]! += nx; normals[ib * 3 + 1]! += ny; normals[ib * 3 + 2]! += nz;
-        normals[ic * 3]! += nx; normals[ic * 3 + 1]! += ny; normals[ic * 3 + 2]! += nz;
+        const ax = positions[ia * 3]!,
+            ay = positions[ia * 3 + 1]!,
+            az = positions[ia * 3 + 2]!;
+        const bx = positions[ib * 3]!,
+            by = positions[ib * 3 + 1]!,
+            bz = positions[ib * 3 + 2]!;
+        const cx = positions[ic * 3]!,
+            cy = positions[ic * 3 + 1]!,
+            cz = positions[ic * 3 + 2]!;
+        const e1x = bx - ax,
+            e1y = by - ay,
+            e1z = bz - az;
+        const e2x = cx - ax,
+            e2y = cy - ay,
+            e2z = cz - az;
+        const nx = e1y * e2z - e1z * e2y,
+            ny = e1z * e2x - e1x * e2z,
+            nz = e1x * e2y - e1y * e2x;
+        normals[ia * 3]! += nx;
+        normals[ia * 3 + 1]! += ny;
+        normals[ia * 3 + 2]! += nz;
+        normals[ib * 3]! += nx;
+        normals[ib * 3 + 1]! += ny;
+        normals[ib * 3 + 2]! += nz;
+        normals[ic * 3]! += nx;
+        normals[ic * 3 + 1]! += ny;
+        normals[ic * 3 + 2]! += nz;
     }
     for (let i = 0; i < vertexCount; i++) {
-        const x = normals[i * 3]!, y = normals[i * 3 + 1]!, z = normals[i * 3 + 2]!;
+        const x = normals[i * 3]!,
+            y = normals[i * 3 + 1]!,
+            z = normals[i * 3 + 2]!;
         const len = Math.hypot(x, y, z) || 1;
         normals[i * 3] = x / len;
         normals[i * 3 + 1] = y / len;

--- a/packages/babylon-lite/src/loader-gltf/gltf-normals.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-normals.ts
@@ -1,0 +1,39 @@
+/** glTF smooth-normal generation — dynamically imported.
+ *
+ *  Isolated from the core loader so scenes whose assets always provide the NORMAL
+ *  attribute (the common case) never bundle or fetch this code. Loaded lazily by
+ *  `load-gltf.ts` only when a primitive omits NORMAL.
+ *
+ *  Zero module-level side effects — safe for tree-shaking.
+ */
+
+/** Compute smooth (area-weighted) vertex normals from positions + indices. Used when a glTF
+ *  primitive omits the NORMAL attribute (the spec allows this and requires clients to generate
+ *  normals — e.g. THREE.GLTFExporter output for morph-only meshes). */
+export function computeSmoothNormals(positions: Float32Array, indices: Uint16Array | Uint32Array, vertexCount: number): Float32Array {
+    const normals = new Float32Array(vertexCount * 3);
+    const indexed = indices.length > 0;
+    const triCount = indexed ? (indices.length / 3) | 0 : (vertexCount / 3) | 0;
+    for (let f = 0; f < triCount; f++) {
+        const ia = indexed ? indices[f * 3]! : f * 3;
+        const ib = indexed ? indices[f * 3 + 1]! : f * 3 + 1;
+        const ic = indexed ? indices[f * 3 + 2]! : f * 3 + 2;
+        const ax = positions[ia * 3]!, ay = positions[ia * 3 + 1]!, az = positions[ia * 3 + 2]!;
+        const bx = positions[ib * 3]!, by = positions[ib * 3 + 1]!, bz = positions[ib * 3 + 2]!;
+        const cx = positions[ic * 3]!, cy = positions[ic * 3 + 1]!, cz = positions[ic * 3 + 2]!;
+        const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
+        const e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
+        const nx = e1y * e2z - e1z * e2y, ny = e1z * e2x - e1x * e2z, nz = e1x * e2y - e1y * e2x;
+        normals[ia * 3]! += nx; normals[ia * 3 + 1]! += ny; normals[ia * 3 + 2]! += nz;
+        normals[ib * 3]! += nx; normals[ib * 3 + 1]! += ny; normals[ib * 3 + 2]! += nz;
+        normals[ic * 3]! += nx; normals[ic * 3 + 1]! += ny; normals[ic * 3 + 2]! += nz;
+    }
+    for (let i = 0; i < vertexCount; i++) {
+        const x = normals[i * 3]!, y = normals[i * 3 + 1]!, z = normals[i * 3 + 2]!;
+        const len = Math.hypot(x, y, z) || 1;
+        normals[i * 3] = x / len;
+        normals[i * 3 + 1] = y / len;
+        normals[i * 3 + 2] = z / len;
+    }
+    return normals;
+}

--- a/packages/babylon-lite/src/loader-gltf/load-gltf.ts
+++ b/packages/babylon-lite/src/loader-gltf/load-gltf.ts
@@ -342,7 +342,7 @@ async function extractAllMeshes(
                 return idx !== undefined ? resolveAccessor(json, binChunk, idx) : null;
             };
             const posData = resolveAttr("POSITION")!;
-            const normData = resolveAttr("NORMAL")!;
+            const normData = resolveAttr("NORMAL");
             const uvData = resolveAttr("TEXCOORD_0");
             const uv2Data = resolveAttr("TEXCOORD_1");
             const tanData = resolveAttr("TANGENT");
@@ -372,9 +372,15 @@ async function extractAllMeshes(
             // Fire material fetch without awaiting — all materials load in parallel
             matPromises.push(getMat(primitive.material));
 
+            // Smooth-normal generation is lazily imported on first need — assets that
+            // always provide NORMAL (the common case) never bundle or fetch this code.
+            const normals = normData
+                ? (normData._data as Float32Array)
+                : (await import("./gltf-normals.js")).computeSmoothNormals(posData._data as Float32Array, indices, posData._count);
+
             partials.push({
                 _positions: posData._data as Float32Array,
-                _normals: normData._data as Float32Array,
+                _normals: normals,
                 _tangents: tanData ? (tanData._data as Float32Array) : null,
                 _uvs: uvData ? (uvData._data as Float32Array) : new Float32Array(posData._count * 2),
                 _uv2s: uv2Data ? (uv2Data._data as Float32Array) : null,


### PR DESCRIPTION
## Summary
Some glTF exporters (e.g. `THREE.GLTFExporter` output for morph-only meshes) omit the `NORMAL` attribute. The glTF spec permits this and requires clients to generate normals. The loader previously assumed `NORMAL` was always present (`resolveAttr("NORMAL")!`), so such assets rendered incorrectly.

## Fix
Generate area-weighted **smooth normals** from positions + indices, but **only when `NORMAL` is absent**.

## Bundle size — only used when needed
The generator lives in a new `gltf-normals.ts` module that is **dynamically imported on first need** (`await import("./gltf-normals.js")`), exactly mirroring the existing `gltf-color-normalize` lazy-import pattern. It is emitted as a separate `sceneN-gltf-normals-*.js` chunk, so scenes whose assets always provide `NORMAL` (the common case) **never bundle or fetch this code** — per-scene bundle size is unchanged.

## Validation (local)
- `pnpm build:bundle-scenes` ✅ — `gltf-normals.ts` confirmed as a separate lazy chunk in every glTF scene's `bundle-info`.
- Bundle-size spec: **141/141 pass** — no ceiling regression.
- glTF parity scenes (5, 7, 34, 35, 152) pass with MAD ≈ 0.000.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
