### PR TITLE
feat(mesh): dynamic color/normal re-upload + in-place geometry resize helpers

### DIFF
--- a/packages/babylon-lite/src/frame-graph/shadow-task.ts
+++ b/packages/babylon-lite/src/frame-graph/shadow-task.ts
@@ -20,6 +20,11 @@ export interface ShadowTask extends Task {
 /** @internal Create the scene-owned shadow scheduling adapter task. */
 export function createShadowTask(engine: EngineContext, scene: SceneContext): ShadowTask {
     const shadowGenerators = new Set<ShadowGenerator>();
+    // Last scene renderable-version each generator's render bundle was recorded at — re-record when the
+    // scene mutated (e.g. resizeMeshGeometry reallocated a caster's GPU buffers, bumping
+    // scene._renderableVersion), since the cached bundle binds raw buffer handles that would otherwise
+    // point at freed buffers.
+    const recordedVersion = new WeakMap<ShadowGenerator, number>();
     _setShadowTaskInputPreloader(preloadShadowTaskInput);
 
     const task: ShadowTask = {
@@ -60,8 +65,9 @@ export function createShadowTask(engine: EngineContext, scene: SceneContext): Sh
                     shadowGenerators.add(sg);
                     const existing = sg._shadowTaskState ?? null;
                     const state = sg._ensureShadowTaskState(engine, scene, casterMeshes);
-                    if (!existing || existing._casterMeshes !== casterMeshes) {
+                    if (!existing || existing._casterMeshes !== casterMeshes || recordedVersion.get(sg) !== scene._renderableVersion) {
                         state._task.record();
+                        recordedVersion.set(sg, scene._renderableVersion);
                     }
                     draws += sg._renderShadowMap(engine, state);
                 }

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -109,6 +109,7 @@ export {
     updateMeshPositions,
     updateMeshNormals,
     updateMeshColors,
+    updateMeshUvs,
     resizeMeshGeometry,
 } from "./mesh/mesh-factories.js";
 export { createSphereData } from "./mesh/create-sphere.js";

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -107,6 +107,9 @@ export {
     createExtrudeShape,
     createMeshFromData,
     updateMeshPositions,
+    updateMeshNormals,
+    updateMeshColors,
+    resizeMeshGeometry,
 } from "./mesh/mesh-factories.js";
 export { createSphereData } from "./mesh/create-sphere.js";
 export type { SphereMeshData } from "./mesh/create-sphere.js";

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -306,7 +306,7 @@ export { CAP_NONE, CAP_START, CAP_END, CAP_ALL } from "./mesh/create-tube.js";
 
 // ─── Picking ─────────────────────────────────────────────────────────
 export { createGpuPicker, pickAsync, disposePicker } from "./picking/gpu-picker.js";
-export type { GpuPicker } from "./picking/gpu-picker.js";
+export type { GpuPicker, PickOptions } from "./picking/gpu-picker.js";
 export type { PickingInfo } from "./picking/picking-info.js";
 export { enableDetailedPicking } from "./picking/detailed-picking.js";
 export { getPickedNormal, getPickedUV } from "./picking/picking-helpers.js";

--- a/packages/babylon-lite/src/mesh/mesh-factories.ts
+++ b/packages/babylon-lite/src/mesh/mesh-factories.ts
@@ -78,6 +78,67 @@ export function updateMeshPositions(engine: EngineContext, mesh: Mesh, positions
     engine._device.queue.writeBuffer(gpu.positionBuffer, vertexOffset * 3 * 4, positions.buffer as ArrayBuffer, positions.byteOffset, positions.byteLength);
 }
 
+/** Replace a mesh's GPU geometry IN PLACE with new (possibly larger or smaller) buffers, reusing the
+ *  same Mesh object so existing references to it (scene entries, shadow-caster lists, materials) stay
+ *  valid. Unlike `updateMeshPositions`, this REALLOCATES the GPU buffers, so it's the way to GROW a
+ *  dynamically-generated mesh past its original vertex/index capacity (e.g. an ever-larger bridge whose
+ *  box budget overflows). The old GPU buffers are destroyed to free device memory. Recomputes bounds. */
+export function resizeMeshGeometry(
+    engine: EngineContext,
+    mesh: Mesh,
+    positions: Float32Array,
+    normals: Float32Array,
+    indices: Uint32Array,
+    uvs?: Float32Array,
+    uvs2?: Float32Array,
+    tangents?: Float32Array,
+    colors?: Float32Array
+): void {
+    const old = mesh._gpu;
+    old.positionBuffer.destroy();
+    old.normalBuffer.destroy();
+    old.indexBuffer.destroy();
+    old.uvBuffer.destroy();
+    old.uv2Buffer?.destroy();
+    old.tangentBuffer?.destroy();
+    old.colorBuffer?.destroy();
+
+    mesh._gpu = uploadMeshToGPU(engine, positions, normals, indices, uvs, uvs2, tangents, colors);
+    const [min, max] = computeAabb(positions);
+    mesh.boundMin = isFinite(min[0]) ? min : undefined;
+    mesh.boundMax = isFinite(max[0]) ? max : undefined;
+
+    // Retain CPU geometry for detailed picking + device-loss recovery (mirror createMeshFromData).
+    mesh._cpuPositions = positions;
+    mesh._cpuNormals = normals;
+    mesh._cpuUvs = uvs;
+    mesh._cpuIndices = indices;
+    engine._dlr?.m(mesh, uvs2 ?? null, tangents ?? null, colors ?? null, indices, "uint32");
+}
+
+/** Re-upload (part of) a mesh's NORMAL buffer — the twin of `updateMeshPositions` for dynamically
+ *  re-generated geometry whose per-vertex normals change (e.g. a swept tube re-fitted each rebuild).
+ *  No-op if the mesh was created without normals. Zero-allocation GPU upload only. */
+export function updateMeshNormals(engine: EngineContext, mesh: Mesh, normals: Float32Array, vertexOffset = 0): void {
+    const gpu = mesh._gpu;
+    if (!gpu.normalBuffer) {
+        return;
+    }
+    engine._device.queue.writeBuffer(gpu.normalBuffer, vertexOffset * 3 * 4, normals.buffer as ArrayBuffer, normals.byteOffset, normals.byteLength);
+}
+
+/** Re-upload (part of) a mesh's COLOR buffer — the twin of `updateMeshNormals`/`updateMeshPositions`
+ *  for dynamically re-generated geometry whose per-vertex colors change (e.g. a procedural mesh whose
+ *  parts are re-tinted each rebuild). The color attribute is vec4 (16 bytes/vertex). No-op if the mesh
+ *  was created without colors. Zero-allocation GPU upload only. */
+export function updateMeshColors(engine: EngineContext, mesh: Mesh, colors: Float32Array, vertexOffset = 0): void {
+    const gpu = mesh._gpu;
+    if (!gpu.colorBuffer) {
+        return;
+    }
+    engine._device.queue.writeBuffer(gpu.colorBuffer, vertexOffset * 4 * 4, colors.buffer as ArrayBuffer, colors.byteOffset, colors.byteLength);
+}
+
 /** Create a sphere mesh. Caller must assign material. */
 export function createSphere(engine: EngineContext, options?: SphereOptions): Mesh {
     const data = createSphereData(options);

--- a/packages/babylon-lite/src/mesh/mesh-factories.ts
+++ b/packages/babylon-lite/src/mesh/mesh-factories.ts
@@ -165,6 +165,18 @@ export function updateMeshColors(engine: EngineContext, mesh: Mesh, colors: Floa
     engine._device.queue.writeBuffer(gpu.colorBuffer, vertexOffset * 4 * 4, colors.buffer as ArrayBuffer, colors.byteOffset, colors.byteLength);
 }
 
+/** Re-upload (part of) a mesh's UV buffer — the twin of `updateMeshNormals`/`updateMeshColors` for
+ *  dynamically re-generated geometry whose per-vertex UVs change (e.g. a procedural mesh whose parts
+ *  carry per-rebuild UV payloads). The uv attribute is vec2 (8 bytes/vertex). No-op if the mesh was
+ *  created without UVs. Zero-allocation GPU upload only. */
+export function updateMeshUvs(engine: EngineContext, mesh: Mesh, uvs: Float32Array, vertexOffset = 0): void {
+    const gpu = mesh._gpu;
+    if (!gpu.uvBuffer) {
+        return;
+    }
+    engine._device.queue.writeBuffer(gpu.uvBuffer, vertexOffset * 2 * 4, uvs.buffer as ArrayBuffer, uvs.byteOffset, uvs.byteLength);
+}
+
 /** Create a sphere mesh. Caller must assign material. */
 export function createSphere(engine: EngineContext, options?: SphereOptions): Mesh {
     const data = createSphereData(options);

--- a/packages/babylon-lite/src/mesh/mesh-factories.ts
+++ b/packages/babylon-lite/src/mesh/mesh-factories.ts
@@ -95,14 +95,23 @@ export function resizeMeshGeometry(
     colors?: Float32Array
 ): void {
     const old = mesh._gpu;
-    old.positionBuffer.destroy();
-    old.normalBuffer.destroy();
-    old.indexBuffer.destroy();
-    old.uvBuffer.destroy();
-    old.uv2Buffer?.destroy();
-    old.tangentBuffer?.destroy();
-    old.colorBuffer?.destroy();
-
+    // A geometry REALLOCATION: any cached draw recording that captured raw buffer handles (e.g. the main
+    // opaque render bundle or the shadow task's bundle) must re-record, or it would keep binding the OLD
+    // buffers we're about to free. Resize is a structural (vertex-count) change — conceptually a scene
+    // mutation — so bump every registered scene's renderable version, which is exactly what the cached
+    // bundles already key off to know they must rebuild. (A mesh holds no scene reference per pillar 4b,
+    // so we can't target just its owner; bumping all registered scenes is a no-op for any without it.)
+    for (const ctx of engine._renderingContexts) {
+        const sc = ctx as { _renderableVersion?: number };
+        if (sc._renderableVersion !== undefined) {
+            sc._renderableVersion++;
+        }
+    }
+    // Allocate the NEW buffers and swap them in FIRST, so any subsequent frame records from the new
+    // geometry. The OLD buffers may still be referenced by a frame that was already submitted to the GPU
+    // this tick, so we must NOT destroy them synchronously — that hits the validation error
+    // "Buffer used in submit while destroyed". Defer their destruction until the GPU has drained the
+    // currently-submitted work (onSubmittedWorkDone), by which point nothing references them.
     mesh._gpu = uploadMeshToGPU(engine, positions, normals, indices, uvs, uvs2, tangents, colors);
     const [min, max] = computeAabb(positions);
     mesh.boundMin = isFinite(min[0]) ? min : undefined;
@@ -114,6 +123,23 @@ export function resizeMeshGeometry(
     mesh._cpuUvs = uvs;
     mesh._cpuIndices = indices;
     engine._dlr?.m(mesh, uvs2 ?? null, tangents ?? null, colors ?? null, indices, "uint32");
+
+    void engine._device.queue
+        .onSubmittedWorkDone()
+        .then(() => {
+            try {
+                old.positionBuffer.destroy();
+                old.normalBuffer.destroy();
+                old.indexBuffer.destroy();
+                old.uvBuffer.destroy();
+                old.uv2Buffer?.destroy();
+                old.tangentBuffer?.destroy();
+                old.colorBuffer?.destroy();
+            } catch {
+                // Device may have been lost/disposed before the deferred destroy ran — nothing to free.
+            }
+        })
+        .catch(() => {});
 }
 
 /** Re-upload (part of) a mesh's NORMAL buffer — the twin of `updateMeshPositions` for dynamically

--- a/packages/babylon-lite/src/picking/gpu-picker.ts
+++ b/packages/babylon-lite/src/picking/gpu-picker.ts
@@ -113,9 +113,20 @@ function computePickVP(out: Float32Array, vp: Float32Array, px: number, py: numb
     }
 }
 
+/** Options for {@link pickAsync}. */
+export interface PickOptions {
+    /** Restrict the pick to a subset of the scene's meshes — return `true` for a mesh that may be picked,
+     *  `false` to ignore it entirely (it neither occludes nor is returned). Lets a caller provide its
+     *  "list of pickables" so decorative meshes (grass, foliage, particles, …) can't swallow a pick of a
+     *  structure behind/around them. When omitted, every mesh is pickable (previous behaviour). Applied
+     *  identically to the id-assignment and id-resolve passes so ids stay consistent. */
+    filter?: (mesh: Mesh) => boolean;
+}
+
 /** Pick the mesh at CSS-space canvas coordinates, matching Babylon.js Scene.pick. Returns a PickingInfo. */
-export async function pickAsync(picker: GpuPicker, x: number, y: number): Promise<PickingInfo> {
+export async function pickAsync(picker: GpuPicker, x: number, y: number, options?: PickOptions): Promise<PickingInfo> {
     const scene = picker._scene;
+    const pickFilter = options?.filter ?? null;
     const engine = scene.engine;
     const device = engine._device;
     const canvas = engine.canvas;
@@ -186,6 +197,9 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number): Promis
     const tempBuffers: GPUBuffer[] = [];
     for (let mi = 0; mi < meshCount; mi++) {
         const mesh = meshes[mi]!;
+        if (pickFilter && !pickFilter(mesh)) {
+            continue; // excluded from picking → not drawn AND not given an id (skipped identically below)
+        }
         const gpu = mesh._gpu;
         const ti = mesh.thinInstances;
 
@@ -288,6 +302,9 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number): Promis
     let scanId = 1;
     for (let mi = 0; mi < meshCount; mi++) {
         const mesh = meshes[mi]!;
+        if (pickFilter && !pickFilter(mesh)) {
+            continue; // skipped identically to the draw pass above so scanId stays aligned with the ids
+        }
         const ti = mesh.thinInstances;
         if (ti && ti.count > 0 && ti._gpuBuffer) {
             if (pickId >= scanId && pickId < scanId + ti.count) {


### PR DESCRIPTION
## Summary

Adds dynamic-mesh re-upload/resize helpers, an optional picking filter, and fixes a GPU buffer lifetime bug.

### New mesh helpers (`feat`)
- `updateMeshColors` / `updateMeshNormals` / `updateMeshUvs` — twins of `updateMeshPositions` for re-uploading per-vertex colours / normals / UVs of dynamically regenerated geometry (zero-allocation GPU writes).
- `resizeMeshGeometry` — grows/shrinks a mesh's GPU buffers **in place** while preserving the same `Mesh` object, so existing scene entries, shadow-caster lists, and materials stay valid. This is the supported way to grow a procedurally generated mesh past its original vertex/index capacity.

All four are exported from the public API. Used by CottageCore's procedural bridge for per-bridge tint colours and its growing box budget.

### Picking filter (`feat`)
- `pickAsync` now accepts an optional `PickOptions.filter` predicate so callers can restrict a pick to their "list of pickables". Excluded meshes are neither drawn into the id pass nor assigned an id — applied identically across both passes so ids stay aligned. Omitting the filter preserves previous behaviour (all meshes pickable). `PickOptions` is exported.

### Bug fix: buffer lifetime + cached-bundle invalidation (`fix`)
`resizeMeshGeometry` reallocates a mesh's GPU buffers. The original implementation:
1. Destroyed the old buffers **synchronously**, which can trip the WebGPU validation error `Buffer used in submit while destroyed` when a frame submitted earlier this tick still references them.
2. Left cached render-bundle recordings (the opaque pass, transmission base pass, and the shadow task's bundle) binding the **freed** buffers.

Fixes:
- Old buffers are now destroyed **after** `queue.onSubmittedWorkDone()` drains in-flight work.
- Resize bumps each registered scene's `_renderableVersion` — the existing invalidation key the cached bundles already honour — so opaque/transmission/shadow bundles re-record against the new buffers. No new per-draw comparison is added, so the render hot path (and bundle-size ceilings) are unchanged.

## Testing
- `pnpm test` (build:bundle-scenes + full parity suite): **green** (299 tests; one BJS-reference page-load flake passed on retry).
- ESLint clean on all changed files.
