### PR TITLE
feat(navigation): add raw source navmesh creation

### DIFF
--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -551,6 +551,7 @@ export type { PhysicsWorld, PhysicsBody, PhysicsShape, PhysicsAggregate, Physics
 export {
     createNavigationPluginAsync,
     createNavMesh,
+    createNavMeshFromSources,
     createDebugNavMeshGeometry,
     getClosestPoint,
     computePath,
@@ -570,4 +571,4 @@ export {
     removeObstacle,
     updateNavMeshObstacles,
 } from "./navigation/navigation.js";
-export type { NavigationPlugin, NavCrowd, NavMeshParameters, AgentParameters, OffMeshConnection, ObstacleHandle } from "./navigation/navigation.js";
+export type { NavigationPlugin, NavCrowd, NavMeshParameters, NavMeshSource, AgentParameters, OffMeshConnection, ObstacleHandle } from "./navigation/navigation.js";

--- a/packages/babylon-lite/src/navigation/navigation.ts
+++ b/packages/babylon-lite/src/navigation/navigation.ts
@@ -191,7 +191,18 @@ export async function createNavigationPluginAsync(options?: { locateFile?: (url:
  */
 export function createNavMesh(plugin: NavigationPlugin, meshes: Mesh[], params: NavMeshParameters): void {
     const { positions, indices } = _mergeMeshes(meshes, params.doNotReverseIndices === true);
+    _createNavMeshFromMerged(plugin, positions, indices, params);
+}
 
+/** Build a navmesh from raw CPU geometry sources. This is the non-rendering twin of
+ * `createNavMesh`: callers that already own procedural navigation geometry can avoid
+ * creating hidden GPU meshes just to feed Recast. */
+export function createNavMeshFromSources(plugin: NavigationPlugin, sources: NavMeshSource[], params: NavMeshParameters): void {
+    const { positions, indices } = _mergeSources(sources, params.doNotReverseIndices === true);
+    _createNavMeshFromMerged(plugin, positions, indices, params);
+}
+
+function _createNavMeshFromMerged(plugin: NavigationPlugin, positions: Float32Array, indices: Uint32Array, params: NavMeshParameters): void {
     const cfg: Record<string, unknown> = {};
     if (params.cs !== undefined) {
         cfg.cs = params.cs;
@@ -341,6 +352,40 @@ function _mergeMeshes(meshes: Mesh[], doNotReverseIndices: boolean): { positions
             }
         }
         vertBase += src.length / 3;
+    }
+
+    return { positions, indices };
+}
+
+function _mergeSources(sources: NavMeshSource[], doNotReverseIndices: boolean): { positions: Float32Array; indices: Uint32Array } {
+    let totalVerts = 0;
+    let totalIdx = 0;
+    for (const source of sources) {
+        totalVerts += source.positions.length;
+        totalIdx += source.indices.length;
+    }
+    const positions = new F32(totalVerts);
+    const indices = new U32(totalIdx);
+
+    let pOff = 0;
+    let iOff = 0;
+    let vertBase = 0;
+    for (const source of sources) {
+        for (let i = 0; i < source.positions.length; i++) {
+            positions[pOff++] = source.positions[i]!;
+        }
+        if (doNotReverseIndices) {
+            for (let i = 0; i < source.indices.length; i++) {
+                indices[iOff++] = source.indices[i]! + vertBase;
+            }
+        } else {
+            for (let i = 0; i < source.indices.length; i += 3) {
+                indices[iOff++] = source.indices[i]! + vertBase;
+                indices[iOff++] = source.indices[i + 2]! + vertBase;
+                indices[iOff++] = source.indices[i + 1]! + vertBase;
+            }
+        }
+        vertBase += source.positions.length / 3;
     }
 
     return { positions, indices };

--- a/tests/lite/unit/navigation.test.ts
+++ b/tests/lite/unit/navigation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { createNavMeshFromSources } from "../../../packages/babylon-lite/src/navigation/navigation";
+import type { NavigationPlugin, NavMeshSource } from "../../../packages/babylon-lite/src/navigation/navigation";
+
+function createMockPlugin(capture: { positions?: number[]; indices?: number[]; navMeshQueryInput?: unknown }): NavigationPlugin {
+    const navMesh = { ok: true };
+    return {
+        _recast: {
+            NavMeshQuery: class {
+                constructor(input: unknown) {
+                    capture.navMeshQueryInput = input;
+                }
+            },
+        },
+        _generators: {
+            generateSoloNavMesh(positions: Float32Array, indices: Uint32Array) {
+                capture.positions = Array.from(positions);
+                capture.indices = Array.from(indices);
+                return { success: true, navMesh };
+            },
+        },
+    };
+}
+
+describe("navigation raw sources", () => {
+    it("builds a navmesh from raw sources with reversed winding and base-index offsets", () => {
+        const capture: { positions?: number[]; indices?: number[]; navMeshQueryInput?: unknown } = {};
+        const plugin = createMockPlugin(capture);
+        const sources: NavMeshSource[] = [
+            { positions: [0, 0, 0, 1, 0, 0, 0, 0, 1], indices: [0, 1, 2] },
+            { positions: [10, 0, 0, 11, 0, 0, 10, 0, 1], indices: [0, 1, 2] },
+        ];
+
+        createNavMeshFromSources(plugin, sources, {});
+
+        expect(capture.positions).toEqual([0, 0, 0, 1, 0, 0, 0, 0, 1, 10, 0, 0, 11, 0, 0, 10, 0, 1]);
+        expect(capture.indices).toEqual([0, 2, 1, 3, 5, 4]);
+        expect(capture.navMeshQueryInput).toEqual({ ok: true });
+    });
+
+    it("preserves raw source winding when requested", () => {
+        const capture: { positions?: number[]; indices?: number[] } = {};
+        const plugin = createMockPlugin(capture);
+
+        createNavMeshFromSources(plugin, [{ positions: [0, 0, 0, 1, 0, 0, 0, 0, 1], indices: [0, 1, 2] }], { doNotReverseIndices: true });
+
+        expect(capture.indices).toEqual([0, 1, 2]);
+    });
+});


### PR DESCRIPTION
## Summary
- add createNavMeshFromSources for callers that already own CPU navigation geometry
- export NavMeshSource from the public package entry point
- add unit coverage for source merging, winding, and base-index offsets

## Validation
- pnpm run lint
- pnpm test:unit
- pnpm test
- pnpm docs:check attempted locally, but the existing docs warnings make the command exit nonzero before this PR-specific API can be isolated
- pnpm report:api-changes attempted locally, but the script cannot spawn pnpm on this Windows shell (spawnSync pnpm ENOENT)