### PR TITLE
feat(mesh): renderOnTop overlay surfaces + ShaderMaterial shadow casting

### DIFF
--- a/packages/babylon-lite/src/frame-graph/transmission.ts
+++ b/packages/babylon-lite/src/frame-graph/transmission.ts
@@ -265,8 +265,15 @@ export function executePassWithTransmission(task: RenderTask, engine: EngineCont
     let pass = beginTaskPass(task, null, sampleCount, false);
     let draws = drawBaseTask(task, pass);
     let lastPipeline: GPURenderPipeline | null = null;
+    let overlay: DrawBinding[] | null = null;
     for (let i = 0; i < transparent.length; i++) {
         const binding = transparent[i]!;
+        // `Mesh.renderOnTop` surfaces draw last — after the scene-colour grab — so they sit on top of the
+        // transmissive surface and are excluded from what it refracts (e.g. lily pads on water).
+        if (binding.renderable.mesh?.renderOnTop === true) {
+            (overlay ??= []).push(binding);
+            continue;
+        }
         const transmissive = binding.renderable._transmissive === true;
         if (transmissive && canUpdateTransmission(state)) {
             pass.end();
@@ -284,6 +291,9 @@ export function executePassWithTransmission(task: RenderTask, engine: EngineCont
             lastPipeline = binding.pipeline;
         }
         draws += binding.draw(pass, engine);
+    }
+    if (overlay) {
+        draws += drawList(pass, overlay, engine);
     }
     pass.end();
     return draws;

--- a/packages/babylon-lite/src/material/shader/no-color-view.ts
+++ b/packages/babylon-lite/src/material/shader/no-color-view.ts
@@ -1,0 +1,17 @@
+/** ShaderMaterial material view helper with no colour output (for shadow casting). */
+
+import { createMaterialView } from "../material-view.js";
+import type { MaterialView } from "../material.js";
+import type { ShaderMaterial } from "./shader-material.js";
+
+/**
+ * Create a no-colour view over a ShaderMaterial source, used by the shadow caster pass.
+ *
+ * Unlike standard/PBR/node, a ShaderMaterial needs no feature flag to drop its colour output: the shader
+ * pipeline already omits the fragment stage when the render target has no colour attachment (the depth-only
+ * shadow map). The view exists purely so the caster gets its OWN renderable + system UBO (written with the
+ * shadow camera's view-projection) instead of clobbering the source material's main-pass UBO.
+ */
+export function createShaderNoColorMaterialView(source: ShaderMaterial): MaterialView {
+    return createMaterialView(source, { features: 0 });
+}

--- a/packages/babylon-lite/src/material/shader/shader-group-builder.ts
+++ b/packages/babylon-lite/src/material/shader/shader-group-builder.ts
@@ -11,3 +11,9 @@ export const shaderGroupBuilder: MeshGroupBuilder = async (scene, meshes) => {
     shaderGroupBuilder._rebuildSingle = result.rebuildSingle;
     return result;
 };
+
+// Marks this family so the shadow caster pass can render a custom ShaderMaterial into the (depth-only)
+// shadow map via a no-color material view — the shader pipeline already drops its fragment stage when the
+// render target has no colour attachment, and each view gets its own system UBO (written with the shadow
+// camera), so a ShaderMaterial mesh can cast like the standard/pbr/node families.
+shaderGroupBuilder._materialFamily = "shader";

--- a/packages/babylon-lite/src/mesh/mesh.ts
+++ b/packages/babylon-lite/src/mesh/mesh.ts
@@ -88,6 +88,12 @@ export interface Mesh extends SceneNode {
     /** User-controlled render order. Lower = drawn first within phase.
      *  Only affects ordering within the opaque or transparent phase. */
     renderOrder?: number;
+    /** On a transmission-enabled render task, draw this transparent mesh LAST — after the transmissive
+     *  surface and after the scene-colour grab — so it sits on top of the water/glass AND is excluded from
+     *  what that surface refracts (e.g. lily pads resting on water should not appear in the refraction).
+     *  Enable transmission on the task with `enableRenderTaskTransmission`; only transparent surfaces
+     *  (`needAlphaBlending`) are deferred. No effect on tasks without transmission. */
+    renderOnTop?: boolean;
     /** Thin instance data (CPU-side). GPU buffer managed by render system. */
     thinInstances?: ThinInstanceData | null;
     // name, children, position, rotation, rotationQuaternion, scaling,

--- a/packages/babylon-lite/src/render/renderable.ts
+++ b/packages/babylon-lite/src/render/renderable.ts
@@ -118,5 +118,5 @@ export type MeshGroupBuilder = ((scene: SceneContext, meshes: Mesh[]) => Promise
     /** @internal */
     _rebuildSingle?: (scene: SceneContext, mesh: Mesh, materialOverride?: Material) => Renderable;
     /** @internal */
-    _materialFamily?: "standard" | "pbr" | "node";
+    _materialFamily?: "standard" | "pbr" | "node" | "shader";
 };

--- a/packages/babylon-lite/src/shadow/pcf-shadow-task-hooks.ts
+++ b/packages/babylon-lite/src/shadow/pcf-shadow-task-hooks.ts
@@ -42,21 +42,25 @@ export interface PcfTaskState extends ShadowTaskInternalState {
 type StandardNoColorFactory = typeof import("../material/standard/no-color-view.js").createStandardNoColorMaterialView;
 type PbrNoColorFactory = typeof import("../material/pbr/no-color-view.js").createPbrNoColorMaterialView;
 type NodeNoColorFactory = typeof import("../material/node/no-color-view.js").createNodeNoColorMaterialView;
+type ShaderNoColorFactory = typeof import("../material/shader/no-color-view.js").createShaderNoColorMaterialView;
 
 let createStandardNoColorMaterialView: StandardNoColorFactory;
 let createPbrNoColorMaterialView: PbrNoColorFactory;
 let createNodeNoColorMaterialView: NodeNoColorFactory;
+let createShaderNoColorMaterialView: ShaderNoColorFactory;
 
 export async function preloadPcfShadowTaskState(casterMeshes: readonly Mesh[]): Promise<void> {
     const loads: Promise<void>[] = [];
     let needsStandard = false;
     let needsPbr = false;
     let needsNode = false;
+    let needsShader = false;
     for (const mesh of casterMeshes) {
         const family = mesh.material?._buildGroup._materialFamily;
         needsStandard ||= family === "standard";
         needsPbr ||= family === "pbr";
         needsNode ||= family === "node";
+        needsShader ||= family === "shader";
     }
     if (needsStandard && !createStandardNoColorMaterialView) {
         loads.push(
@@ -76,6 +80,13 @@ export async function preloadPcfShadowTaskState(casterMeshes: readonly Mesh[]): 
         loads.push(
             import("../material/node/no-color-view.js").then((module) => {
                 createNodeNoColorMaterialView = module.createNodeNoColorMaterialView;
+            })
+        );
+    }
+    if (needsShader && !createShaderNoColorMaterialView) {
+        loads.push(
+            import("../material/shader/no-color-view.js").then((module) => {
+                createShaderNoColorMaterialView = module.createShaderNoColorMaterialView;
             })
         );
     }
@@ -182,6 +193,10 @@ export function getNoColorView(material: Material, cache: Map<Material, Material
         view = createPbrNoColorMaterialView(material as Parameters<PbrNoColorFactory>[0]);
     } else if (family === "node") {
         view = createNodeNoColorMaterialView(material as Parameters<NodeNoColorFactory>[0]);
+    } else if (family === "shader") {
+        // Custom ShaderMaterial caster: the shader pipeline drops its fragment stage for the depth-only
+        // shadow target on its own, so the view just hands it a private system UBO (shadow-camera VP).
+        view = createShaderNoColorMaterialView(material as Parameters<typeof createShaderNoColorMaterialView>[0]);
     }
     cache.set(material, view!);
     return view!;


### PR DESCRIPTION
## Summary

Two small, opt-in engine additions, implemented to add **zero bundle bytes to scenes that don't use them** (core render path stays byte-identical to master):

### 1. Mesh.renderOnTop (transmission overlay)
On a transmission-enabled render task, a transparent mesh marked enderOnTop draws **after** the transmissive surface and **after** the scene-colour grab, so it sits on top of the water/glass and is excluded from what that surface refracts (e.g. lily pads resting on water shouldn't appear in the refraction). The logic lives entirely inside the dynamically-imported transmission module — `executePassWithTransmission` partitions `_transparentBindings` on `mesh.renderOnTop` and draws the deferred ones last. No core `render-task.ts` changes.

### 2. ShaderMaterial shadow casting
A custom `ShaderMaterial` can now cast shadows like the standard/pbr/node families, via a no-colour material view (`createShaderNoColorMaterialView`). The shader pipeline already drops its fragment stage for the depth-only shadow target, so the view just hands the caster its own system UBO written with the shadow camera. Wired into the **existing** conditional dynamic-import pattern in `pcf-shadow-task-hooks` (`needsShader` → `import("./shader/no-color-view.js")`), so the factory is only fetched when a shader-family caster is actually present.

## Bundle-size verification (measured)

Core `render-task.ts` / `pbr-renderable.ts` are **byte-identical to master**. Measured real on-disk deltas:
- Pure scenes (e.g. scene1 BoomBox PBR): **0 counted bytes** (any emitted transmission/shadow chunks are never fetched).
- ShaderMaterial scenes: **~+15 B** (the `_materialFamily` family tag).
- Transmission scenes: **~+90 B** (they use the transmission module).
- Shadow scenes: small, follows the existing per-family `needsX` dispatch pattern.

`pnpm test:parity` green; bundle-size spec passes with **no ceiling breaches** (master deltas are warning-level only).