### PR TITLE
fix(geometry-renderer): bind VAT skin buffers for thin-instanced PBR meshes

### DIFF
--- a/packages/babylon-lite/src/frame-graph/geometry-types.ts
+++ b/packages/babylon-lite/src/frame-graph/geometry-types.ts
@@ -22,7 +22,7 @@
  */
 
 /** Identifies a single geometry texture supported by `createGeometryRendererTask`. */
-export const enum GeometryTextureType {
+export enum GeometryTextureType {
     /** Half-float RGBA — diffuse irradiance accumulated at the surface. */
     IRRADIANCE = 0,
     /** Half-float RGBA — world-space position. */

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -122,6 +122,7 @@ export {
     updateMeshUv2,
     updateMeshTangents,
     resizeMeshGeometry,
+    invalidateRenderBundles,
 } from "./mesh/mesh-factories.js";
 export { createSphereData } from "./mesh/create-sphere.js";
 export type { SphereMeshData } from "./mesh/create-sphere.js";
@@ -238,6 +239,7 @@ export {
     removeThinInstance,
     setThinInstanceMatrix,
     setThinInstances,
+    setThinInstanceCount,
     flushThinInstances,
     setThinInstanceColors,
     enableThinInstanceGpuCulling,

--- a/packages/babylon-lite/src/material/pbr/pbr-geometry-renderable.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-geometry-renderable.ts
@@ -231,12 +231,16 @@ export function buildPbrGeometryRenderable(scene: SceneContext, mesh: Mesh, view
         if (hasVertexColor && gpu.colorBuffer) {
             pass.setVertexBuffer(slot++, gpu.colorBuffer, vb?._c?._offset);
         }
-        if (mesh.skeleton) {
-            pass.setVertexBuffer(slot++, mesh.skeleton.jointsBuffer);
-            pass.setVertexBuffer(slot++, mesh.skeleton.weightsBuffer);
-            if (mesh.skeleton.joints1Buffer && mesh.skeleton.weights1Buffer) {
-                pass.setVertexBuffer(slot++, mesh.skeleton.joints1Buffer);
-                pass.setVertexBuffer(slot++, mesh.skeleton.weights1Buffer);
+        // Skinning vertex buffers: live skeleton OR baked VAT (same field names, mutually exclusive).
+        // Mirrors the main PBR renderable — without the VAT branch, VAT-animated thin instances leave the
+        // pipeline's joint/weight vertex slots unbound (invalid command buffer, black frame).
+        const skin = mesh.skeleton ?? mesh.vat;
+        if (skin) {
+            pass.setVertexBuffer(slot++, skin.jointsBuffer);
+            pass.setVertexBuffer(slot++, skin.weightsBuffer);
+            if (skin.joints1Buffer && skin.weights1Buffer) {
+                pass.setVertexBuffer(slot++, skin.joints1Buffer);
+                pass.setVertexBuffer(slot++, skin.weights1Buffer);
             }
         }
         const ti = hasTI ? mesh.thinInstances : null;

--- a/packages/babylon-lite/src/mesh/mesh-factories.ts
+++ b/packages/babylon-lite/src/mesh/mesh-factories.ts
@@ -68,6 +68,20 @@ export function createMeshFromData(
     return mesh;
 }
 
+/** Force every registered scene's cached render + shadow bundles to RE-RECORD on the next frame, by bumping
+ *  each rendering context's `_renderableVersion` (the same signal a mesh add/remove or `resizeMeshGeometry`
+ *  emits). Use after an out-of-band GPU buffer REALLOCATION that the cached bundles can't otherwise notice —
+ *  e.g. growing a thin-instanced mesh's matrix buffer past its capacity (the bundle captured the old buffer
+ *  handle and would bind a freed buffer). A no-op-cheap version bump; the actual re-record happens lazily. */
+export function invalidateRenderBundles(engine: EngineContext): void {
+    for (const ctx of engine._renderingContexts) {
+        const sc = ctx as { _renderableVersion?: number };
+        if (sc._renderableVersion !== undefined) {
+            sc._renderableVersion++;
+        }
+    }
+}
+
 /** Update a mesh's GPU vertex positions in place (e.g. CPU vertex animation).
  *  `positions` must hold tightly-packed XYZ floats matching the mesh's vertex count.
  *  `vertexOffset` is the first vertex to overwrite (defaults to 0).

--- a/packages/babylon-lite/src/mesh/thin-instance.ts
+++ b/packages/babylon-lite/src/mesh/thin-instance.ts
@@ -81,6 +81,24 @@ export function setThinInstances(mesh: Mesh, matrices: Float32Array | Float64Arr
     }
 }
 
+/** Update ONLY the active instance count (and re-upload the [0,count) matrix range), leaving `_capacity`
+ *  — and therefore the already-allocated GPU buffer — untouched. This is the way to vary how many instances
+ *  draw FRAME-TO-FRAME on an established thin-instanced mesh WITHOUT recreating the GPU buffer (which would
+ *  invalidate any cached render/shadow bundle that captured the old buffer handle). Pre-size the buffer once
+ *  with `setThinInstances(mesh, matrices, capacity)`, then call this each update with `count <= capacity`.
+ *  The draw reads `count` live, so the bundle stays valid. Caller must keep writing into the SAME `matrices`
+ *  array the mesh already references. No-op if the mesh isn't thin-instanced yet. */
+export function setThinInstanceCount(mesh: Mesh, count: number): void {
+    const ti = mesh.thinInstances;
+    if (!ti) {
+        return;
+    }
+    ti.count = count;
+    ti._version++;
+    ti._dirtyMin = 0;
+    ti._dirtyMax = count;
+}
+
 /** Add one instance. Returns its index. Grows capacity as needed. */
 export function addThinInstance(mesh: Mesh, matrix: Mat4): number {
     const ti = mesh.thinInstances;

--- a/packages/babylon-lite/src/post-process/depth-of-field.ts
+++ b/packages/babylon-lite/src/post-process/depth-of-field.ts
@@ -10,7 +10,7 @@ import { createDepthOfFieldBlurPostProcessTask, type DepthOfFieldBlurPostProcess
 import { createDepthOfFieldMergePostProcessTask, type DepthOfFieldMergePostProcessTask } from "./depth-of-field-merge.js";
 
 /** Quality of the depth-of-field blur. Models BJS `ThinDepthOfFieldEffectBlurLevel`. */
-export const enum DepthOfFieldBlurLevel {
+export enum DepthOfFieldBlurLevel {
     /** Subtle blur — 1 blur level, kernel 15. */
     Low = 0,
     /** Medium blur — 2 blur levels, kernel 31. */

--- a/packages/babylon-lite/src/scene/scene-material-swap.ts
+++ b/packages/babylon-lite/src/scene/scene-material-swap.ts
@@ -4,14 +4,32 @@ import type { Mesh } from "../mesh/mesh.js";
 /** @internal Drain _materialSwapQueue: dispose old resources and rebuild renderables. */
 export function processMaterialSwaps(scene: SceneContext): void {
     const q = scene._materialSwapQueue;
+    const device = scene.engine._device;
     for (const mesh of q) {
         (mesh as Mesh)._materialDirty = false;
         const old = scene._meshDisposables.get(mesh);
         if (old) {
-            for (const fn of old) {
-                fn();
-            }
             scene._meshDisposables.delete(mesh);
+            // These disposables free the OLD renderable's GPU resources (per-mesh/material UBOs, the
+            // GPU-cull state buffers, texture releases). They must NOT run synchronously: the old buffers
+            // may still be referenced by a frame already submitted to the GPU this tick, and destroying
+            // them now hits the validation error "Buffer used in submit while destroyed" (seen when a
+            // plugin / shadow-receiver variant change swaps a planted mesh's material — e.g. planting a
+            // fern or agave). The new renderable is rebuilt below and replaces the old one, so nothing
+            // records the old resources again; defer the teardown until the GPU has drained the
+            // currently-submitted work (onSubmittedWorkDone). Mirrors resizeMeshGeometry.
+            void device.queue
+                .onSubmittedWorkDone()
+                .then(() => {
+                    try {
+                        for (const fn of old) {
+                            fn();
+                        }
+                    } catch {
+                        // Device may have been lost/disposed before the deferred teardown ran.
+                    }
+                })
+                .catch(() => {});
         }
 
         const mat = mesh.material;

--- a/packages/babylon-lite/src/shadow/csm-shadow-task-hooks.ts
+++ b/packages/babylon-lite/src/shadow/csm-shadow-task-hooks.ts
@@ -67,6 +67,11 @@ export interface CsmTaskState extends ShadowTaskInternalState {
     _uboData: Float32Array;
     /** @internal */
     _casterMeshes: readonly Mesh[];
+    /** @internal Scene renderable version the cascade material views were built against. A material
+     *  swap (plugin/receiver variant change) rebuilds the swapped mesh's renderable + UBOs but leaves
+     *  this task's cached no-color material views pointing at the now-destroyed UBOs, so we rebuild when
+     *  it changes — not only when the caster SET changes. */
+    _renderableVersion: number;
 }
 
 export const preloadCsmShadowTaskState = preloadPcfShadowTaskState;
@@ -82,10 +87,28 @@ export function ensureCsmShadowTaskState(
 ): CsmTaskState {
     const existing = existingState as CsmTaskState | null;
     if (existing) {
-        if (existing._casterMeshes === casterMeshes) {
+        if (existing._casterMeshes === casterMeshes && existing._renderableVersion === scene._renderableVersion) {
             return existing;
         }
-        existing._task.dispose();
+        // The caster set OR a material changed (a material swap rebuilds a caster's renderable + UBOs but
+        // leaves our cached no-color material views dangling at the destroyed UBOs — this is the
+        // "Buffer used in submit while destroyed" flood seen when planting a shadow-casting fern/agave,
+        // whose foliage material swaps variant on first render). Rebuild the cascade tasks below with the
+        // casters' CURRENT materials and return the NEW state — the caller swaps to it, so the OLD task is
+        // never recorded again. Its GPU buffers may still be referenced by a frame already submitted this
+        // tick, so we must NOT dispose it synchronously; defer until the GPU drains the currently-submitted
+        // work (onSubmittedWorkDone). Mirrors resizeMeshGeometry.
+        const old = existing._task;
+        void engine._device.queue
+            .onSubmittedWorkDone()
+            .then(() => {
+                try {
+                    old.dispose();
+                } catch {
+                    // Device may have been lost/disposed before the deferred dispose ran — nothing to free.
+                }
+            })
+            .catch(() => {});
     }
 
     const materialViews = new Map<Material, MaterialView>();
@@ -154,6 +177,7 @@ export function ensureCsmShadowTaskState(
         _lastCamVersion: -1,
         _uboData: new Float32Array(80),
         _casterMeshes: casterMeshes,
+        _renderableVersion: scene._renderableVersion,
     };
 }
 

--- a/tests/lite/unit/audit/no-direct-mat4-writes.test.ts
+++ b/tests/lite/unit/audit/no-direct-mat4-writes.test.ts
@@ -78,7 +78,7 @@ const LINE_ALLOWLIST = new Set<string>([
     // produces the same F32 bytes packMat4IntoF32 would write for offset 0.
     // TODO(HPM-followup): collapse into packMat4IntoF32 to fully retire the
     // opaque-Mat4-as-array-like dependency.
-    "packages/babylon-lite/src/mesh/thin-instance.ts:90",
+    "packages/babylon-lite/src/mesh/thin-instance.ts:108",
 ]);
 
 /** Variable-name heuristic: matrix-like identifiers. */


### PR DESCRIPTION
Re-opened cleanly after PR #200 was merged prematurely (and reverted in f7f7314d). This branch is rebased on current master and will be merged only after all checks are green.

## Summary
- bind VAT (mesh.vat) skin buffers for thin-instanced PBR meshes in the geometry renderer, mirroring the main PBR renderable (skin = mesh.skeleton ?? mesh.vat); fixes unbound joint/weight slots -> black frame for VAT meshes through the geometry renderer
- make DepthOfFieldBlurLevel and GeometryTextureType regular enums (not const enums) so isolatedModules consumers can reference members
- include scene material swap + CSM shadow task hook updates