### PR TITLE
feat(sprite): dynamic sprite-atlas appends + sub-rect sources

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
+    "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint", "vitest.explorer"]
 }

--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -1,19 +1,19 @@
 {
   "scene1": {
-    "rawKB": 87.8,
-    "gzipKB": 35.9,
+    "rawKB": 87.5,
+    "gzipKB": 36.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene1-background-dds-skybox-DmLRZHzZ.js",
-      "scene1-background-ground-BYjZU-Yl.js",
-      "scene1-cubemap-skybox-material-XbbAQxC0.js",
-      "scene1-generate-mipmaps-CF3oVGwh.js",
-      "scene1-gltf-glb-parser-BdYiApo0.js",
+      "scene1-background-dds-skybox-CgGmXgIE.js",
+      "scene1-background-ground-CxVqTMX-.js",
+      "scene1-cubemap-skybox-material-MchLijit.js",
+      "scene1-generate-mipmaps-DZsftTXf.js",
+      "scene1-gltf-glb-parser-BL74Wcec.js",
       "scene1-ibl-fragment-CeRrvT96.js",
-      "scene1-pbr-renderable-WB9rB7jI.js",
-      "scene1-rgbd-decode-Baow08lG.js",
+      "scene1-pbr-renderable-xCK6tSMC.js",
+      "scene1-rgbd-decode-JSHbS7uW.js",
       "scene1-scene-uniforms-FTYH6Ct0.js",
-      "scene1-singlelight-hemispheric-wgsl-Cd4vq3C3.js",
+      "scene1-singlelight-hemispheric-wgsl-dhCCcXC9.js",
       "scene1-wgsl-helpers-CkUi9P9Q.js",
       "scene1.js"
     ],
@@ -22,10 +22,10 @@
   },
   "scene2": {
     "rawKB": 45.1,
-    "gzipKB": 17.9,
+    "gzipKB": 18.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene2-standard-renderable-CqhwuQLf.js",
+      "scene2-standard-renderable-QIQaqQ1i.js",
       "scene2-wgsl-helpers-CwHFFXvt.js",
       "scene2.js"
     ],
@@ -33,13 +33,13 @@
     "bjsGzipKB": 343.7
   },
   "scene3": {
-    "rawKB": 52.2,
-    "gzipKB": 20.7,
+    "rawKB": 52.1,
+    "gzipKB": 20.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene3-scene-uniforms-FTYH6Ct0.js",
-      "scene3-skybox-renderable-YpXbsk_C.js",
-      "scene3-standard-renderable-D6XPU66Y.js",
+      "scene3-skybox-renderable-B8grT7_v.js",
+      "scene3-standard-renderable-Bv5zWO74.js",
       "scene3-wgsl-helpers-DkIRJkUm.js",
       "scene3.js"
     ],
@@ -47,16 +47,16 @@
     "bjsGzipKB": 346
   },
   "scene4": {
-    "rawKB": 70.7,
-    "gzipKB": 27.5,
+    "rawKB": 70.3,
+    "gzipKB": 27.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene4-esm-shadow-view-7yqUFA1x.js",
-      "scene4-generate-mipmaps-qGQ1D0G4.js",
+      "scene4-generate-mipmaps-C5qTY_Nn.js",
       "scene4-material-view-Dua1bl7W.js",
-      "scene4-no-color-view-Dnnoli02.js",
+      "scene4-no-color-view-DfmThiOr.js",
       "scene4-shadow-task-DKE6tIG9.js",
-      "scene4-standard-renderable-D0ug5VO6.js",
+      "scene4-standard-renderable-DWw_Eoxq.js",
       "scene4-std-shadow-fragment-pwyXRo4i.js",
       "scene4-wgsl-helpers-CwHFFXvt.js",
       "scene4.js"
@@ -65,40 +65,40 @@
     "bjsGzipKB": 372.5
   },
   "scene5": {
-    "rawKB": 87.4,
-    "gzipKB": 36.1,
+    "rawKB": 87.3,
+    "gzipKB": 36.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene5-create-morph-targets-DqCohDYt.js",
-      "scene5-create-skeleton-B3GDXNiG.js",
-      "scene5-generate-mipmaps-QZIkv2U-.js",
-      "scene5-gltf-animation-DLz_CLqn.js",
+      "scene5-create-morph-targets-CbGb7EdR.js",
+      "scene5-create-skeleton-b0a0O5jh.js",
+      "scene5-generate-mipmaps-nR8UxaS-.js",
+      "scene5-gltf-animation-C4kEGbXo.js",
       "scene5-gltf-color-normalize-DA3N7QfB.js",
-      "scene5-gltf-feature-animations--f872iuG.js",
-      "scene5-gltf-feature-morph-BY-Ac06l.js",
-      "scene5-gltf-feature-registry-qQs5OIVl.js",
-      "scene5-gltf-feature-skeleton-D0i0mGhn.js",
-      "scene5-morph-fragment-vx6oCW-d.js",
-      "scene5-pbr-renderable-DCsfVoVQ.js",
+      "scene5-gltf-feature-animations-D5jXMn5O.js",
+      "scene5-gltf-feature-morph-C0KeEImV.js",
+      "scene5-gltf-feature-registry-bhclzHr-.js",
+      "scene5-gltf-feature-skeleton-IxeKbEYC.js",
+      "scene5-morph-fragment-DrzlvBTO.js",
+      "scene5-pbr-renderable-5tAn3rXh.js",
       "scene5-pbr-template-ext-BMNgm5oJ.js",
-      "scene5-singlelight-hemispheric-wgsl-DqgA-ELW.js",
-      "scene5-skeleton-fragment-DIcMWlYc.js",
+      "scene5-singlelight-hemispheric-wgsl-B4FRjIJ-.js",
+      "scene5-skeleton-fragment-CT0RkABi.js",
       "scene5.js"
     ],
     "bjsRawKB": 2206.6,
     "bjsGzipKB": 529.2
   },
   "scene6": {
-    "rawKB": 72,
-    "gzipKB": 29.6,
+    "rawKB": 71.7,
+    "gzipKB": 29.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene6-background-dds-skybox-DWCKo485.js",
-      "scene6-background-ground-CHyAu1zy.js",
-      "scene6-cubemap-skybox-material-DY-CbIqt.js",
+      "scene6-background-dds-skybox-CkkU4ShI.js",
+      "scene6-background-ground-ORk7ccv7.js",
+      "scene6-cubemap-skybox-material-BaksBS45.js",
       "scene6-ibl-fragment-CeRrvT96.js",
-      "scene6-pbr-renderable-CzW06LD8.js",
-      "scene6-rgbd-decode-Baow08lG.js",
+      "scene6-pbr-renderable-Cpm6Bob2.js",
+      "scene6-rgbd-decode-qZMQbYz_.js",
       "scene6-scene-uniforms-FTYH6Ct0.js",
       "scene6-wgsl-helpers-CkUi9P9Q.js",
       "scene6.js"
@@ -107,24 +107,24 @@
     "bjsGzipKB": 549.2
   },
   "scene7": {
-    "rawKB": 101.7,
-    "gzipKB": 42,
+    "rawKB": 101.1,
+    "gzipKB": 42.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene7-background-ground-aeyiUjk-.js",
-      "scene7-background-solid-skybox-DAKV5sdx.js",
-      "scene7-create-skeleton-C0XIGYxk.js",
-      "scene7-generate-mipmaps-BYvyUqct.js",
-      "scene7-gltf-animation-DX9jxXcY.js",
-      "scene7-gltf-feature-animations-C0kTye-R.js",
-      "scene7-gltf-feature-registry-BZPBu_wx.js",
-      "scene7-gltf-feature-skeleton-Cggs_1Dy.js",
+      "scene7-background-ground-DKNa8vK4.js",
+      "scene7-background-solid-skybox-C5pZAsdd.js",
+      "scene7-create-skeleton-xdZ7V4Ou.js",
+      "scene7-generate-mipmaps-BRQTgujU.js",
+      "scene7-gltf-animation-CedLRWTt.js",
+      "scene7-gltf-feature-animations-Dotpmxxc.js",
+      "scene7-gltf-feature-registry-DMCme_KS.js",
+      "scene7-gltf-feature-skeleton-DNUX4GBP.js",
       "scene7-ibl-fragment-CeRrvT96.js",
-      "scene7-pbr-renderable-C-2KXIyv.js",
-      "scene7-rgbd-decode-Baow08lG.js",
+      "scene7-pbr-renderable-aMA6hJBP.js",
+      "scene7-rgbd-decode-C9OJGqTP.js",
       "scene7-scene-uniforms-FTYH6Ct0.js",
-      "scene7-singlelight-hemispheric-wgsl-Fr8FSLlE.js",
-      "scene7-skeleton-fragment-BgaZp3s5.js",
+      "scene7-singlelight-hemispheric-wgsl-DbXoSTyY.js",
+      "scene7-skeleton-fragment-B6HM9Bia.js",
       "scene7-skybox.vertex-D1KSfOUq.js",
       "scene7-wgsl-helpers-CkUi9P9Q.js",
       "scene7.js"
@@ -133,16 +133,16 @@
     "bjsGzipKB": 678.1
   },
   "scene8": {
-    "rawKB": 73,
-    "gzipKB": 29,
+    "rawKB": 72.9,
+    "gzipKB": 29.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene8-background-hdr-skybox-BXPd6giq.js",
+      "scene8-background-hdr-skybox-DfswLJkt.js",
       "scene8-ibl-fragment-CeRrvT96.js",
-      "scene8-pbr-renderable-CLbT2AFL.js",
+      "scene8-pbr-renderable-KBCPS2Q5.js",
       "scene8-scene-size-CBRA6KcU.js",
       "scene8-scene-uniforms-FTYH6Ct0.js",
-      "scene8-singlelight-point-wgsl-CebE2ZHo.js",
+      "scene8-singlelight-point-wgsl-3FMcKKX_.js",
       "scene8.js"
     ],
     "bjsRawKB": 1699.1,
@@ -150,17 +150,17 @@
   },
   "scene9": {
     "rawKB": 57.6,
-    "gzipKB": 23.2,
+    "gzipKB": 23.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene9-generate-mipmaps-CUImEqsf.js",
+      "scene9-generate-mipmaps-xw5BdfZd.js",
       "scene9-normal-map-fragment-BjHVJ1qk.js",
       "scene9-point-light-ESYN5_k0.js",
-      "scene9-standard-renderable-D94Z3l6Q.js",
-      "scene9-std-ambient-fragment-DfI42o1E.js",
-      "scene9-std-opacity-fragment-c9nfqs9e.js",
-      "scene9-std-reflection-fragment-D8pqO81U.js",
-      "scene9-std-specular-fragment-viPpPcjG.js",
+      "scene9-standard-renderable-2LLwe8Ti.js",
+      "scene9-std-ambient-fragment-BT8qGSob.js",
+      "scene9-std-opacity-fragment-CzsLM3vw.js",
+      "scene9-std-reflection-fragment-BsZScuvI.js",
+      "scene9-std-specular-fragment-lgpgl8DR.js",
       "scene9-wgsl-helpers-CwHFFXvt.js",
       "scene9.js"
     ],
@@ -168,12 +168,12 @@
     "bjsGzipKB": 731.9
   },
   "scene10": {
-    "rawKB": 50.6,
-    "gzipKB": 20.6,
+    "rawKB": 50.8,
+    "gzipKB": 20.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene10-pbr-renderable-Cv6IXXwL.js",
-      "scene10-singlelight-hemispheric-wgsl-BuzlXO_s.js",
+      "scene10-pbr-renderable-DZ5sVHeS.js",
+      "scene10-singlelight-hemispheric-wgsl-BKPPYH4N.js",
       "scene10.js"
     ],
     "bjsRawKB": 1643.1,
@@ -181,63 +181,63 @@
   },
   "scene11": {
     "rawKB": 82.9,
-    "gzipKB": 34.2,
+    "gzipKB": 34.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene11-create-skeleton-D8FLx1nh.js",
-      "scene11-generate-mipmaps-DsnIv00r.js",
-      "scene11-gltf-animation-DLIo2NIq.js",
+      "scene11-create-skeleton-THePrIor.js",
+      "scene11-generate-mipmaps-Dq1i2GoW.js",
+      "scene11-gltf-animation-DO_0bxF5.js",
       "scene11-gltf-ext-spec-gloss-D60sFZYX.js",
-      "scene11-gltf-feature-animations-DRGi1ExM.js",
-      "scene11-gltf-feature-registry-BVm0pufD.js",
-      "scene11-gltf-feature-skeleton-Y3weotBW.js",
-      "scene11-gltf-glb-parser-BdYiApo0.js",
-      "scene11-pbr-renderable-DdKMwobq.js",
-      "scene11-singlelight-hemispheric-wgsl-CpUUucid.js",
-      "scene11-skeleton-fragment-fvI-ceZZ.js",
+      "scene11-gltf-feature-animations-Cof7XcUp.js",
+      "scene11-gltf-feature-registry-eOu5AAh4.js",
+      "scene11-gltf-feature-skeleton-C14ILxfr.js",
+      "scene11-gltf-glb-parser-B0CzN8nR.js",
+      "scene11-pbr-renderable-B8I_m0BH.js",
+      "scene11-singlelight-hemispheric-wgsl-DBwLPDrH.js",
+      "scene11-skeleton-fragment-Cxb4K7sz.js",
       "scene11.js"
     ],
     "bjsRawKB": 2207.1,
     "bjsGzipKB": 529.3
   },
   "scene12": {
-    "rawKB": 99.3,
-    "gzipKB": 40.1,
+    "rawKB": 98.9,
+    "gzipKB": 40.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene12-create-skeleton-DJHF_cDg.js",
-      "scene12-generate-mipmaps-BHLLbmvx.js",
-      "scene12-gltf-animation-DjB9xPPv.js",
-      "scene12-gltf-feature-animations-CIpAY-fm.js",
-      "scene12-gltf-feature-registry-DB4Y8MMW.js",
-      "scene12-gltf-feature-skeleton-Jz4yjjVC.js",
-      "scene12-gltf-glb-parser-BdYiApo0.js",
+      "scene12-create-skeleton-CnmD2Stx.js",
+      "scene12-generate-mipmaps-BXRZOuzM.js",
+      "scene12-gltf-animation-DfEx1Yl8.js",
+      "scene12-gltf-feature-animations-BUCuwl5B.js",
+      "scene12-gltf-feature-registry-a_FJq83J.js",
+      "scene12-gltf-feature-skeleton-vvaVuEfU.js",
+      "scene12-gltf-glb-parser-CZv4TIaJ.js",
       "scene12-ibl-fragment-CeRrvT96.js",
-      "scene12-pbr-renderable-DngTQlY5.js",
-      "scene12-reflectance-fragment-BcH3N_t1.js",
-      "scene12-rgbd-decode-Baow08lG.js",
+      "scene12-pbr-renderable-Cy9E9ZSA.js",
+      "scene12-reflectance-fragment-Cs1v8qcp.js",
+      "scene12-rgbd-decode-Db4SKbB2.js",
       "scene12-scene-material-swap-BfoPtupw.js",
       "scene12-scene-uniforms-FTYH6Ct0.js",
-      "scene12-singlelight-directional-wgsl-DR0aYG-V.js",
-      "scene12-skeleton-fragment-C2n5E6Bm.js",
+      "scene12-singlelight-directional-wgsl-DU2VEOXk.js",
+      "scene12-skeleton-fragment-9535wJfB.js",
       "scene12.js"
     ],
     "bjsRawKB": 2209.2,
     "bjsGzipKB": 531.5
   },
   "scene13": {
-    "rawKB": 83.1,
-    "gzipKB": 33.6,
+    "rawKB": 82.9,
+    "gzipKB": 33.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene13-background-ground-BTHAgBSj.js",
-      "scene13-generate-mipmaps-CIsWw6bc.js",
-      "scene13-gltf-glb-parser-BdYiApo0.js",
+      "scene13-background-ground-CH_ZUv1h.js",
+      "scene13-generate-mipmaps-D9XYu3Cz.js",
+      "scene13-gltf-glb-parser-HP2v-3hE.js",
       "scene13-ibl-fragment-CeRrvT96.js",
-      "scene13-pbr-renderable-DTh31tdl.js",
-      "scene13-rgbd-decode-Baow08lG.js",
+      "scene13-pbr-renderable-Y2YkUidG.js",
+      "scene13-rgbd-decode-CmtmNnLb.js",
       "scene13-scene-uniforms-FTYH6Ct0.js",
-      "scene13-singlelight-hemispheric-wgsl-CMkgZ1vD.js",
+      "scene13-singlelight-hemispheric-wgsl-BZ4nhqjZ.js",
       "scene13-wgsl-helpers-CkUi9P9Q.js",
       "scene13.js"
     ],
@@ -245,20 +245,20 @@
     "bjsGzipKB": 674.6
   },
   "scene14": {
-    "rawKB": 88,
-    "gzipKB": 36,
+    "rawKB": 87.7,
+    "gzipKB": 36.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene14-background-dds-skybox-h78-agcy.js",
-      "scene14-background-ground-DHjVSpOC.js",
-      "scene14-cubemap-skybox-material-BzYjo4Jk.js",
-      "scene14-generate-mipmaps-CtYa-18E.js",
-      "scene14-gltf-glb-parser-BdYiApo0.js",
+      "scene14-background-dds-skybox-ChW7ia67.js",
+      "scene14-background-ground-CfIOQyyv.js",
+      "scene14-cubemap-skybox-material-B13THLlY.js",
+      "scene14-generate-mipmaps-BHbMFPIn.js",
+      "scene14-gltf-glb-parser-B--vN_CU.js",
       "scene14-ibl-fragment-CeRrvT96.js",
-      "scene14-pbr-renderable-BjkkCPKX.js",
-      "scene14-rgbd-decode-Baow08lG.js",
+      "scene14-pbr-renderable-CCPY0Q_J.js",
+      "scene14-rgbd-decode-BdaP5z1T.js",
       "scene14-scene-uniforms-FTYH6Ct0.js",
-      "scene14-singlelight-hemispheric-wgsl-DDx8LOLn.js",
+      "scene14-singlelight-hemispheric-wgsl-Q-eHTfjt.js",
       "scene14-wgsl-helpers-CkUi9P9Q.js",
       "scene14.js"
     ],
@@ -266,11 +266,11 @@
     "bjsGzipKB": 675.3
   },
   "scene15": {
-    "rawKB": 45.4,
-    "gzipKB": 18,
+    "rawKB": 45.5,
+    "gzipKB": 18.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene15-standard-renderable-C5SlPbaq.js",
+      "scene15-standard-renderable-BFnKYsLT.js",
       "scene15-wgsl-helpers-CwHFFXvt.js",
       "scene15.js"
     ],
@@ -279,12 +279,12 @@
   },
   "scene16": {
     "rawKB": 46.8,
-    "gzipKB": 18.6,
+    "gzipKB": 18.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene16-standard-renderable-CXEgXCBp.js",
+      "scene16-standard-renderable-CNj-Xfy6.js",
       "scene16-thin-instance-fragment-CBn2miAC.js",
-      "scene16-thin-instance-gpu-Bdko0Q-0.js",
+      "scene16-thin-instance-gpu-D87Xj2dn.js",
       "scene16-wgsl-helpers-CwHFFXvt.js",
       "scene16.js"
     ],
@@ -293,18 +293,18 @@
   },
   "scene17": {
     "rawKB": 83.4,
-    "gzipKB": 34.4,
+    "gzipKB": 34.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene17-generate-mipmaps-snYSUMBc.js",
+      "scene17-generate-mipmaps-Dd1Mfq1c.js",
       "scene17-ibl-fragment-CeRrvT96.js",
-      "scene17-pbr-renderable-Df8vonGl.js",
-      "scene17-rgbd-decode-DCi_9yYh.js",
+      "scene17-pbr-renderable-D_SOHTYF.js",
+      "scene17-rgbd-decode-CPqMSicj.js",
       "scene17-shader-composer-CaVjAPiK.js",
-      "scene17-singlelight-hemispheric-wgsl-BqremcMP.js",
-      "scene17-standard-renderable-C1PXPJUm.js",
+      "scene17-singlelight-hemispheric-wgsl-kp2YQ4jQ.js",
+      "scene17-standard-renderable-DnRmGPOf.js",
       "scene17-thin-instance-fragment-CBn2miAC.js",
-      "scene17-thin-instance-gpu-CQSc9Zy3.js",
+      "scene17-thin-instance-gpu-EbYqyUYP.js",
       "scene17-wgsl-helpers-CwHFFXvt.js",
       "scene17.js"
     ],
@@ -312,15 +312,15 @@
     "bjsGzipKB": 415.6
   },
   "scene18": {
-    "rawKB": 58.9,
-    "gzipKB": 23.4,
+    "rawKB": 58.7,
+    "gzipKB": 23.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene18-generate-mipmaps-CrP1te90.js",
+      "scene18-generate-mipmaps-CORvzSVx.js",
       "scene18-material-view-Dua1bl7W.js",
-      "scene18-no-color-view-Dv4u5RXK.js",
+      "scene18-no-color-view-DX5rFWCN.js",
       "scene18-shadow-task-t_t6oLxe.js",
-      "scene18-standard-renderable-CqbAT3jv.js",
+      "scene18-standard-renderable-BzM6aYAj.js",
       "scene18-std-shadow-fragment-pwyXRo4i.js",
       "scene18-wgsl-helpers-CwHFFXvt.js",
       "scene18.js"
@@ -329,34 +329,34 @@
     "bjsGzipKB": 358.5
   },
   "scene19": {
-    "rawKB": 67.4,
-    "gzipKB": 27.4,
+    "rawKB": 67.5,
+    "gzipKB": 27.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene19-clearcoat-fragment-CSSK7r-C.js",
+      "scene19-clearcoat-fragment-RteyRbNz.js",
       "scene19-ibl-fragment-CeRrvT96.js",
-      "scene19-pbr-renderable-BExCBNsJ.js",
-      "scene19-rgbd-decode-DCi_9yYh.js",
-      "scene19-singlelight-hemispheric-wgsl-tYyQB818.js",
+      "scene19-pbr-renderable-Dkjd2KDd.js",
+      "scene19-rgbd-decode-DACTRVVC.js",
+      "scene19-singlelight-hemispheric-wgsl-CiqGahlI.js",
       "scene19.js"
     ],
     "bjsRawKB": 1665.4,
     "bjsGzipKB": 403
   },
   "scene20": {
-    "rawKB": 77.3,
-    "gzipKB": 32,
+    "rawKB": 77,
+    "gzipKB": 32.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene20-background-dds-skybox-CM58ySkp.js",
-      "scene20-background-ground-BThUU1gp.js",
-      "scene20-cubemap-skybox-material-DV0PACAE.js",
+      "scene20-background-dds-skybox-C70twE20.js",
+      "scene20-background-ground-DVr5CM1z.js",
+      "scene20-cubemap-skybox-material-CMYL5-43.js",
       "scene20-emissive-fragment-TZ7y0AWD.js",
       "scene20-ibl-fragment-CeRrvT96.js",
-      "scene20-pbr-renderable-DfN2WZwh.js",
-      "scene20-rgbd-decode-Baow08lG.js",
+      "scene20-pbr-renderable-lCl3PvIz.js",
+      "scene20-rgbd-decode-BBMI74ng.js",
       "scene20-scene-uniforms-FTYH6Ct0.js",
-      "scene20-singlelight-hemispheric-wgsl-COn3wZDF.js",
+      "scene20-singlelight-hemispheric-wgsl-CzYRa1O5.js",
       "scene20-wgsl-helpers-CkUi9P9Q.js",
       "scene20.js"
     ],
