### PR TITLE
fix(screenshot): same-frame swapchain readback via zero-cost lazy pre-frame hook

### DIFF
--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -57,8 +57,8 @@
     ]
   },
   "scene5": {
-    "rawKB": 87.4,
-    "gzipKB": 36.4,
+    "rawKB": 87.5,
+    "gzipKB": 36.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene5-create-morph-targets-CbGb7EdR.js",
@@ -399,7 +399,7 @@
   },
   "scene25": {
     "rawKB": 50.4,
-    "gzipKB": 20,
+    "gzipKB": 20.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene25-standard-renderable-0Cb4e15X.js",
@@ -427,7 +427,7 @@
     ]
   },
   "scene27": {
-    "rawKB": 78.4,
+    "rawKB": 78.5,
     "gzipKB": 32,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -759,7 +759,7 @@
     ]
   },
   "scene60": {
-    "rawKB": 54.6,
+    "rawKB": 54.7,
     "gzipKB": 22.4,
     "ignoredRawKB": 4,
     "runtimeChunks": [
@@ -945,7 +945,7 @@
     ]
   },
   "scene69": {
-    "rawKB": 89.9,
+    "rawKB": 90,
     "gzipKB": 35.8,
     "ignoredRawKB": 13.3,
     "runtimeChunks": [
@@ -988,7 +988,7 @@
     ]
   },
   "scene71": {
-    "rawKB": 90.1,
+    "rawKB": 90.2,
     "gzipKB": 35.8,
     "ignoredRawKB": 12.9,
     "runtimeChunks": [
@@ -1228,7 +1228,7 @@
     ]
   },
   "scene82": {
-    "rawKB": 65.4,
+    "rawKB": 65.5,
     "gzipKB": 29.4,
     "ignoredRawKB": 8.4,
     "runtimeChunks": [
@@ -1451,7 +1451,7 @@
   },
   "scene91": {
     "rawKB": 56.6,
-    "gzipKB": 22.7,
+    "gzipKB": 22.6,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene91-generate-mipmaps-CUt8_7AA.js",
@@ -1469,7 +1469,7 @@
     ]
   },
   "scene93": {
-    "rawKB": 19.8,
+    "rawKB": 19.9,
     "gzipKB": 8.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -1594,7 +1594,7 @@
   },
   "scene113": {
     "rawKB": 60,
-    "gzipKB": 23.2,
+    "gzipKB": 23.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene113-standard-renderable-g9Eq5NeQ.js",
@@ -1717,7 +1717,7 @@
     ]
   },
   "scene127": {
-    "rawKB": 55.3,
+    "rawKB": 55.4,
     "gzipKB": 21.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -1871,7 +1871,7 @@
   },
   "scene145": {
     "rawKB": 87.2,
-    "gzipKB": 35.4,
+    "gzipKB": 35.5,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene145-bake-local-matrix-67U-IT8C.js",
@@ -1897,7 +1897,7 @@
     ]
   },
   "scene146": {
-    "rawKB": 109.3,
+    "rawKB": 109.4,
     "gzipKB": 44.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2036,7 +2036,7 @@
   },
   "scene155": {
     "rawKB": 56.2,
-    "gzipKB": 21.8,
+    "gzipKB": 21.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene155-standard-renderable-D3rxGhli.js",
@@ -2091,8 +2091,8 @@
     ]
   },
   "scene159": {
-    "rawKB": 35.2,
-    "gzipKB": 14,
+    "rawKB": 35.3,
+    "gzipKB": 14.1,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene159-shader-renderable-DmP4E6kk.js",
@@ -2180,7 +2180,7 @@
   },
   "scene171": {
     "rawKB": 93.7,
-    "gzipKB": 37.9,
+    "gzipKB": 38,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene171-generate-mipmaps-BhnoKVJc.js",
@@ -2214,7 +2214,7 @@
     ]
   },
   "scene174": {
-    "rawKB": 94.3,
+    "rawKB": 94.4,
     "gzipKB": 38.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2315,7 +2315,7 @@
     ]
   },
   "scene181": {
-    "rawKB": 42.9,
+    "rawKB": 42.8,
     "gzipKB": 15.9,
     "ignoredRawKB": 671.9,
     "runtimeChunks": [
@@ -2435,7 +2435,7 @@
     ]
   },
   "scene210": {
-    "rawKB": 72.4,
+    "rawKB": 72.5,
     "gzipKB": 29.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
@@ -2451,7 +2451,7 @@
   },
   "scene211": {
     "rawKB": 84.8,
-    "gzipKB": 35.2,
+    "gzipKB": 35.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene211-create-skeleton-B8f27Dli.js",

--- a/packages/babylon-lite/src/engine/engine.ts
+++ b/packages/babylon-lite/src/engine/engine.ts
@@ -3,7 +3,7 @@ import type { Texture2D, Texture2DOptions } from "../texture/texture-2d.js";
 import { _setHpmAllocator } from "../math/_matrix-allocator.js";
 import type { RenderTarget } from "./render-target.js";
 import { createRenderTarget } from "./render-target.js";
-import type { CaptureService } from "./screenshot-readback.js";
+import type { CapturePreFrame, CaptureService } from "./screenshot-readback.js";
 
 /** Babylon Lite version string. */
 export const VERSION = "0.1.0";
@@ -114,12 +114,21 @@ export interface EngineContext {
     _swapchainCopySrc?: boolean;
 
     /** @internal Screenshot readback hook, dynamically installed by `captureScreenshot` on
-     *  first use. `renderFrame` calls it once per frame via optional chaining; it records the
-     *  swapchain copy into the frame encoder (reconfiguring the swapchain with COPY_SRC the
-     *  first time, then copying on the following frame). Kept off `EngineContext` until a
-     *  capture is requested so the copy/unpack code (`screenshot-readback.js`) stays out of
-     *  every bundle that never captures a frame. */
+     *  first use. `renderFrame` calls it once per frame (after the contexts record) via optional
+     *  chaining; it records the swapchain copy into the frame encoder for any queued requests.
+     *  By the time it runs the swapchain is already COPY_SRC-capable (see `_capturePreFrame`), so
+     *  the copy lands in the current frame. Kept off `EngineContext` until a capture is requested
+     *  so the copy/unpack code (`screenshot-readback.js`) stays out of every bundle that never
+     *  captures a frame. */
     _captureService?: CaptureService;
+
+    /** @internal Pre-acquire screenshot hook, installed alongside `_captureService` by
+     *  `captureScreenshot` on first use. `renderFrame` calls it via optional chaining BEFORE
+     *  acquiring this frame's swapchain texture; on the first queued capture it reconfigures the
+     *  swapchain with COPY_SRC (reconfiguring expires the current texture, so it must run before
+     *  acquire, never mid-frame). Kept off `EngineContext` until a capture is requested so the
+     *  reconfigure code stays out of every non-capturing bundle. */
+    _capturePreFrame?: CapturePreFrame;
 
     /** @internal Per-frame floating-origin offset updater. Set when the engine
      *  was created with `useFloatingOrigin: true` (which requires
@@ -532,6 +541,11 @@ export function renderFrame(engine: EngineContext, delta: number): void {
     const encoder = engine._device.createCommandEncoder({ label: "frame" });
     engine._currentEncoder = encoder;
     engine._currentDelta = delta;
+    // A queued screenshot (`captureScreenshot`) needs the swapchain marked COPY_SRC before this
+    // frame's texture is acquired — reconfiguring the context EXPIRES the current canvas texture,
+    // so it cannot run mid-frame. The hook is installed lazily by `captureScreenshot`, so
+    // non-capturing engines ship none of the reconfigure code and pay only this short-circuit.
+    engine._capturePreFrame?.(engine);
     _refreshScRT(engine);
 
     let drawCalls = 0;

--- a/packages/babylon-lite/src/engine/screenshot-readback.ts
+++ b/packages/babylon-lite/src/engine/screenshot-readback.ts
@@ -7,6 +7,11 @@ import { BU, TU } from "./gpu-flags.js";
  *  swapchain copy for any queued capture requests into the frame's encoder. */
 export type CaptureService = (engine: EngineContext, encoder: GPUCommandEncoder) => void;
 
+/** @internal Pre-acquire hook driven by `renderFrame` (installed alongside `_captureService`).
+ *  Called before the frame's swapchain texture is acquired; reconfigures the swapchain with
+ *  COPY_SRC the first time a capture is queued. */
+export type CapturePreFrame = (engine: EngineContext) => void;
+
 /** A single readback in flight: the buffer the frame's copy lands in, plus the dimensions /
  *  padding needed to unpack it, and the requests waiting on this frame. */
 interface PendingReadback {
@@ -23,23 +28,35 @@ function alignBytesPerRow(width: number): number {
     return Math.ceil((width * 4) / 256) * 256;
 }
 
+/** Pre-acquire hook. Called by `renderFrame` BEFORE `_refreshScRT` acquires this frame's
+ *  swapchain texture. On the first queued capture it reconfigures the swapchain with COPY_SRC
+ *  so the just-acquired texture is copyable. Reconfiguring here (not after the scene has
+ *  recorded) is mandatory: `configure()` expires the current canvas texture, so doing it
+ *  mid-frame would invalidate the recorded texture and fail the submit. */
+function preFrame(engine: EngineContext): void {
+    const queue = engine._captureQueue;
+    if (!queue || queue.length === 0 || engine._swapchainCopySrc) {
+        return;
+    }
+    engine._swapchainCopySrc = true;
+    engine._context.configure({ device: engine._device, format: engine.format, alphaMode: engine._alphaMode, usage: TU.RENDER_ATTACHMENT | TU.COPY_SRC });
+}
+
 /** The readback hook. Called once per frame after the contexts have recorded (so the swapchain
  *  texture holds this frame) and before the encoder is finished.
  *
- *  On the first queued capture the swapchain is still RENDER_ATTACHMENT-only, so it is
- *  reconfigured with COPY_SRC and the copy is deferred one frame — the texture acquired for the
- *  current frame predates the reconfigure and is not copyable. The next frame's `_refreshScRT`
- *  picks up a COPY_SRC texture and the copy is recorded then. Once the swapchain is copyable,
- *  subsequent captures copy on the very next serviced frame. */
+ *  By the time this runs the swapchain is already COPY_SRC-capable: `preFrame` reconfigured it
+ *  before the frame's texture was acquired, so the copy can be recorded straight into this
+ *  frame's encoder. */
 function service(engine: EngineContext, encoder: GPUCommandEncoder): void {
     const queue = engine._captureQueue;
     if (!queue || queue.length === 0) {
         return;
     }
-
+    // The swapchain only becomes copyable once `preFrame` has reconfigured it and `renderFrame`
+    // has acquired a COPY_SRC texture; until then there is nothing copyable, so wait for the next
+    // frame (the request stays queued).
     if (!engine._swapchainCopySrc) {
-        engine._swapchainCopySrc = true;
-        engine._context.configure({ device: engine._device, format: engine.format, alphaMode: engine._alphaMode, usage: TU.RENDER_ATTACHMENT | TU.COPY_SRC });
         return;
     }
 
@@ -71,6 +88,11 @@ function service(engine: EngineContext, encoder: GPUCommandEncoder): void {
 async function finish(pend: PendingReadback): Promise<void> {
     const { buffer, width, height, bytesPerRow, bgra, reqs } = pend;
     try {
+        // Yield one microtask so `renderFrame` submits this frame's encoder (which holds the copy)
+        // BEFORE we map the buffer: mapAsync moves the buffer to a pending-map state synchronously,
+        // and a buffer pending map cannot be used by a command buffer in a submit — calling it before
+        // the submit would invalidate the whole frame and read back an empty (all-black) buffer.
+        await Promise.resolve();
         await buffer.mapAsync(GPUMapMode.READ);
         const src = new Uint8Array(buffer.getMappedRange());
         const out = new Uint8ClampedArray(width * height * 4);
@@ -114,4 +136,10 @@ async function finish(pend: PendingReadback): Promise<void> {
  *  Returns the per-frame readback hook installed on `engine._captureService`. */
 export function createCaptureService(): CaptureService {
     return service;
+}
+
+/** @internal Factory invoked by `captureScreenshot` after this module is dynamically imported.
+ *  Returns the pre-acquire hook installed on `engine._capturePreFrame`. */
+export function createCapturePreFrame(): CapturePreFrame {
+    return preFrame;
 }

--- a/packages/babylon-lite/src/engine/screenshot.ts
+++ b/packages/babylon-lite/src/engine/screenshot.ts
@@ -35,17 +35,19 @@ export interface Screenshot {
  * Multiple calls queued before the next serviced frame share a single GPU copy and all
  * resolve with the same image.
  *
- * The readback implementation (and the one-time COPY_SRC swapchain reconfigure it needs) is
- * loaded lazily on the first call, so engines that never capture a screenshot ship none of
- * it and keep a plain, compression-friendly RENDER_ATTACHMENT swapchain.
+ * The readback implementation is loaded lazily on the first call, so engines that never
+ * capture a screenshot ship none of it. The swapchain stays a plain, compression-friendly
+ * RENDER_ATTACHMENT surface until the first capture is queued, at which point `renderFrame`
+ * reconfigures it once with COPY_SRC (before acquiring that frame's texture).
  */
 export function captureScreenshot(engine: EngineContext): Promise<Screenshot> {
     const promise = new Promise<Screenshot>((resolve, reject) => {
         (engine._captureQueue ??= []).push({ resolve, reject });
     });
     if (!engine._captureService) {
-        void import("./screenshot-readback.js").then(({ createCaptureService }) => {
+        void import("./screenshot-readback.js").then(({ createCaptureService, createCapturePreFrame }) => {
             engine._captureService ??= createCaptureService();
+            engine._capturePreFrame ??= createCapturePreFrame();
         });
     }
     return promise;

--- a/tests/lite/unit/screenshot-swapchain.test.ts
+++ b/tests/lite/unit/screenshot-swapchain.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
 import { captureScreenshot } from "../../../packages/babylon-lite/src/engine/screenshot";
-import { createCaptureService } from "../../../packages/babylon-lite/src/engine/screenshot-readback";
+import { createCapturePreFrame, createCaptureService } from "../../../packages/babylon-lite/src/engine/screenshot-readback";
 
 interface ConfigureCall {
     usage?: number;
@@ -29,8 +29,6 @@ function makeHarness(): Harness {
     return { engine, configureCalls };
 }
 
-const encoder = { copyTextureToBuffer: () => undefined } as unknown as GPUCommandEncoder;
-
 describe("screenshot swapchain COPY_SRC", () => {
     it("captureScreenshot queues a request without configuring the swapchain itself", () => {
         const { engine, configureCalls } = makeHarness();
@@ -42,19 +40,48 @@ describe("screenshot swapchain COPY_SRC", () => {
         expect(engine._swapchainCopySrc).toBeFalsy();
     });
 
-    it("first serviced frame reconfigures with COPY_SRC and defers the copy", () => {
+    it("preFrame reconfigures with COPY_SRC on the first queued capture", () => {
         const { engine, configureCalls } = makeHarness();
         engine._captureQueue = [{ resolve: () => undefined, reject: () => undefined }];
-        const service = createCaptureService();
+        const preFrame = createCapturePreFrame();
 
-        service(engine, encoder);
+        preFrame(engine);
 
         expect(engine._swapchainCopySrc).toBe(true);
         expect(configureCalls).toHaveLength(1);
         const usage = configureCalls[0]!.usage ?? 0;
         expect(usage & GPUTextureUsage.COPY_SRC).toBeTruthy();
         expect(usage & GPUTextureUsage.RENDER_ATTACHMENT).toBeTruthy();
-        // Copy deferred — the request is still queued for the next frame.
+        // The request stays queued for the readback hook to copy this same frame.
+        expect(engine._captureQueue).toHaveLength(1);
+    });
+
+    it("preFrame then service copies into the same frame and clears the queue", () => {
+        const { engine, configureCalls } = makeHarness();
+        engine._captureQueue = [{ resolve: () => undefined, reject: () => undefined }];
+        const preFrame = createCapturePreFrame();
+        const service = createCaptureService();
+        let copied = 0;
+        const enc = { copyTextureToBuffer: () => copied++ } as unknown as GPUCommandEncoder;
+
+        preFrame(engine);
+        service(engine, enc);
+
+        expect(configureCalls).toHaveLength(1);
+        expect(copied).toBe(1);
+        expect(engine._captureQueue).toBeUndefined();
+    });
+
+    it("service waits (no copy, request stays queued) until the swapchain is copyable", () => {
+        const { engine } = makeHarness();
+        engine._captureQueue = [{ resolve: () => undefined, reject: () => undefined }];
+        let copied = 0;
+        const enc = { copyTextureToBuffer: () => copied++ } as unknown as GPUCommandEncoder;
+        const service = createCaptureService();
+
+        service(engine, enc);
+
+        expect(copied).toBe(0);
         expect(engine._captureQueue).toHaveLength(1);
     });
 
@@ -72,13 +99,13 @@ describe("screenshot swapchain COPY_SRC", () => {
         expect(engine._captureQueue).toBeUndefined();
     });
 
-    it("never reconfigures again on later frames", () => {
+    it("preFrame never reconfigures again on later frames", () => {
         const { engine, configureCalls } = makeHarness();
         engine._swapchainCopySrc = true;
         engine._captureQueue = [{ resolve: () => undefined, reject: () => undefined }];
-        const service = createCaptureService();
+        const preFrame = createCapturePreFrame();
 
-        service(engine, encoder);
+        preFrame(engine);
 
         expect(configureCalls).toHaveLength(0);
     });


### PR DESCRIPTION
## What

Fixes two issues in captureScreenshot swapchain readback, while keeping the entire screenshot path **fully lazy** so non-capturing scenes ship none of it.

### 1. All-black readback
`finish()` mapped the staging buffer before `renderFrame` had submitted the encoder holding the copy. `mapAsync` synchronously moves the buffer to a pending-map state, and a pending-map buffer can't be used by a command buffer in a submit — so the frame was invalidated and the readback came back empty (all black). Fixed by yielding one microtask before `mapAsync` so the submit happens first.

### 2. First capture deferred a frame
The COPY_SRC swapchain reconfigure used to run mid-frame inside the readback hook (after the scene had already recorded), so the first capture had to be deferred to the next frame (the just-acquired texture wasn't copyable). It now runs **before** the frame's texture is acquired, so the copy records straight into the same frame's encoder.

## How (zero-cost architecture)

`configure()` expires the current canvas texture, so the reconfigure must happen before `_refreshScRT` acquires the frame's texture. To do this without leaking screenshot code into every bundle, the reconfigure lives in the dynamically-imported `screenshot-readback` module and is installed lazily as a new `_capturePreFrame` hook — the same zero-cost optional-chained pattern already used for `_captureService` / `_updateFOOffset`. `renderFrame` only ever ships one extra optional-chained call.

- **scene1 (BoomBox PBR) bundle: 87.6 KB → 87.6 KB — zero movement.** The screenshot code stays fully tree-shaken out of non-capturing scenes. A handful of unrelated scenes shift by ±0.1 KB purely from rounding (one even decreases), all far within ceilings.

## Tests
- `pnpm lint` — clean
- `pnpm test:unit` — 407 passed (incl. rewritten `screenshot-swapchain` hook tests covering preFrame reconfigure + same-frame copy)
- `pnpm build:bundle-scenes` — ok
- `pnpm test:parity` — 336 passed, no MAD regression, all bundle-size ceilings hold

No bundle-size ceiling changes. No golden-reference changes.
