### PR TITLE
fix(vat): scene 219 free-run animation (instance fps was 0)

### DIFF
--- a/lab/lite/src/lite/scene219.ts
+++ b/lab/lite/src/lite/scene219.ts
@@ -72,7 +72,9 @@ async function main(): Promise<void> {
         const identity = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
         setThinInstances(mesh, identity, 1);
         if (swim) {
-            handle.setInstances(frozenParams(swim, 0));
+            // Free-running playback: fps = the clip's fps so handle.update() advances the frame each
+            // frame. (?seekTime overrides this in onBeforeRender with a frozen, fps=0 params set.)
+            handle.setInstances(new Float32Array([swim.fromRow, swim.fromRow + swim.frameCount - 1, 0, swim.fps]));
         }
         canvas.dataset.vatBones = String(baked.boneCount);
         canvas.dataset.vatFrames = String(baked.frameCount);


### PR DESCRIPTION
Scene 219 initialised its per-instance VAT params via \rozenParams\ (fps=0), so without \?seekTime\ the per-instance frame never advanced and the shark sat at frame 0 (it looked static in the lab). Initialise with the clip's fps instead so free-running playback animates; \?seekTime\ still freezes the pose via the fps=0 params set in \onBeforeRender\, so parity is unaffected (MAD=0.000).

Verified: free-run animates (two captures 1.6 s apart differ), still one draw call.