@@ -364,41 +364,41 @@
     "bjsGzipKB": 569.9
   },
   "scene21": {
-    "rawKB": 83.9,
-    "gzipKB": 33.9,
+    "rawKB": 83.7,
+    "gzipKB": 34.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene21-background-hdr-skybox-D8jsulx2.js",
-      "scene21-cubemap-skybox-material-BAKiYHRV.js",
-      "scene21-generate-mipmaps-B7dDUjA-.js",
-      "scene21-gltf-glb-parser-BdYiApo0.js",
+      "scene21-background-hdr-skybox-BFSTrX8R.js",
+      "scene21-cubemap-skybox-material-C3UxmKjm.js",
+      "scene21-generate-mipmaps-CgiBNqfS.js",
+      "scene21-gltf-glb-parser-CpuJfvpr.js",
       "scene21-ibl-fragment-CeRrvT96.js",
-      "scene21-pbr-renderable-DJ9Jug4T.js",
-      "scene21-rgbd-decode-Baow08lG.js",
+      "scene21-pbr-renderable-D_Jhe-_8.js",
+      "scene21-rgbd-decode-CMNByIEz.js",
       "scene21-scene-material-swap-BfoPtupw.js",
       "scene21-scene-uniforms-FTYH6Ct0.js",
-      "scene21-sheen-fragment-Ci85T3pe.js",
+      "scene21-sheen-fragment-Bbota5Tx.js",
       "scene21.js"
     ],
     "bjsRawKB": 2812.4,
     "bjsGzipKB": 678.2
   },
   "scene22": {
-    "rawKB": 95.2,
-    "gzipKB": 38.1,
+    "rawKB": 94.8,
+    "gzipKB": 38.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene22-esm-shadow-view-CNnhm5C_.js",
-      "scene22-generate-mipmaps-Bm7uT3Qf.js",
+      "scene22-esm-shadow-view-LUvy5u4F.js",
+      "scene22-generate-mipmaps-VA3zSaRr.js",
       "scene22-material-view-Dua1bl7W.js",
-      "scene22-multilight-wgsl-D5ZzPSx3.js",
-      "scene22-no-color-view-CA5XxuSx.js",
-      "scene22-pbr-renderable-3CmRboA1.js",
+      "scene22-multilight-wgsl-BEjCsBqE.js",
+      "scene22-no-color-view-I0NGyxgW.js",
+      "scene22-pbr-renderable-BuNDYVj9.js",
       "scene22-pbr-shadow-fragment-CSEDArnD.js",
       "scene22-shader-composer-CaVjAPiK.js",
       "scene22-shadow-fragment-core-Dbe1xNkt.js",
-      "scene22-shadow-task-DZltX9Pn.js",
-      "scene22-standard-renderable-C8_G6-c0.js",
+      "scene22-shadow-task-BTFzYHIB.js",
+      "scene22-standard-renderable-DLD4Grzk.js",
       "scene22-wgsl-helpers-CwHFFXvt.js",
       "scene22.js"
     ],
@@ -406,17 +406,17 @@
     "bjsGzipKB": 448.3
   },
   "scene23": {
-    "rawKB": 76.4,
-    "gzipKB": 31.1,
+    "rawKB": 76,
+    "gzipKB": 31.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene23-anisotropy-fragment-bzTn6eiT.js",
-      "scene23-background-dds-skybox-BdvWEKLd.js",
-      "scene23-background-ground-CO4Kt342.js",
-      "scene23-cubemap-skybox-material-BvqASV8O.js",
+      "scene23-background-dds-skybox-8HgrHHc9.js",
+      "scene23-background-ground-CIq0OHbS.js",
+      "scene23-cubemap-skybox-material-vMtHeywl.js",
       "scene23-ibl-fragment-CeRrvT96.js",
-      "scene23-pbr-renderable-zqgr3bif.js",
-      "scene23-rgbd-decode-Baow08lG.js",
+      "scene23-pbr-renderable-FqrULi0q.js",
+      "scene23-rgbd-decode-7mt_Iw3B.js",
       "scene23-scene-uniforms-FTYH6Ct0.js",
       "scene23-wgsl-helpers-CkUi9P9Q.js",
       "scene23.js"
@@ -426,19 +426,19 @@
   },
   "scene24": {
     "rawKB": 57.2,
-    "gzipKB": 23.7,
+    "gzipKB": 23.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene24-bake-local-matrix-67U-IT8C.js",
-      "scene24-cube-texture-DWu8YwZz.js",
-      "scene24-generate-mipmaps-Drut-PkZ.js",
-      "scene24-parse-camera-C5teympL.js",
+      "scene24-cube-texture-CRhDUiiS.js",
+      "scene24-generate-mipmaps-BaRC2la_.js",
+      "scene24-parse-camera-D4iQaH48.js",
       "scene24-point-light-Dzvg6X6L.js",
-      "scene24-standard-renderable-BDxHHxyq.js",
-      "scene24-std-ambient-fragment-CcKpKlZC.js",
-      "scene24-std-cube-reflection-fragment-7YQxc0DU.js",
-      "scene24-std-opacity-fragment-C4ksFCLL.js",
-      "scene24-std-specular-fragment-IOeAaXCa.js",
+      "scene24-standard-renderable-BAGzWyaG.js",
+      "scene24-std-ambient-fragment-qLXGuA_5.js",
+      "scene24-std-cube-reflection-fragment-QMf1Qd6k.js",
+      "scene24-std-opacity-fragment-BZwWqo7S.js",
+      "scene24-std-specular-fragment-DhCYMq1P.js",
       "scene24-wgsl-helpers-CwHFFXvt.js",
       "scene24.js"
     ],
@@ -447,10 +447,10 @@
   },
   "scene25": {
     "rawKB": 50.3,
-    "gzipKB": 19.8,
+    "gzipKB": 20,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene25-standard-renderable-Co9g1GCD.js",
+      "scene25-standard-renderable-0Cb4e15X.js",
       "scene25-wgsl-helpers-CwHFFXvt.js",
       "scene25.js"
     ],
@@ -458,41 +458,41 @@
     "bjsGzipKB": 335.9
   },
   "scene26": {
-    "rawKB": 86.4,
-    "gzipKB": 35,
+    "rawKB": 86.3,
+    "gzipKB": 35.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene26-emissive-fragment-DssORO9L.js",
-      "scene26-generate-mipmaps-BELKGD4M.js",
-      "scene26-gltf-glb-parser-BdYiApo0.js",
+      "scene26-generate-mipmaps-fz4NkUex.js",
+      "scene26-gltf-glb-parser-C6MhXxK0.js",
       "scene26-ibl-fragment-CeRrvT96.js",
       "scene26-ibl-skybox-wgsl-CFIBOHHx.js",
       "scene26-pbr-aces-wgsl-XxSkrbTG.js",
-      "scene26-pbr-renderable-CkQEvRFv.js",
-      "scene26-rgbd-decode-DCi_9yYh.js",
+      "scene26-pbr-renderable-BYWrs23A.js",
+      "scene26-rgbd-decode-NezlUuK3.js",
       "scene26-scene-material-swap-BfoPtupw.js",
-      "scene26-singlelight-point-wgsl-Qt73-6pk.js",
-      "scene26-subsurface-fragment-DwHh2JG-.js",
+      "scene26-singlelight-point-wgsl-C6O6u3VE.js",
+      "scene26-subsurface-fragment-CuQPhwCY.js",
       "scene26.js"
     ],
     "bjsRawKB": 2513.7,
     "bjsGzipKB": 620.2
   },
   "scene27": {
-    "rawKB": 78.1,
-    "gzipKB": 31.6,
+    "rawKB": 78.3,
+    "gzipKB": 31.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene27-generate-mipmaps-D9lS9rqF.js",
+      "scene27-generate-mipmaps-C_Uu-3vq.js",
       "scene27-gltf-ext-dielectric-BD8fbfh2.js",
-      "scene27-gltf-feature-registry-irjqLeiH.js",
-      "scene27-gltf-feature-variants-OvA8E4iV.js",
-      "scene27-gltf-glb-parser-BdYiApo0.js",
-      "scene27-gltf-pbr-builder-ext-CgDTxYek.js",
-      "scene27-gltf-variants-CuAt6Kxe.js",
-      "scene27-pbr-renderable-DzDZmCrn.js",
-      "scene27-reflectance-fragment-BGEgfPhz.js",
-      "scene27-singlelight-hemispheric-wgsl-CRsqbZpS.js",
+      "scene27-gltf-feature-registry-BvhMJqHt.js",
+      "scene27-gltf-feature-variants-4oro3aXu.js",
+      "scene27-gltf-glb-parser-By8noE3G.js",
+      "scene27-gltf-pbr-builder-ext-Ci9-zSIk.js",
+      "scene27-gltf-variants-CloTggE6.js",
+      "scene27-pbr-renderable-BU_u-iJt.js",
+      "scene27-reflectance-fragment-DEly-U39.js",
+      "scene27-singlelight-hemispheric-wgsl-zGaFHbfA.js",
       "scene27-texture-2d-DQo3n8D6.js",
       "scene27.js"
     ],
@@ -501,16 +501,16 @@
   },
   "scene28": {
     "rawKB": 82.4,
-    "gzipKB": 32.9,
+    "gzipKB": 33.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene28-clearcoat-fragment-JixntrVf.js",
-      "scene28-generate-mipmaps-B0lI1mYw.js",
+      "scene28-clearcoat-fragment-CZ6sbATo.js",
+      "scene28-generate-mipmaps-Co5kXW3U.js",
       "scene28-gltf-ext-clearcoat-BgaLgSgD.js",
-      "scene28-gltf-feature-registry-CdXkwpzc.js",
+      "scene28-gltf-feature-registry-Dc5UhvM8.js",
       "scene28-ibl-fragment-CeRrvT96.js",
-      "scene28-pbr-renderable-CRs_v5TD.js",
-      "scene28-rgbd-decode-Baow08lG.js",
+      "scene28-pbr-renderable-Do6Se2VT.js",
+      "scene28-rgbd-decode-wUvHpHPX.js",
       "scene28-scene-uniforms-FTYH6Ct0.js",
       "scene28.js"
     ],
@@ -519,20 +519,20 @@
   },
   "scene29": {
     "rawKB": 85.1,
-    "gzipKB": 34.7,
+    "gzipKB": 35,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene29-generate-mipmaps-BFS72U4l.js",
+      "scene29-generate-mipmaps-DbegQHQ8.js",
       "scene29-gltf-ext-sheen-Cje8BD0o.js",
       "scene29-gltf-ext-uv-transform-tUSEOqA7.js",
-      "scene29-gltf-feature-registry-C2F01x1U.js",
-      "scene29-gltf-pbr-builder-ext-Gw6OMS_B.js",
+      "scene29-gltf-feature-registry-CtOWw_aN.js",
+      "scene29-gltf-pbr-builder-ext-BvfabSGG.js",
       "scene29-ibl-fragment-CeRrvT96.js",
-      "scene29-pbr-renderable-cMe9RKW3.js",
+      "scene29-pbr-renderable-DkdVD4fS.js",
       "scene29-pbr-template-ext-BMNgm5oJ.js",
-      "scene29-rgbd-decode-Baow08lG.js",
+      "scene29-rgbd-decode-DZaCQfRj.js",
       "scene29-scene-uniforms-FTYH6Ct0.js",
-      "scene29-sheen-fragment-BxU1lww5.js",
+      "scene29-sheen-fragment-D2PEIBr0.js",
       "scene29-texture-2d-DQo3n8D6.js",
       "scene29-uv-transform-fragment-CSKooEw-.js",
       "scene29.js"
@@ -541,24 +541,24 @@
     "bjsGzipKB": 672
   },
   "scene30": {
-    "rawKB": 98.9,
-    "gzipKB": 40.4,
+    "rawKB": 98.8,
+    "gzipKB": 40.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene30-alpha-test-fragment-CcGPBGlc.js",
-      "scene30-generate-mipmaps-B07GdZMy.js",
+      "scene30-alpha-test-fragment-Dp7v2RIU.js",
+      "scene30-generate-mipmaps-DKfMdJ6W.js",
       "scene30-gltf-ext-dielectric-BD8fbfh2.js",
       "scene30-gltf-ext-uv-transform-DQN5DAiE.js",
-      "scene30-gltf-feature-draco-Dp1Q_d-R.js",
-      "scene30-gltf-feature-registry-BJr9C1u_.js",
-      "scene30-gltf-glb-parser-BdYiApo0.js",
-      "scene30-gltf-pbr-builder-ext-BLH-jeNY.js",
+      "scene30-gltf-feature-draco-BSbw1ZBU.js",
+      "scene30-gltf-feature-registry-Bgg2PfYJ.js",
+      "scene30-gltf-glb-parser-DJ0cTJ-4.js",
+      "scene30-gltf-pbr-builder-ext-UoNohl7u.js",
       "scene30-ibl-fragment-CeRrvT96.js",
-      "scene30-pbr-refraction-CUb97Vqv.js",
-      "scene30-pbr-renderable-BjjZJ73V.js",
+      "scene30-pbr-refraction-Dcp1J1Zn.js",
+      "scene30-pbr-renderable-86rM89VA.js",
       "scene30-pbr-template-ext-BMNgm5oJ.js",
-      "scene30-pbr-transmission-ext-DTuxUqjd.js",
-      "scene30-rgbd-decode-Baow08lG.js",
+      "scene30-pbr-transmission-ext-B_4K9QKX.js",
+      "scene30-rgbd-decode-RQYTGqhL.js",
       "scene30-scene-uniforms-FTYH6Ct0.js",
       "scene30-texture-2d-DQo3n8D6.js",
       "scene30-uv-transform-fragment-CSKooEw-.js",
@@ -569,17 +569,17 @@
   },
   "scene31": {
     "rawKB": 77.5,
-    "gzipKB": 31.3,
+    "gzipKB": 31.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene31-emissive-fragment-D9YgD8Tf.js",
-      "scene31-generate-mipmaps-Dz93Wm_G.js",
+      "scene31-emissive-fragment-BaCWdWiK.js",
+      "scene31-generate-mipmaps-Dq9Q3PQ0.js",
       "scene31-gltf-ext-emissive-strength-CButLZnK.js",
-      "scene31-gltf-feature-registry-DzamS564.js",
-      "scene31-gltf-glb-parser-BdYiApo0.js",
+      "scene31-gltf-feature-registry-D29SoyMk.js",
+      "scene31-gltf-glb-parser-CzRZVo57.js",
       "scene31-ibl-fragment-CeRrvT96.js",
-      "scene31-pbr-renderable-5ZBTorv8.js",
-      "scene31-rgbd-decode-Baow08lG.js",
+      "scene31-pbr-renderable-Cy8YGXQ6.js",
+      "scene31-rgbd-decode-C5kd6U3R.js",
       "scene31-scene-uniforms-FTYH6Ct0.js",
       "scene31.js"
     ],
@@ -588,41 +588,41 @@
   },
   "scene32": {
     "rawKB": 77.4,
-    "gzipKB": 31.3,
+    "gzipKB": 31.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene32-generate-mipmaps-BG2Dgu4F.js",
+      "scene32-generate-mipmaps-D5z-_ysd.js",
       "scene32-gltf-ext-unlit-1vUYfF7v.js",
-      "scene32-gltf-feature-registry-VhxGLtoZ.js",
-      "scene32-gltf-glb-parser-BdYiApo0.js",
+      "scene32-gltf-feature-registry-CwxGLE4u.js",
+      "scene32-gltf-glb-parser-BX2AS-bF.js",
       "scene32-ibl-fragment-CeRrvT96.js",
-      "scene32-pbr-renderable-jw7X64MN.js",
-      "scene32-rgbd-decode-Baow08lG.js",
+      "scene32-pbr-renderable-B1Qx3zb9.js",
+      "scene32-rgbd-decode-3FngBUdB.js",
       "scene32-scene-uniforms-FTYH6Ct0.js",
-      "scene32-unlit-fragment-DR8kCjzW.js",
+      "scene32-unlit-fragment-DYNWudHP.js",
       "scene32.js"
     ],
     "bjsRawKB": 2785.6,
     "bjsGzipKB": 672
   },
   "scene33": {
-    "rawKB": 97.7,
-    "gzipKB": 39.3,
+    "rawKB": 97.6,
+    "gzipKB": 39.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene33-generate-mipmaps-BQ6dPQxN.js",
+      "scene33-generate-mipmaps-D7X9V4X_.js",
       "scene33-gltf-ext-dielectric-BD8fbfh2.js",
-      "scene33-gltf-feature-lights-punctual-D-Z6Su5R.js",
-      "scene33-gltf-feature-registry-DNnv65hF.js",
-      "scene33-gltf-glb-parser-BdYiApo0.js",
+      "scene33-gltf-feature-lights-punctual-g3ns1PNY.js",
+      "scene33-gltf-feature-registry-D45QBmE8.js",
+      "scene33-gltf-glb-parser-DMBUHtjv.js",
       "scene33-ibl-fragment-CeRrvT96.js",
-      "scene33-light-base-037m_Qwf.js",
-      "scene33-multilight-wgsl-y-tQkc0t.js",
-      "scene33-pbr-refraction-0WZdGUmY.js",
-      "scene33-pbr-renderable-Dxiasrab.js",
-      "scene33-pbr-transmission-ext-DctrWgL2.js",
-      "scene33-point-light-DeuSjNwU.js",
-      "scene33-rgbd-decode-Baow08lG.js",
+      "scene33-light-base-SJy-sLMD.js",
+      "scene33-multilight-wgsl-DpDtghxN.js",
+      "scene33-pbr-refraction-D29vlTlV.js",
+      "scene33-pbr-renderable-CHusuzAr.js",
+      "scene33-pbr-transmission-ext-KN9Gpv_w.js",
+      "scene33-point-light-CcVWqAnQ.js",
+      "scene33-rgbd-decode-3bEbw5la.js",
       "scene33-scene-uniforms-FTYH6Ct0.js",
       "scene33.js"
     ],
@@ -630,42 +630,42 @@
     "bjsGzipKB": 672
   },
   "scene34": {
-    "rawKB": 88.5,
-    "gzipKB": 36.3,
+    "rawKB": 88.3,
+    "gzipKB": 36.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene34-generate-mipmaps-Dkjp5xLU.js",
-      "scene34-gltf-animation-3ohppMDm.js",
-      "scene34-gltf-ext-node-visibility-DsFyUz4w.js",
-      "scene34-gltf-feature-animation-pointer-DwDrVNhj.js",
-      "scene34-gltf-feature-animations-BlFl_Sro.js",
-      "scene34-gltf-feature-registry-VD7qneol.js",
-      "scene34-gltf-glb-parser-BdYiApo0.js",
+      "scene34-generate-mipmaps-ChMdgf75.js",
+      "scene34-gltf-animation-DxjCEBS2.js",
+      "scene34-gltf-ext-node-visibility-CyR_MQR5.js",
+      "scene34-gltf-feature-animation-pointer-BvFaPIiV.js",
+      "scene34-gltf-feature-animations-CdvPwMVA.js",
+      "scene34-gltf-feature-registry-BAa4NvKj.js",
+      "scene34-gltf-glb-parser-BxoFTGKn.js",
       "scene34-ibl-fragment-CeRrvT96.js",
-      "scene34-pbr-renderable-Nk0N2Dps.js",
-      "scene34-rgbd-decode-Baow08lG.js",
+      "scene34-pbr-renderable-BghcfFFA.js",
+      "scene34-rgbd-decode-ByPAsdES.js",
       "scene34-scene-uniforms-FTYH6Ct0.js",
-      "scene34-visibility-_iDrqaeV.js",
+      "scene34-visibility-fb8svtso.js",
       "scene34.js"
     ],
     "bjsRawKB": 2799,
     "bjsGzipKB": 675.5
   },
   "scene35": {
-    "rawKB": 80.6,
-    "gzipKB": 32.7,
+    "rawKB": 80.5,
+    "gzipKB": 33,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene35-generate-mipmaps-C9nmXb8N.js",
-      "scene35-gltf-feature-gpu-instancing-Dd1qyY5T.js",
-      "scene35-gltf-feature-registry-BjGfWh2a.js",
-      "scene35-gltf-glb-parser-BdYiApo0.js",
+      "scene35-generate-mipmaps-ByfC6wwV.js",
+      "scene35-gltf-feature-gpu-instancing-aiofVXLy.js",
+      "scene35-gltf-feature-registry-Cubo6LSq.js",
+      "scene35-gltf-glb-parser-BJyme4Vk.js",
       "scene35-ibl-fragment-CeRrvT96.js",
-      "scene35-pbr-renderable-Ceq8exLs.js",
-      "scene35-rgbd-decode-Baow08lG.js",
+      "scene35-pbr-renderable-DZw9Rcaw.js",
+      "scene35-rgbd-decode-U56TFVGU.js",
       "scene35-scene-uniforms-FTYH6Ct0.js",
       "scene35-thin-instance-fragment-CBn2miAC.js",
-      "scene35-thin-instance-gpu-DPLqMnHZ.js",
+      "scene35-thin-instance-gpu-BssrSfbn.js",
       "scene35.js"
     ],
     "bjsRawKB": 2785.6,
@@ -673,10 +673,10 @@
   },
   "scene36": {
     "rawKB": 49.7,
-    "gzipKB": 19.4,
+    "gzipKB": 19.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene36-standard-renderable-DHUi-KOd.js",
+      "scene36-standard-renderable-C-sssVVi.js",
       "scene36-std-emissive-fragment-DthzsVUc.js",
       "scene36-wgsl-helpers-CwHFFXvt.js",
       "scene36.js"
@@ -686,24 +686,24 @@
   },
   "scene37": {
     "rawKB": 91.5,
-    "gzipKB": 37.2,
+    "gzipKB": 37.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene37-generate-mipmaps-tHOhBumz.js",
+      "scene37-generate-mipmaps-mp9BfKkg.js",
       "scene37-gltf-color-normalize-DA3N7QfB.js",
       "scene37-gltf-ext-dielectric-BD8fbfh2.js",
       "scene37-gltf-ext-sheen-Cje8BD0o.js",
       "scene37-gltf-ext-uv-transform-hVTzf5Q9.js",
-      "scene37-gltf-feature-registry-_7ONbRbe.js",
-      "scene37-gltf-glb-parser-BdYiApo0.js",
-      "scene37-gltf-pbr-builder-ext-CWswZH8-.js",
+      "scene37-gltf-feature-registry-CKCGF4Q5.js",
+      "scene37-gltf-glb-parser-CkbGcOCI.js",
+      "scene37-gltf-pbr-builder-ext-BZPjy_UI.js",
       "scene37-ibl-fragment-CeRrvT96.js",
-      "scene37-pbr-renderable-BwHCBtwW.js",
+      "scene37-pbr-renderable-DzYhC0tR.js",
       "scene37-pbr-template-ext-BMNgm5oJ.js",
-      "scene37-reflectance-fragment-Do0t-CYw.js",
-      "scene37-rgbd-decode-Baow08lG.js",
+      "scene37-reflectance-fragment-DrFCPiL4.js",
+      "scene37-rgbd-decode-D3VLnI-E.js",
       "scene37-scene-uniforms-FTYH6Ct0.js",
-      "scene37-sheen-fragment-BqTGbdey.js",
+      "scene37-sheen-fragment-DS5jyHGb.js",
       "scene37-texture-2d-DQo3n8D6.js",
       "scene37-uv-transform-fragment-CSKooEw-.js",
       "scene37.js"
@@ -712,11 +712,11 @@
     "bjsGzipKB": 672
   },
   "scene38": {
-    "rawKB": 59.5,
-    "gzipKB": 23.3,
+    "rawKB": 59.4,
+    "gzipKB": 23.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene38-standard-renderable-B59cfNeL.js",
+      "scene38-standard-renderable-dcjL1jMh.js",
       "scene38-wgsl-helpers-CwHFFXvt.js",
       "scene38.js"
     ],
@@ -725,10 +725,10 @@
   },
   "scene40": {
     "rawKB": 46.7,
-    "gzipKB": 18.7,
+    "gzipKB": 18.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene40-standard-renderable-DH6_OHTf.js",
+      "scene40-standard-renderable-DPdENwbA.js",
       "scene40-wgsl-helpers-CwHFFXvt.js",
       "scene40.js"
     ],
@@ -736,8 +736,8 @@
     "bjsGzipKB": 354.9
   },
   "scene50": {
-    "rawKB": 15.6,
-    "gzipKB": 6.7,
+    "rawKB": 15.7,
+    "gzipKB": 6.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene50.js"
@@ -746,8 +746,8 @@
     "bjsGzipKB": 195.1
   },
   "scene51": {
-    "rawKB": 16.1,
-    "gzipKB": 6.8,
+    "rawKB": 16.3,
+    "gzipKB": 7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene51.js"
@@ -757,10 +757,10 @@
   },
   "scene52": {
     "rawKB": 56.3,
-    "gzipKB": 22.3,
+    "gzipKB": 22.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene52-standard-renderable-B1QMI3FR.js",
+      "scene52-standard-renderable-Dp5qT4QW.js",
       "scene52-wgsl-helpers-CwHFFXvt.js",
       "scene52.js"
     ],
@@ -768,11 +768,11 @@
     "bjsGzipKB": 363.8
   },
   "scene53": {
-    "rawKB": 56.6,
-    "gzipKB": 22.3,
+    "rawKB": 56.5,
+    "gzipKB": 22.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene53-standard-renderable-BA8AK66l.js",
+      "scene53-standard-renderable-CfS6Ol2O.js",
       "scene53-wgsl-helpers-CwHFFXvt.js",
       "scene53.js"
     ],
@@ -780,13 +780,13 @@
     "bjsGzipKB": 368.8
   },
   "scene54": {
-    "rawKB": 58.5,
-    "gzipKB": 23.4,
+    "rawKB": 58.4,
+    "gzipKB": 23.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene54-billboard-renderable-OSFTAbvY.js",
+      "scene54-billboard-renderable-Dj1jOpTx.js",
       "scene54-scene-uniforms-FTYH6Ct0.js",
-      "scene54-standard-renderable-CZoh6jvu.js",
+      "scene54-standard-renderable-BmkHadPA.js",
       "scene54-wgsl-helpers-CwHFFXvt.js",
       "scene54.js"
     ],
