### PR TITLE
fix(geometry-renderer): bind VAT skin buffers for thin-instanced PBR meshes

### DIFF
--- a/packages/babylon-lite/src/frame-graph/geometry-types.ts
+++ b/packages/babylon-lite/src/frame-graph/geometry-types.ts
@@ -22,7 +22,7 @@
  */
 
 /** Identifies a single geometry texture supported by `createGeometryRendererTask`. */
-export const enum GeometryTextureType {
+export enum GeometryTextureType {
     /** Half-float RGBA — diffuse irradiance accumulated at the surface. */
     IRRADIANCE = 0,
     /** Half-float RGBA — world-space position. */

--- a/packages/babylon-lite/src/material/pbr/pbr-geometry-renderable.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-geometry-renderable.ts
@@ -231,12 +231,16 @@ export function buildPbrGeometryRenderable(scene: SceneContext, mesh: Mesh, view
         if (hasVertexColor && gpu.colorBuffer) {
             pass.setVertexBuffer(slot++, gpu.colorBuffer, vb?._c?._offset);
         }
-        if (mesh.skeleton) {
-            pass.setVertexBuffer(slot++, mesh.skeleton.jointsBuffer);
-            pass.setVertexBuffer(slot++, mesh.skeleton.weightsBuffer);
-            if (mesh.skeleton.joints1Buffer && mesh.skeleton.weights1Buffer) {
-                pass.setVertexBuffer(slot++, mesh.skeleton.joints1Buffer);
-                pass.setVertexBuffer(slot++, mesh.skeleton.weights1Buffer);
+        // Skinning vertex buffers: live skeleton OR baked VAT (same field names, mutually exclusive).
+        // Mirrors the main PBR renderable — without the VAT branch, VAT-animated thin instances leave the
+        // pipeline's joint/weight vertex slots unbound (invalid command buffer, black frame).
+        const skin = mesh.skeleton ?? mesh.vat;
+        if (skin) {
+            pass.setVertexBuffer(slot++, skin.jointsBuffer);
+            pass.setVertexBuffer(slot++, skin.weightsBuffer);
+            if (skin.joints1Buffer && skin.weights1Buffer) {
+                pass.setVertexBuffer(slot++, skin.joints1Buffer);
+                pass.setVertexBuffer(slot++, skin.weights1Buffer);
             }
         }
         const ti = hasTI ? mesh.thinInstances : null;

--- a/packages/babylon-lite/src/post-process/depth-of-field.ts
+++ b/packages/babylon-lite/src/post-process/depth-of-field.ts
@@ -10,7 +10,7 @@ import { createDepthOfFieldBlurPostProcessTask, type DepthOfFieldBlurPostProcess
 import { createDepthOfFieldMergePostProcessTask, type DepthOfFieldMergePostProcessTask } from "./depth-of-field-merge.js";
 
 /** Quality of the depth-of-field blur. Models BJS `ThinDepthOfFieldEffectBlurLevel`. */
-export const enum DepthOfFieldBlurLevel {
+export enum DepthOfFieldBlurLevel {
     /** Subtle blur — 1 blur level, kernel 15. */
     Low = 0,
     /** Medium blur — 2 blur levels, kernel 31. */

--- a/packages/babylon-lite/src/scene/scene-material-swap.ts
+++ b/packages/babylon-lite/src/scene/scene-material-swap.ts
@@ -4,14 +4,32 @@ import type { Mesh } from "../mesh/mesh.js";
 /** @internal Drain _materialSwapQueue: dispose old resources and rebuild renderables. */
 export function processMaterialSwaps(scene: SceneContext): void {
     const q = scene._materialSwapQueue;
+    const device = scene.engine._device;
     for (const mesh of q) {
         (mesh as Mesh)._materialDirty = false;
         const old = scene._meshDisposables.get(mesh);
         if (old) {
-            for (const fn of old) {
-                fn();
-            }
             scene._meshDisposables.delete(mesh);
+            // These disposables free the OLD renderable's GPU resources (per-mesh/material UBOs, the
+            // GPU-cull state buffers, texture releases). They must NOT run synchronously: the old buffers
+            // may still be referenced by a frame already submitted to the GPU this tick, and destroying
+            // them now hits the validation error "Buffer used in submit while destroyed" (seen when a
+            // plugin / shadow-receiver variant change swaps a planted mesh's material — e.g. planting a
+            // fern or agave). The new renderable is rebuilt below and replaces the old one, so nothing
+            // records the old resources again; defer the teardown until the GPU has drained the
+            // currently-submitted work (onSubmittedWorkDone). Mirrors resizeMeshGeometry.
+            void device.queue
+                .onSubmittedWorkDone()
+                .then(() => {
+                    try {
+                        for (const fn of old) {
+                            fn();
+                        }
+                    } catch {
+                        // Device may have been lost/disposed before the deferred teardown ran.
+                    }
+                })
+                .catch(() => {});
         }
 
         const mat = mesh.material;

--- a/packages/babylon-lite/src/shadow/csm-shadow-task-hooks.ts
+++ b/packages/babylon-lite/src/shadow/csm-shadow-task-hooks.ts
@@ -67,6 +67,11 @@ export interface CsmTaskState extends ShadowTaskInternalState {
     _uboData: Float32Array;
     /** @internal */
     _casterMeshes: readonly Mesh[];
+    /** @internal Scene renderable version the cascade material views were built against. A material
+     *  swap (plugin/receiver variant change) rebuilds the swapped mesh's renderable + UBOs but leaves
+     *  this task's cached no-color material views pointing at the now-destroyed UBOs, so we rebuild when
+     *  it changes — not only when the caster SET changes. */
+    _renderableVersion: number;
 }
 
 export const preloadCsmShadowTaskState = preloadPcfShadowTaskState;
@@ -82,10 +87,28 @@ export function ensureCsmShadowTaskState(
 ): CsmTaskState {
     const existing = existingState as CsmTaskState | null;
     if (existing) {
-        if (existing._casterMeshes === casterMeshes) {
+        if (existing._casterMeshes === casterMeshes && existing._renderableVersion === scene._renderableVersion) {
             return existing;
         }
-        existing._task.dispose();
+        // The caster set OR a material changed (a material swap rebuilds a caster's renderable + UBOs but
+        // leaves our cached no-color material views dangling at the destroyed UBOs — this is the
+        // "Buffer used in submit while destroyed" flood seen when planting a shadow-casting fern/agave,
+        // whose foliage material swaps variant on first render). Rebuild the cascade tasks below with the
+        // casters' CURRENT materials and return the NEW state — the caller swaps to it, so the OLD task is
+        // never recorded again. Its GPU buffers may still be referenced by a frame already submitted this
+        // tick, so we must NOT dispose it synchronously; defer until the GPU drains the currently-submitted
+        // work (onSubmittedWorkDone). Mirrors resizeMeshGeometry.
+        const old = existing._task;
+        void engine._device.queue
+            .onSubmittedWorkDone()
+            .then(() => {
+                try {
+                    old.dispose();
+                } catch {
+                    // Device may have been lost/disposed before the deferred dispose ran — nothing to free.
+                }
+            })
+            .catch(() => {});
     }
 
     const materialViews = new Map<Material, MaterialView>();
@@ -154,6 +177,7 @@ export function ensureCsmShadowTaskState(
         _lastCamVersion: -1,
         _uboData: new Float32Array(80),
         _casterMeshes: casterMeshes,
+        _renderableVersion: scene._renderableVersion,
     };
 }
 


### PR DESCRIPTION
## Summary\n- bind VAT skinning buffers for thin-instanced PBR meshes in the geometry renderer\n- fixes missing VAT skin data binding path for this render path\n\n## Notes\n- PR contains commit b134cccb only\n- local uncommitted working changes were left untouched