### PR TITLE
Bundle all runtime dependencies and guard against future leaks

### DIFF
--- a/packages/babylon-lite/package.json
+++ b/packages/babylon-lite/package.json
@@ -55,7 +55,6 @@
         "@recast-navigation/core": "0.43.0",
         "@recast-navigation/generators": "0.43.0",
         "@recast-navigation/wasm": "0.43.0",
-        "draco3d": "^1.5.7",
         "manifold-3d": "3.4.0"
     }
 }

--- a/packages/babylon-lite/vite.config.ts
+++ b/packages/babylon-lite/vite.config.ts
@@ -102,13 +102,6 @@ function emitPackageJson(outDir: string): Plugin {
                     },
                 },
                 sideEffects: false,
-                dependencies: {
-                    draco3d: "^1.5.7",
-                    "manifold-3d": "3.4.0",
-                    "@recast-navigation/core": "0.43.0",
-                    "@recast-navigation/generators": "0.43.0",
-                    "@recast-navigation/wasm": "0.43.0",
-                },
             };
             writeFileSync(resolve(outDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
         },
@@ -126,9 +119,6 @@ export default defineConfig(({ mode }) => {
                 fileName: "index",
             },
             outDir,
-            rollupOptions: {
-                external: [/^@recast-navigation\//],
-            },
             sourcemap: true,
             minify: mode === "prod" ? "esbuild" : false,
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,9 +139,6 @@ importers:
       '@recast-navigation/wasm':
         specifier: 0.43.0
         version: 0.43.0
-      draco3d:
-        specifier: ^1.5.7
-        version: 1.5.7
       manifold-3d:
         specifier: 3.4.0
         version: 3.4.0(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)
@@ -1796,9 +1793,6 @@ packages:
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
-
-  draco3d@1.5.7:
-    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5155,8 +5149,6 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.4.2: {}
-
-  draco3d@1.5.7: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/tests/lite/build/public-api-types.test.ts
+++ b/tests/lite/build/public-api-types.test.ts
@@ -1,11 +1,13 @@
 import { spawnSync } from "child_process";
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { resolve } from "path";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 const ROOT = resolve(__dirname, "../../..");
 const PACKAGE_DIR = resolve(ROOT, "packages/babylon-lite");
-const DTS_PATH = resolve(PACKAGE_DIR, "dist/index.d.ts");
+const DIST_DIR = resolve(PACKAGE_DIR, "dist");
+const DTS_PATH = resolve(DIST_DIR, "index.d.ts");
+const PACKAGE_JSON_PATH = resolve(DIST_DIR, "package.json");
 
 // Invoke binaries directly via their JS entry points and the current node
 // executable, so the test does not depend on PATH (which may not contain
@@ -14,17 +16,19 @@ const NODE = process.execPath;
 const VITE_JS = resolve(PACKAGE_DIR, "node_modules/vite/bin/vite.js");
 const TSC_JS = resolve(ROOT, "node_modules/typescript/bin/tsc");
 
-describe("public API .d.ts", () => {
-    it("builds and type-checks cleanly with no references to internal-only types", () => {
-        // Build babylon-lite to produce dist/index.d.ts.
-        const build = spawnSync(NODE, [VITE_JS, "build"], {
-            cwd: PACKAGE_DIR,
-            encoding: "utf-8",
-        });
-        if (build.status !== 0) {
-            throw new Error(`babylon-lite build failed:\n${build.stdout ?? ""}${build.stderr ?? ""}`);
-        }
+// Build babylon-lite once for all dist/* assertions in this file.
+beforeAll(() => {
+    const build = spawnSync(NODE, [VITE_JS, "build"], {
+        cwd: PACKAGE_DIR,
+        encoding: "utf-8",
+    });
+    if (build.status !== 0) {
+        throw new Error(`babylon-lite build failed:\n${build.stdout ?? ""}${build.stderr ?? ""}`);
+    }
+}, 300_000);
 
+describe("dist/index.d.ts", () => {
+    it("type-checks cleanly with no references to internal-only types", () => {
         expect(existsSync(DTS_PATH)).toBe(true);
 
         // Type-check the generated declaration file in isolation, without
@@ -67,4 +71,46 @@ describe("public API .d.ts", () => {
         }
         expect(result.status).toBe(0);
     }, 300_000);
+
+    it("does not reference any external (npm) modules", () => {
+        expect(existsSync(DTS_PATH)).toBe(true);
+
+        const dts = readFileSync(DTS_PATH, "utf-8");
+
+        // Collect every module specifier the .d.ts file refers to via:
+        //   - top-level `import ... from "X"` declarations
+        //   - top-level `export ... from "X"` re-exports
+        //   - inline `import("X").Y` type expressions
+        //   - triple-slash `<reference types="X" />` directives
+        const specifiers = new Set<string>();
+        for (const m of dts.matchAll(/(?:^|\n)\s*(?:import|export)[^;\n]*?\sfrom\s+["']([^"']+)["']/g)) {
+            specifiers.add(m[1]!);
+        }
+        for (const m of dts.matchAll(/\bimport\s*\(\s*["']([^"']+)["']\s*\)/g)) {
+            specifiers.add(m[1]!);
+        }
+        for (const m of dts.matchAll(/\/\/\/\s*<reference\s+types\s*=\s*["']([^"']+)["']/g)) {
+            specifiers.add(m[1]!);
+        }
+
+        // Any specifier that is not a relative path is a leaked external type:
+        // the rolled-up d.ts is supposed to be fully self-contained so that
+        // consumers never need to install any of our build-time dependencies.
+        const external = [...specifiers].filter((s) => !s.startsWith("./") && !s.startsWith("../"));
+        expect(external, `dist/index.d.ts leaks types from external modules: ${external.join(", ")}`).toEqual([]);
+    });
+});
+
+describe("dist/package.json", () => {
+    it("declares no runtime dependencies", () => {
+        expect(existsSync(PACKAGE_JSON_PATH)).toBe(true);
+
+        const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf-8")) as Record<string, unknown>;
+
+        // The published package must bundle every transitive runtime dep as an
+        // opaque implementation detail — no `dependencies` and no
+        // `peerDependencies` should ever appear in dist/package.json.
+        expect(pkg.dependencies ?? {}).toEqual({});
+        expect(pkg.peerDependencies ?? {}).toEqual({});
+    });
 });


### PR DESCRIPTION
## Summary

The published `@babylonjs/lite` package was previously declaring `draco3d`, `manifold-3d`, and the three `@recast-navigation/*` packages as runtime `dependencies`, forcing consumers to install them. Most of that wasn't even correct:

- **`draco3d`** — never imported anywhere in `packages/babylon-lite/src/`. The decoder is loaded at runtime via a `<script>` tag pointing at a static `draco_decoder.js` the consumer hosts themselves (configurable via `setDracoBaseUrl`). The npm package was a no-op dependency.
- **`manifold-3d`** — actually used by `csg2.ts`, but the JS + WASM were already being bundled (Rollup's `external` list only matched `@recast-navigation/*`). Listing it as a runtime dep just installed a second, unused copy.
- **`@recast-navigation/*`** — correctly external, but inconsistent with the philosophy of shipping a self-contained package.

## Changes

- `packages/babylon-lite/vite.config.ts` — removed `rollupOptions.external` (so recast is now bundled like manifold) and removed the `dependencies` block from the emitted `dist/package.json`. The published package now ships with zero runtime deps.
- `packages/babylon-lite/package.json` — dropped the unused `draco3d` entry from the source manifest (cosmetic; source manifest is never published).
- `tests/lite/build/public-api-types.test.ts` — added two new guardrails and shared the build via `beforeAll`:
  - `dist/package.json` must have empty `dependencies` and `peerDependencies`.
  - `dist/index.d.ts` must contain zero non-relative module specifiers (no `import`, `export ... from`, inline `import("...")`, or `<reference types>` pointing at npm packages). This catches the case where bundled-in runtime code accidentally surfaces an external type on the public API.

## Verification

`pnpm test:build` — 3 passed (type-check, no external types in d.ts, no runtime deps in package.json).

Build output confirms recast is now inlined (`recast-navigation.wasm-*.js` chunks, ~1.1 MB each as base64 WASM, dynamically imported only on first `createNavigationPluginAsync()` call).