@@ -794,24 +794,24 @@
     "bjsGzipKB": 368.7
   },
   "scene55": {
-    "rawKB": 30.5,
-    "gzipKB": 12.4,
+    "rawKB": 30.6,
+    "gzipKB": 12.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene55-billboard-renderable-je_nINla.js",
+      "scene55-billboard-renderable-BDDv7N1P.js",
       "scene55.js"
     ],
     "bjsRawKB": 1000.2,
     "bjsGzipKB": 240.4
   },
   "scene56": {
-    "rawKB": 58.8,
-    "gzipKB": 23.5,
+    "rawKB": 58.7,
+    "gzipKB": 23.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene56-billboard-renderable-CYuTRHVe.js",
+      "scene56-billboard-renderable-D-ufoeZ2.js",
       "scene56-scene-uniforms-FTYH6Ct0.js",
-      "scene56-standard-renderable-C82aIjJS.js",
+      "scene56-standard-renderable-B9U5vpkI.js",
       "scene56-wgsl-helpers-CwHFFXvt.js",
       "scene56.js"
     ],
@@ -819,13 +819,13 @@
     "bjsGzipKB": 359.7
   },
   "scene57": {
-    "rawKB": 58.7,
-    "gzipKB": 23.4,
+    "rawKB": 58.6,
+    "gzipKB": 23.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene57-billboard-renderable-CHEfRNmv.js",
+      "scene57-billboard-renderable-jmbOSGq2.js",
       "scene57-scene-uniforms-FTYH6Ct0.js",
-      "scene57-standard-renderable-DZCusmg1.js",
+      "scene57-standard-renderable-x9ZahErJ.js",
       "scene57-wgsl-helpers-CwHFFXvt.js",
       "scene57.js"
     ],
@@ -833,8 +833,8 @@
     "bjsGzipKB": 348.6
   },
   "scene58": {
-    "rawKB": 18.7,
-    "gzipKB": 7.7,
+    "rawKB": 18.9,
+    "gzipKB": 7.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene58.js"
@@ -843,13 +843,13 @@
     "bjsGzipKB": 195.2
   },
   "scene59": {
-    "rawKB": 61.8,
-    "gzipKB": 24.5,
+    "rawKB": 61.7,
+    "gzipKB": 24.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene59-billboard-renderable-Dqxh6p1g.js",
+      "scene59-billboard-renderable-BFn7ZFg5.js",
       "scene59-scene-uniforms-FTYH6Ct0.js",
-      "scene59-standard-renderable-CCKR0zRA.js",
+      "scene59-standard-renderable-CJzj_2sV.js",
       "scene59-wgsl-helpers-CwHFFXvt.js",
       "scene59.js"
     ],
