### PR TITLE
feat(material): ShaderMaterial normal-buffer view + fix(loader) KHR_texture_basisu strided accessor types

### DIFF
--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -177,6 +177,8 @@ export { createStandardNoColorMaterialView } from "./material/standard/no-color-
 export { createPbrMaterial } from "./material/pbr/pbr-material.js";
 export { createShaderMaterial, setShaderUniform, setShaderTexture, setShaderFloat, setShaderVector3, setShaderMatrix } from "./material/shader/shader-material.js";
 export { createShaderNoColorMaterialView } from "./material/shader/no-color-view.js";
+export { createShaderNormalMaterialView } from "./material/shader/normal-view.js";
+export type { ShaderNormalViewConfig } from "./material/shader/normal-view.js";
 export { createGridMaterial } from "./material/grid/grid-material.js";
 export type { GridMaterialOptions, GridVec3 } from "./material/grid/grid-material.js";
 export { createPbrNoColorMaterialView } from "./material/pbr/no-color-view.js";

--- a/packages/babylon-lite/src/loader-gltf/gltf-ext-basisu.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-ext-basisu.ts
@@ -18,6 +18,9 @@ import { decodeKtx2ImageBitmapFromBuffer, uploadKtx2Texture2D } from "../texture
 
 const NAME = "KHR_texture_basisu";
 const FLOAT = 5126;
+// glTF accessor component types → byte size. Interleaved (strided) vertex attributes can be any of these,
+// not just FLOAT (e.g. a normalized `COLOR_0: UNSIGNED_BYTE`), so the strided reader must handle them all.
+const COMPONENT_BYTES: Record<number, number> = { 5120: 1, 5121: 1, 5122: 2, 5123: 2, 5125: 4, 5126: 4 };
 const TYPE_SIZES: Record<string, number> = {
     SCALAR: 1,
     VEC2: 2,
@@ -194,25 +197,60 @@ async function uploadOrmTexture(data: BasisuMaterialData, ctx: GltfMatExtCtx): P
     return tex;
 }
 
