### PR TITLE
feat(material): add opt-in transmissive ShaderMaterial + expose transmission API

### DIFF
--- a/packages/babylon-lite/src/frame-graph/transmission.ts
+++ b/packages/babylon-lite/src/frame-graph/transmission.ts
@@ -60,11 +60,41 @@ export function enableSceneTransmission(scene: SceneContext, engine: EngineConte
     }
 }
 
-export function enableRenderTaskTransmission(task: RenderTask, engine: EngineContext): void {
+export interface TransmissionOptions {
+    /** When true (the default), retarget the task's color buffer to a linear `rgba16float`
+     *  offscreen and tone-map it in a trailing image-processing pass — the model PBR
+     *  transmission uses so refractive materials read scene color in *linear* space.
+     *
+     *  Set false to perform ONLY the mid-pass scene-color grab: the task's render target
+     *  format / sample count / clear are left untouched and no tone-map pass is added. Use
+     *  this for consumers that own their tone mapping / post (e.g. a custom depth-of-field
+     *  stack) and just need the opaque scene color exposed to a custom transmissive
+     *  `ShaderMaterial`. */
+    linear?: boolean;
+}
+
+/** Handle to a render task's scene-color grab, returned by `enableRenderTaskTransmission`. */
+export interface SceneColorGrab {
+    /** The live opaque-scene-color texture sampled by transmissive surfaces, or null before the
+     *  frame graph has built the task at least once. Its identity changes when the task rebuilds
+     *  (e.g. on resize), so consumers that bind it to a custom material should re-bind when it
+     *  changes. */
+    readonly texture: Texture2D | null;
+}
+
+export function enableRenderTaskTransmission(task: RenderTask, engine: EngineContext, options?: TransmissionOptions): SceneColorGrab {
+    const linear = options?.linear !== false;
+    const grab: SceneColorGrab = {
+        get texture(): Texture2D | null {
+            return (task._targetSignature as { _transmissionTexture?: Texture2D })._transmissionTexture ?? null;
+        },
+    };
     if (task._executeWithTransmission) {
-        return;
+        return grab;
     }
-    retargetRenderTaskToLinearOffscreen(task, engine);
+    if (linear) {
+        retargetRenderTaskToLinearOffscreen(task, engine);
+    }
     let state: RenderTaskTransmissionState | null = null;
     const record = task.record.bind(task);
     const execute = task.execute?.bind(task);
@@ -76,7 +106,7 @@ export function enableRenderTaskTransmission(task: RenderTask, engine: EngineCon
         record();
         configureTransmissionSource(state, task, engine);
     };
-    if (execute) {
+    if (linear && execute) {
         task.execute = () => executeRenderTaskLinear(task.scene, execute);
     }
     task.dispose = () => {
@@ -85,6 +115,7 @@ export function enableRenderTaskTransmission(task: RenderTask, engine: EngineCon
         dispose?.();
     };
     task._executeWithTransmission = (sampleCount) => executePassWithTransmission(task, engine, state!, sampleCount);
+    return grab;
 }
 
 function retargetRenderTaskToLinearOffscreen(task: RenderTask, engine: EngineContext): void {

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -47,6 +47,8 @@ export type { ShadowTask } from "./frame-graph/shadow-task.js";
 export type { RenderTarget, RenderTargetDescriptor } from "./engine/render-target.js";
 export { createRenderTarget } from "./engine/render-target.js";
 export { createRenderTargetTexture } from "./texture/rtt.js";
+export { enableSceneTransmission, enableRenderTaskTransmission } from "./frame-graph/transmission.js";
+export type { TransmissionOptions, SceneColorGrab } from "./frame-graph/transmission.js";
 
 // ─── Fullscreen Effects ─────────────────────────────────────────────
 export { createEffectWrapper, setEffectUniforms, setEffectTexture, createEffectRenderTask, disposeEffectWrapper } from "./effect/effect-renderer.js";

--- a/packages/babylon-lite/src/material/shader/shader-material.ts
+++ b/packages/babylon-lite/src/material/shader/shader-material.ts
@@ -37,6 +37,13 @@ export interface ShaderMaterialOptions {
      *  standard src-over; "additive" adds the fragment's premultiplied-by-alpha
      *  color to the framebuffer, which is the right choice for glows/light FX. */
     readonly blendMode?: "alpha" | "additive";
+    /** Mark this surface as transmissive/refractive: the renderer grabs the opaque scene color
+     *  behind it just before it draws, so the fragment can sample what is *through* it (water,
+     *  glass). Requires `needAlphaBlending` (the surface composites over the grabbed scene
+     *  color). Enable the scene-color grab on the surface's render task with
+     *  `enableRenderTaskTransmission`, then bind the resulting texture via `setShaderTexture`.
+     *  Default false. */
+    readonly transmissive?: boolean;
     readonly needAlphaTesting?: boolean;
     readonly backFaceCulling?: boolean;
     readonly depthWrite?: boolean;
@@ -91,6 +98,8 @@ export interface ShaderMaterial extends Material {
     readonly defines: readonly ShaderDefine[];
     readonly needAlphaBlending: boolean;
     readonly blendMode: "alpha" | "additive";
+    /** True for transmissive/refractive surfaces (see `ShaderMaterialOptions.transmissive`). */
+    readonly transmissive: boolean;
     readonly needAlphaTesting: boolean;
     readonly backFaceCulling: boolean;
     readonly depthWrite: boolean;
@@ -214,6 +223,10 @@ export function createShaderMaterial(options: ShaderMaterialOptions): ShaderMate
     }
     defines.sort((a, b) => a.name.localeCompare(b.name));
 
+    if (options.transmissive && !(options.needAlphaBlending ?? false)) {
+        throw new Error("ShaderMaterial: `transmissive` requires `needAlphaBlending` (the surface composites over the grabbed opaque scene color).");
+    }
+
     return {
         name: options.name,
         vertexSource: options.vertexSource,
@@ -224,6 +237,7 @@ export function createShaderMaterial(options: ShaderMaterialOptions): ShaderMate
         defines,
         needAlphaBlending: options.needAlphaBlending ?? false,
         blendMode: options.blendMode ?? "alpha",
+        transmissive: options.transmissive ?? false,
         needAlphaTesting: options.needAlphaTesting ?? false,
         backFaceCulling: options.backFaceCulling ?? true,
         depthWrite: options.depthWrite ?? true,

--- a/packages/babylon-lite/src/material/shader/shader-renderable.ts
+++ b/packages/babylon-lite/src/material/shader/shader-renderable.ts
@@ -213,6 +213,7 @@ function createTransparentRenderable(scene: SceneContext, material: ShaderMateri
     const r: Renderable = {
         order: packet.mesh.renderOrder ?? 200,
         isTransparent: true,
+        _transmissive: material.transmissive,
         mesh: packet.mesh,
         _worldCenter: sortCenter,
         bind(eng, sig) {


### PR DESCRIPTION
## Summary

Adds an opt-in **transmissive** surface mode to ShaderMaterial so custom refractive surfaces (water, glass) can sample the opaque scene color behind them, and exposes the transmission API publicly.

## Changes

- **ShaderMaterialOptions.transmissive** (default alse): marks a surface as transmissive/refractive. The renderer grabs the opaque scene color just before drawing the surface so the fragment can sample what is *through* it. Requires 
eedAlphaBlending — validated at creation (throws otherwise). Surfaced as a _transmissive flag on the renderable.
- **nableRenderTaskTransmission** now returns a **SceneColorGrab** handle (live opaque-scene-color texture) and accepts **TransmissionOptions { linear }**:
  - linear (default 	rue): retarget the task color buffer to a linear gba16float offscreen + trailing tone-map pass (model PBR-transmission behaviour).
  - linear: false: mid-pass scene-color grab only — no offscreen retarget / tone-map pass — for consumers that own their tone mapping / post.
- Export nableSceneTransmission, nableRenderTaskTransmission, and the TransmissionOptions / SceneColorGrab types from the package index.

## Guardrails

- Opt-in only — scenes that don't use it are unaffected.
-  pnpm lint (eslint + tsc) green.
- pnpm test (build:bundle-scenes + test:parity) validated.