@@ -857,15 +857,15 @@
     "bjsGzipKB": 357.7
   },
   "scene60": {
-    "rawKB": 54.4,
-    "gzipKB": 22,
+    "rawKB": 54.5,
+    "gzipKB": 22.3,
     "ignoredRawKB": 4,
     "runtimeChunks": [
       "scene60-_math-factory-DFVyS8gB.js",
       "scene60-fragment-output-CfRmfbPv.js",
       "scene60-input-block-Dx-s01X8.js",
       "scene60-node-registry-CadvdDye.js",
-      "scene60-node-renderable-D3_LK0LW.js",
+      "scene60-node-renderable-D80rjSle.js",
       "scene60-transform-block-CTO4A4d-.js",
       "scene60-vertex-output-C7G5u6Y0.js",
       "scene60.js"
@@ -874,8 +874,8 @@
     "bjsGzipKB": 525
   },
   "scene61": {
-    "rawKB": 53.3,
-    "gzipKB": 22.5,
+    "rawKB": 53.4,
+    "gzipKB": 22.9,
     "ignoredRawKB": 7.3,
     "runtimeChunks": [
       "scene61-_math-factory-DFVyS8gB.js",
@@ -883,7 +883,7 @@
       "scene61-fragment-output-CfRmfbPv.js",
       "scene61-input-block-DpRZ-Ft1.js",
       "scene61-node-registry-BLVdOM7s.js",
-      "scene61-node-renderable-BIzupA4h.js",
+      "scene61-node-renderable-Bc6SqVGY.js",
       "scene61-scale-block-6qtIvFiz.js",
       "scene61-transform-block-CNLo7x5_.js",
       "scene61-vertex-output-C7G5u6Y0.js",
@@ -893,16 +893,16 @@
     "bjsGzipKB": 525.1
   },
   "scene62": {
-    "rawKB": 59,
-    "gzipKB": 24.5,
+    "rawKB": 59.1,
+    "gzipKB": 24.9,
     "ignoredRawKB": 5.3,
     "runtimeChunks": [
       "scene62-_math-factory-DFVyS8gB.js",
       "scene62-fragment-output-CfRmfbPv.js",
-      "scene62-generate-mipmaps-pBtPea8u.js",
+      "scene62-generate-mipmaps-BPTGASCY.js",
       "scene62-input-block-BgDpnyI_.js",
       "scene62-node-registry-Br5texho.js",
-      "scene62-node-renderable-DJQZfzpG.js",
+      "scene62-node-renderable-DC1M1pRn.js",
       "scene62-texture-block-qpJiHpPr.js",
       "scene62-transform-block-BSlYzxBO.js",
       "scene62-vertex-output-C7G5u6Y0.js",
@@ -912,8 +912,8 @@
     "bjsGzipKB": 525.1
   },
   "scene63": {
-    "rawKB": 57.6,
-    "gzipKB": 23.8,
+    "rawKB": 57.7,
+    "gzipKB": 24.2,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
       "scene63-_math-factory-DFVyS8gB.js",
@@ -921,7 +921,7 @@
       "scene63-input-block-DtZeDmLA.js",
       "scene63-light-block-CgTopKLU.js",
       "scene63-node-registry-rFrgV52w.js",
-      "scene63-node-renderable-CgPEheSx.js",
+      "scene63-node-renderable-CeU0Z0rl.js",
       "scene63-transform-block-CvEP0L-h.js",
       "scene63-vertex-output-C7G5u6Y0.js",
       "scene63.js"
@@ -930,8 +930,8 @@
     "bjsGzipKB": 525.9
   },
   "scene64": {
-    "rawKB": 55.9,
-    "gzipKB": 22.9,
+    "rawKB": 56,
+    "gzipKB": 23.3,
     "ignoredRawKB": 4.3,
     "runtimeChunks": [
       "scene64-_math-factory-DFVyS8gB.js",
@@ -939,7 +939,7 @@
       "scene64-input-block-CmvPVsv0.js",
       "scene64-morph-targets-CsnL5CDS.js",
       "scene64-node-registry-BGlOKEWI.js",
-      "scene64-node-renderable-Cb6gQ-Q-.js",
+      "scene64-node-renderable-ClUuN-9v.js",
       "scene64-transform-block-C-HoggRW.js",
       "scene64-vertex-output-C7G5u6Y0.js",
       "scene64.js"
@@ -948,8 +948,8 @@
     "bjsGzipKB": 528
   },
   "scene65": {
-    "rawKB": 73.6,
-    "gzipKB": 29.9,
+    "rawKB": 73.3,
+    "gzipKB": 30.2,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
       "scene65-_math-factory-DFVyS8gB.js",
@@ -959,10 +959,10 @@
       "scene65-light-block-XCXiIzop.js",
       "scene65-material-view-Dua1bl7W.js",
       "scene65-node-flags-3CD_c1Kp.js",
-      "scene65-node-registry-uQFqmpth.js",
-      "scene65-node-renderable-CRHGzOS9.js",
-      "scene65-node-shadow-DGK1QqE_.js",
-      "scene65-shadow-task-D6lP1Bd2.js",
+      "scene65-node-registry-HYoiaEYu.js",
+      "scene65-node-renderable-BUnfwGol.js",
+      "scene65-node-shadow-BY0HoKUN.js",
+      "scene65-shadow-task-B86V2Y46.js",
       "scene65-transform-block-DDRhlmcT.js",
       "scene65-vertex-output-C7G5u6Y0.js",
       "scene65.js"
@@ -971,8 +971,8 @@
     "bjsGzipKB": 545.8
   },
   "scene66": {
-    "rawKB": 88.4,
-    "gzipKB": 40.4,
+    "rawKB": 88.1,
+    "gzipKB": 40.7,
     "ignoredRawKB": 5.5,
     "runtimeChunks": [
       "scene66-_math-factory-DFVyS8gB.js",
@@ -985,7 +985,7 @@
       "scene66-fog-block-CUWwapOp.js",
       "scene66-fragment-output-CfRmfbPv.js",
       "scene66-front-facing-BE20bXNF.js",
-      "scene66-generate-mipmaps-D7MjUuq6.js",
+      "scene66-generate-mipmaps-B1ZQ8ZA_.js",
       "scene66-input-block-BKxsuJgd.js",
       "scene66-instances-block-ClV6QcvR.js",
       "scene66-lerp-block-C-aAgJ4A.js",
@@ -997,14 +997,14 @@
       "scene66-negate-block--YegGQDT.js",
       "scene66-no-color-view-CIGis567.js",
       "scene66-node-flags-3CD_c1Kp.js",
-      "scene66-node-registry-B_Ea15dU.js",
-      "scene66-node-renderable-CzhPJJSY.js",
-      "scene66-node-shadow-fpSaAatb.js",
+      "scene66-node-registry-CxS3_bAE.js",
+      "scene66-node-renderable-C22G_51y.js",
+      "scene66-node-shadow-Cy57LC4F.js",
       "scene66-normalize-block-i-7IPb6A.js",
       "scene66-oneminus-block-C_JubHUo.js",
       "scene66-perturb-normal-Bqx-TYaB.js",
       "scene66-reflection-texture-block-DVZpi6Yq.js",
-      "scene66-shadow-task-DxLpJfh3.js",
+      "scene66-shadow-task-BddeV_0i.js",
       "scene66-subtract-block-Hxi-scSa.js",
       "scene66-texture-block-qpJiHpPr.js",
       "scene66-transform-block-CSMiS9fY.js",
@@ -1018,19 +1018,19 @@
   },
   "scene67": {
     "rawKB": 75.8,
-    "gzipKB": 31.5,
+    "gzipKB": 31.9,
     "ignoredRawKB": 9.6,
     "runtimeChunks": [
       "scene67-_math-factory-DFVyS8gB.js",
       "scene67-fragment-output-CfRmfbPv.js",
       "scene67-input-block-C3R5NLd7.js",
-      "scene67-node-env-9-digQG0.js",
+      "scene67-node-env-qYXpqh6a.js",
       "scene67-node-registry-HEYWs9TG.js",
-      "scene67-node-renderable-CIeKUk4c.js",
+      "scene67-node-renderable-DP1Z4q-M.js",
       "scene67-pbr-metallic-roughness-block-D4ponzyR.js",
       "scene67-pbr-mr-helper-core-B-eTRTiT.js",
       "scene67-reflection-block-CIXuH-z0.js",
-      "scene67-rgbd-decode-Baow08lG.js",
+      "scene67-rgbd-decode-B40kelZF.js",
       "scene67-transform-block-rM3lkwUr.js",
       "scene67-vertex-output-C7G5u6Y0.js",
       "scene67.js"
@@ -1040,19 +1040,19 @@
   },
   "scene68": {
     "rawKB": 90.4,
-    "gzipKB": 35.1,
+    "gzipKB": 35.5,
     "ignoredRawKB": 11.4,
     "runtimeChunks": [
       "scene68-_math-factory-DFVyS8gB.js",
       "scene68-clearcoat-block-BPLkmxQ1.js",
       "scene68-fragment-output-CfRmfbPv.js",
       "scene68-input-block-CMznN6K7.js",
-      "scene68-node-env-9-digQG0.js",
+      "scene68-node-env-BmDVlYJR.js",
       "scene68-node-registry-DApWtVeG.js",
-      "scene68-node-renderable-CRHqDn8e.js",
+      "scene68-node-renderable-Bdim_Vtp.js",
       "scene68-pbr-metallic-roughness-block-full-D6C912Hk.js",
       "scene68-reflection-block-CIXuH-z0.js",
-      "scene68-rgbd-decode-Baow08lG.js",
+      "scene68-rgbd-decode-hVgExCFE.js",
       "scene68-transform-block-W9o3XBNz.js",
       "scene68-vertex-output-C7G5u6Y0.js",
       "scene68.js"
@@ -1061,20 +1061,20 @@
     "bjsGzipKB": 564.3
   },
   "scene69": {
-    "rawKB": 89.9,
-    "gzipKB": 35.3,
+    "rawKB": 89.8,
+    "gzipKB": 35.7,
     "ignoredRawKB": 13.3,
     "runtimeChunks": [
       "scene69-_math-factory-DFVyS8gB.js",
       "scene69-clearcoat-block-BPLkmxQ1.js",
       "scene69-fragment-output-CfRmfbPv.js",
       "scene69-input-block-DlAP62bA.js",
-      "scene69-node-env-9-digQG0.js",
+      "scene69-node-env-CLyiyONV.js",
       "scene69-node-registry-C4wezeMX.js",
-      "scene69-node-renderable-Brjke5W9.js",
+      "scene69-node-renderable-BPA6FQxv.js",
       "scene69-pbr-metallic-roughness-block-full-DTeJOcfz.js",
       "scene69-reflection-block-CIXuH-z0.js",
-      "scene69-rgbd-decode-Baow08lG.js",
+      "scene69-rgbd-decode-Buimsxf_.js",
       "scene69-sheen-block-DPtS9jU8.js",
       "scene69-transform-block-9HPeqD3I.js",
       "scene69-vertex-output-C7G5u6Y0.js",
@@ -1085,7 +1085,7 @@
   },
   "scene70": {
     "rawKB": 90.2,
-    "gzipKB": 35.9,
+    "gzipKB": 36.3,
     "ignoredRawKB": 14.9,
     "runtimeChunks": [
       "scene70-_math-factory-DFVyS8gB.js",
@@ -1093,13 +1093,13 @@
       "scene70-clearcoat-block-BPLkmxQ1.js",
       "scene70-fragment-output-CfRmfbPv.js",
       "scene70-input-block-Db0MJXes.js",
-      "scene70-node-env-9-digQG0.js",
+      "scene70-node-env-4ZRwgEb_.js",
       "scene70-node-registry-DYQ-NwZn.js",
-      "scene70-node-renderable-seBcTAC9.js",
+      "scene70-node-renderable-BzLqRfaF.js",
       "scene70-pbr-metallic-roughness-block-full-DcgmRC5G.js",
       "scene70-perturb-normal-Bqx-TYaB.js",
       "scene70-reflection-block-CIXuH-z0.js",
-      "scene70-rgbd-decode-Baow08lG.js",
+      "scene70-rgbd-decode-CBYrTgBv.js",
       "scene70-transform-block-C-Fv9v1c.js",
       "scene70-vertex-output-C7G5u6Y0.js",
       "scene70.js"
@@ -1108,20 +1108,20 @@
     "bjsGzipKB": 564.5
   },
   "scene71": {
-    "rawKB": 90.1,
-    "gzipKB": 35.3,
+    "rawKB": 90,
+    "gzipKB": 35.7,
     "ignoredRawKB": 12.9,
     "runtimeChunks": [
       "scene71-_math-factory-DFVyS8gB.js",
       "scene71-fragment-output-CfRmfbPv.js",
       "scene71-input-block-DDVjNkyD.js",
-      "scene71-node-env-9-digQG0.js",
+      "scene71-node-env-z9bvnvMK.js",
       "scene71-node-registry-OF2GU_NH.js",
-      "scene71-node-renderable-CU70pM95.js",
+      "scene71-node-renderable-DcSIHyXA.js",
       "scene71-pbr-metallic-roughness-block-full-B9M9WJa7.js",
       "scene71-reflection-block-CIXuH-z0.js",
       "scene71-refraction-block-CNhcdLis.js",
-      "scene71-rgbd-decode-Baow08lG.js",
+      "scene71-rgbd-decode-_4sbXxfW.js",
       "scene71-subsurface-block-DAwWnSbB.js",
       "scene71-transform-block-DmQXXRvt.js",
       "scene71-vertex-output-C7G5u6Y0.js",
@@ -1131,8 +1131,8 @@
     "bjsGzipKB": 564.4
   },
   "scene72": {
-    "rawKB": 107.7,
-    "gzipKB": 43,
+    "rawKB": 107.4,
+    "gzipKB": 43.4,
     "ignoredRawKB": 3.3,
     "runtimeChunks": [
       "scene72-_math-factory-DFVyS8gB.js",
@@ -1140,21 +1140,21 @@
       "scene72-anisotropy-block-DShn3fIV.js",
       "scene72-clearcoat-block-BPLkmxQ1.js",
       "scene72-fragment-output-CfRmfbPv.js",
-      "scene72-generate-mipmaps-CpX-AFRr.js",
+      "scene72-generate-mipmaps-CCvd-A1S.js",
       "scene72-input-block-CwsdVAEj.js",
       "scene72-lerp-block-BvdxNwIV.js",
       "scene72-material-view-Dua1bl7W.js",
       "scene72-multiply-block-D_sMIxWb.js",
       "scene72-no-color-view-BDusEge-.js",
-      "scene72-node-env-9-digQG0.js",
+      "scene72-node-env-DEj3wHeF.js",
       "scene72-node-flags-3CD_c1Kp.js",
-      "scene72-node-renderable-DsjvZY_u.js",
+      "scene72-node-renderable-Cq-TLQbR.js",
       "scene72-pbr-metallic-roughness-block-full-_JEZLZiJ.js",
       "scene72-perturb-normal-Bqx-TYaB.js",
       "scene72-reflection-block-CIXuH-z0.js",
       "scene72-refraction-block-CNhcdLis.js",
-      "scene72-rgbd-decode-Baow08lG.js",
-      "scene72-shadow-task-ksqPj9dV.js",
+      "scene72-rgbd-decode-PGd42at7.js",
+      "scene72-shadow-task-Dnzr-Piz.js",
       "scene72-sheen-block-DPtS9jU8.js",
       "scene72-subsurface-block-DAwWnSbB.js",
       "scene72-subtract-block-CyBlvApI.js",
@@ -1168,29 +1168,29 @@
     "bjsGzipKB": 585.1
   },
   "scene73": {
-    "rawKB": 140.8,
-    "gzipKB": 55.9,
+    "rawKB": 140.7,
+    "gzipKB": 56.5,
     "ignoredRawKB": 3.3,
     "runtimeChunks": [
       "scene73-_math-factory-DFVyS8gB.js",
       "scene73-clearcoat-block-BPLkmxQ1.js",
-      "scene73-clearcoat-fragment-C7fsiLpJ.js",
+      "scene73-clearcoat-fragment-Co5heqaa.js",
       "scene73-color-splitter-BK-XgtrJ.js",
       "scene73-fragment-output-CfRmfbPv.js",
-      "scene73-generate-mipmaps-BrVeiYYT.js",
+      "scene73-generate-mipmaps-BhEKmVEd.js",
       "scene73-gltf-ext-clearcoat-BgaLgSgD.js",
-      "scene73-gltf-feature-registry-C0WZhyJt.js",
-      "scene73-gltf-glb-parser-BdYiApo0.js",
+      "scene73-gltf-feature-registry-Dg8L4eBu.js",
+      "scene73-gltf-glb-parser-Bm1IrZjT.js",
       "scene73-ibl-fragment-CeRrvT96.js",
       "scene73-input-block-lrbZBZJO.js",
-      "scene73-node-env-9-digQG0.js",
-      "scene73-node-renderable-aVyQZIKY.js",
+      "scene73-node-env-2j3ozSNZ.js",
+      "scene73-node-renderable-DD0xLoRD.js",
       "scene73-pbr-metallic-roughness-block-full-CgKHgEzu.js",
-      "scene73-pbr-renderable-LOosKkFn.js",
+      "scene73-pbr-renderable-CF4hqAyF.js",
       "scene73-perturb-normal-Bqx-TYaB.js",
       "scene73-reflection-block-CIXuH-z0.js",
-      "scene73-rgbd-decode-Baow08lG.js",
-      "scene73-swapchain-overlay-DDEHaTMc.js",
+      "scene73-rgbd-decode-CwLEQpZm.js",
+      "scene73-swapchain-overlay-CRrB-CT2.js",
       "scene73-texture-block-qpJiHpPr.js",
       "scene73-transform-block-CCvg31Cx.js",
       "scene73-vertex-output-C7G5u6Y0.js",
@@ -1201,7 +1201,7 @@
   },
   "scene74": {
     "rawKB": 8.1,
-    "gzipKB": 3.4,
+    "gzipKB": 3.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene74.js"
@@ -1210,11 +1210,11 @@
     "bjsGzipKB": 175
   },
   "scene75": {
-    "rawKB": 48.6,
-    "gzipKB": 19.2,
+    "rawKB": 48.4,
+    "gzipKB": 19.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene75-standard-renderable-_ub2Dloc.js",
+      "scene75-standard-renderable-CED9r6r1.js",
       "scene75-wgsl-helpers-CwHFFXvt.js",
       "scene75.js"
     ],
@@ -1222,7 +1222,7 @@
     "bjsGzipKB": 400.9
   },
   "scene76": {
-    "rawKB": 9.1,
+    "rawKB": 9,
     "gzipKB": 3.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -1232,8 +1232,8 @@
     "bjsGzipKB": 175.4
   },
   "scene77": {
-    "rawKB": 58.5,
-    "gzipKB": 24.7,
+    "rawKB": 58.6,
+    "gzipKB": 25.2,
     "ignoredRawKB": 7,
     "runtimeChunks": [
       "scene77-_math-factory-DFVyS8gB.js",
@@ -1244,7 +1244,7 @@
       "scene77-node-registry-MZJkPhd3.js",
       "scene77-node-registry-extra-compat-WJskWIWa.js",
       "scene77-node-registry-extra-math-BDZZMEV4.js",
-      "scene77-node-renderable-DNp3HCj6.js",
+      "scene77-node-renderable-jb0lk7CX.js",
       "scene77-opposite-block-DWEPm0Z5.js",
       "scene77-teleport-in-block-DJKPTgKE.js",
       "scene77-teleport-out-block-C2Djod45.js",
@@ -1258,8 +1258,8 @@
     "bjsGzipKB": 524.3
   },
   "scene78": {
-    "rawKB": 56.5,
-    "gzipKB": 26.6,
+    "rawKB": 56.7,
+    "gzipKB": 27,
     "ignoredRawKB": 9.7,
     "runtimeChunks": [
       "scene78-_math-factory-DFVyS8gB.js",
@@ -1276,7 +1276,7 @@
       "scene78-multiply-block-DKKfQJFj.js",
       "scene78-node-registry-CUYEywnK.js",
       "scene78-node-registry-extra-math-CKvWkhfv.js",
-      "scene78-node-renderable-CEBFXSfc.js",
+      "scene78-node-renderable-nHZtY26V.js",
       "scene78-normalize-block-BUk4O2XX.js",
       "scene78-reciprocal-block-DilmIM2-.js",
       "scene78-reflect-block-CSAIYNw5.js",
@@ -1292,8 +1292,8 @@
     "bjsGzipKB": 525.4
   },
   "scene79": {
-    "rawKB": 60.1,
-    "gzipKB": 26.8,
+    "rawKB": 60.2,
+    "gzipKB": 27.2,
     "ignoredRawKB": 8.1,
     "runtimeChunks": [
       "scene79-_math-factory-DFVyS8gB.js",
@@ -1307,7 +1307,7 @@
       "scene79-nlerp-block-DCTQwLVE.js",
       "scene79-node-registry-CJ482XCy.js",
       "scene79-node-registry-extra-math-Dw_l0pN0.js",
-      "scene79-node-renderable-CjnIzLPF.js",
+      "scene79-node-renderable-CLViwFMH.js",
       "scene79-random-number-block-Cc5cHymD.js",
       "scene79-transform-block-Dt_QHxTW.js",
       "scene79-vector-merger-YcC3xFyg.js",
@@ -1320,8 +1320,8 @@
     "bjsGzipKB": 525.1
   },
   "scene80": {
-    "rawKB": 59.5,
-    "gzipKB": 25.9,
+    "rawKB": 59.7,
+    "gzipKB": 26.2,
     "ignoredRawKB": 6,
     "runtimeChunks": [
       "scene80-_math-factory-DFVyS8gB.js",
@@ -1333,7 +1333,7 @@
       "scene80-input-block-CRfb77r9.js",
       "scene80-node-registry-C7HntA8G.js",
       "scene80-node-registry-extra-procedural-CIYNG1uF.js",
-      "scene80-node-renderable-CrCOTQfF.js",
+      "scene80-node-renderable-DecafDBy.js",
       "scene80-posterize-block-PW8UWjyJ.js",
       "scene80-replace-color-block-jNV1Iu7G.js",
       "scene80-transform-block-DM6P_1Fx.js",
@@ -1345,8 +1345,8 @@
     "bjsGzipKB": 524.8
   },
   "scene81": {
-    "rawKB": 65.5,
-    "gzipKB": 29,
+    "rawKB": 65.6,
+    "gzipKB": 29.4,
     "ignoredRawKB": 7,
     "runtimeChunks": [
       "scene81-_math-factory-DFVyS8gB.js",
@@ -1356,7 +1356,7 @@
       "scene81-input-block-DjQ0htzg.js",
       "scene81-node-registry-Cysny8Hz.js",
       "scene81-node-registry-extra-procedural-DVqOq6t1.js",
-      "scene81-node-renderable-CwRLE9P8.js",
+      "scene81-node-renderable-0MU8pXij.js",
       "scene81-panner-block-fcbonbH6.js",
       "scene81-rotate2d-block-PoTUVgvt.js",
       "scene81-scale-block-6qtIvFiz.js",
@@ -1370,8 +1370,8 @@
     "bjsGzipKB": 525.9
   },
   "scene82": {
-    "rawKB": 65.2,
-    "gzipKB": 28.9,
+    "rawKB": 65.4,
+    "gzipKB": 29.3,
     "ignoredRawKB": 8.4,
     "runtimeChunks": [
       "scene82-_math-factory-DFVyS8gB.js",
@@ -1384,7 +1384,7 @@
       "scene82-node-registry-B8WONfzs.js",
       "scene82-node-registry-extra-math-B_9Eknx7.js",
       "scene82-node-registry-extra-procedural-Bmt_Y40q.js",
-      "scene82-node-renderable-Ble4h4UZ.js",
+      "scene82-node-renderable-CDCjyh9e.js",
       "scene82-scale-block-6qtIvFiz.js",
       "scene82-simplex-perlin-3d-block-Cfood6_x.js",
       "scene82-transform-block-Dmzn7Riu.js",
@@ -1399,8 +1399,8 @@
     "bjsGzipKB": 525.1
   },
   "scene83": {
-    "rawKB": 69.4,
-    "gzipKB": 32.5,
+    "rawKB": 69.5,
+    "gzipKB": 32.8,
     "ignoredRawKB": 11.4,
     "runtimeChunks": [
       "scene83-_math-factory-DFVyS8gB.js",
@@ -1409,13 +1409,13 @@
       "scene83-color-merger-0HZ9FICW.js",
       "scene83-derivative-block-CJk1WuGL.js",
       "scene83-fragment-output-CfRmfbPv.js",
-      "scene83-generate-mipmaps-B5OnfwXc.js",
+      "scene83-generate-mipmaps-B34mqnUx.js",
       "scene83-height-to-normal-block-CQM_Hw2Y.js",
       "scene83-image-source-Bl5Ls-FU.js",
       "scene83-input-block-PzznsC_q.js",
       "scene83-light-block-BI8u6d_3.js",
       "scene83-multiply-block-G4bDy_QN.js",
-      "scene83-node-renderable-rThXlVWQ.js",
+      "scene83-node-renderable-KURIknRi.js",
       "scene83-normal-blend-block-BVPL4brK.js",
       "scene83-perturb-normal-Bqx-TYaB.js",
       "scene83-scale-block-6qtIvFiz.js",
@@ -1432,8 +1432,8 @@
     "bjsGzipKB": 527.2
   },
   "scene84": {
-    "rawKB": 82.9,
-    "gzipKB": 35.2,
+    "rawKB": 83,
+    "gzipKB": 35.5,
     "ignoredRawKB": 5.5,
     "runtimeChunks": [
       "scene84-_math-factory-DFVyS8gB.js",
@@ -1443,14 +1443,14 @@
       "scene84-frag-depth-block-DFZCC8Qe.js",
       "scene84-fragment-output-CfRmfbPv.js",
       "scene84-input-block-CBDHkrmD.js",
-      "scene84-node-registry-IhxsbK6l.js",
-      "scene84-node-registry-extra-advanced-_Jz_tIam.js",
-      "scene84-node-registry-extra-math-Dw24Kfdg.js",
-      "scene84-node-registry-extra-procedural-xVdwYSgx.js",
-      "scene84-node-renderable-CCVYECmz.js",
+      "scene84-node-registry-extra-advanced-ByR_JT73.js",
+      "scene84-node-registry-extra-math-D4nVipxX.js",
+      "scene84-node-registry-extra-procedural-Ik03rJqJ.js",
+      "scene84-node-registry-wGA9AWVI.js",
+      "scene84-node-renderable-DjKsmpVm.js",
       "scene84-screen-size-block-yVY2pHhh.js",
       "scene84-screen-space-block-Cfi3u-na.js",
-      "scene84-standard-renderable-Cn4CzWTi.js",
+      "scene84-standard-renderable-CefbqrKz.js",
       "scene84-transform-block-PEh7VaCZ.js",
       "scene84-twirl-block-tQLhuAc6.js",
       "scene84-vector-splitter-BMf4DQi8.js",
@@ -1462,8 +1462,8 @@
     "bjsGzipKB": 543.2
   },
   "scene85": {
-    "rawKB": 59.2,
-    "gzipKB": 25.6,
+    "rawKB": 59.3,
+    "gzipKB": 25.9,
     "ignoredRawKB": 6.5,
     "runtimeChunks": [
       "scene85-_math-factory-DFVyS8gB.js",
@@ -1476,7 +1476,7 @@
       "scene85-node-registry-DwTn9OGj.js",
       "scene85-node-registry-extra-advanced-BHEcVu1g.js",
       "scene85-node-registry-extra-procedural-CIRC8AQw.js",
-      "scene85-node-renderable-Dpy36U1_.js",
+      "scene85-node-renderable-D2PcRu6z.js",
       "scene85-scale-block-6qtIvFiz.js",
       "scene85-transform-block-DDhnh2Z5.js",
       "scene85-vector-merger-YcC3xFyg.js",
@@ -1487,8 +1487,8 @@
     "bjsGzipKB": 524.9
   },
   "scene86": {
-    "rawKB": 58.6,
-    "gzipKB": 26.4,
+    "rawKB": 58.8,
+    "gzipKB": 26.8,
     "ignoredRawKB": 8,
     "runtimeChunks": [
       "scene86-_math-factory-DFVyS8gB.js",
@@ -1503,7 +1503,7 @@
       "scene86-node-registry-C_0vsZEK.js",
       "scene86-node-registry-extra-compat-BySiaXlE.js",
       "scene86-node-registry-extra-procedural-B0-_-3_0.js",
-      "scene86-node-renderable-DkG2iNFz.js",
+      "scene86-node-renderable-ipy1mp2X.js",
       "scene86-reflection-texture-base-block-CklyAZSo.js",
       "scene86-scale-block-6qtIvFiz.js",
       "scene86-transform-block-Cf9qywIP.js",
@@ -1516,7 +1516,7 @@
   },
   "scene87": {
     "rawKB": 93.1,
-    "gzipKB": 36.8,
+    "gzipKB": 37.2,
     "ignoredRawKB": 12,
     "runtimeChunks": [
       "scene87-_math-factory-DFVyS8gB.js",
@@ -1524,13 +1524,13 @@
       "scene87-image-processing-block-BZE0hSms.js",
       "scene87-input-block-B0pvoVCO.js",
       "scene87-iridescence-block-BtJ3SYHs.js",
-      "scene87-node-env-9-digQG0.js",
+      "scene87-node-env-DRjKPzh1.js",
       "scene87-node-registry-DacsjK9F.js",
       "scene87-node-registry-extra-compat-DA2oTCsk.js",
-      "scene87-node-renderable-DNAWFd4t.js",
+      "scene87-node-renderable-Bx4xKtEU.js",
       "scene87-pbr-metallic-roughness-block-full-Calo8UUD.js",
       "scene87-reflection-block-CIXuH-z0.js",
-      "scene87-rgbd-decode-Baow08lG.js",
+      "scene87-rgbd-decode-CE89s4fh.js",
       "scene87-transform-block-PbUiwa3z.js",
       "scene87-vertex-output-C7G5u6Y0.js",
       "scene87.js"
@@ -1539,8 +1539,8 @@
     "bjsGzipKB": 563.8
   },
   "scene88": {
-    "rawKB": 59.4,
-    "gzipKB": 26.1,
+    "rawKB": 59.5,
+    "gzipKB": 26.5,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
       "scene88-_math-factory-DFVyS8gB.js",
@@ -1553,7 +1553,7 @@
       "scene88-node-registry-BW7Y4VrF.js",
       "scene88-node-registry-extra-compat-NqgyiD-S.js",
       "scene88-node-registry-extra-math-BzNJZp4Y.js",
-      "scene88-node-renderable-VQqUpaAM.js",
+      "scene88-node-renderable-Dgtm7VuR.js",
       "scene88-step-block-sbiWJXfG.js",
       "scene88-storage-read-block-DkBAxglb.js",
       "scene88-storage-write-block-BSqc-AKf.js",
@@ -1568,8 +1568,8 @@
     "bjsGzipKB": 524.8
   },
   "scene89": {
-    "rawKB": 58.8,
-    "gzipKB": 26.2,
+    "rawKB": 59,
+    "gzipKB": 26.6,
     "ignoredRawKB": 7.6,
     "runtimeChunks": [
       "scene89-_math-factory-DFVyS8gB.js",
@@ -1582,7 +1582,7 @@
       "scene89-node-registry-CB6643fp.js",
       "scene89-node-registry-extra-compat-DjvO4Ffj.js",
       "scene89-node-registry-extra-math-BaLrv1wL.js",
-      "scene89-node-renderable-DUcik3sJ.js",
+      "scene89-node-renderable-peasgcEI.js",
       "scene89-step-block-sbiWJXfG.js",
       "scene89-storage-read-block-DkBAxglb.js",
       "scene89-storage-write-block-BSqc-AKf.js",
@@ -1597,12 +1597,12 @@
     "bjsGzipKB": 524.9
   },
   "scene90": {
-    "rawKB": 57.5,
-    "gzipKB": 22.5,
+    "rawKB": 57.4,
+    "gzipKB": 22.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene90-generate-mipmaps-DG1Tcl7Z.js",
-      "scene90-standard-renderable-D92OBvS0.js",
+      "scene90-generate-mipmaps-SRXClq-S.js",
+      "scene90-standard-renderable-B7CR7t3Z.js",
       "scene90-wgsl-helpers-CwHFFXvt.js",
       "scene90.js"
     ],
@@ -1610,12 +1610,12 @@
     "bjsGzipKB": 345.7
   },
   "scene91": {
-    "rawKB": 56.6,
-    "gzipKB": 22.4,
+    "rawKB": 56.5,
+    "gzipKB": 22.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene91-generate-mipmaps-DEgDnSqu.js",
-      "scene91-standard-renderable-iRzEeVB6.js",
+      "scene91-generate-mipmaps-CUt8_7AA.js",
+      "scene91-standard-renderable-FqVw5Z8a.js",
       "scene91-wgsl-helpers-CwHFFXvt.js",
       "scene91.js"
     ],
@@ -1623,8 +1623,8 @@
     "bjsGzipKB": 345.2
   },
   "scene92": {
-    "rawKB": 18.6,
-    "gzipKB": 7.7,
+    "rawKB": 18.7,
+    "gzipKB": 7.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene92.js"
@@ -1633,8 +1633,8 @@
     "bjsGzipKB": 195.2
   },
   "scene93": {
-    "rawKB": 19.7,
-    "gzipKB": 8,
+    "rawKB": 19.8,
+    "gzipKB": 8.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene93.js"
@@ -1643,12 +1643,12 @@
     "bjsGzipKB": 195.4
   },
   "scene94": {
-    "rawKB": 62.8,
-    "gzipKB": 24.3,
+    "rawKB": 62.6,
+    "gzipKB": 24.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene94-billboard-renderable-xM8JY5Gb.js",
-      "scene94-standard-renderable-Dt9_nyXC.js",
+      "scene94-billboard-renderable-CLXJq3n5.js",
+      "scene94-standard-renderable-BAShu0pi.js",
       "scene94-wgsl-helpers-CwHFFXvt.js",
       "scene94.js"
     ],
@@ -1656,12 +1656,12 @@
     "bjsGzipKB": 368.7
   },
   "scene95": {
-    "rawKB": 64,
-    "gzipKB": 24.6,
+    "rawKB": 63.8,
+    "gzipKB": 24.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene95-billboard-renderable-DCwBd27N.js",
-      "scene95-standard-renderable-CzECrfiy.js",
+      "scene95-billboard-renderable-BFh52LN-.js",
+      "scene95-standard-renderable-BbyxIrv6.js",
       "scene95-wgsl-helpers-CwHFFXvt.js",
       "scene95.js"
     ],
@@ -1669,8 +1669,8 @@
     "bjsGzipKB": 369
   },
   "scene96": {
-    "rawKB": 15.3,
-    "gzipKB": 6.5,
+    "rawKB": 15.4,
+    "gzipKB": 6.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene96.js"
@@ -1679,8 +1679,8 @@
     "bjsGzipKB": 195.1
   },
   "scene97": {
-    "rawKB": 15.7,
-    "gzipKB": 6.7,
+    "rawKB": 15.9,
+    "gzipKB": 6.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene97.js"
@@ -1689,13 +1689,13 @@
     "bjsGzipKB": 198.4
   },
   "scene98": {
-    "rawKB": 58.8,
-    "gzipKB": 23.5,
+    "rawKB": 58.7,
+    "gzipKB": 23.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene98-billboard-renderable-CH3StRyg.js",
+      "scene98-billboard-renderable-XBvu03_e.js",
       "scene98-scene-uniforms-FTYH6Ct0.js",
-      "scene98-standard-renderable-BwurfSv_.js",
+      "scene98-standard-renderable-DFh6CwSb.js",
       "scene98-wgsl-helpers-CwHFFXvt.js",
       "scene98.js"
     ],
@@ -1704,10 +1704,10 @@
   },
   "scene110": {
     "rawKB": 48.9,
-    "gzipKB": 19,
+    "gzipKB": 19.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene110-standard-renderable-DD000rh4.js",
+      "scene110-standard-renderable-DAIn2EfL.js",
       "scene110-wgsl-helpers-CwHFFXvt.js",
       "scene110.js"
     ],
@@ -1715,31 +1715,31 @@
     "bjsGzipKB": 345.6
   },
   "scene111": {
-    "rawKB": 132.5,
-    "gzipKB": 53.2,
+    "rawKB": 132.1,
+    "gzipKB": 53.6,
     "ignoredRawKB": 6.4,
     "runtimeChunks": [
       "scene111-_math-factory-DFVyS8gB.js",
       "scene111-esm-shadow-view-BYvK4l6C.js",
-      "scene111-esm-shadow-view-CY13e8ZD.js",
+      "scene111-esm-shadow-view-CIkHDIKj.js",
       "scene111-fragment-output-CfRmfbPv.js",
-      "scene111-input-block-Dbknt2tJ.js",
-      "scene111-light-block-B_yti3r3.js",
+      "scene111-input-block-BNbwxAq0.js",
+      "scene111-light-block-DIG-lWWx.js",
       "scene111-material-view-Dua1bl7W.js",
-      "scene111-multilight-wgsl-BYN4mcXt.js",
+      "scene111-multilight-wgsl-CUUKCPve.js",
       "scene111-no-color-view-BSBcE0Kf.js",
-      "scene111-no-color-view-CP6xVwEg.js",
+      "scene111-no-color-view-DKXgSA-w.js",
       "scene111-no-color-view-DvvwhelJ.js",
       "scene111-node-flags-3CD_c1Kp.js",
-      "scene111-node-registry-qc-SxWs8.js",
-      "scene111-node-renderable-CqwDUVaD.js",
-      "scene111-node-shadow-CMDpglyc.js",
-      "scene111-pbr-renderable-DT-gWMTP.js",
+      "scene111-node-registry-mNgnF1Ng.js",
+      "scene111-node-renderable-Dt9TCJ5v.js",
+      "scene111-node-shadow-BfOz5ano.js",
+      "scene111-pbr-renderable-BC6ju-ok.js",
       "scene111-pbr-shadow-fragment-CFzpdZcF.js",
-      "scene111-shader-composer-CKmD43OT.js",
+      "scene111-shader-composer-DjW8e4Zd.js",
       "scene111-shadow-fragment-core-Dbe1xNkt.js",
-      "scene111-shadow-task-BQy7A947.js",
-      "scene111-standard-renderable-BsVdgSYH.js",
+      "scene111-shadow-task-gtI-unAh.js",
+      "scene111-standard-renderable-CaKxBP6p.js",
       "scene111-std-shadow-fragment-u3x2t2qW.js",
       "scene111-transform-block-xSHzJVmq.js",
       "scene111-vertex-output-C7G5u6Y0.js",
@@ -1750,24 +1750,24 @@
     "bjsGzipKB": 598.7
   },
   "scene112": {
-    "rawKB": 115.8,
-    "gzipKB": 46.2,
+    "rawKB": 115.2,
+    "gzipKB": 46.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene112-background-dds-skybox-BXxqB0tl.js",
-      "scene112-background-ground-CDoKIkj4.js",
-      "scene112-cubemap-skybox-material-CJfKTj4b.js",
-      "scene112-generate-mipmaps-A8hYD_sF.js",
-      "scene112-gltf-ext-basisu-CsJE6_me.js",
+      "scene112-background-dds-skybox-DgpWmq9B.js",
+      "scene112-background-ground-DgAOu0TW.js",
+      "scene112-cubemap-skybox-material-gHa5MqJz.js",
+      "scene112-generate-mipmaps-lSz5ynqB.js",
+      "scene112-gltf-ext-basisu-B-KzX7js.js",
       "scene112-gltf-ext-dielectric-BD8fbfh2.js",
-      "scene112-gltf-feature-registry-BbZqLg3z.js",
+      "scene112-gltf-feature-registry-Dds7RJQE.js",
       "scene112-ibl-fragment-CeRrvT96.js",
-      "scene112-pbr-refraction-Dbe2gg1Z.js",
-      "scene112-pbr-renderable-drvv_xDQ.js",
-      "scene112-pbr-transmission-ext-Dt7IAefx.js",
-      "scene112-rgbd-decode-Baow08lG.js",
+      "scene112-pbr-refraction-2Z6TTKw8.js",
+      "scene112-pbr-renderable-BOn4l4Mi.js",
+      "scene112-pbr-transmission-ext-t_fZ008K.js",
+      "scene112-rgbd-decode-CCG7-bTA.js",
       "scene112-scene-uniforms-FTYH6Ct0.js",
-      "scene112-singlelight-hemispheric-wgsl-CvhHpHui.js",
+      "scene112-singlelight-hemispheric-wgsl-DOCvx1HF.js",
       "scene112-wgsl-helpers-CkUi9P9Q.js",
       "scene112.js"
     ],
@@ -1775,11 +1775,11 @@
     "bjsGzipKB": 676.1
   },
   "scene113": {
-    "rawKB": 60,
-    "gzipKB": 22.9,
+    "rawKB": 59.8,
+    "gzipKB": 23.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene113-standard-renderable-DbTNsfkt.js",
+      "scene113-standard-renderable-g9Eq5NeQ.js",
       "scene113-wgsl-helpers-CwHFFXvt.js",
       "scene113.js"
     ],
@@ -1787,42 +1787,42 @@
     "bjsGzipKB": 343.8
   },
   "scene114": {
-    "rawKB": 78,
-    "gzipKB": 29.8,
+    "rawKB": 77.7,
+    "gzipKB": 30.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene114-morph-fragment-DG3PIgWW.js",
-      "scene114-pbr-renderable-TGx3pLDy.js",
+      "scene114-morph-fragment-CeIKrYfs.js",
+      "scene114-pbr-renderable-XysqoZq6.js",
       "scene114-pbr-template-ext-BMNgm5oJ.js",
-      "scene114-singlelight-hemispheric-wgsl-D2guQdrs.js",
-      "scene114-skeleton-fragment-BybWGsc2.js",
-      "scene114-unlit-fragment-pE8Yx7lX.js",
+      "scene114-singlelight-hemispheric-wgsl-BBbUhs-e.js",
+      "scene114-skeleton-fragment-BTWJ852o.js",
+      "scene114-unlit-fragment-6DPfcXUC.js",
       "scene114.js"
     ],
     "bjsRawKB": 1790.2,
     "bjsGzipKB": 432.8
   },
   "scene115": {
-    "rawKB": 120.3,
-    "gzipKB": 48.4,
+    "rawKB": 119.7,
+    "gzipKB": 48.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene115-create-morph-targets-Bg2KkeoS.js",
-      "scene115-create-skeleton-Cwjf-dNK.js",
-      "scene115-generate-mipmaps-LeLiP-zG.js",
-      "scene115-gltf-animation-CkJi51pD.js",
+      "scene115-create-morph-targets-_ECgIusp.js",
+      "scene115-create-skeleton-DvYNxDg5.js",
+      "scene115-generate-mipmaps-D-QKkH4I.js",
+      "scene115-gltf-animation-DSk0bwUG.js",
       "scene115-gltf-color-normalize-DA3N7QfB.js",
-      "scene115-gltf-feature-animations-B6wjGwiQ.js",
-      "scene115-gltf-feature-morph-DYyNUXpz.js",
-      "scene115-gltf-feature-registry-BACh2BNW.js",
-      "scene115-gltf-feature-skeleton-BJQWWSAW.js",
+      "scene115-gltf-feature-animations-BgGBVRZS.js",
+      "scene115-gltf-feature-morph-CE7juud1.js",
+      "scene115-gltf-feature-registry-zcsJjyNo.js",
+      "scene115-gltf-feature-skeleton-Ci71Yt4S.js",
       "scene115-morph-fragment-D7WyEV80.js",
-      "scene115-pbr-renderable-Cdj6MIVR.js",
+      "scene115-pbr-renderable-aMRgqx62.js",
       "scene115-pbr-template-ext-BMNgm5oJ.js",
       "scene115-shader-composer-DlM-8YlO.js",
-      "scene115-singlelight-hemispheric-wgsl-K-tiIJyV.js",
+      "scene115-singlelight-hemispheric-wgsl-S_l5yVjz.js",
       "scene115-skeleton-fragment-BPPYwLzL.js",
-      "scene115-standard-renderable-gSmtyeh-.js",
+      "scene115-standard-renderable-slkmBiy3.js",
       "scene115-wgsl-helpers-CwHFFXvt.js",
       "scene115.js"
     ],
@@ -1831,15 +1831,15 @@
   },
   "scene116": {
     "rawKB": 74,
-    "gzipKB": 30.1,
+    "gzipKB": 30.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene116-pbr-renderable-N31dhml4.js",
+      "scene116-pbr-renderable-WGDVaJqF.js",
       "scene116-shader-composer-CaVjAPiK.js",
-      "scene116-singlelight-hemispheric-wgsl-CWDzeKrY.js",
-      "scene116-standard-renderable--iod5fVV.js",
-      "scene116-std-emissive-fragment-BOEWjGGv.js",
-      "scene116-unlit-fragment-LGZg5PB5.js",
+      "scene116-singlelight-hemispheric-wgsl-pJ3Hftzo.js",
+      "scene116-standard-renderable-itPyi0xw.js",
+      "scene116-std-emissive-fragment-DBEWc8sM.js",
+      "scene116-unlit-fragment-DZaoNHUx.js",
       "scene116-wgsl-helpers-CwHFFXvt.js",
       "scene116.js"
     ],
@@ -1847,8 +1847,8 @@
     "bjsGzipKB": 421.6
   },
   "scene120": {
-    "rawKB": 34.3,
-    "gzipKB": 13.3,
+    "rawKB": 34.2,
+    "gzipKB": 13.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene120.js"
@@ -1857,8 +1857,8 @@
     "bjsGzipKB": 361.9
   },
   "scene121": {
-    "rawKB": 34.5,
-    "gzipKB": 13.3,
+    "rawKB": 34.4,
+    "gzipKB": 13.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene121.js"
@@ -1867,36 +1867,36 @@
     "bjsGzipKB": 362
   },
   "scene122": {
-    "rawKB": 47.1,
-    "gzipKB": 18.5,
+    "rawKB": 46.8,
+    "gzipKB": 18.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene122-gaussian-splatting-pipeline-sh-53-tWOFI.js",
+      "scene122-gaussian-splatting-pipeline-sh-DUk7Ltal.js",
       "scene122.js"
     ]
   },
   "scene123": {
-    "rawKB": 43.8,
-    "gzipKB": 17.4,
+    "rawKB": 43.5,
+    "gzipKB": 17.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene123-gaussian-splatting-pipeline-sh-CgxdnX-t.js",
+      "scene123-gaussian-splatting-pipeline-sh-B4Og6q6y.js",
       "scene123.js"
     ]
   },
   "scene124": {
-    "rawKB": 49.8,
-    "gzipKB": 19.5,
+    "rawKB": 49.6,
+    "gzipKB": 19.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene124-gaussian-splatting-pipeline-sh-DSdoH18f.js",
-      "scene124-splat-ply-compressed-D-fMhYTB.js",
+      "scene124-gaussian-splatting-pipeline-sh-Dm4iw2mR.js",
+      "scene124-splat-ply-compressed-4vnSZMqI.js",
       "scene124.js"
     ]
   },
   "scene125": {
-    "rawKB": 36.2,
-    "gzipKB": 14,
+    "rawKB": 36.1,
+    "gzipKB": 14.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene125.js"
@@ -1904,44 +1904,44 @@
   },
   "scene126": {
     "rawKB": 34.5,
-    "gzipKB": 13.4,
+    "gzipKB": 13.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene126.js"
     ]
   },
   "scene127": {
-    "rawKB": 55.5,
-    "gzipKB": 20.9,
+    "rawKB": 55.1,
+    "gzipKB": 21.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene127-shader-renderable-D6FgUNvs.js",
+      "scene127-shader-renderable-UKLX4YfY.js",
       "scene127.js"
     ]
   },
   "scene128": {
-    "rawKB": 55.4,
-    "gzipKB": 20.8,
+    "rawKB": 55,
+    "gzipKB": 21.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene128-shader-renderable-B7rTsixn.js",
+      "scene128-shader-renderable-DkC-sYLO.js",
       "scene128.js"
     ]
   },
   "scene129": {
-    "rawKB": 80.2,
-    "gzipKB": 30.1,
+    "rawKB": 79.4,
+    "gzipKB": 30.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene129-gs-picking-pipeline-Dk7hZr3y.js",
-      "scene129-standard-renderable-BwOygYAl.js",
+      "scene129-gs-picking-pipeline-wk9cVMav.js",
+      "scene129-standard-renderable-BudlQS_7.js",
       "scene129-wgsl-helpers-CwHFFXvt.js",
       "scene129.js"
     ]
   },
   "scene140": {
-    "rawKB": 95.5,
-    "gzipKB": 40.8,
+    "rawKB": 95.2,
+    "gzipKB": 41.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene140-_math-factory-DFVyS8gB.js",
@@ -1954,7 +1954,7 @@
       "scene140-fog-block-CUWwapOp.js",
       "scene140-fragment-output-CfRmfbPv.js",
       "scene140-front-facing-BE20bXNF.js",
-      "scene140-generate-mipmaps-D8vyFQEw.js",
+      "scene140-generate-mipmaps-DvMR8OcP.js",
       "scene140-input-block-_1ymrwAS.js",
       "scene140-instances-block-ClV6QcvR.js",
       "scene140-lerp-block-vFicSisS.js",
@@ -1966,14 +1966,14 @@
       "scene140-negate-block-BHKNRsp7.js",
       "scene140-no-color-view-Bf6EFWnB.js",
       "scene140-node-flags-3CD_c1Kp.js",
-      "scene140-node-registry-BenQWxNk.js",
-      "scene140-node-renderable-DOOQ3_lo.js",
-      "scene140-node-shadow-BujSPIa0.js",
+      "scene140-node-registry-B5rfiGWK.js",
+      "scene140-node-renderable-BjoKwKCv.js",
+      "scene140-node-shadow-CtmIZq-L.js",
       "scene140-normalize-block-DF8IC9k_.js",
       "scene140-oneminus-block-CS0SK7Sc.js",
       "scene140-perturb-normal-Bqx-TYaB.js",
       "scene140-reflection-texture-block-DVZpi6Yq.js",
-      "scene140-shadow-task-DpDvzdYi.js",
+      "scene140-shadow-task-C3LCTlF8.js",
       "scene140-subtract-block-Cf35mB59.js",
       "scene140-texture-block-qpJiHpPr.js",
       "scene140-transform-block-vyE-wAbL.js",
@@ -1984,29 +1984,29 @@
     ]
   },
   "scene141": {
-    "rawKB": 127.8,
-    "gzipKB": 49.8,
+    "rawKB": 127.6,
+    "gzipKB": 50.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene141-_math-factory-DFVyS8gB.js",
       "scene141-esm-shadow-view-B5mKuT0s.js",
       "scene141-esm-shadow-view-BN170hQU.js",
-      "scene141-esm-shadow-view-Be53DQaa.js",
+      "scene141-esm-shadow-view-DlnhdXYO.js",
       "scene141-fragment-output-CfRmfbPv.js",
-      "scene141-input-block-4CA0c9M-.js",
-      "scene141-light-block-CLqz_q9U.js",
+      "scene141-input-block-DeD8qHQW.js",
+      "scene141-light-block-Cw7snrHM.js",
       "scene141-material-view-Dua1bl7W.js",
       "scene141-node-flags-3CD_c1Kp.js",
-      "scene141-node-registry-BvMFYDb-.js",
-      "scene141-node-renderable-Bb1kx8_f.js",
-      "scene141-node-shadow-DlFYdcs3.js",
-      "scene141-pbr-renderable-6bjN4sp_.js",
+      "scene141-node-registry-D3EKDytg.js",
+      "scene141-node-renderable-B-jL01zq.js",
+      "scene141-node-shadow-DKAppxqv.js",
+      "scene141-pbr-renderable-BPY3gIKs.js",
       "scene141-pbr-shadow-fragment-DHDAZ1HL.js",
-      "scene141-shader-composer-E4dohuZU.js",
+      "scene141-shader-composer-DvaDeUF7.js",
       "scene141-shadow-fragment-core-Dbe1xNkt.js",
-      "scene141-shadow-task-DO-9ZD6d.js",
-      "scene141-singlelight-directional-wgsl-CHNC6QQf.js",
-      "scene141-standard-renderable-CNxUgpdS.js",
+      "scene141-shadow-task-nSjqtTZf.js",
+      "scene141-singlelight-directional-wgsl-CWSBhWWj.js",
+      "scene141-standard-renderable-CttY0X3S.js",
       "scene141-transform-block-DWUOQ_Fz.js",
       "scene141-vertex-output-C7G5u6Y0.js",
       "scene141-wgsl-helpers-CwHFFXvt.js",
@@ -2014,97 +2014,205 @@
     ]
   },
   "scene142": {
-    "rawKB": 59.8,
-    "gzipKB": 22,
+    "rawKB": 59.2,
+    "gzipKB": 22.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene142-standard-renderable-KRB4ilWh.js",
+      "scene142-standard-renderable-B_t70WCp.js",
       "scene142-wgsl-helpers-CwHFFXvt.js",
       "scene142.js"
     ]
   },
   "scene143": {
-    "rawKB": 66.6,
-    "gzipKB": 26,
+    "rawKB": 68.3,
+    "gzipKB": 26.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene143-generate-mipmaps-BHg7ig5Q.js",
+      "scene143-generate-mipmaps-CiyhUZPA.js",
       "scene143-normal-map-fragment-vZfuB--u.js",
       "scene143-point-light-CHHO5fr1.js",
-      "scene143-standard-renderable-Bql4BLMN.js",
-      "scene143-std-ambient-fragment-DfNksGf2.js",
-      "scene143-std-opacity-fragment-WkUvUjcf.js",
-      "scene143-std-reflection-fragment-BwP7HuHT.js",
-      "scene143-std-specular-fragment-Dz_UTmZm.js",
+      "scene143-standard-renderable-CX6Ht7fN.js",
+      "scene143-std-ambient-fragment-CU5U7ir2.js",
+      "scene143-std-opacity-fragment-CemSBefU.js",
+      "scene143-std-reflection-fragment-C0JzRn7P.js",
+      "scene143-std-specular-fragment-BugkvqOj.js",
       "scene143-wgsl-helpers-CwHFFXvt.js",
       "scene143.js"
     ]
   },
   "scene144": {
-    "rawKB": 106.5,
-    "gzipKB": 42.3,
+    "rawKB": 105.6,
+    "gzipKB": 42.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene144-create-skeleton-eW1vAhm9.js",
-      "scene144-generate-mipmaps-D-9T90wu.js",
-      "scene144-gltf-animation-DwxymLfp.js",
+      "scene144-create-skeleton-pj3iqxnA.js",
+      "scene144-generate-mipmaps-Cor1BEDV.js",
+      "scene144-gltf-animation-UI95Bm2D.js",
       "scene144-gltf-ext-spec-gloss-D60sFZYX.js",
-      "scene144-gltf-feature-animations-wI0pj2wo.js",
-      "scene144-gltf-feature-registry-CMhOjs3t.js",
-      "scene144-gltf-feature-skeleton-Crw95s57.js",
-      "scene144-gltf-glb-parser-BdYiApo0.js",
-      "scene144-gltf-pbr-builder-ext-D2KTZ-wP.js",
+      "scene144-gltf-feature-animations-DisCkZBR.js",
+      "scene144-gltf-feature-registry-wCI4i4xE.js",
+      "scene144-gltf-feature-skeleton-Z79RaVAz.js",
+      "scene144-gltf-glb-parser-CXf6hcyj.js",
+      "scene144-gltf-pbr-builder-ext-BTPOeZlO.js",
       "scene144-ibl-fragment-CeRrvT96.js",
-      "scene144-pbr-renderable-BnJa5o2Q.js",
-      "scene144-rgbd-decode-Baow08lG.js",
+      "scene144-pbr-renderable-B7qVqu9Y.js",
+      "scene144-rgbd-decode-DNSQ_egC.js",
       "scene144-scene-uniforms-FTYH6Ct0.js",
-      "scene144-skeleton-fragment-BbASLi3w.js",
+      "scene144-skeleton-fragment-B-3JbBem.js",
       "scene144-texture-2d-DQo3n8D6.js",
       "scene144.js"
     ]
   },
-  "scene150": {
-    "rawKB": 53.2,
-    "gzipKB": 20.7,
+  "scene145": {
+    "rawKB": 87,
+    "gzipKB": 35.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene150-standard-renderable-DwNg67hS.js",
+      "scene145-bake-local-matrix-67U-IT8C.js",
+      "scene145-cube-texture-bz_MFCWw.js",
+      "scene145-generate-mipmaps-CtEeNBnX.js",
+      "scene145-geometry-view-DpM4Nm0-.js",
+      "scene145-mip-count-CdXF1U-X.js",
+      "scene145-parse-camera-BudUvY4l.js",
+      "scene145-point-light-3PsjZ-1e.js",
+      "scene145-shader-composer-CGJNaKHW.js",
+      "scene145-standard-material-BQ6K2jTm.js",
+      "scene145-standard-pipeline-DMSxr_kG.js",
+      "scene145-standard-renderable-juLUZ-Mk.js",
+      "scene145-std-ambient-fragment-j76jAxDB.js",
+      "scene145-std-cube-reflection-fragment-n1FDnhvv.js",
+      "scene145-std-opacity-fragment-CSXWRd8g.js",
+      "scene145-std-specular-fragment-DBvtJbxm.js",
+      "scene145-thin-instance-fragment-CBn2miAC.js",
+      "scene145-thin-instance-gpu-jO2uLISJ.js",
+      "scene145-ubo-layout-Cs5YvLYZ.js",
+      "scene145-wgsl-helpers-CwHFFXvt.js",
+      "scene145.js"
+    ]
+  },
+  "scene146": {
+    "rawKB": 109.2,
+    "gzipKB": 44.1,
+    "ignoredRawKB": 0,
+    "runtimeChunks": [
+      "scene146-alpha-test-fragment-C__pU5i7.js",
+      "scene146-background-ground-75B7HsFe.js",
+      "scene146-background-solid-skybox-BF1FkF15.js",
+      "scene146-generate-mipmaps-CTNbmyOv.js",
+      "scene146-ibl-fragment-CeRrvT96.js",
+      "scene146-pbr-geometry-view-D6jmgOy4.js",
+      "scene146-pbr-renderable-DcAD169m.js",
+      "scene146-rgbd-decode-D7WSUxiT.js",
+      "scene146-scene-uniforms-FTYH6Ct0.js",
+      "scene146-shader-composer-DnjPn5ra.js",
+      "scene146-skybox.vertex-D1KSfOUq.js",
+      "scene146-ubo-layout-CaKc5tGR.js",
+      "scene146-wgsl-helpers-DHWOYtor.js",
+      "scene146.js"
+    ]
+  },
+  "scene147": {
+    "rawKB": 99.7,
+    "gzipKB": 39.6,
+    "ignoredRawKB": 0,
+    "runtimeChunks": [
+      "scene147-directional-light-CPWdJeqd.js",
+      "scene147-generate-mipmaps-BHtJ_n9D.js",
+      "scene147-gltf-feature-lights-punctual-Dkf1gFoR.js",
+      "scene147-gltf-feature-registry-kwdCFqhD.js",
+      "scene147-gltf-glb-parser-CGQS4coo.js",
+      "scene147-multilight-wgsl-k1Tk1iuY.js",
+      "scene147-pbr-geometry-view-BM4ozkCS.js",
+      "scene147-pbr-renderable-DRjUkS2O.js",
+      "scene147-shader-composer-DryGKEb0.js",
+      "scene147-ubo-layout-Cs5YvLYZ.js",
+      "scene147.js"
+    ]
+  },
+  "scene148": {
+    "rawKB": 105.5,
+    "gzipKB": 41.3,
+    "ignoredRawKB": 0,
+    "runtimeChunks": [
+      "scene148-directional-light-BB8zyNr5.js",
+      "scene148-generate-mipmaps-BLtjpApD.js",
+      "scene148-gltf-feature-lights-punctual-xcGFeUZG.js",
+      "scene148-gltf-feature-registry-DJqLTUUx.js",
+      "scene148-gltf-glb-parser-klvGHI7-.js",
+      "scene148-pbr-geometry-view-BglYUSuz.js",
+      "scene148-pbr-renderable-B00mx_TL.js",
+      "scene148-shader-composer-CQe4PMyA.js",
+      "scene148-singlelight-hemispheric-wgsl-DW67n2EU.js",
+      "scene148-ubo-layout-Cs5YvLYZ.js",
+      "scene148.js"
+    ]
+  },
+  "scene149": {
+    "rawKB": 110.1,
+    "gzipKB": 42.2,
+    "ignoredRawKB": 0,
+    "runtimeChunks": [
+      "scene149-_math-factory-DFVyS8gB.js",
+      "scene149-directional-light-DPHJbILX.js",
+      "scene149-fragment-output-CfRmfbPv.js",
+      "scene149-generate-mipmaps-B3URn2Ed.js",
+      "scene149-geometry-texture-output-BfeQftmX.js",
+      "scene149-gltf-feature-lights-punctual-CANErv6T.js",
+      "scene149-gltf-feature-registry-BFAuBHHr.js",
+      "scene149-gltf-glb-parser-YH0OY2On.js",
+      "scene149-input-block-YcQTs81v.js",
+      "scene149-light-base-DRuRLO1X.js",
+      "scene149-light-matrix-C5CpBrkV.js",
+      "scene149-node-geometry-view-CDVGfdV8.js",
+      "scene149-node-renderable-D-zy_5Ah.js",
+      "scene149-texture-block-qpJiHpPr.js",
+      "scene149-transform-block-DIn9rrpC.js",
+      "scene149-vertex-output-C7G5u6Y0.js",
+      "scene149.js"
+    ]
+  },
+  "scene150": {
+    "rawKB": 53.2,
+    "gzipKB": 20.8,
+    "ignoredRawKB": 0,
+    "runtimeChunks": [
+      "scene150-standard-renderable-DWknjl6a.js",
       "scene150-wgsl-helpers-CwHFFXvt.js",
       "scene150.js"
     ]
   },
   "scene151": {
     "rawKB": 53.4,
-    "gzipKB": 20.7,
+    "gzipKB": 20.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene151-standard-renderable-DnnN5Chc.js",
+      "scene151-standard-renderable-idbg3bRN.js",
       "scene151-wgsl-helpers-CwHFFXvt.js",
       "scene151.js"
     ]
   },
   "scene152": {
-    "rawKB": 88,
-    "gzipKB": 35.9,
+    "rawKB": 87.9,
+    "gzipKB": 36.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene152-create-skeleton-Bvq6XxRL.js",
-      "scene152-generate-mipmaps-CNpqA4fX.js",
-      "scene152-gltf-animation-D5Igzacv.js",
+      "scene152-create-skeleton-D831UCHQ.js",
+      "scene152-generate-mipmaps-BV2B6C7B.js",
+      "scene152-gltf-animation-CnYyvFsf.js",
       "scene152-gltf-ext-spec-gloss-D60sFZYX.js",
-      "scene152-gltf-feature-animations-CLR4mkzc.js",
-      "scene152-gltf-feature-registry-iOETwtAX.js",
-      "scene152-gltf-feature-skeleton-DU4NDZo8.js",
-      "scene152-gltf-glb-parser-BdYiApo0.js",
-      "scene152-pbr-renderable-B4xezPVM.js",
-      "scene152-singlelight-hemispheric-wgsl-CLJPIqFR.js",
-      "scene152-skeleton-fragment-CjEdQNRX.js",
+      "scene152-gltf-feature-animations-CnTbb4PD.js",
+      "scene152-gltf-feature-registry-BYCGdLju.js",
+      "scene152-gltf-feature-skeleton-5cTf9093.js",
+      "scene152-gltf-glb-parser-Dr_B2hXm.js",
+      "scene152-pbr-renderable-Di77lVmL.js",
+      "scene152-singlelight-hemispheric-wgsl-Bh61w63n.js",
+      "scene152-skeleton-fragment-CbLWQawC.js",
       "scene152.js"
     ]
   },
   "scene153": {
     "rawKB": 7.9,
-    "gzipKB": 3.3,
+    "gzipKB": 3.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene153.js"
@@ -2112,460 +2220,460 @@
   },
   "scene154": {
     "rawKB": 53.6,
-    "gzipKB": 20.7,
+    "gzipKB": 21,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene154-standard-renderable-D040eC2x.js",
+      "scene154-standard-renderable-WVS0Deog.js",
       "scene154-wgsl-helpers-CwHFFXvt.js",
       "scene154.js"
     ]
   },
   "scene155": {
     "rawKB": 56.1,
-    "gzipKB": 21.6,
+    "gzipKB": 21.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene155-standard-renderable-D6L2EPl3.js",
+      "scene155-standard-renderable-D3rxGhli.js",
       "scene155-wgsl-helpers-CwHFFXvt.js",
       "scene155.js"
     ]
   },
   "scene156": {
     "rawKB": 56.8,
-    "gzipKB": 21.9,
+    "gzipKB": 22,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene156-standard-renderable-B5beBY6Y.js",
+      "scene156-standard-renderable-BVJ_UJwn.js",
       "scene156-wgsl-helpers-CwHFFXvt.js",
       "scene156.js"
     ]
   },
   "scene157": {
-    "rawKB": 91.6,
-    "gzipKB": 36.8,
+    "rawKB": 91.5,
+    "gzipKB": 37.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene157-create-skeleton-B8bEUdeo.js",
-      "scene157-generate-mipmaps-DkEBsR0H.js",
-      "scene157-gltf-animation-B4spokaJ.js",
-      "scene157-gltf-feature-animations-D5zLvuJg.js",
-      "scene157-gltf-feature-registry-Dwz7P99k.js",
-      "scene157-gltf-feature-skeleton-DZ6OjH0I.js",
-      "scene157-gltf-glb-parser-BdYiApo0.js",
-      "scene157-multilight-wgsl-D5RzUsQK.js",
-      "scene157-pbr-renderable-CfMkKJlS.js",
-      "scene157-skeleton-fragment-C_J7yw_Y.js",
+      "scene157-create-skeleton-9V1wtFWq.js",
+      "scene157-generate-mipmaps-B8HNhWYX.js",
+      "scene157-gltf-animation-CaT-ffLX.js",
+      "scene157-gltf-feature-animations-BmbbAU_6.js",
+      "scene157-gltf-feature-registry-C9nVMZFA.js",
+      "scene157-gltf-feature-skeleton-CwQQ8zPU.js",
+      "scene157-gltf-glb-parser-DZ4Xgxsa.js",
+      "scene157-multilight-wgsl-Dj3wN78q.js",
+      "scene157-pbr-renderable-CW8qpDil.js",
+      "scene157-skeleton-fragment-BDEjzTLV.js",
       "scene157.js"
     ]
   },
   "scene158": {
-    "rawKB": 92.1,
-    "gzipKB": 37,
+    "rawKB": 91.9,
+    "gzipKB": 37.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene158-create-skeleton-DZHlRvAX.js",
-      "scene158-generate-mipmaps-BMiErm6Y.js",
-      "scene158-gltf-animation-B7xo2jtJ.js",
-      "scene158-gltf-feature-animations-BtDAMSJC.js",
-      "scene158-gltf-feature-registry-iQdYdBRN.js",
-      "scene158-gltf-feature-skeleton-DXXymRG7.js",
-      "scene158-gltf-glb-parser-BdYiApo0.js",
-      "scene158-multilight-wgsl-DRVVgAaX.js",
-      "scene158-pbr-renderable-DKA6_ePR.js",
-      "scene158-skeleton-fragment-E7suqpco.js",
+      "scene158-create-skeleton-PAGSuLSj.js",
+      "scene158-generate-mipmaps-B83D1Wxu.js",
+      "scene158-gltf-animation-Cyed-CxH.js",
+      "scene158-gltf-feature-animations-azyG8s3N.js",
+      "scene158-gltf-feature-registry-BSumTWzA.js",
+      "scene158-gltf-feature-skeleton-CDrJ-tlN.js",
+      "scene158-gltf-glb-parser-BhqojsL9.js",
+      "scene158-multilight-wgsl-DcNjyBs3.js",
+      "scene158-pbr-renderable-DujvFx_8.js",
+      "scene158-skeleton-fragment-M63s1Boa.js",
       "scene158.js"
     ]
   },
   "scene159": {
     "rawKB": 34.9,
-    "gzipKB": 13.7,
+    "gzipKB": 13.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene159-shader-renderable-C3zkxBxj.js",
+      "scene159-shader-renderable-C4E2zbJl.js",
       "scene159.js"
     ]
   },
   "scene160": {
     "rawKB": 37,
-    "gzipKB": 14.4,
+    "gzipKB": 14.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene160-shader-renderable-CeMCvE4l.js",
+      "scene160-shader-renderable-C-Qw1pEi.js",
       "scene160.js"
     ]
   },
   "scene161": {
-    "rawKB": 35.2,
-    "gzipKB": 13.9,
+    "rawKB": 35.3,
+    "gzipKB": 14.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene161-shader-renderable-pJhYrwrX.js",
+      "scene161-shader-renderable-DkRRGASD.js",
       "scene161.js"
     ]
   },
   "scene162": {
-    "rawKB": 34.9,
-    "gzipKB": 13.8,
+    "rawKB": 35,
+    "gzipKB": 14,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene162-shader-renderable-CNmNCVWa.js",
+      "scene162-shader-renderable-CvBCVkCm.js",
       "scene162.js"
     ]
   },
   "scene163": {
-    "rawKB": 34.6,
-    "gzipKB": 13.6,
+    "rawKB": 34.7,
+    "gzipKB": 13.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene163-shader-renderable-DrIiS-sZ.js",
+      "scene163-shader-renderable-BJC_X8n3.js",
       "scene163.js"
     ]
   },
   "scene164": {
-    "rawKB": 94.5,
-    "gzipKB": 38.1,
+    "rawKB": 94.1,
+    "gzipKB": 38.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene164-create-morph-targets-DkEaLlZR.js",
-      "scene164-create-skeleton-DMuWI2Dr.js",
-      "scene164-generate-mipmaps-VoKkFqy8.js",
-      "scene164-gltf-animation-BmyE0Cti.js",
+      "scene164-create-morph-targets-CBudIH0a.js",
+      "scene164-create-skeleton-CBLyRVMO.js",
+      "scene164-generate-mipmaps-CRxOzrCE.js",
+      "scene164-gltf-animation-AvLu0YSx.js",
       "scene164-gltf-color-normalize-DA3N7QfB.js",
-      "scene164-gltf-feature-animations-CzWjC8XS.js",
-      "scene164-gltf-feature-morph-CyzZ9fUZ.js",
-      "scene164-gltf-feature-registry-CFDzzIW9.js",
-      "scene164-gltf-feature-skeleton-DRPdr2Bk.js",
-      "scene164-morph-fragment-1yZHqXB9.js",
-      "scene164-pbr-renderable-Cy9C7lpp.js",
+      "scene164-gltf-feature-animations-BmGkGCU8.js",
+      "scene164-gltf-feature-morph-TriYqvx0.js",
+      "scene164-gltf-feature-registry-CGdN1Dlu.js",
+      "scene164-gltf-feature-skeleton-CK1t4uLr.js",
+      "scene164-morph-fragment-BgSZM5MJ.js",
+      "scene164-pbr-renderable-DzdE12aU.js",
       "scene164-pbr-template-ext-BMNgm5oJ.js",
-      "scene164-singlelight-hemispheric-wgsl-D21aFDXO.js",
-      "scene164-skeleton-fragment-BylU934Q.js",
+      "scene164-singlelight-hemispheric-wgsl-Fg5myMvi.js",
+      "scene164-skeleton-fragment-Cs7Ptb67.js",
       "scene164.js"
     ]
   },
   "scene165": {
     "rawKB": 39.6,
-    "gzipKB": 15.7,
+    "gzipKB": 15.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene165-shader-renderable-Cdxg01B4.js",
-      "scene165-shader-thin-instance-DLGjCPiz.js",
-      "scene165-thin-instance-gpu-CQmqVOrj.js",
+      "scene165-shader-renderable-7YT1YSht.js",
+      "scene165-shader-thin-instance-ClxndMiQ.js",
+      "scene165-thin-instance-gpu-EhBRZoEE.js",
       "scene165.js"
     ]
   },
   "scene170": {
-    "rawKB": 49.8,
-    "gzipKB": 19.5,
+    "rawKB": 49.7,
+    "gzipKB": 19.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene170-standard-renderable-Dan2QV4w.js",
+      "scene170-standard-renderable-xTMwdBkZ.js",
       "scene170-wgsl-helpers-CwHFFXvt.js",
       "scene170.js"
     ]
   },
   "scene171": {
-    "rawKB": 93.6,
-    "gzipKB": 37.7,
+    "rawKB": 93.5,
+    "gzipKB": 37.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene171-generate-mipmaps-BT8hxlHx.js",
-      "scene171-gltf-glb-parser-BdYiApo0.js",
-      "scene171-pbr-renderable-BxYNwRl_.js",
+      "scene171-generate-mipmaps-BhnoKVJc.js",
+      "scene171-gltf-glb-parser-COBAbifQ.js",
+      "scene171-pbr-renderable-B4FaMr53.js",
       "scene171-shader-composer-DlM-8YlO.js",
-      "scene171-singlelight-hemispheric-wgsl-DNYRozlL.js",
-      "scene171-standard-renderable-CGYFq0bo.js",
+      "scene171-singlelight-hemispheric-wgsl-CobamZfq.js",
+      "scene171-standard-renderable-oFGyP4Db.js",
       "scene171-wgsl-helpers-CwHFFXvt.js",
       "scene171.js"
     ]
   },
   "scene172": {
-    "rawKB": 58,
-    "gzipKB": 22.5,
+    "rawKB": 57.9,
+    "gzipKB": 22.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene172-standard-renderable-BvyRA3i2.js",
+      "scene172-standard-renderable-DqUokfSZ.js",
       "scene172-wgsl-helpers-CwHFFXvt.js",
       "scene172.js"
     ]
   },
   "scene173": {
-    "rawKB": 60,
-    "gzipKB": 23.2,
+    "rawKB": 59.9,
+    "gzipKB": 23.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene173-standard-renderable-CTd05CKS.js",
+      "scene173-standard-renderable-59pJMF6b.js",
       "scene173-wgsl-helpers-CwHFFXvt.js",
       "scene173.js"
     ]
   },
   "scene174": {
-    "rawKB": 94.3,
-    "gzipKB": 38.1,
+    "rawKB": 94.1,
+    "gzipKB": 38.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene174-generate-mipmaps-H1xbNO4y.js",
-      "scene174-gltf-glb-parser-BdYiApo0.js",
-      "scene174-pbr-renderable-DFyhKEoo.js",
+      "scene174-generate-mipmaps-DpCURRWO.js",
+      "scene174-gltf-glb-parser-V10AO6Mf.js",
+      "scene174-pbr-renderable-CYiavnJ3.js",
       "scene174-shader-composer-DlM-8YlO.js",
-      "scene174-singlelight-hemispheric-wgsl-CSjXWK2g.js",
-      "scene174-standard-renderable-D2pa-WVy.js",
+      "scene174-singlelight-hemispheric-wgsl-BWHLvtQH.js",
+      "scene174-standard-renderable-Cq0pUQIp.js",
       "scene174-wgsl-helpers-CwHFFXvt.js",
       "scene174.js"
     ]
   },
   "scene175": {
     "rawKB": 92.5,
-    "gzipKB": 37.4,
+    "gzipKB": 37.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene175-generate-mipmaps-CfTJ8JPc.js",
-      "scene175-gltf-glb-parser-BdYiApo0.js",
-      "scene175-pbr-renderable-BQfJKiJa.js",
+      "scene175-generate-mipmaps-D58hsfbt.js",
+      "scene175-gltf-glb-parser-BmlEZ507.js",
+      "scene175-pbr-renderable-C7KBB_Lm.js",
       "scene175-shader-composer-DlM-8YlO.js",
-      "scene175-singlelight-hemispheric-wgsl-DtShUeHo.js",
-      "scene175-standard-renderable-97Mgaywe.js",
+      "scene175-singlelight-hemispheric-wgsl-DqeJ2jt3.js",
+      "scene175-standard-renderable-DNOBp-Yc.js",
       "scene175-wgsl-helpers-CwHFFXvt.js",
       "scene175.js"
     ]
   },
   "scene176": {
-    "rawKB": 98,
-    "gzipKB": 38.7,
+    "rawKB": 97.6,
+    "gzipKB": 38.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene176-generate-mipmaps-cqLJxvwS.js",
+      "scene176-generate-mipmaps-B65xeSR6.js",
       "scene176-gltf-ext-dielectric-BD8fbfh2.js",
-      "scene176-gltf-feature-registry-B5JPoNDq.js",
+      "scene176-gltf-feature-registry-mVLMJOMf.js",
       "scene176-ibl-fragment-CeRrvT96.js",
       "scene176-ibl-skybox-wgsl-CFIBOHHx.js",
-      "scene176-pbr-refraction-BtaRwxNA.js",
-      "scene176-pbr-renderable-DDW2LOrB.js",
-      "scene176-pbr-transmission-ext-DHqUTi_Z.js",
-      "scene176-reflectance-fragment-CLLQQJfo.js",
-      "scene176-rgbd-decode-Baow08lG.js",
+      "scene176-pbr-refraction-Z3OcrIin.js",
+      "scene176-pbr-renderable-Dx4cpqBA.js",
+      "scene176-pbr-transmission-ext-iy8ZLMGB.js",
+      "scene176-reflectance-fragment-B5ODTcHk.js",
+      "scene176-rgbd-decode-CUDdySsr.js",
       "scene176-scene-uniforms-FTYH6Ct0.js",
       "scene176.js"
     ]
   },
   "scene177": {
     "rawKB": 68.3,
-    "gzipKB": 27.5,
+    "gzipKB": 27.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene177-ibl-fragment-CeRrvT96.js",
       "scene177-ibl-skybox-wgsl-CFIBOHHx.js",
-      "scene177-iridescence-fragment-DQvGQpn2.js",
-      "scene177-pbr-renderable-CJl-pHYB.js",
-      "scene177-rgbd-decode-Baow08lG.js",
+      "scene177-iridescence-fragment-Dqr9v9Eq.js",
+      "scene177-pbr-renderable-v1UcnDdW.js",
+      "scene177-rgbd-decode-DeVpaebs.js",
       "scene177-scene-uniforms-FTYH6Ct0.js",
       "scene177.js"
     ]
   },
   "scene178": {
-    "rawKB": 85.2,
-    "gzipKB": 34.1,
+    "rawKB": 85,
+    "gzipKB": 34.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene178-generate-mipmaps-CeY0d8YU.js",
+      "scene178-generate-mipmaps-BSD0XJPC.js",
       "scene178-gltf-ext-iridescence-b4LVniAM.js",
-      "scene178-gltf-feature-registry-D3ig71q7.js",
-      "scene178-gltf-glb-parser-BdYiApo0.js",
+      "scene178-gltf-feature-registry-DlyaLJ9Q.js",
+      "scene178-gltf-glb-parser-D02mjtc4.js",
       "scene178-ibl-fragment-CeRrvT96.js",
       "scene178-ibl-skybox-wgsl-CFIBOHHx.js",
-      "scene178-iridescence-fragment-C3K2z8Fm.js",
-      "scene178-pbr-renderable-D1ITDuqK.js",
-      "scene178-rgbd-decode-Baow08lG.js",
+      "scene178-iridescence-fragment-BPlgCkSV.js",
+      "scene178-pbr-renderable-D7LjssBO.js",
+      "scene178-rgbd-decode-CdgbKFYr.js",
       "scene178-scene-uniforms-FTYH6Ct0.js",
       "scene178.js"
     ]
   },
   "scene179": {
-    "rawKB": 70.3,
-    "gzipKB": 28.2,
+    "rawKB": 70.4,
+    "gzipKB": 28.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene179-alpha-test-fragment-CIemjWVM.js",
-      "scene179-generate-mipmaps-DS6_DiwM.js",
-      "scene179-pbr-renderable-DfwIjSfc.js",
+      "scene179-alpha-test-fragment-BaX_J1Vy.js",
+      "scene179-generate-mipmaps-BQDWTtuU.js",
+      "scene179-pbr-renderable-4dIj6Fon.js",
       "scene179.js"
     ]
   },
   "scene200": {
     "rawKB": 45,
-    "gzipKB": 17.8,
+    "gzipKB": 18,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene200-standard-renderable-CjyVqrhA.js",
+      "scene200-standard-renderable-dxaF9FD_.js",
       "scene200-wgsl-helpers-CwHFFXvt.js",
       "scene200.js"
     ]
   },
   "scene201": {
     "rawKB": 46.4,
-    "gzipKB": 18.6,
+    "gzipKB": 18.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene201-_mat4-storage-f64-BGhyFY70.js",
+      "scene201-_mat4-storage-f64-BubF55_X.js",
       "scene201-floating-origin-kzkNzc8m.js",
       "scene201-pack-mat4-with-offset-BS-Lz8k7.js",
-      "scene201-standard-renderable-xSZGoqPZ.js",
+      "scene201-standard-renderable-ChEofalk.js",
       "scene201-wgsl-helpers-CwHFFXvt.js",
       "scene201.js"
     ]
   },
   "scene210": {
-    "rawKB": 72.2,
-    "gzipKB": 29.4,
+    "rawKB": 72.3,
+    "gzipKB": 29.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene210-generate-mipmaps-B8MX86A8.js",
-      "scene210-gltf-feature-registry-CZijwvhc.js",
+      "scene210-generate-mipmaps-CljmZtkl.js",
+      "scene210-gltf-feature-registry-CEGtpq91.js",
       "scene210-gltf-feature-xmp-S8Tl-XNQ.js",
-      "scene210-gltf-glb-parser-BdYiApo0.js",
-      "scene210-gltf-interleave-Dm2i78t1.js",
-      "scene210-pbr-renderable-DxbyCYXa.js",
-      "scene210-singlelight-hemispheric-wgsl-CfuW7YPH.js",
+      "scene210-gltf-glb-parser-fJOQf1ny.js",
+      "scene210-gltf-interleave-Bol_Arfo.js",
+      "scene210-pbr-renderable-CEYNV8Kt.js",
+      "scene210-singlelight-hemispheric-wgsl-CdvzWv12.js",
       "scene210.js"
     ]
   },
   "scene211": {
     "rawKB": 84.6,
-    "gzipKB": 34.9,
+    "gzipKB": 35.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene211-create-skeleton-CQTZt5d-.js",
-      "scene211-generate-mipmaps-9pDQSFe9.js",
-      "scene211-gltf-animation-DF1M1AzA.js",
-      "scene211-gltf-ext-quantization-2wENuzgS.js",
-      "scene211-gltf-feature-animations-fhi8Vajb.js",
-      "scene211-gltf-feature-meshopt-BV7W0QVm.js",
-      "scene211-gltf-feature-registry-FEeX42Sj.js",
-      "scene211-gltf-feature-skeleton-D5pnm0pB.js",
-      "scene211-pbr-renderable-B1Yz8hkQ.js",
-      "scene211-singlelight-hemispheric-wgsl-BStvzl1Q.js",
-      "scene211-skeleton-fragment-yKW-dSzA.js",
+      "scene211-create-skeleton-B8f27Dli.js",
+      "scene211-generate-mipmaps-DaaqPp_1.js",
+      "scene211-gltf-animation-BdhR3kHh.js",
+      "scene211-gltf-ext-quantization-Do-ofjB-.js",
+      "scene211-gltf-feature-animations-DZIi4-ME.js",
+      "scene211-gltf-feature-meshopt-Dt65KW5n.js",
+      "scene211-gltf-feature-registry-BTABZIYF.js",
+      "scene211-gltf-feature-skeleton-BREMKqOv.js",
+      "scene211-pbr-renderable-B0qOM9b0.js",
+      "scene211-singlelight-hemispheric-wgsl-DPzX_tFI.js",
+      "scene211-skeleton-fragment-C8qy2ftF.js",
       "scene211.js"
     ]
   },
   "scene212": {
-    "rawKB": 99.4,
-    "gzipKB": 39.3,
+    "rawKB": 99.1,
+    "gzipKB": 39.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene212-generate-mipmaps-BREZAFpD.js",
+      "scene212-generate-mipmaps-CZbdZ12a.js",
       "scene212-gltf-ext-dielectric-BD8fbfh2.js",
-      "scene212-gltf-feature-registry-B3MetgxM.js",
-      "scene212-gltf-glb-parser-BdYiApo0.js",
+      "scene212-gltf-feature-registry-BHDHGJxM.js",
+      "scene212-gltf-glb-parser-DGu0UWDd.js",
       "scene212-ibl-fragment-CeRrvT96.js",
       "scene212-ibl-skybox-wgsl-CFIBOHHx.js",
-      "scene212-pbr-refraction-DgXWEO1-.js",
-      "scene212-pbr-renderable-DRWDvXbi.js",
-      "scene212-pbr-transmission-ext-B_7vS8FE.js",
-      "scene212-reflectance-fragment-Bcr00Qu1.js",
+      "scene212-pbr-refraction-BiQrol3V.js",
+      "scene212-pbr-renderable-l_yZQgvQ.js",
+      "scene212-pbr-transmission-ext-D3BpaZes.js",
+      "scene212-reflectance-fragment-DddZUBln.js",
       "scene212-refraction-dispersion-wgsl-BKvBCmZU.js",
-      "scene212-rgbd-decode-Baow08lG.js",
+      "scene212-rgbd-decode-CXY-9fsD.js",
       "scene212-scene-uniforms-FTYH6Ct0.js",
       "scene212.js"
     ]
   },
   "scene213": {
     "rawKB": 42.8,
-    "gzipKB": 16.3,
+    "gzipKB": 16.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene213-shader-renderable-ityHri7z.js",
+      "scene213-shader-renderable-D6QEq7L4.js",
       "scene213.js"
     ]
   },
   "scene214": {
     "rawKB": 64,
-    "gzipKB": 25.2,
+    "gzipKB": 25.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene214-material-view-Dua1bl7W.js",
       "scene214-no-color-view-DMKScy5I.js",
       "scene214-shadow-task-kZBQCrfU.js",
-      "scene214-standard-renderable-BKmNcqXh.js",
+      "scene214-standard-renderable-wDHFq5lG.js",
       "scene214-std-shadow-fragment-KMUO_xPH.js",
       "scene214-wgsl-helpers-CwHFFXvt.js",
       "scene214.js"
     ]
   },
   "scene215": {
-    "rawKB": 75.3,
-    "gzipKB": 30.1,
+    "rawKB": 75.5,
+    "gzipKB": 30.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene215-material-view-Dua1bl7W.js",
-      "scene215-multilight-wgsl-CJovw31G.js",
+      "scene215-multilight-wgsl-CdZX6YeA.js",
       "scene215-no-color-view-C2WYvPEP.js",
-      "scene215-pbr-renderable-JoCChLzV.js",
-      "scene215-pbr-shadow-fragment-BOFeZrZc.js",
-      "scene215-shadow-task-DmLNojii.js",
-      "scene215-singlelight-directional-wgsl-CP9e2nM7.js",
+      "scene215-pbr-renderable-CTWxiEsz.js",
+      "scene215-pbr-shadow-fragment-DYeWYt3Q.js",
+      "scene215-shadow-task-DKxi3YT6.js",
+      "scene215-singlelight-directional-wgsl-Ca3Luctu.js",
       "scene215.js"
     ]
   },
   "scene216": {
-    "rawKB": 51.9,
-    "gzipKB": 21.1,
+    "rawKB": 52.1,
+    "gzipKB": 21.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene216-pbr-fog-wgsl-BuLKZvgv.js",
-      "scene216-pbr-renderable-Bojq8NO_.js",
-      "scene216-singlelight-hemispheric-wgsl-hncvxTnw.js",
+      "scene216-pbr-renderable-DX-F6fa0.js",
+      "scene216-singlelight-hemispheric-wgsl-DCRDQ-Ny.js",
       "scene216.js"
     ]
   },
   "scene217": {
-    "rawKB": 75.7,
-    "gzipKB": 30.3,
+    "rawKB": 75.8,
+    "gzipKB": 30.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene217-multilight-wgsl-CLZAmdk3.js",
-      "scene217-pbr-renderable-BgIJQhvF.js",
-      "scene217-shader-composer-DZScTwY6.js",
-      "scene217-standard-renderable-DT95GVFv.js",
+      "scene217-multilight-wgsl-B1Dnc4nB.js",
+      "scene217-pbr-renderable-DQk2wxZL.js",
+      "scene217-shader-composer-U6XlTIgo.js",
+      "scene217-standard-renderable-D-TAaqN0.js",
       "scene217-wgsl-helpers-CwHFFXvt.js",
       "scene217.js"
     ]
   },
   "scene218": {
     "rawKB": 86.3,
-    "gzipKB": 35.3,
+    "gzipKB": 35.7,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene218-create-skeleton-DWjuzetT.js",
-      "scene218-generate-mipmaps-Cg_-N0u3.js",
-      "scene218-gltf-animation-isxz4Pns.js",
+      "scene218-create-skeleton-By02aoAt.js",
+      "scene218-generate-mipmaps-SbnlCr9H.js",
+      "scene218-gltf-animation-ofuTIxfR.js",
       "scene218-gltf-ext-spec-gloss-D60sFZYX.js",
-      "scene218-gltf-feature-animations-CmqkrZKO.js",
-      "scene218-gltf-feature-registry-CVj6DqoM.js",
-      "scene218-gltf-feature-skeleton-C5lA5jdf.js",
-      "scene218-gltf-glb-parser-BdYiApo0.js",
-      "scene218-pbr-renderable-CpzKVwzd.js",
-      "scene218-singlelight-hemispheric-wgsl-Bg4H9PAi.js",
+      "scene218-gltf-feature-animations-zXGzeXYr.js",
+      "scene218-gltf-feature-registry-CZB-P1hR.js",
+      "scene218-gltf-feature-skeleton-MgilnTuc.js",
+      "scene218-gltf-glb-parser-BXHcqEF1.js",
+      "scene218-pbr-renderable-Cl_2WElo.js",
+      "scene218-singlelight-hemispheric-wgsl-DoMP8ai3.js",
       "scene218.js"
     ]
   },
   "scene219": {
-    "rawKB": 88.8,
-    "gzipKB": 36.4,
+    "rawKB": 88.7,
+    "gzipKB": 36.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
-      "scene219-create-skeleton-p4EHfpUx.js",
-      "scene219-generate-mipmaps-B_oKNngo.js",
-      "scene219-gltf-animation-C1Os36Ng.js",
+      "scene219-create-skeleton-HyG4hflt.js",
+      "scene219-generate-mipmaps-Chp_jvIr.js",
+      "scene219-gltf-animation-DvYwVi-G.js",
       "scene219-gltf-ext-spec-gloss-D60sFZYX.js",
-      "scene219-gltf-feature-animations-BaUGwAmW.js",
-      "scene219-gltf-feature-registry-DkWc4-XR.js",
-      "scene219-gltf-feature-skeleton-B1gFD0z1.js",
-      "scene219-gltf-glb-parser-BdYiApo0.js",
-      "scene219-pbr-renderable-DXJasq6y.js",
-      "scene219-singlelight-hemispheric-wgsl-BIYQZenG.js",
+      "scene219-gltf-feature-animations-Bzs5XLnq.js",
+      "scene219-gltf-feature-registry-Ct2S29Fl.js",
+      "scene219-gltf-feature-skeleton-sxIGS_OG.js",
+      "scene219-gltf-glb-parser-PDyH09Yg.js",
+      "scene219-pbr-renderable-CTKx_VwD.js",
+      "scene219-singlelight-hemispheric-wgsl-B6s0gC_c.js",
       "scene219-thin-instance-fragment-CBn2miAC.js",
-      "scene219-thin-instance-gpu-cQtprm7y.js",
+      "scene219-thin-instance-gpu-6jJGiRcH.js",
       "scene219.js"
     ]
   }

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -332,7 +332,7 @@ export type { RenderTargetSignature } from "./engine/render-target.js";
 export type { SpriteAtlas, SpriteFrame, SpriteSampling, GridAtlasOptions, LoadAtlasOptions } from "./sprite/shared/sprite-atlas.js";
 export { createGridSpriteAtlas, loadSpriteAtlas } from "./sprite/shared/sprite-atlas.js";
 export type { SpriteAtlasFrameSource, SpriteAtlasPackOptions } from "./sprite/shared/sprite-atlas-packer.js";