+// Read one interleaved attribute component, decoding its glTF component type to a float. NORMALIZED integer
+// attributes (the `normalized` accessor flag) map to [0,1] (unsigned) or [-1,1] (signed); non-normalized ones
+// pass through as their integer value. DataView handles unaligned little-endian reads, so any stride is fine.
+function readComponent(view: DataView, offset: number, componentType: number, normalized: boolean): number {
+    switch (componentType) {
+        case FLOAT:
+            return view.getFloat32(offset, true);
+        case 5125: {
+            const v = view.getUint32(offset, true);
+            return normalized ? v / 4294967295 : v;
+        }
+        case 5123: {
+            const v = view.getUint16(offset, true);
+            return normalized ? v / 65535 : v;
+        }
+        case 5122: {
+            const v = view.getInt16(offset, true);
+            return normalized ? Math.max(v / 32767, -1) : v;
+        }
+        case 5121: {
+            const v = view.getUint8(offset);
+            return normalized ? v / 255 : v;
+        }
+        case 5120: {
+            const v = view.getInt8(offset);
+            return normalized ? Math.max(v / 127, -1) : v;
+        }
+        default:
+            throw new Error(`${NAME}: strided accessor uses unsupported component type: ${componentType}`);
+    }
+}
+
 function readStridedFloat(json: any, binChunk: DataView, accessorIdx: number): Float32Array {
     const accessor = json.accessors[accessorIdx];
     const bufferView = json.bufferViews[accessor.bufferView];
-    if (accessor.componentType !== FLOAT) {
-        throw new Error(`${NAME}: strided accessor ${accessorIdx} uses unsupported component type: ${accessor.componentType}`);
+    const componentType = accessor.componentType;
+    const compBytes = COMPONENT_BYTES[componentType];
+    if (!compBytes) {
+        throw new Error(`${NAME}: strided accessor ${accessorIdx} uses unsupported component type: ${componentType}`);
     }
     const componentCount = TYPE_SIZES[accessor.type] ?? 1;
-    const elementBytes = componentCount * 4;
+    const elementBytes = componentCount * compBytes;
     const byteStride = bufferView.byteStride ?? elementBytes;
     if (byteStride < elementBytes) {
         throw new Error(`${NAME}: invalid accessor stride ${byteStride} for accessor ${accessorIdx}`);
     }
+    const normalized = accessor.normalized === true;
     const baseOffset = binChunk.byteOffset + (bufferView.byteOffset ?? 0) + (accessor.byteOffset ?? 0);
     const view = new DV(binChunk.buffer);
     const out = new F32(accessor.count * componentCount);
     for (let i = 0, o = 0; i < accessor.count; i++) {
         const src = baseOffset + i * byteStride;
         for (let c = 0; c < componentCount; c++, o++) {
-            out[o] = view.getFloat32(src + c * 4, true);
+            out[o] = readComponent(view, src + c * compBytes, componentType, normalized);
         }
     }
     return out;

--- a/packages/babylon-lite/src/material/shader/normal-view.ts
+++ b/packages/babylon-lite/src/material/shader/normal-view.ts
@@ -1,0 +1,60 @@
+/** ShaderMaterial view helper that re-renders a custom material as a geometric
+ *  NORMAL buffer (a lightweight, single-attachment alternative to the full
+ *  geometry renderer for the screen-space-effect — e.g. cavity — use case).
+ *
+ *  Babylon-Lite does not own a ShaderMaterial's fragment, so this view cannot
+ *  post-patch the user fragment the way the Standard/PBR geometry views do.
+ *  Instead it REUSES the source material's vertex stage (so instancing,
+ *  displacement, and all bindings stay correct) and SUBSTITUTES the fragment
+ *  with a generated `mainFragment` that writes the per-fragment GEOMETRIC normal
+ *  (`normalize(cross(dpdx(P), dpdy(P)))`, P = a world-position varying the
+ *  source already emits) into a single colour attachment, encoded `n*0.5+0.5`.
+ *
+ *  The substitution rides the existing shader pipeline unchanged: the renderable
+ *  reads `material.fragmentSource`, which the view overrides; the prelude (scene
+ *  UBO, system/custom uniforms, samplers) is still prepended, so `scene.view` is
+ *  available and the source's bind-group layout is reused (the normal fragment
+ *  simply doesn't reference the material's textures). Render the view into an
+ *  rgba8/rgba16f colour + depth target; cleared alpha 0 marks "no geometry".
+ *
+ *  Requirement (validated by the caller): the source vertex stage must output
+ *  the world position as a `vec3<f32>` varying at `worldPosLocation` (default
+ *  `@location(0)`, named `vWorldPos`). Every Lite ShaderMaterial that wants a
+ *  normal buffer must keep that varying at a stable location. */
+
+import { createMaterialView } from "../material-view.js";
+import type { MaterialView } from "../material.js";
+import type { ShaderMaterial } from "./shader-material.js";
+
+/** Configuration for {@link createShaderNormalMaterialView}. */
+export interface ShaderNormalViewConfig {
+    /** Name of the world-position varying the source vertex stage emits. Default `"vWorldPos"`. */
+    readonly worldPosVarying?: string;
+    /** `@location()` of that varying in the vertex output struct. Default `0`. */
+    readonly worldPosLocation?: number;
+    /** Output space of the encoded normal: `"view"` (default — ready for
+     *  Blender-style screen-space curvature) or `"world"`. */
+    readonly space?: "view" | "world";
+}
+
+/** WGSL `mainFragment` that emits the encoded geometric normal. */
+function buildNormalFragment(varying: string, location: number, space: "view" | "world"): string {
+    const nExpr = space === "world" ? "nW" : "normalize((scene.view * vec4<f32>(nW, 0.0)).xyz)";
+    return `struct CavityNormalIn { @location(${location}) ${varying}: vec3<f32>, };
+@fragment fn mainFragment(input: CavityNormalIn) -> @location(0) vec4<f32> {
+  let nW = normalize(cross(dpdx(input.${varying}), dpdy(input.${varying})));
+  let n = ${nExpr};
+  return vec4<f32>(n * 0.5 + vec3<f32>(0.5), 1.0);
+}`;
+}
+
+/** Wrap a ShaderMaterial as a normal-buffer view. The returned view renders the
+ *  source's geometry (instancing/displacement intact) but writes the geometric
+ *  normal instead of the material's colour. Idempotent-friendly: create one per
+ *  source and reuse it. */
+export function createShaderNormalMaterialView(source: ShaderMaterial, config: ShaderNormalViewConfig = {}): MaterialView {
+    const view = createMaterialView(source, { features: 0 });
+    const frag = buildNormalFragment(config.worldPosVarying ?? "vWorldPos", config.worldPosLocation ?? 0, config.space ?? "view");
+    Object.defineProperty(view, "fragmentSource", { value: frag, enumerable: true, configurable: true });
+    return view;
+}


### PR DESCRIPTION
## Summary

Two changes to the Babylon Lite engine:

### 1. feat(material): `createShaderNormalMaterialView`

A new ShaderMaterial view that re-renders a custom material as a **geometric normal buffer** — a lightweight, single-attachment alternative to the full geometry renderer for screen-space effects (e.g. cavity / curvature).

- Reuses the source material's **vertex stage** (instancing, displacement, and all bindings stay correct) and substitutes a generated `mainFragment` that writes `normalize(cross(dpdx(P), dpdy(P)))` into a single colour attachment, encoded `n * 0.5 + 0.5`.
- Output space configurable via `ShaderNormalViewConfig.space`: `"view"` (default) or `"world"`; world-position varying name/location are configurable (default `vWorldPos` `@location(0)`).
- Rides the existing shader pipeline unchanged — no new bind-group layout, no core changes.

New public API: `createShaderNormalMaterialView`, `ShaderNormalViewConfig`.

### 2. fix(loader): all component types in `KHR_texture_basisu` strided accessors

The interleaved (strided) accessor reader assumed every component was a `FLOAT` and **threw** for any other component type. Interleaved vertex attributes can use any glTF component type (e.g. a normalized `COLOR_0` as `UNSIGNED_BYTE`), so such assets failed to load.

- Add a `COMPONENT_BYTES` map and compute element/stride sizes from the real component byte size instead of hardcoding `* 4`.
- Add `readComponent()` to decode each component per its type via `DataView` (unaligned little-endian reads at any stride).
- Honor the accessor `normalized` flag: unsigned → `[0, 1]`, signed → `[-1, 1]` (clamped). Unsupported types still throw a clear error.

## Testing

- `pnpm lint` (eslint + tsc) ✅
- Parity / bundle-size / API-report guardrails run in CI. Both changes are additive/decode-path only — no parity movement expected.