-export { createSpriteAtlasFromFrames } from "./sprite/shared/sprite-atlas-packer.js";
+export { appendSpriteAtlasFrames, createSpriteAtlasFromFrames } from "./sprite/shared/sprite-atlas-packer.js";
 export type { Sprite2DLayer, Sprite2DLayerOptions, Sprite2DProps, Sprite2DView, Sprite2DDepthMode, SpriteBlendMode } from "./sprite/sprite-2d.js";
 export type { SpriteBlendDescriptor } from "./sprite/sprite-blend.js";
 export { spriteBlendAlpha, spriteBlendPremultiplied, spriteBlendAdditive, spriteBlendMultiply } from "./sprite/sprite-blend.js";

--- a/packages/babylon-lite/src/sprite/shared/sprite-atlas-packer.ts
+++ b/packages/babylon-lite/src/sprite/shared/sprite-atlas-packer.ts
@@ -48,7 +48,8 @@ export interface SpriteAtlasFrameSource {
     /** Top-left y of the sub-rect to pack, in texels into `pixels`. Default `0`. */
     readonly srcY?: number;
     /** Bytes between consecutive rows of `pixels`. Default `width * 4` (tightly packed).
-     *  Must be `>= width * 4`. */
+     *  Must satisfy `(srcX + width) * 4 <= srcStrideBytes` — i.e. each row's sub-rect window
+     *  must fit within one stride, so reads do not spill into the next row. */
     readonly srcStrideBytes?: number;
     /** Pivot in [0,1] of the frame. Default `[0.5, 0.5]`. */
     readonly pivot?: readonly [number, number];
@@ -117,8 +118,14 @@ function shelfPack(
         if (srcX < 0 || srcY < 0) {
             throw new Error(`${fnLabel}: frame ${i} has negative sub-rect origin (srcX=${srcX}, srcY=${srcY}).`);
         }
-        if (srcStride < s.width * 4) {
-            throw new Error(`${fnLabel}: frame ${i} srcStrideBytes ${srcStride} is less than width * 4 (${s.width * 4}).`);
+        // Each row's read window is `[srcX*4, (srcX+width)*4)` bytes inside one `srcStride`-byte row.
+        // The window must fit within the stride, otherwise per-row reads spill into the *next* row's
+        // start and produce silently-corrupt uploads. Subsumes the looser `srcStride >= width*4` check
+        // (which only handled the srcX=0 case).
+        if ((srcX + s.width) * 4 > srcStride) {
+            throw new Error(
+                `${fnLabel}: frame ${i} sub-rect row extent (srcX + width) * 4 = ${(srcX + s.width) * 4} exceeds srcStrideBytes ${srcStride} (would spill into next row).`
+            );
         }
         // Last byte we need to read = (srcY + height - 1) * srcStride + (srcX + width) * 4.
         const requiredBytes = (srcY + s.height - 1) * srcStride + (srcX + s.width) * 4;
@@ -168,13 +175,20 @@ function shelfPack(
  */
 export function createSpriteAtlasFromFrames(engine: EngineContext, sources: readonly SpriteAtlasFrameSource[], options: SpriteAtlasPackOptions = {}): SpriteAtlas {
     const padding = options.paddingPx ?? 1;
-    const maxWidth = options.maxWidthPx ?? 1024;
+    const requestedMaxWidth = options.maxWidthPx ?? 1024;
 
     if (sources.length === 0 && !options.capacityPx) {
         throw new Error(
             "createSpriteAtlasFromFrames: at least one frame is required, or pass options.capacityPx to create an empty atlas with reserved capacity for appendSpriteAtlasFrames."
         );
     }
+
+    // When `capacityPx` is supplied, clamp the shelf width to the texture width so packing
+    // honors the actual atlas bound (matching what `appendSpriteAtlasFrames` does later).
+    // Otherwise a `maxWidthPx` wider than `capacityPx[0]` lets frames flow past the texture's
+    // right edge and we'd reject the atlas as "too small" even though a narrower shelf would
+    // have wrapped the frames vertically and fit them.
+    const maxWidth = options.capacityPx ? Math.min(requestedMaxWidth, options.capacityPx[0]) : requestedMaxWidth;
 
     // Pack against an unbounded height first so we can discover the content footprint and
     // then decide the final texture dimensions (content-fit vs. caller-supplied capacity).

--- a/packages/babylon-lite/src/sprite/shared/sprite-atlas-packer.ts
+++ b/packages/babylon-lite/src/sprite/shared/sprite-atlas-packer.ts
@@ -9,19 +9,48 @@
  * corresponds to `sources[i]` — so callers can map their own per-frame metadata
  * by index. Each `SpriteFrame.name` carries the source `name` when supplied.
  *
+ * Two operations are supported:
+ *   - `createSpriteAtlasFromFrames` — build a new atlas. Pre-allocate headroom for
+ *     later growth via `options.capacityPx`.
+ *   - `appendSpriteAtlasFrames` — pack additional frames into the existing texture
+ *     without rebuilding it. Issues one `queue.writeTexture` per frame; the GPU
+ *     texture, its view, and any bind groups that reference it remain valid.
+ *
+ * Sub-rect sources: every `SpriteAtlasFrameSource` may describe a sub-rectangle of a
+ * larger pixel buffer via `srcX` / `srcY` / `srcStrideBytes`. This lets callers feed
+ * e.g. a freshly rasterized glyph straight from a wasm memory view into the atlas
+ * without first copying out the trimmed sub-rect.
+ *
  * Tree-shaken: importing this drags in nothing a plain sprite scene pays for.
  */
 import { U8 } from "../../engine/typed-arrays.js";
 import type { EngineContext } from "../../engine/engine.js";
 import { createTexture2DFromPixels } from "../../texture/pixels-texture.js";
-import type { SpriteAtlas, SpriteFrame, SpriteSampling } from "./sprite-atlas.js";
+import type { SpriteAtlas, SpriteAtlasPackState, SpriteFrame, SpriteSampling } from "./sprite-atlas.js";
 
-/** One source frame for `createSpriteAtlasFromFrames`. */
+/** One source frame for `createSpriteAtlasFromFrames` / `appendSpriteAtlasFrames`. The packed
+ *  region is `width × height` texels. By default the source is read as a tightly-packed RGBA8
+ *  buffer of exactly that size starting at byte 0; the optional `srcX` / `srcY` / `srcStrideBytes`
+ *  fields let the source describe a sub-rectangle of a larger buffer (e.g. the trimmed glyph
+ *  region inside a wasm-owned rasterizer scratch surface) without forcing the caller to copy out
+ *  the sub-rect first. */
 export interface SpriteAtlasFrameSource {
-    /** Tightly packed RGBA8 bytes — `width * height * 4`, row-major, top-to-bottom, straight alpha. */
+    /** RGBA8 bytes, row-major, top-to-bottom, straight alpha. When `srcX` / `srcY` /
+     *  `srcStrideBytes` are all defaulted, this must be exactly `width * height * 4` bytes;
+     *  when sub-rect fields are supplied, it must be large enough to cover the rect
+     *  (see those fields' docs). */
     readonly pixels: Uint8Array;
+    /** Width of the frame to pack (texels written to the atlas). */
     readonly width: number;
+    /** Height of the frame to pack (texels written to the atlas). */
     readonly height: number;
+    /** Top-left x of the sub-rect to pack, in texels into `pixels`. Default `0`. */
+    readonly srcX?: number;
+    /** Top-left y of the sub-rect to pack, in texels into `pixels`. Default `0`. */
+    readonly srcY?: number;
+    /** Bytes between consecutive rows of `pixels`. Default `width * 4` (tightly packed).
+     *  Must be `>= width * 4`. */
+    readonly srcStrideBytes?: number;
     /** Pivot in [0,1] of the frame. Default `[0.5, 0.5]`. */
     readonly pivot?: readonly [number, number];
     /** Recorded on the emitted `SpriteFrame.name`. */
@@ -37,62 +66,142 @@ export interface SpriteAtlasPackOptions {
     /** Min/mag filter for the packed texture. Default `"nearest"`. */
     sampling?: SpriteSampling;
     premultipliedAlpha?: boolean;
+    /** Pre-allocate the atlas texture at this `[width, height]` regardless of initial-content
+     *  size, leaving headroom for later `appendSpriteAtlasFrames` calls (which never grow the
+     *  texture). Required when `sources` is empty. Defaults to the size required by the initial
+     *  `sources` (no append headroom). */
+    capacityPx?: readonly [number, number];
 }
 
-/**
- * Pack `sources` into a single `SpriteAtlas`. Shelf-packs in input order: each
- * frame is placed left-to-right on the current shelf, wrapping to a new shelf
- * (row) when it would overflow `maxWidthPx`. The texture is sized exactly to the
- * packed content.
- */
-export function createSpriteAtlasFromFrames(engine: EngineContext, sources: readonly SpriteAtlasFrameSource[], options: SpriteAtlasPackOptions = {}): SpriteAtlas {
-    if (sources.length === 0) {
-        throw new Error("createSpriteAtlasFromFrames: at least one frame is required.");
-    }
-    const padding = options.paddingPx ?? 1;
-    const maxWidth = options.maxWidthPx ?? 1024;
+/** @internal Result of `shelfPack`: per-frame placements + the updated shelf cursor. */
+interface ShelfPackResult {
+    xs: number[];
+    ys: number[];
+    penX: number;
+    penY: number;
+    shelfHeight: number;
+    /** Right-most x-extent reached during packing — only meaningful for sizing a fresh atlas. */
+    contentWidth: number;
+    /** Bottom-most y-extent reached during packing — only meaningful for sizing a fresh atlas. */
+    contentHeight: number;
+}
 
-    // Shelf-pack in input order; record each frame's top-left into xs/ys.
+/** @internal Shelf-pack `sources` starting at the given cursor. Validates each source's pixel
+ *  buffer (incl. sub-rect bounds) before placing it. `maxHeight` is the hard ceiling that
+ *  triggers an "atlas full" error on overflow — pass `Number.MAX_SAFE_INTEGER` during initial
+ *  sizing to defer the cap to the caller-resolved atlas height. */
+function shelfPack(
+    sources: readonly SpriteAtlasFrameSource[],
+    padding: number,
+    maxWidth: number,
+    maxHeight: number,
+    startPenX: number,
+    startPenY: number,
+    startShelfHeight: number,
+    fnLabel: string
+): ShelfPackResult {
     const xs = new Array<number>(sources.length);
     const ys = new Array<number>(sources.length);
-    let penX = 0;
-    let penY = 0;
-    let shelfHeight = 0;
-    let atlasWidth = 1;
+    let penX = startPenX;
+    let penY = startPenY;
+    let shelfHeight = startShelfHeight;
+    let contentWidth = 0;
+
     for (let i = 0; i < sources.length; i++) {
         const s = sources[i]!;
         if (s.width < 1 || s.height < 1) {
-            throw new Error(`createSpriteAtlasFromFrames: frame ${i} has non-positive size ${s.width}x${s.height}.`);
+            throw new Error(`${fnLabel}: frame ${i} has non-positive size ${s.width}x${s.height}.`);
         }
-        if (s.pixels.length < s.width * s.height * 4) {
-            throw new Error(`createSpriteAtlasFromFrames: frame ${i} pixel buffer too short — need ${s.width * s.height * 4} bytes, got ${s.pixels.length}.`);
+        const srcX = s.srcX ?? 0;
+        const srcY = s.srcY ?? 0;
+        const srcStride = s.srcStrideBytes ?? s.width * 4;
+        if (srcX < 0 || srcY < 0) {
+            throw new Error(`${fnLabel}: frame ${i} has negative sub-rect origin (srcX=${srcX}, srcY=${srcY}).`);
         }
+        if (srcStride < s.width * 4) {
+            throw new Error(`${fnLabel}: frame ${i} srcStrideBytes ${srcStride} is less than width * 4 (${s.width * 4}).`);
+        }
+        // Last byte we need to read = (srcY + height - 1) * srcStride + (srcX + width) * 4.
+        const requiredBytes = (srcY + s.height - 1) * srcStride + (srcX + s.width) * 4;
+        if (s.pixels.length < requiredBytes) {
+            throw new Error(
+                `${fnLabel}: frame ${i} pixel buffer too short — need ${requiredBytes} bytes ` +
+                    `(srcX=${srcX}, srcY=${srcY}, srcStride=${srcStride}, w=${s.width}, h=${s.height}), got ${s.pixels.length}.`
+            );
+        }
+        // Wrap to a new shelf if this frame doesn't fit on the current one.
         if (penX > 0 && penX + s.width > maxWidth) {
             penY += shelfHeight + padding;
             penX = 0;
             shelfHeight = 0;
         }
+        if (s.width > maxWidth) {
+            throw new Error(`${fnLabel}: frame ${i} width ${s.width} exceeds shelf max width ${maxWidth}.`);
+        }
+        if (penY + s.height > maxHeight) {
+            throw new Error(`${fnLabel}: cannot fit frame ${i} (${s.width}x${s.height}) — atlas height capacity ${maxHeight} exhausted at y=${penY}.`);
+        }
         xs[i] = penX;
         ys[i] = penY;
         const rightEdge = penX + s.width;
-        if (rightEdge > atlasWidth) {
-            atlasWidth = rightEdge;
+        if (rightEdge > contentWidth) {
+            contentWidth = rightEdge;
         }
         penX = rightEdge + padding;
         if (s.height > shelfHeight) {
             shelfHeight = s.height;
         }
     }
-    const atlasHeight = penY + shelfHeight;
 
-    // Composite every frame into one transparent RGBA8 buffer.
+    const contentHeight = sources.length === 0 ? startPenY : penY + shelfHeight;
+    return { xs, ys, penX, penY, shelfHeight, contentWidth, contentHeight };
+}
+
+/**
+ * Pack `sources` into a single `SpriteAtlas`. Shelf-packs in input order: each
+ * frame is placed left-to-right on the current shelf, wrapping to a new shelf
+ * (row) when it would overflow `maxWidthPx`. The texture is sized exactly to the
+ * packed content unless `options.capacityPx` is supplied to reserve headroom for
+ * later `appendSpriteAtlasFrames` calls.
+ *
+ * Pass `sources: []` together with `options.capacityPx` to create an empty atlas
+ * sized for future appends.
+ */
+export function createSpriteAtlasFromFrames(engine: EngineContext, sources: readonly SpriteAtlasFrameSource[], options: SpriteAtlasPackOptions = {}): SpriteAtlas {
+    const padding = options.paddingPx ?? 1;
+    const maxWidth = options.maxWidthPx ?? 1024;
+
+    if (sources.length === 0 && !options.capacityPx) {
+        throw new Error(
+            "createSpriteAtlasFromFrames: at least one frame is required, or pass options.capacityPx to create an empty atlas with reserved capacity for appendSpriteAtlasFrames."
+        );
+    }
+
+    // Pack against an unbounded height first so we can discover the content footprint and
+    // then decide the final texture dimensions (content-fit vs. caller-supplied capacity).
+    const placement = shelfPack(sources, padding, maxWidth, Number.MAX_SAFE_INTEGER, 0, 0, 0, "createSpriteAtlasFromFrames");
+
+    const atlasWidth = options.capacityPx ? options.capacityPx[0] : Math.max(1, placement.contentWidth);
+    const atlasHeight = options.capacityPx ? options.capacityPx[1] : Math.max(1, placement.contentHeight);
+    if (atlasWidth < 1 || atlasHeight < 1) {
+        throw new Error(`createSpriteAtlasFromFrames: atlas dimensions must be >= 1 (got ${atlasWidth}x${atlasHeight}).`);
+    }
+    if (placement.contentWidth > atlasWidth || placement.contentHeight > atlasHeight) {
+        throw new Error(`createSpriteAtlasFromFrames: capacityPx ${atlasWidth}x${atlasHeight} too small for initial content ${placement.contentWidth}x${placement.contentHeight}.`);
+    }
+
+    // Composite every initial frame into one transparent RGBA8 buffer sized to the full atlas
+    // capacity (which may be larger than the content footprint when capacityPx is set).
     const data = new U8(atlasWidth * atlasHeight * 4);
     for (let i = 0; i < sources.length; i++) {
         const s = sources[i]!;
+        const srcX = s.srcX ?? 0;
+        const srcY = s.srcY ?? 0;
+        const srcStride = s.srcStrideBytes ?? s.width * 4;
         const rowBytes = s.width * 4;
         for (let row = 0; row < s.height; row++) {
-            const srcOffset = row * rowBytes;
-            const dstOffset = ((ys[i]! + row) * atlasWidth + xs[i]!) * 4;
+            const srcOffset = (srcY + row) * srcStride + srcX * 4;
+            const dstOffset = ((placement.ys[i]! + row) * atlasWidth + placement.xs[i]!) * 4;
             data.set(s.pixels.subarray(srcOffset, srcOffset + rowBytes), dstOffset);
         }
     }
@@ -108,17 +217,101 @@ export function createSpriteAtlasFromFrames(engine: EngineContext, sources: read
         const s = sources[i]!;
         frames[i] = {
             name: s.name,
-            uvMin: [xs[i]! / atlasWidth, ys[i]! / atlasHeight],
-            uvMax: [(xs[i]! + s.width) / atlasWidth, (ys[i]! + s.height) / atlasHeight],
+            uvMin: [placement.xs[i]! / atlasWidth, placement.ys[i]! / atlasHeight],
+            uvMax: [(placement.xs[i]! + s.width) / atlasWidth, (placement.ys[i]! + s.height) / atlasHeight],
             sourceSizePx: [s.width, s.height],
             pivot: s.pivot ?? [0.5, 0.5],
         };
     }
 
+    // Attach packer state so future appendSpriteAtlasFrames calls can resume shelf-packing.
+    // `_packState` is `@internal` on the SpriteAtlas type — readonly to public consumers,
+    // mutable here because the packer owns it.
+    const packState: SpriteAtlasPackState = {
+        penX: placement.penX,
+        penY: placement.penY,
+        shelfHeight: placement.shelfHeight,
+        maxWidth,
+        padding,
+    };
     return {
         texture,
         textureSizePx: [atlasWidth, atlasHeight],
         frames,
         premultipliedAlpha: options.premultipliedAlpha ?? false,
+        _packState: packState,
     };
+}
+
+/**
+ * Append `sources` into the remaining free space of an atlas previously built by
+ * `createSpriteAtlasFromFrames`. The existing `GPUTexture` (and any bind group already
+ * referencing it) stays valid — each new frame is uploaded with a single
+ * `queue.writeTexture` and the UV slots of the *existing* frames are not touched, so
+ * sprite instances already drawing from this atlas remain correct.
+ *
+ * Returns the integer indices of the newly-appended frames in `atlas.frames`, in input
+ * order. Sources are validated and placed before any texel is written, so a thrown
+ * "atlas full" error leaves the atlas state untouched (all-or-nothing semantics).
+ *
+ * Throws when:
+ *   - The atlas was built by `createGridSpriteAtlas` / `loadSpriteAtlas` (no packer state).
+ *   - Any source has invalid size / sub-rect / pixel buffer length.
+ *   - A source wider than `maxWidthPx` is supplied (cannot fit any shelf).
+ *   - The packed sources would overflow the atlas height. Pre-size the atlas via
+ *     `createSpriteAtlasFromFrames(engine, [...], { capacityPx: [w, h] })` to reserve room.
+ */
+export function appendSpriteAtlasFrames(engine: EngineContext, atlas: SpriteAtlas, sources: readonly SpriteAtlasFrameSource[]): number[] {
+    if (sources.length === 0) {
+        return [];
+    }
+    const state = atlas._packState;
+    if (!state) {
+        throw new Error("appendSpriteAtlasFrames: atlas was not built by createSpriteAtlasFromFrames (no packer state).");
+    }
+    const [atlasW, atlasH] = atlas.textureSizePx;
+    const shelfMaxWidth = Math.min(state.maxWidth, atlasW);
+
+    // Phase 1: validate every source and compute placements; throws before mutating anything.
+    const placement = shelfPack(sources, state.padding, shelfMaxWidth, atlasH, state.penX, state.penY, state.shelfHeight, "appendSpriteAtlasFrames");
+
+    // Phase 2: commit — upload texels and append SpriteFrame entries.
+    const device = engine._device;
+    const texture = atlas.texture.texture;
+    // `SpriteAtlas.frames` is `readonly SpriteFrame[]` to consumers, but the packer owns the
+    // underlying Array and appends in place — keeps existing frame references and indices stable.
+    const framesOut = atlas.frames as SpriteFrame[];
+    const baseIndex = framesOut.length;
+    const newIndices = new Array<number>(sources.length);
+
+    for (let i = 0; i < sources.length; i++) {
+        const s = sources[i]!;
+        const srcX = s.srcX ?? 0;
+        const srcY = s.srcY ?? 0;
+        const srcStride = s.srcStrideBytes ?? s.width * 4;
+        // writeTexture's dataLayout.offset is added on top of the typed array's own byteOffset,
+        // so we can hand WebGPU the full source buffer and let it walk the sub-rect directly —
+        // no intermediate copy.
+        const dataOffset = srcY * srcStride + srcX * 4;
+        device.queue.writeTexture(
+            { texture, origin: { x: placement.xs[i]!, y: placement.ys[i]! } },
+            s.pixels as Uint8Array<ArrayBuffer>,
+            { offset: dataOffset, bytesPerRow: srcStride, rowsPerImage: s.height },
+            { width: s.width, height: s.height }
+        );
+        newIndices[i] = baseIndex + i;
+        framesOut.push({
+            name: s.name,
+            uvMin: [placement.xs[i]! / atlasW, placement.ys[i]! / atlasH],
+            uvMax: [(placement.xs[i]! + s.width) / atlasW, (placement.ys[i]! + s.height) / atlasH],
+            sourceSizePx: [s.width, s.height],
+            pivot: s.pivot ?? [0.5, 0.5],
+        });
+    }
+
+    state.penX = placement.penX;
+    state.penY = placement.penY;
+    state.shelfHeight = placement.shelfHeight;
+
+    return newIndices;
 }

--- a/packages/babylon-lite/src/sprite/shared/sprite-atlas-packer.ts
+++ b/packages/babylon-lite/src/sprite/shared/sprite-atlas-packer.ts
@@ -296,7 +296,10 @@ export function appendSpriteAtlasFrames(engine: EngineContext, atlas: SpriteAtla
         const dataOffset = srcY * srcStride + srcX * 4;
         device.queue.writeTexture(
             { texture, origin: { x: placement.xs[i]!, y: placement.ys[i]! } },
-            s.pixels,
+            // Cast `Uint8Array<ArrayBufferLike>` → `Uint8Array<ArrayBuffer>` so the WebGPU
+            // `GPUAllowSharedBufferSource` overload accepts it. `pixels` is supplied by the caller
+            // as plain bytes (we never construct it from a `SharedArrayBuffer`), so this is sound.
+            s.pixels as Uint8Array<ArrayBuffer>,
             { offset: dataOffset, bytesPerRow: srcStride, rowsPerImage: s.height },
             { width: s.width, height: s.height }
         );

--- a/packages/babylon-lite/src/sprite/shared/sprite-atlas-packer.ts
+++ b/packages/babylon-lite/src/sprite/shared/sprite-atlas-packer.ts
@@ -31,9 +31,8 @@ import type { SpriteAtlas, SpriteAtlasPackState, SpriteFrame, SpriteSampling } f
 /** One source frame for `createSpriteAtlasFromFrames` / `appendSpriteAtlasFrames`. The packed
  *  region is `width × height` texels. By default the source is read as a tightly-packed RGBA8
  *  buffer of exactly that size starting at byte 0; the optional `srcX` / `srcY` / `srcStrideBytes`
- *  fields let the source describe a sub-rectangle of a larger buffer (e.g. the trimmed glyph
- *  region inside a wasm-owned rasterizer scratch surface) without forcing the caller to copy out
- *  the sub-rect first. */
+ *  fields let the source describe a sub-rectangle of a larger buffer without forcing the caller
+ *  to copy out the sub-rect first. */
 export interface SpriteAtlasFrameSource {
     /** RGBA8 bytes, row-major, top-to-bottom, straight alpha. When `srcX` / `srcY` /
      *  `srcStrideBytes` are all defaulted, this must be exactly `width * height * 4` bytes;
@@ -225,8 +224,9 @@ export function createSpriteAtlasFromFrames(engine: EngineContext, sources: read
     }
 
     // Attach packer state so future appendSpriteAtlasFrames calls can resume shelf-packing.
-    // `_packState` is `@internal` on the SpriteAtlas type — readonly to public consumers,
-    // mutable here because the packer owns it.
+    // `_packState` and `_frames` are `@internal` on the SpriteAtlas type — `frames` stays
+    // `readonly` to public consumers, while `_frames` aliases the same array so the packer
+    // can push to it without casting.
     const packState: SpriteAtlasPackState = {
         penX: placement.penX,
         penY: placement.penY,
@@ -240,6 +240,7 @@ export function createSpriteAtlasFromFrames(engine: EngineContext, sources: read
         frames,
         premultipliedAlpha: options.premultipliedAlpha ?? false,
         _packState: packState,
+        _frames: frames,
     };
 }
 
@@ -266,7 +267,8 @@ export function appendSpriteAtlasFrames(engine: EngineContext, atlas: SpriteAtla
         return [];
     }
     const state = atlas._packState;
-    if (!state) {
+    const framesOut = atlas._frames;
+    if (!state || !framesOut) {
         throw new Error("appendSpriteAtlasFrames: atlas was not built by createSpriteAtlasFromFrames (no packer state).");
     }
     const [atlasW, atlasH] = atlas.textureSizePx;
@@ -275,12 +277,11 @@ export function appendSpriteAtlasFrames(engine: EngineContext, atlas: SpriteAtla
     // Phase 1: validate every source and compute placements; throws before mutating anything.
     const placement = shelfPack(sources, state.padding, shelfMaxWidth, atlasH, state.penX, state.penY, state.shelfHeight, "appendSpriteAtlasFrames");
 
-    // Phase 2: commit — upload texels and append SpriteFrame entries.
+    // Phase 2: commit — upload texels and append SpriteFrame entries. `framesOut` is the same
+    // array `atlas.frames` exposes — appending here keeps existing frame references and indices
+    // stable for consumers already drawing from this atlas.
     const device = engine._device;
     const texture = atlas.texture.texture;
-    // `SpriteAtlas.frames` is `readonly SpriteFrame[]` to consumers, but the packer owns the
-    // underlying Array and appends in place — keeps existing frame references and indices stable.
-    const framesOut = atlas.frames as SpriteFrame[];
     const baseIndex = framesOut.length;
     const newIndices = new Array<number>(sources.length);
 
@@ -295,7 +296,7 @@ export function appendSpriteAtlasFrames(engine: EngineContext, atlas: SpriteAtla
         const dataOffset = srcY * srcStride + srcX * 4;
         device.queue.writeTexture(
             { texture, origin: { x: placement.xs[i]!, y: placement.ys[i]! } },
-            s.pixels as Uint8Array<ArrayBuffer>,
+            s.pixels,
             { offset: dataOffset, bytesPerRow: srcStride, rowsPerImage: s.height },
             { width: s.width, height: s.height }
         );

--- a/packages/babylon-lite/src/sprite/shared/sprite-atlas.ts
+++ b/packages/babylon-lite/src/sprite/shared/sprite-atlas.ts
@@ -36,6 +36,26 @@ export interface SpriteAtlas {
     readonly textureSizePx: readonly [number, number];
     readonly frames: readonly SpriteFrame[];
     readonly premultipliedAlpha: boolean;
+    /** @internal Mutable shelf-pack cursor + parameters carried by atlases built via the runtime
+     *  packer (`createSpriteAtlasFromFrames`). `appendSpriteAtlasFrames` resumes packing into the
+     *  remaining capacity using this state. Absent on atlases built via `createGridSpriteAtlas` /
+     *  `loadSpriteAtlas` — those cannot be appended to. */
+    _packState?: SpriteAtlasPackState;
+}
+
+/** @internal Shelf-pack cursor + parameters for runtime atlas packing. Mutated by
+ *  `appendSpriteAtlasFrames` to track free space across calls. */
+export interface SpriteAtlasPackState {
+    /** Current shelf x-cursor (px). */
+    penX: number;
+    /** Current shelf y-cursor (px). */
+    penY: number;
+    /** Height of the current shelf (px); the next shelf will start at `penY + shelfHeight + padding`. */
+    shelfHeight: number;
+    /** Shelf wrap width (px); from `SpriteAtlasPackOptions.maxWidthPx`. */
+    maxWidth: number;
+    /** Gap between packed frames (px); from `SpriteAtlasPackOptions.paddingPx`. */
+    padding: number;
 }
 
 /** Options for `createGridSpriteAtlas`. */

--- a/packages/babylon-lite/src/sprite/shared/sprite-atlas.ts
+++ b/packages/babylon-lite/src/sprite/shared/sprite-atlas.ts
@@ -41,6 +41,10 @@ export interface SpriteAtlas {
      *  remaining capacity using this state. Absent on atlases built via `createGridSpriteAtlas` /
      *  `loadSpriteAtlas` — those cannot be appended to. */
     _packState?: SpriteAtlasPackState;
+    /** @internal Mutable alias of `frames` (same underlying array) for the runtime packer to
+     *  push new entries into without casting away `readonly`. Always set together with
+     *  `_packState` (i.e. only on atlases built via `createSpriteAtlasFromFrames`). */
+    _frames?: SpriteFrame[];
 }
 
 /** @internal Shelf-pack cursor + parameters for runtime atlas packing. Mutated by

--- a/tests/lite/unit/sprite-atlas-packer.test.ts
+++ b/tests/lite/unit/sprite-atlas-packer.test.ts
@@ -118,10 +118,28 @@ describe("createSpriteAtlasFromFrames — sub-rect sources", () => {
         expect(Array.from(composited.subarray(1 * 16 + 3 * 4, 1 * 16 + 4 * 4))).toEqual([0, 0, 255, 255]);
     });
 
-    it("validates srcStrideBytes is at least width * 4", () => {
+    it("rejects sub-rect rows that would spill past srcStrideBytes (srcX = 0)", () => {
+        // srcStride=4 (one texel per row) but width=2 — the row read window is 8 bytes, larger
+        // than the stride. The classic "stride less than width * 4" case.
         const probe = makeMockEngine();
         expect(() => createSpriteAtlasFromFrames(probe.engine, [{ pixels: new Uint8Array(16), width: 2, height: 2, srcStrideBytes: 4 }], { paddingPx: 0 })).toThrow(
-            /srcStrideBytes 4 is less than width \* 4/
+            /sub-rect row extent .* exceeds srcStrideBytes/
+        );
+    });
+
+    it("rejects sub-rect rows that would spill past srcStrideBytes (srcX > 0)", () => {
+        // Regression: srcStride=8 admits width=2 at srcX=0, but srcX=1 + width=2 needs columns
+        // 1..3 — three texels = 12 bytes, exceeding the 8-byte stride. Without an explicit
+        // `(srcX+width)*4 <= srcStride` check this passes the legacy "stride >= width*4"
+        // validation and the per-row `pixels.subarray(srcOffset, srcOffset+rowBytes)` reads
+        // spill into the *next* row's start, producing silently-corrupt atlas uploads.
+        const probe = makeMockEngine();
+        // Buffer: 2 rows × 2 texels = 16 bytes total. requiredBytes = (0+1)*8 + (1+2)*4 = 20 — but
+        // we only get 16, which means the buffer-length check would also catch it; bump to 3 rows
+        // to isolate the *stride* violation from the *length* violation.
+        const pixels = new Uint8Array(3 * 8); // 24 bytes; length passes, stride still fails
+        expect(() => createSpriteAtlasFromFrames(probe.engine, [{ pixels, width: 2, height: 1, srcX: 1, srcStrideBytes: 8 }], { paddingPx: 0 })).toThrow(
+            /sub-rect row extent .* exceeds srcStrideBytes/
         );
     });
 
@@ -149,8 +167,24 @@ describe("createSpriteAtlasFromFrames — sub-rect sources", () => {
 
     it("rejects capacityPx smaller than the initial content footprint", () => {
         const probe = makeMockEngine();
-        const big = makePaddedFrame(8, 8, [1, 2, 3, 4]);
-        expect(() => createSpriteAtlasFromFrames(probe.engine, [big], { capacityPx: [4, 4], paddingPx: 0 })).toThrow(/capacityPx 4x4 too small for initial content/);
+        // Frame fits horizontally inside capacityPx[0]=4 (so the shelf-width clamp doesn't
+        // trip), but is taller than capacityPx[1]=4, so the post-pack content-vs-capacity
+        // size check fires.
+        const tall = makePaddedFrame(4, 8, [1, 2, 3, 4]);
+        expect(() => createSpriteAtlasFromFrames(probe.engine, [tall], { capacityPx: [4, 4], paddingPx: 0 })).toThrow(/capacityPx 4x4 too small for initial content/);
+    });
+
+    it("clamps shelf width to capacityPx[0] so frames wrap to fit a narrower capacity", () => {
+        // capacityPx is narrower than the default maxWidthPx of 1024, so without clamping the
+        // packer would place all four frames on one 32-wide shelf, exceed capacityPx[0]=8, and
+        // throw "capacityPx too small". With clamping, the shelf wraps at 8 → 4 shelves of 8x8
+        // → fits within the 8x32 capacity.
+        const probe = makeMockEngine();
+        const frames = [makePaddedFrame(8, 8, [1, 1, 1, 255]), makePaddedFrame(8, 8, [2, 2, 2, 255]), makePaddedFrame(8, 8, [3, 3, 3, 255]), makePaddedFrame(8, 8, [4, 4, 4, 255])];
+        const atlas = createSpriteAtlasFromFrames(probe.engine, frames, { capacityPx: [8, 32], paddingPx: 0 });
+        expect(atlas.textureSizePx).toEqual([8, 32]);
+        // Four 8x8 frames, all at x=0, y=0/8/16/24.
+        expect(atlas.frames.map((f) => f.uvMin[1])).toEqual([0, 8 / 32, 16 / 32, 24 / 32]);
     });
 
     it("sizes existing-frame UVs against capacityPx, not against the content footprint", () => {

--- a/tests/lite/unit/sprite-atlas-packer.test.ts
+++ b/tests/lite/unit/sprite-atlas-packer.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi } from "vitest";
+
+const G = globalThis as unknown as Record<string, unknown>;
+G.GPUTextureUsage ??= { RENDER_ATTACHMENT: 16, TEXTURE_BINDING: 4, COPY_DST: 8, COPY_SRC: 1 };
+
+import { appendSpriteAtlasFrames, createSpriteAtlasFromFrames, type SpriteAtlasFrameSource } from "../../../packages/babylon-lite/src/sprite/shared/sprite-atlas-packer";
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+
+interface MockWriteTextureCall {
+    destination: GPUTexelCopyTextureInfo;
+    data: Uint8Array;
+    dataLayout: GPUTexelCopyBufferLayout;
+    size: GPUExtent3DStrict;
+}
+
+interface MockWriteFullTextureCall {
+    bytesPerRow: number;
+    rowsPerImage: number;
+    bytes: Uint8Array;
+}
+
+interface MockEngineProbe {
+    engine: EngineContext;
+    createdTextures: { width: number; height: number; texture: GPUTexture }[];
+    writeTextureCalls: MockWriteTextureCall[];
+    writeFullCalls: MockWriteFullTextureCall[];
+}
+
+function makeMockEngine(): MockEngineProbe {
+    const createdTextures: MockEngineProbe["createdTextures"] = [];
+    const writeTextureCalls: MockWriteTextureCall[] = [];
+    const writeFullCalls: MockWriteFullTextureCall[] = [];
+    const queue = {
+        writeTexture: vi.fn((destination: GPUTexelCopyTextureInfo, data: BufferSource, dataLayout: GPUTexelCopyBufferLayout, size: GPUExtent3DStrict) => {
+            const view = data as Uint8Array;
+            // Snapshot the slice the GPU would actually read so tests can assert on it.
+            const offset = dataLayout.offset ?? 0;
+            const bytesPerRow = dataLayout.bytesPerRow!;
+            const w = (size as { width: number }).width;
+            const h = (size as { height: number }).height;
+            const lastByte = offset + (h - 1) * bytesPerRow + w * 4;
+            const snapshot = new Uint8Array(view.buffer.slice(view.byteOffset + offset, view.byteOffset + lastByte));
+            writeTextureCalls.push({ destination, data: snapshot, dataLayout, size });
+        }),
+    };
+    const device = {
+        createTexture: vi.fn((descriptor: GPUTextureDescriptor) => {
+            const size = descriptor.size as { width: number; height: number };
+            const tex = {
+                createView: vi.fn(() => ({ _kind: "view" })),
+                destroy: vi.fn(),
+            } as unknown as GPUTexture;
+            createdTextures.push({ width: size.width, height: size.height, texture: tex });
+            return tex;
+        }),
+        createSampler: vi.fn(() => ({ _kind: "sampler" })),
+        queue,
+    } as unknown as GPUDevice;
+    // Wrap writeTexture so the "initial upload" by createTexture2DFromPixels gets recorded
+    // separately from the sub-rect appends we want to assert on.
+    const originalWriteTexture = queue.writeTexture;
+    queue.writeTexture = vi.fn((destination: GPUTexelCopyTextureInfo, data: BufferSource, dataLayout: GPUTexelCopyBufferLayout, size: GPUExtent3DStrict) => {
+        const isFullCreate = dataLayout.offset === undefined && (destination as { origin?: unknown }).origin === undefined;
+        if (isFullCreate) {
+            const view = data as Uint8Array;
+            writeFullCalls.push({
+                bytesPerRow: dataLayout.bytesPerRow!,
+                rowsPerImage: dataLayout.rowsPerImage!,
+                bytes: new Uint8Array(view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength)),
+            });
+            return;
+        }
+        originalWriteTexture(destination, data, dataLayout, size);
+    });
+
+    const engine = {
+        _device: device,
+    } as unknown as EngineContext;
+
+    return { engine, createdTextures, writeTextureCalls, writeFullCalls };
+}
+
+/** Build a 2-pixel-wide solid-color frame at the given color, surrounded by 1 px of zeros on every
+ *  side inside a `(w+2) × (h+2)` source buffer. Returns the buffer + the sub-rect that targets the
+ *  inner solid region — exercises `srcX` / `srcY` / `srcStrideBytes`. */
+function makePaddedFrame(w: number, h: number, color: readonly [number, number, number, number]): SpriteAtlasFrameSource {
+    const stride = (w + 2) * 4;
+    const pixels = new Uint8Array((h + 2) * stride);
+    for (let y = 1; y <= h; y++) {
+        for (let x = 1; x <= w; x++) {
+            const off = y * stride + x * 4;
+            pixels[off] = color[0];
+            pixels[off + 1] = color[1];
+            pixels[off + 2] = color[2];
+            pixels[off + 3] = color[3];
+        }
+    }
+    return { pixels, width: w, height: h, srcX: 1, srcY: 1, srcStrideBytes: stride };
+}
+
+describe("createSpriteAtlasFromFrames — sub-rect sources", () => {
+    it("copies only the requested sub-rect into the composited atlas buffer", () => {
+        const probe = makeMockEngine();
+        // 4x4 atlas built from two 2x2 sub-rects of larger 4x4 source buffers.
+        const red = makePaddedFrame(2, 2, [255, 0, 0, 255]);
+        const blue = makePaddedFrame(2, 2, [0, 0, 255, 255]);
+        const atlas = createSpriteAtlasFromFrames(probe.engine, [red, blue], { paddingPx: 0, maxWidthPx: 4 });
+
+        expect(atlas.textureSizePx).toEqual([4, 2]);
+        expect(probe.writeFullCalls).toHaveLength(1);
+        const composited = probe.writeFullCalls[0]!.bytes;
+        // Atlas is 4x2; red occupies [0,0..2,2), blue occupies [2,0..4,2).
+        // Verify the (0,0) red pixel.
+        expect(Array.from(composited.subarray(0, 4))).toEqual([255, 0, 0, 255]);
+        // Verify the (2,0) blue pixel (right shelf neighbor).
+        expect(Array.from(composited.subarray(2 * 4, 3 * 4))).toEqual([0, 0, 255, 255]);
+        // Verify row 1, column 3 is blue's bottom-right corner.
+        expect(Array.from(composited.subarray(1 * 16 + 3 * 4, 1 * 16 + 4 * 4))).toEqual([0, 0, 255, 255]);
+    });
+
+    it("validates srcStrideBytes is at least width * 4", () => {
+        const probe = makeMockEngine();
+        expect(() => createSpriteAtlasFromFrames(probe.engine, [{ pixels: new Uint8Array(16), width: 2, height: 2, srcStrideBytes: 4 }], { paddingPx: 0 })).toThrow(
+            /srcStrideBytes 4 is less than width \* 4/
+        );
+    });
+
+    it("validates the source buffer covers the requested sub-rect", () => {
+        const probe = makeMockEngine();
+        expect(() => createSpriteAtlasFromFrames(probe.engine, [{ pixels: new Uint8Array(8), width: 2, height: 2 /* needs 16 bytes */ }], { paddingPx: 0 })).toThrow(
+            /pixel buffer too short/
+        );
+    });
+
+    it("allows empty sources when capacityPx is provided", () => {
+        const probe = makeMockEngine();
+        const atlas = createSpriteAtlasFromFrames(probe.engine, [], { capacityPx: [64, 64] });
+        expect(atlas.frames).toHaveLength(0);
+        expect(atlas.textureSizePx).toEqual([64, 64]);
+        expect(atlas._packState).toBeDefined();
+        expect(atlas._packState!.penX).toBe(0);
+        expect(atlas._packState!.penY).toBe(0);
+    });
+
+    it("rejects empty sources without capacityPx", () => {
+        const probe = makeMockEngine();
+        expect(() => createSpriteAtlasFromFrames(probe.engine, [])).toThrow(/at least one frame is required/);
+    });
+
+    it("rejects capacityPx smaller than the initial content footprint", () => {
+        const probe = makeMockEngine();
+        const big = makePaddedFrame(8, 8, [1, 2, 3, 4]);
+        expect(() => createSpriteAtlasFromFrames(probe.engine, [big], { capacityPx: [4, 4], paddingPx: 0 })).toThrow(/capacityPx 4x4 too small for initial content/);
+    });
+
+    it("sizes existing-frame UVs against capacityPx, not against the content footprint", () => {
+        const probe = makeMockEngine();
+        const frame = makePaddedFrame(4, 4, [10, 20, 30, 40]);
+        const atlas = createSpriteAtlasFromFrames(probe.engine, [frame], { capacityPx: [16, 16], paddingPx: 0 });
+        // Frame sits at (0,0) — uvMax should be 4/16 = 0.25, not 4/4 = 1.
+        expect(atlas.frames[0]!.uvMin).toEqual([0, 0]);
+        expect(atlas.frames[0]!.uvMax).toEqual([0.25, 0.25]);
+    });
+});
+
+describe("appendSpriteAtlasFrames", () => {
+    it("packs new frames into the reserved capacity and returns their indices", () => {
+        const probe = makeMockEngine();
+        const first = makePaddedFrame(4, 4, [255, 0, 0, 255]);
+        const atlas = createSpriteAtlasFromFrames(probe.engine, [first], { capacityPx: [16, 16], paddingPx: 0, maxWidthPx: 16 });
+
+        const second = makePaddedFrame(4, 4, [0, 255, 0, 255]);
+        const third = makePaddedFrame(4, 4, [0, 0, 255, 255]);
+        const indices = appendSpriteAtlasFrames(probe.engine, atlas, [second, third]);
+
+        expect(indices).toEqual([1, 2]);
+        expect(atlas.frames).toHaveLength(3);
+        // Second frame should sit at x=4, y=0 (padding=0, max width=16).
+        expect(atlas.frames[1]!.uvMin).toEqual([4 / 16, 0]);
+        expect(atlas.frames[1]!.uvMax).toEqual([8 / 16, 4 / 16]);
+        // Third frame at x=8, y=0.
+        expect(atlas.frames[2]!.uvMin).toEqual([8 / 16, 0]);
+        expect(atlas.frames[2]!.uvMax).toEqual([12 / 16, 4 / 16]);
+    });
+
+    it("uploads each appended frame with one writeTexture targeting its packed origin", () => {
+        const probe = makeMockEngine();
+        const seed = makePaddedFrame(2, 2, [0, 0, 0, 0]);
+        const atlas = createSpriteAtlasFromFrames(probe.engine, [seed], { capacityPx: [16, 16], paddingPx: 0 });
+
+        const red = makePaddedFrame(2, 2, [255, 0, 0, 255]);
+        appendSpriteAtlasFrames(probe.engine, atlas, [red]);
+
+        expect(probe.writeTextureCalls).toHaveLength(1);
+        const call = probe.writeTextureCalls[0]!;
+        // Origin should match the packed position (right after the seed at x=2, y=0).
+        expect((call.destination as { origin?: { x: number; y: number } }).origin).toEqual({ x: 2, y: 0 });
+        expect((call.size as { width: number; height: number }).width).toBe(2);
+        expect((call.size as { width: number; height: number }).height).toBe(2);
+        // dataLayout should describe the sub-rect: bytesPerRow = srcStride = (2+2)*4 = 16,
+        // offset = srcY * stride + srcX * 4 = 1*16 + 1*4 = 20.
+        expect(call.dataLayout.bytesPerRow).toBe(16);
+        expect(call.dataLayout.offset).toBe(20);
+    });
+
+    it("does not touch existing frames' UV slots when appending (existing sprites stay correct)", () => {
+        const probe = makeMockEngine();
+        const a = makePaddedFrame(4, 4, [1, 1, 1, 1]);
+        const atlas = createSpriteAtlasFromFrames(probe.engine, [a], { capacityPx: [16, 16], paddingPx: 0 });
+        const beforeUvMin = atlas.frames[0]!.uvMin;
+        const beforeUvMax = atlas.frames[0]!.uvMax;
+
+        appendSpriteAtlasFrames(probe.engine, atlas, [makePaddedFrame(4, 4, [2, 2, 2, 2])]);
+
+        // The frame[0] tuple instances must be the same references with unchanged values.
+        expect(atlas.frames[0]!.uvMin).toBe(beforeUvMin);
+        expect(atlas.frames[0]!.uvMax).toBe(beforeUvMax);
+        expect(atlas.frames[0]!.uvMin).toEqual([0, 0]);
+        expect(atlas.frames[0]!.uvMax).toEqual([4 / 16, 4 / 16]);
+    });
+
+    it("wraps to a new shelf when the next frame doesn't fit on the current one", () => {
+        const probe = makeMockEngine();
+        // Capacity = 16x16, maxWidthPx = 8. Two 6x4 frames fit side-by-side won't (6+6=12 > 8) → wrap.
+        const seed = makePaddedFrame(6, 4, [1, 1, 1, 1]);
+        const atlas = createSpriteAtlasFromFrames(probe.engine, [seed], { capacityPx: [16, 16], maxWidthPx: 8, paddingPx: 0 });
+        const next = makePaddedFrame(6, 4, [2, 2, 2, 2]);
+        appendSpriteAtlasFrames(probe.engine, atlas, [next]);
+        // Wrapped: new shelf starts at y=4.
+        expect(atlas.frames[1]!.uvMin).toEqual([0, 4 / 16]);
+        expect(atlas.frames[1]!.uvMax).toEqual([6 / 16, 8 / 16]);
+    });
+
+    it("throws and leaves the atlas untouched when an appended frame would overflow capacity", () => {
+        const probe = makeMockEngine();
+        const seed = makePaddedFrame(2, 2, [1, 1, 1, 1]);
+        const atlas = createSpriteAtlasFromFrames(probe.engine, [seed], { capacityPx: [4, 4], paddingPx: 0 });
+        const before = atlas.frames.length;
+        const tall = makePaddedFrame(2, 8, [2, 2, 2, 2]); // 8 > capacity height 4.
+        expect(() => appendSpriteAtlasFrames(probe.engine, atlas, [tall])).toThrow(/atlas height capacity 4 exhausted/);
+        expect(atlas.frames).toHaveLength(before);
+        expect(probe.writeTextureCalls).toHaveLength(0);
+    });
+
+    it("throws when the atlas was not built by createSpriteAtlasFromFrames", () => {
+        const probe = makeMockEngine();
+        const fakeAtlas = {
+            texture: { texture: {} as GPUTexture } as never,
+            textureSizePx: [64, 64] as const,
+            frames: [],
+            premultipliedAlpha: false,
+            // No _packState — simulates createGridSpriteAtlas / loadSpriteAtlas output.
+        };
+        expect(() => appendSpriteAtlasFrames(probe.engine, fakeAtlas as never, [makePaddedFrame(2, 2, [0, 0, 0, 0])])).toThrow(/was not built by createSpriteAtlasFromFrames/);
+    });
+
+    it("is a no-op when given an empty source list", () => {
+        const probe = makeMockEngine();
+        const seed = makePaddedFrame(2, 2, [1, 2, 3, 4]);
+        const atlas = createSpriteAtlasFromFrames(probe.engine, [seed], { capacityPx: [16, 16] });
+        const writesBefore = probe.writeTextureCalls.length;
+        const indices = appendSpriteAtlasFrames(probe.engine, atlas, []);
+        expect(indices).toEqual([]);
+        expect(atlas.frames).toHaveLength(1);
+        expect(probe.writeTextureCalls.length).toBe(writesBefore);
+    });
+});


### PR DESCRIPTION
## Summary

Lets `SpriteAtlas` instances built by `createSpriteAtlasFromFrames` grow at
runtime: callers can now pre-reserve atlas capacity and stream additional
frames into the same `GPUTexture` later (one `queue.writeTexture` per
appended frame), without rebuilding the atlas, recreating bind groups, or
invalidating UVs of frames that are already drawing. Also adds `srcX` /
`srcY` / `srcStrideBytes` to `SpriteAtlasFrameSource` so callers can pack
a sub-rectangle of a larger pixel buffer (e.g. a freshly rasterized glyph
inside a wasm rasterizer's scratch surface) without copying out the
sub-rect first.

Motivation: streaming glyph rasterization for the upcoming text path —
glyphs become known incrementally, so the atlas must grow incrementally
too, and rasterizers usually hand us a sub-rect inside a larger buffer
they own.

## Changes

### Public API (additive — no breaking changes)

- **New export:** `appendSpriteAtlasFrames(engine, atlas, sources)` — packs
  additional frames into the existing atlas texture using a shelf-pack
  cursor stored on the atlas. Returns the indices of the new
  `SpriteFrame`s in `atlas.frames`. Validates all sources before
  touching any texels, so an "atlas full" error leaves the atlas
  untouched (all-or-nothing).
- **`SpriteAtlasPackOptions.capacityPx?: [w, h]`** — pre-allocate the
  atlas texture larger than the initial content footprint, reserving
  room for later appends. Required when `sources` is empty (lets callers
  build an empty atlas sized for future growth).
- **`SpriteAtlasFrameSource.srcX` / `srcY` / `srcStrideBytes`** — describe a
  sub-rectangle of `pixels` rather than requiring a tightly-packed
  `width * height * 4` buffer.

### Internal

- `SpriteAtlas._packState` (`@internal`) — shelf cursor + packer
  parameters carried by atlases built via `createSpriteAtlasFromFrames`.
  Absent on atlases built via `createGridSpriteAtlas` / `loadSpriteAtlas`
  (those throw if appended to).
- `SpriteAtlas._frames` (`@internal`) — mutable alias of `frames` (same
  underlying array) so the packer can `push` new entries without casting
  away `readonly`. Always co-present with `_packState`.
- Shared `shelfPack` helper used by both create and append paths; same
  shelf-wrap rules, same validation messages tagged by call site.

### Misc

- `vitest.explorer` added to `.vscode/extensions.json` recommendations
  (matches the Vitest workflow now used for these unit tests).

## Testing

- New: [tests/lite/unit/sprite-atlas-packer.test.ts](tests/lite/unit/sprite-atlas-packer.test.ts) — 14 cases
  covering both surfaces:
  - **Sub-rect sources:** sub-rect copy correctness, `srcStrideBytes`
    validation, source-buffer length validation.
  - **`capacityPx`:** empty-sources with capacity, rejection of empty
    sources without capacity, rejection of capacity smaller than initial
    content, UV sizing against capacity (not content footprint).
  - **`appendSpriteAtlasFrames`:** returned indices + `frames`
    placement, single `writeTexture` per appended frame targeting the
    packed origin, existing-frame UVs untouched, shelf wrap on overflow
    of current shelf, atlas-full error leaves state untouched, error
    when atlas wasn't built by the packer, no-op on empty input.
- No parity / bundle-size / golden changes — this PR only adds new code
  paths exercised by unit tests; no existing scene exercises them yet.