### PR TITLE
feat(camera): geospatial touch pinch, keyboard parity & test backfill

### DIFF
--- a/docs/lite/architecture/38-geospatial-camera.md
+++ b/docs/lite/architecture/38-geospatial-camera.md
@@ -148,7 +148,12 @@ Interactions:
 - **Wheel** — zoom; toward the cursor by default (`zoomToCursor`), else along the
   look vector. Zoom speed scales with distance to the target and is suppressed
   while dragging/rotating. `zoomInertia = 0.9` (others 0 by default).
-- **Keyboard** — arrows tilt, W/A/S/D pan, +/− zoom.
+- **Touch** — single-finger drag pans (via pointer events); a two-finger pinch
+  zooms toward the centroid (analytic raycast) and promotes to a pan once the
+  centroid drifts ≥ 20 px. Pointer-driven pan/rotate is suppressed while two
+  fingers are down, and `gesture*`/native pinch-zoom are prevented.
+- **Keyboard** — arrows pan (drag from the canvas centre), Ctrl+arrows tilt
+  (pitch/yaw), +/− zoom along the look vector.
 - **Collision** (`checkCollisions`) — clamps the eye so it cannot dip below the surface.
 
 ### Globe picking — analytic ray-sphere (key simplification)

--- a/packages/babylon-lite/src/camera/geospatial-camera-controls.ts
+++ b/packages/babylon-lite/src/camera/geospatial-camera-controls.ts
@@ -6,8 +6,7 @@ import { createPickingRay } from "../picking/ray.js";
 import { mat4Invert } from "../math/mat4-invert.js";
 import type { SceneContext } from "../scene/scene-core.js";
 import type { Vec3, Mat4, Mat4Storage } from "../math/types.js";
-
-const REFERENCE_FRAME_RATE = 60;
+import { REFERENCE_FRAME_RATE, integrateInertialVelocity, computePanSpeedMultiplier, computeZoomSpeedMultiplier } from "./geospatial-movement.js";
 
 /** Options for {@link attachGeospatialControls}. */
 export interface GeospatialControlOptions {
@@ -29,7 +28,9 @@ interface PickResult {
  *  - Left-drag: pan (the cursor stays anchored to the globe surface).
  *  - Middle/right-drag: rotate (yaw + pitch / tilt).
  *  - Wheel: zoom (toward the cursor by default).
- *  - Keyboard: arrows = tilt, W/A/S/D = pan, +/- = zoom.
+ *  - Touch: single-finger drag = pan; two-finger pinch = zoom toward the centroid,
+ *    promoting to a pan once the centroid drifts ≥ 20 px.
+ *  - Keyboard: arrows = pan, Ctrl+arrows = tilt (pitch/yaw), +/- = zoom along the look vector.
  *
  * Movement uses Babylon.js's framerate-independent physics model (velocity +
  * inertial decay). Globe picking is analytic ray-sphere against the planet
@@ -89,6 +90,15 @@ export function attachGeospatialControls(camera: GeospatialCamera, canvas: HTMLC
     let lastX = 0;
     let lastY = 0;
     const keysDown = new Set<string>();
+
+    // ── Touch (pinch) state ──
+    const activeTouches = new Map<number, { x: number; y: number }>();
+    let pinchPrevDist = 0;
+    let pinchStartCentroidX = 0;
+    let pinchStartCentroidY = 0;
+    let pinchPanning = false;
+    const PINCH_PAN_THRESHOLD = 20; // px of centroid translation before a pinch also pans
+    const PINCH_ZOOM_SCALE = 0.05; // pixels of finger-spread → zoom-accumulator units
 
     function rectSize(): { width: number; height: number } {
         const r = canvas.getBoundingClientRect();
@@ -394,27 +404,8 @@ export function attachGeospatialControls(camera: GeospatialCamera, canvas: HTMLC
         return 1000 / REFERENCE_FRAME_RATE;
     }
 
-    function frameDecay(inertia: number, dt: number): number {
-        const eff = effectiveDeltaMs(dt);
-        const refMs = 1000 / REFERENCE_FRAME_RATE;
-        return Math.pow(inertia, eff / refMs);
-    }
-
     function nextVelocity(vel: number, pixelDelta: number, inertia: number, dt: number): number {
-        const eff = effectiveDeltaMs(dt);
-        if (eff === 0) {
-            return vel;
-        }
-        const decay = frameDecay(inertia, dt);
-        let v = vel * decay;
-        if (pixelDelta !== 0 || activeInput) {
-            const oneMinus = 1 - inertia;
-            const inputScale = oneMinus > 0 ? (1 - decay) / oneMinus : 1;
-            v += (pixelDelta / eff) * inputScale;
-        } else if (Math.abs(v) < 1e-6) {
-            v = 0;
-        }
-        return v;
+        return integrateInertialVelocity(vel, pixelDelta, inertia, effectiveDeltaMs(dt), activeInput);
     }
 
     function isDragging(): boolean {
@@ -422,17 +413,10 @@ export function attachGeospatialControls(camera: GeospatialCamera, canvas: HTMLC
     }
 
     function computeFrameDeltas(dt: number): void {
-        // Pan dampening near the poles.
+        // Pan dampening near the poles and with altitude.
         const center = camera.center;
         if (panAccumulated.x !== 0 || panAccumulated.y !== 0 || panAccumulated.z !== 0) {
-            const centerRadius = Math.hypot(center.x, center.y, center.z);
-            const currentRadius = Math.hypot(camera.position.x, camera.position.y, camera.position.z);
-            const upZ = centerRadius > 0 ? center.z / centerRadius : 0; // sin(latitude)
-            const cosLat = Math.sqrt(1 - Math.min(1, upZ * upZ));
-            const latDamp = Math.sqrt(Math.abs(cosLat));
-            const height = Math.max(currentRadius - centerRadius, GEO_EPSILON);
-            const latDampScale = Math.max(1, centerRadius / height);
-            panSpeedMultiplier = clampNum(latDampScale * latDamp, 0, 1);
+            panSpeedMultiplier = computePanSpeedMultiplier(center, camera.position);
         } else {
             panSpeedMultiplier = 1;
         }
@@ -443,7 +427,7 @@ export function attachGeospatialControls(camera: GeospatialCamera, canvas: HTMLC
             zoomVelocity = 0;
         } else {
             const target = computedZoomPickPoint ? dist(camera.position, computedZoomPickPoint) : dist(camera.position, center);
-            zoomSpeedMultiplier = target * 0.01;
+            zoomSpeedMultiplier = computeZoomSpeedMultiplier(target);
         }
 
         const eff = effectiveDeltaMs(dt);
@@ -513,42 +497,52 @@ export function attachGeospatialControls(camera: GeospatialCamera, canvas: HTMLC
         const rotateStep = 6; // pixels-equivalent per frame
         const zoomStep = 4;
         const panStep = camera.radius * 0.0015;
+        const ctrl = keysDown.has("ControlLeft") || keysDown.has("ControlRight");
 
-        if (keysDown.has("ArrowLeft")) {
-            rotationAccumulated.y -= rotateStep;
-        }
-        if (keysDown.has("ArrowRight")) {
-            rotationAccumulated.y += rotateStep;
-        }
-        if (keysDown.has("ArrowUp")) {
-            rotationAccumulated.x += rotateStep;
-        }
-        if (keysDown.has("ArrowDown")) {
-            rotationAccumulated.x -= rotateStep;
-        }
+        // +/- : zoom along the look vector (no zoom-to-point pick).
         if (keysDown.has("Equal") || keysDown.has("NumpadAdd")) {
             zoomAccumulated += zoomStep;
+            computedZoomPickPoint = null;
         }
         if (keysDown.has("Minus") || keysDown.has("NumpadSubtract")) {
             zoomAccumulated -= zoomStep;
+            computedZoomPickPoint = null;
         }
 
-        // W/A/S/D pan: move the centre along the local tangent basis.
+        if (ctrl) {
+            // Ctrl + arrows: tilt (pitch) and yaw, matching Babylon.js.
+            if (keysDown.has("ArrowLeft")) {
+                rotationAccumulated.y -= rotateStep;
+            }
+            if (keysDown.has("ArrowRight")) {
+                rotationAccumulated.y += rotateStep;
+            }
+            if (keysDown.has("ArrowUp")) {
+                rotationAccumulated.x += rotateStep;
+            }
+            if (keysDown.has("ArrowDown")) {
+                rotationAccumulated.x -= rotateStep;
+            }
+            return;
+        }
+
+        // Arrows: pan (a drag from the canvas centre). Move the centre along the
+        // local tangent basis; Up = north, Right = east.
         const east: Vec3 = { x: 0, y: 0, z: 0 };
         const north: Vec3 = { x: 0, y: 0, z: 0 };
         const up: Vec3 = { x: 0, y: 0, z: 0 };
         let dn = 0;
         let de = 0;
-        if (keysDown.has("KeyW")) {
+        if (keysDown.has("ArrowUp")) {
             dn += 1;
         }
-        if (keysDown.has("KeyS")) {
+        if (keysDown.has("ArrowDown")) {
             dn -= 1;
         }
-        if (keysDown.has("KeyD")) {
+        if (keysDown.has("ArrowRight")) {
             de += 1;
         }
-        if (keysDown.has("KeyA")) {
+        if (keysDown.has("ArrowLeft")) {
             de -= 1;
         }
         if (dn !== 0 || de !== 0) {
@@ -580,6 +574,13 @@ export function attachGeospatialControls(camera: GeospatialCamera, canvas: HTMLC
         const dy = e.clientY - lastY;
         lastX = e.clientX;
         lastY = e.clientY;
+        // While two fingers are down the gesture is a pinch (handled by the touch
+        // listeners); suppress the pointer-driven pan/rotate the first finger would
+        // otherwise trigger. lastX/Y above stay current so the remaining finger
+        // doesn't jump when one lifts.
+        if (activeTouches.size >= 2) {
+            return;
+        }
         if (mode === "none") {
             return;
         }
@@ -618,6 +619,104 @@ export function attachGeospatialControls(camera: GeospatialCamera, canvas: HTMLC
         keysDown.delete(e.code);
     }
 
+    // ── Touch (two-finger pinch = zoom toward centroid; ≥20 px centroid drift = pan) ──
+
+    function firstTwoTouches(): [{ x: number; y: number }, { x: number; y: number }] {
+        const it = activeTouches.values();
+        const a = it.next().value as { x: number; y: number };
+        const b = it.next().value as { x: number; y: number };
+        return [a, b];
+    }
+
+    function onTouchStart(e: TouchEvent): void {
+        for (let i = 0; i < e.changedTouches.length; i++) {
+            const t = e.changedTouches[i]!;
+            activeTouches.set(t.identifier, { x: t.clientX, y: t.clientY });
+        }
+        if (activeTouches.size >= 2) {
+            // A second finger landed: this is a pinch, not a single-finger pan.
+            // Cancel any in-progress pointer drag and stop the browser hijacking
+            // the gesture as a page zoom (iOS ignores touch-action for pinch).
+            e.preventDefault();
+            if (mode === "pan") {
+                stopDrag();
+            }
+            mode = "none";
+            const [p0, p1] = firstTwoTouches();
+            pinchPrevDist = Math.hypot(p1.x - p0.x, p1.y - p0.y);
+            pinchStartCentroidX = (p0.x + p1.x) / 2;
+            pinchStartCentroidY = (p0.y + p1.y) / 2;
+            pinchPanning = false;
+        }
+    }
+
+    function onTouchMove(e: TouchEvent): void {
+        for (let i = 0; i < e.changedTouches.length; i++) {
+            const t = e.changedTouches[i]!;
+            if (activeTouches.has(t.identifier)) {
+                activeTouches.set(t.identifier, { x: t.clientX, y: t.clientY });
+            }
+        }
+        if (activeTouches.size < 2) {
+            return;
+        }
+        e.preventDefault();
+        activeInput = true;
+        const [p0, p1] = firstTwoTouches();
+        const dist2 = Math.hypot(p1.x - p0.x, p1.y - p0.y);
+        const centroidClientX = (p0.x + p1.x) / 2;
+        const centroidClientY = (p0.y + p1.y) / 2;
+        const rect = canvas.getBoundingClientRect();
+        pointerX = centroidClientX - rect.left;
+        pointerY = centroidClientY - rect.top;
+
+        const centroidDrift = Math.hypot(centroidClientX - pinchStartCentroidX, centroidClientY - pinchStartCentroidY);
+        if (!pinchPanning && centroidDrift > PINCH_PAN_THRESHOLD) {
+            pinchPanning = true;
+            startDrag(pointerX, pointerY);
+        }
+
+        if (pinchPanning) {
+            // Pan dominates: drag the globe under the centroid (zoom is suppressed
+            // while dragging, mirroring the mid-drag zoom lockout).
+            handleDrag(pointerX, pointerY);
+        } else if (pinchPrevDist > 0) {
+            // Zoom toward the centroid: finger-spread Δpx feeds the zoom accumulator.
+            const dDist = dist2 - pinchPrevDist;
+            if (dDist !== 0) {
+                zoomAccumulated += dDist * PINCH_ZOOM_SCALE;
+                const pick = pickScreen(pointerX, pointerY);
+                computedZoomPickPoint = pick.hit && pick.point && zoomToCursor ? pick.point : pickAlongVector(camera._lookAt);
+            }
+        }
+        pinchPrevDist = dist2;
+    }
+
+    function onTouchEnd(e: TouchEvent): void {
+        for (let i = 0; i < e.changedTouches.length; i++) {
+            activeTouches.delete(e.changedTouches[i]!.identifier);
+        }
+        if (activeTouches.size < 2) {
+            if (pinchPanning) {
+                stopDrag();
+                pinchPanning = false;
+            }
+            pinchPrevDist = 0;
+        }
+        // One finger remains: re-anchor lastX/Y so its pointer drag doesn't jump.
+        if (activeTouches.size === 1) {
+            const p = activeTouches.values().next().value as { x: number; y: number };
+            lastX = p.x;
+            lastY = p.y;
+        }
+    }
+
+    // iOS Safari fires non-standard gesture* events and still page-zooms even with
+    // touch-action:none; swallow them so the pinch stays with the camera.
+    function onGesture(e: Event): void {
+        e.preventDefault();
+    }
+
     scene._beforeRender.push(onBeforeRenderTick);
 
     const listeners: [EventTarget, string, EventListener, AddEventListenerOptions?][] = [
@@ -626,6 +725,12 @@ export function attachGeospatialControls(camera: GeospatialCamera, canvas: HTMLC
         [canvas, "pointerup", onPointerUp as EventListener],
         [canvas, "wheel", onWheel as EventListener, { passive: false }],
         [canvas, "contextmenu", onContextMenu as EventListener],
+        [canvas, "touchstart", onTouchStart as EventListener, { passive: false }],
+        [canvas, "touchmove", onTouchMove as EventListener, { passive: false }],
+        [canvas, "touchend", onTouchEnd as EventListener],
+        [canvas, "gesturestart", onGesture as EventListener, { passive: false }],
+        [canvas, "gesturechange", onGesture as EventListener, { passive: false }],
+        [canvas, "gestureend", onGesture as EventListener, { passive: false }],
         [window, "keydown", onKeyDown as EventListener],
         [window, "keyup", onKeyUp as EventListener],
     ];

--- a/packages/babylon-lite/src/camera/geospatial-movement.ts
+++ b/packages/babylon-lite/src/camera/geospatial-movement.ts
@@ -1,0 +1,78 @@
+/** Pure, framerate-independent movement helpers for {@link GeospatialCamera}.
+ *
+ *  These mirror Babylon.js `GeospatialCameraMovement`: an inertial velocity
+ *  integrator with exponential decay normalized to a reference frame rate, plus
+ *  the latitude/altitude pan damping and distance-based zoom scaling. They are
+ *  pure (no per-frame allocation, no scene/camera references) so the inertia and
+ *  scaling behaviour can be unit-tested directly. */
+
+import type { Vec3 } from "../math/types.js";
+import { GEO_EPSILON } from "./geospatial-limits.js";
+
+/** Frame rate the inertia constants are tuned for (Babylon.js assumes 60 fps). */
+export const REFERENCE_FRAME_RATE = 60;
+const REFERENCE_FRAME_MS = 1000 / REFERENCE_FRAME_RATE;
+
+/**
+ * Exponential decay factor for one frame of length `effMs`, normalized so the
+ * effective decay over a fixed wall-clock interval is independent of frame rate:
+ * `inertia ^ (effMs / 16.667)`. An `inertia` of 0 fully stops each frame; higher
+ * values coast longer.
+ */
+export function frameDecay(inertia: number, effMs: number, referenceFrameMs: number = REFERENCE_FRAME_MS): number {
+    return Math.pow(inertia, effMs / referenceFrameMs);
+}
+
+/**
+ * Advance an inertial velocity by one frame. The previous velocity decays by
+ * {@link frameDecay}; fresh input (`pixelDelta`, in pixels for this frame, or a
+ * sustained `hasActiveInput`) is injected scaled so the steady-state velocity is
+ * frame-rate independent. Velocities below 1e-6 with no input snap to 0.
+ */
+export function integrateInertialVelocity(velocity: number, pixelDelta: number, inertia: number, effMs: number, hasActiveInput: boolean): number {
+    if (effMs === 0) {
+        return velocity;
+    }
+    const decay = frameDecay(inertia, effMs);
+    let v = velocity * decay;
+    if (pixelDelta !== 0 || hasActiveInput) {
+        const oneMinus = 1 - inertia;
+        const inputScale = oneMinus > 0 ? (1 - decay) / oneMinus : 1;
+        v += (pixelDelta / effMs) * inputScale;
+    } else if (Math.abs(v) < 1e-6) {
+        v = 0;
+    }
+    return v;
+}
+
+function clamp01(v: number): number {
+    return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+/**
+ * Pan speed multiplier in `[0, 1]` combining two effects:
+ *  - latitude damping `sqrt(cos(lat))` so panning slows as the centre nears a pole,
+ *  - altitude scaling `max(1, centerRadius / height)` so panning is reduced when
+ *    the camera is far above the surface, where `height` is the eye altitude above
+ *    the centre's geocentric shell.
+ * `center` and `position` are ECEF; the result is clamped to `[0, 1]`.
+ */
+export function computePanSpeedMultiplier(center: Vec3, position: Vec3): number {
+    const centerRadius = Math.hypot(center.x, center.y, center.z);
+    const currentRadius = Math.hypot(position.x, position.y, position.z);
+    const sinLat = centerRadius > 0 ? center.z / centerRadius : 0;
+    const cosLat = Math.sqrt(1 - Math.min(1, sinLat * sinLat));
+    const latDamp = Math.sqrt(Math.abs(cosLat));
+    const height = Math.max(currentRadius - centerRadius, GEO_EPSILON);
+    const altitudeScale = Math.max(1, centerRadius / height);
+    return clamp01(altitudeScale * latDamp);
+}
+
+/**
+ * Zoom speed multiplier: `0.01 × distanceToTarget`, matching Babylon.js so the
+ * zoom step grows with the distance from the eye to the point being zoomed
+ * toward (cursor pick or look-vector hit).
+ */
+export function computeZoomSpeedMultiplier(distanceToTarget: number): number {
+    return distanceToTarget * 0.01;
+}

--- a/tests/lite/unit/geospatial-controls.test.ts
+++ b/tests/lite/unit/geospatial-controls.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { attachGeospatialControls } from "../../../packages/babylon-lite/src/camera/geospatial-camera-controls";
+import { createGeospatialCamera } from "../../../packages/babylon-lite/src/camera/geospatial-camera";
+import type { GeospatialCamera } from "../../../packages/babylon-lite/src/camera/geospatial-camera";
+import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
+import type { Vec3 } from "../../../packages/babylon-lite/src/math/types";
+
+const W = 800;
+const H = 600;
+const CX = 400;
+const CY = 300;
+const DT = 1000 / 60;
+
+interface FakeCanvas {
+    listeners: Map<string, EventListener[]>;
+    width: number;
+    height: number;
+    addEventListener(type: string, h: EventListener, opts?: AddEventListenerOptions): void;
+    removeEventListener(type: string, h: EventListener): void;
+    setPointerCapture(): void;
+    releasePointerCapture(): void;
+    getBoundingClientRect(): { left: number; top: number; width: number; height: number; right: number; bottom: number };
+}
+
+function makeCanvas(): FakeCanvas {
+    const listeners = new Map<string, EventListener[]>();
+    return {
+        listeners,
+        width: W,
+        height: H,
+        addEventListener(type, h): void {
+            const arr = listeners.get(type) ?? [];
+            arr.push(h);
+            listeners.set(type, arr);
+        },
+        removeEventListener(type, h): void {
+            const arr = listeners.get(type);
+            if (arr) {
+                const i = arr.indexOf(h);
+                if (i >= 0) {
+                    arr.splice(i, 1);
+                }
+            }
+        },
+        setPointerCapture(): void {
+            return;
+        },
+        releasePointerCapture(): void {
+            return;
+        },
+        getBoundingClientRect() {
+            return { left: 0, top: 0, width: W, height: H, right: W, bottom: H };
+        },
+    };
+}
+
+let windowListeners: Map<string, EventListener[]>;
+
+function makeScene(): SceneContext {
+    return { _beforeRender: [] } as unknown as SceneContext;
+}
+
+function fire(canvas: FakeCanvas, type: string, ev: unknown): void {
+    for (const h of [...(canvas.listeners.get(type) ?? [])]) {
+        h(ev as Event);
+    }
+}
+
+function fireWindow(type: string, ev: unknown): void {
+    for (const h of [...(windowListeners.get(type) ?? [])]) {
+        h(ev as Event);
+    }
+}
+
+function tick(scene: SceneContext, dt = DT): void {
+    for (const cb of [...(scene as unknown as { _beforeRender: Array<(d: number) => void> })._beforeRender]) {
+        cb(dt);
+    }
+}
+
+function pointer(type: string, clientX: number, clientY: number, button = 0): unknown {
+    return { type, clientX, clientY, button, pointerId: 1, preventDefault: vi.fn() };
+}
+
+function wheel(clientX: number, clientY: number, deltaY: number): unknown {
+    return { clientX, clientY, deltaY, preventDefault: vi.fn() };
+}
+
+function key(code: string): unknown {
+    return { code, preventDefault: vi.fn() };
+}
+
+function tp(identifier: number, clientX: number, clientY: number): { identifier: number; clientX: number; clientY: number } {
+    return { identifier, clientX, clientY };
+}
+
+function touchEvent(changed: Array<{ identifier: number; clientX: number; clientY: number }>): unknown {
+    return { changedTouches: changed, preventDefault: vi.fn() };
+}
+
+function copy(v: Vec3): Vec3 {
+    return { x: v.x, y: v.y, z: v.z };
+}
+
+function moved(a: Vec3, b: Vec3): number {
+    return Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+}
+
+describe("attachGeospatialControls — pointer / wheel (M5)", () => {
+    let canvas: FakeCanvas;
+    let camera: GeospatialCamera;
+    let scene: SceneContext;
+
+    beforeEach(() => {
+        windowListeners = new Map();
+        (globalThis as Record<string, unknown>).window = {
+            addEventListener(type: string, h: EventListener): void {
+                const arr = windowListeners.get(type) ?? [];
+                arr.push(h);
+                windowListeners.set(type, arr);
+            },
+            removeEventListener(type: string, h: EventListener): void {
+                const arr = windowListeners.get(type);
+                if (arr) {
+                    const i = arr.indexOf(h);
+                    if (i >= 0) {
+                        arr.splice(i, 1);
+                    }
+                }
+            },
+        };
+        canvas = makeCanvas();
+        camera = createGeospatialCamera({ planetRadius: 100 });
+        scene = makeScene();
+        attachGeospatialControls(camera, canvas as unknown as HTMLCanvasElement, scene);
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>).window;
+    });
+
+    it("a left-drag pans the globe centre", () => {
+        const before = copy(camera.center);
+        fire(canvas, "pointerdown", pointer("pointerdown", CX, CY, 0));
+        fire(canvas, "pointermove", pointer("pointermove", CX + 30, CY, 0));
+        tick(scene);
+        expect(moved(camera.center, before)).toBeGreaterThan(1e-4);
+    });
+
+    it("returning the cursor to the drag start cancels the pan (drag-plane anchor)", () => {
+        const before = copy(camera.center);
+        fire(canvas, "pointerdown", pointer("pointerdown", CX, CY, 0));
+        fire(canvas, "pointermove", pointer("pointermove", CX + 20, CY, 0));
+        fire(canvas, "pointermove", pointer("pointermove", CX, CY, 0)); // back to start
+        tick(scene);
+        // The accumulated pan over the round-trip nets to ~0, so the anchored
+        // surface point (and thus the centre) returns to where it started.
+        expect(moved(camera.center, before)).toBeLessThan(0.5);
+    });
+
+    it("a click with no movement does not pan", () => {
+        const before = copy(camera.center);
+        fire(canvas, "pointerdown", pointer("pointerdown", CX, CY, 0));
+        fire(canvas, "pointerup", pointer("pointerup", CX, CY, 0));
+        tick(scene);
+        expect(camera.center).toEqual(before);
+    });
+
+    it("the wheel zooms toward the cursor (radius decreases on zoom-in)", () => {
+        const before = camera.radius;
+        fire(canvas, "wheel", wheel(CX, CY, -100)); // deltaY < 0 = zoom in
+        for (let i = 0; i < 10; i++) {
+            tick(scene);
+        }
+        expect(camera.radius).toBeLessThan(before);
+    });
+});
+
+describe("attachGeospatialControls — keyboard (M6)", () => {
+    let canvas: FakeCanvas;
+    let camera: GeospatialCamera;
+    let scene: SceneContext;
+
+    beforeEach(() => {
+        windowListeners = new Map();
+        (globalThis as Record<string, unknown>).window = {
+            addEventListener(type: string, h: EventListener): void {
+                const arr = windowListeners.get(type) ?? [];
+                arr.push(h);
+                windowListeners.set(type, arr);
+            },
+            removeEventListener(): void {
+                return;
+            },
+        };
+        canvas = makeCanvas();
+        camera = createGeospatialCamera({ planetRadius: 100 });
+        scene = makeScene();
+        attachGeospatialControls(camera, canvas as unknown as HTMLCanvasElement, scene);
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>).window;
+    });
+
+    it("an arrow key pans the centre (no modifier = pan)", () => {
+        const before = copy(camera.center);
+        fireWindow("keydown", key("ArrowUp"));
+        tick(scene);
+        // ArrowUp pans north → centre gains +z.
+        expect(camera.center.z).toBeGreaterThan(0);
+        expect(moved(camera.center, before)).toBeGreaterThan(1e-4);
+    });
+
+    it("Ctrl+arrow tilts (changes pitch) instead of panning", () => {
+        camera.radius = 150; // open the pitch range (≤ 2·planetRadius)
+        const beforePitch = camera.pitch;
+        const beforeCenter = copy(camera.center);
+        fireWindow("keydown", key("ControlLeft"));
+        fireWindow("keydown", key("ArrowUp"));
+        tick(scene);
+        tick(scene);
+        expect(camera.pitch).toBeGreaterThan(beforePitch);
+        // A tilt should not translate the centre.
+        expect(moved(camera.center, beforeCenter)).toBeLessThan(1e-6);
+    });
+
+    it("+/- zooms along the look vector (radius decreases on +)", () => {
+        const before = camera.radius;
+        fireWindow("keydown", key("Equal"));
+        for (let i = 0; i < 5; i++) {
+            tick(scene);
+        }
+        expect(camera.radius).toBeLessThan(before);
+    });
+});
+
+describe("attachGeospatialControls — touch pinch (M6)", () => {
+    let canvas: FakeCanvas;
+    let camera: GeospatialCamera;
+    let scene: SceneContext;
+
+    beforeEach(() => {
+        windowListeners = new Map();
+        (globalThis as Record<string, unknown>).window = {
+            addEventListener(): void {
+                return;
+            },
+            removeEventListener(): void {
+                return;
+            },
+        };
+        canvas = makeCanvas();
+        camera = createGeospatialCamera({ planetRadius: 100 });
+        scene = makeScene();
+        attachGeospatialControls(camera, canvas as unknown as HTMLCanvasElement, scene);
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>).window;
+    });
+
+    it("a two-finger spread zooms in (radius decreases)", () => {
+        const before = camera.radius;
+        fire(canvas, "touchstart", touchEvent([tp(1, 300, 300), tp(2, 500, 300)])); // 200 px apart
+        fire(canvas, "touchmove", touchEvent([tp(1, 200, 300), tp(2, 600, 300)])); // 400 px apart
+        for (let i = 0; i < 8; i++) {
+            tick(scene);
+        }
+        expect(camera.radius).toBeLessThan(before);
+    });
+
+    it("prevents the browser's native pinch-zoom during a two-finger gesture", () => {
+        fire(canvas, "touchstart", touchEvent([tp(1, 300, 300), tp(2, 500, 300)]));
+        const move = touchEvent([tp(1, 200, 300), tp(2, 600, 300)]) as { preventDefault: ReturnType<typeof vi.fn> };
+        fire(canvas, "touchmove", move);
+        expect(move.preventDefault).toHaveBeenCalled();
+    });
+
+    it("promotes the pinch to a pan once the centroid drifts past the 20 px threshold", () => {
+        const beforeCenter = copy(camera.center);
+        const beforeRadius = camera.radius;
+        // Translate both fingers together (constant spread) so the centroid drifts > 20 px.
+        fire(canvas, "touchstart", touchEvent([tp(1, 300, 300), tp(2, 500, 300)])); // centroid 400
+        fire(canvas, "touchmove", touchEvent([tp(1, 330, 300), tp(2, 530, 300)])); // centroid 430 → engages pan
+        fire(canvas, "touchmove", touchEvent([tp(1, 370, 300), tp(2, 570, 300)])); // centroid 470 → drag delta
+        tick(scene);
+        expect(moved(camera.center, beforeCenter)).toBeGreaterThan(1e-4); // panned
+        expect(camera.radius).toBeCloseTo(beforeRadius, 6); // zoom suppressed mid-drag
+    });
+
+    it("a single-finger touch does not pinch-zoom (left to pointer events)", () => {
+        const before = camera.radius;
+        fire(canvas, "touchstart", touchEvent([tp(1, 300, 300)]));
+        const move = touchEvent([tp(1, 360, 300)]) as { preventDefault: ReturnType<typeof vi.fn> };
+        fire(canvas, "touchmove", move);
+        tick(scene);
+        expect(camera.radius).toBe(before);
+        expect(move.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("ends the pinch when a finger lifts so a lone finger does not keep zooming", () => {
+        fire(canvas, "touchstart", touchEvent([tp(1, 300, 300), tp(2, 500, 300)]));
+        fire(canvas, "touchmove", touchEvent([tp(1, 200, 300), tp(2, 600, 300)]));
+        for (let i = 0; i < 4; i++) {
+            tick(scene);
+        }
+        fire(canvas, "touchend", touchEvent([tp(2, 600, 300)])); // lift one finger
+        const afterLift = camera.radius;
+        // A lone-finger move must inject no zoom (it returns early with < 2 touches).
+        // Assert without ticking so inertial coast can't mask the check.
+        const move = touchEvent([tp(1, 50, 300)]) as { preventDefault: ReturnType<typeof vi.fn> };
+        fire(canvas, "touchmove", move);
+        expect(camera.radius).toBe(afterLift);
+        expect(move.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("registers touch/gesture listeners and removes everything on dispose", () => {
+        const c = makeCanvas();
+        const cam = createGeospatialCamera({ planetRadius: 100 });
+        const dispose = attachGeospatialControls(cam, c as unknown as HTMLCanvasElement, makeScene());
+        expect(c.listeners.get("touchmove")?.length).toBe(1);
+        expect(c.listeners.get("touchstart")?.length).toBe(1);
+        dispose();
+        expect(c.listeners.get("touchmove")?.length).toBe(0);
+        expect(c.listeners.get("pointermove")?.length).toBe(0);
+    });
+});

--- a/tests/lite/unit/geospatial-math.test.ts
+++ b/tests/lite/unit/geospatial-math.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    normalizeRadians,
+    computeLocalBasis,
+    computeLookAtFromYawPitch,
+    computeYawPitchFromLookAt,
+    clampCenterFromPoles,
+    createGeospatialCamera,
+} from "../../../packages/babylon-lite/src/camera/geospatial-camera";
+import { createGeospatialLimits, getEffectivePitchMax, clampZoomDistance } from "../../../packages/babylon-lite/src/camera/geospatial-limits";
+import type { Vec3 } from "../../../packages/babylon-lite/src/math/types";
+
+const POLE_SINE_LIMIT = 0.998749218;
+
+function dot(a: Vec3, b: Vec3): number {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+function len(a: Vec3): number {
+    return Math.hypot(a.x, a.y, a.z);
+}
+
+describe("normalizeRadians", () => {
+    it("wraps angles into [-π, π)", () => {
+        expect(normalizeRadians(0)).toBeCloseTo(0, 12);
+        expect(normalizeRadians(Math.PI / 2)).toBeCloseTo(Math.PI / 2, 12);
+        // 3π wraps to -π.
+        expect(normalizeRadians(3 * Math.PI)).toBeCloseTo(-Math.PI, 12);
+        // A large positive angle and its +2π are congruent after wrapping.
+        const a = normalizeRadians(10.5);
+        const b = normalizeRadians(10.5 + 2 * Math.PI);
+        expect(b).toBeCloseTo(a, 12);
+        expect(a).toBeGreaterThanOrEqual(-Math.PI);
+        expect(a).toBeLessThan(Math.PI);
+    });
+});
+
+describe("computeLocalBasis", () => {
+    it("produces an orthonormal east/north/up frame with up = normalized position", () => {
+        const pos: Vec3 = { x: 3, y: -4, z: 12 }; // mag 13
+        const east: Vec3 = { x: 0, y: 0, z: 0 };
+        const north: Vec3 = { x: 0, y: 0, z: 0 };
+        const up: Vec3 = { x: 0, y: 0, z: 0 };
+        computeLocalBasis(pos, east, north, up);
+
+        expect(len(east)).toBeCloseTo(1, 9);
+        expect(len(north)).toBeCloseTo(1, 9);
+        expect(len(up)).toBeCloseTo(1, 9);
+        expect(dot(east, north)).toBeCloseTo(0, 9);
+        expect(dot(east, up)).toBeCloseTo(0, 9);
+        expect(dot(north, up)).toBeCloseTo(0, 9);
+        // up is the geocentric normal.
+        expect(up.x).toBeCloseTo(3 / 13, 9);
+        expect(up.y).toBeCloseTo(-4 / 13, 9);
+        expect(up.z).toBeCloseTo(12 / 13, 9);
+    });
+
+    it("falls back to a valid frame at the pole (cross(up, north) degenerate)", () => {
+        const pos: Vec3 = { x: 0, y: 0, z: 5 };
+        const east: Vec3 = { x: 0, y: 0, z: 0 };
+        const north: Vec3 = { x: 0, y: 0, z: 0 };
+        const up: Vec3 = { x: 0, y: 0, z: 0 };
+        computeLocalBasis(pos, east, north, up);
+
+        for (const v of [east, north, up]) {
+            expect(Number.isFinite(v.x) && Number.isFinite(v.y) && Number.isFinite(v.z)).toBe(true);
+            expect(len(v)).toBeCloseTo(1, 9);
+        }
+        expect(dot(east, north)).toBeCloseTo(0, 9);
+        expect(dot(east, up)).toBeCloseTo(0, 9);
+        expect(dot(north, up)).toBeCloseTo(0, 9);
+    });
+});
+
+describe("yaw/pitch ↔ lookAt round-trip", () => {
+    it("recovers the yaw/pitch that generated a lookAt direction", () => {
+        const center: Vec3 = { x: 6, y: 0, z: 0 };
+        for (const yaw of [-1.2, 0.0, 0.5, 2.7]) {
+            for (const pitch of [0.2, 0.7, 1.3]) {
+                const lookAt: Vec3 = { x: 0, y: 0, z: 0 };
+                computeLookAtFromYawPitch(yaw, pitch, center, lookAt);
+                expect(len(lookAt)).toBeCloseTo(1, 9);
+
+                const out = { x: 0, y: 0 };
+                computeYawPitchFromLookAt(lookAt, center, 0, out);
+                // Compare yaw modulo 2π (atan2 result vs the input angle).
+                const dy = normalizeRadians(out.x - yaw);
+                expect(dy).toBeCloseTo(0, 6);
+                expect(out.y).toBeCloseTo(pitch, 6);
+            }
+        }
+    });
+
+    it("preserves the previous yaw when looking straight down (pitch ≈ 0)", () => {
+        const center: Vec3 = { x: 0, y: 7, z: 0 };
+        const up: Vec3 = { x: 0, y: 1, z: 0 };
+        // lookAt straight down = -up.
+        const lookAt: Vec3 = { x: -up.x, y: -up.y, z: -up.z };
+        const out = { x: 0, y: 0 };
+        computeYawPitchFromLookAt(lookAt, center, 1.234, out);
+        expect(out.y).toBeCloseTo(0, 6);
+        expect(out.x).toBeCloseTo(1.234, 9); // previous yaw preserved
+    });
+});
+
+describe("clampCenterFromPoles", () => {
+    it("enforces |sin(lat)| ≤ 0.998749218 while preserving magnitude and longitude", () => {
+        const center: Vec3 = { x: 1, y: 0, z: 100 }; // nearly at the pole
+        const magBefore = len(center);
+        const lonBefore = Math.atan2(center.y, center.x);
+        clampCenterFromPoles(center);
+        const mag = len(center);
+        expect(mag).toBeCloseTo(magBefore, 6);
+        expect(Math.abs(center.z / mag)).toBeCloseTo(POLE_SINE_LIMIT, 9);
+        expect(Math.atan2(center.y, center.x)).toBeCloseTo(lonBefore, 9);
+    });
+
+    it("leaves an equatorial centre untouched", () => {
+        const center: Vec3 = { x: 50, y: 50, z: 0 };
+        clampCenterFromPoles(center);
+        expect(center).toEqual({ x: 50, y: 50, z: 0 });
+    });
+});
+
+describe("createGeospatialCamera — default pose & view matrix", () => {
+    it("rests looking straight down at (planetRadius,0,0) from radiusMax", () => {
+        const cam = createGeospatialCamera({ planetRadius: 100 });
+        expect(cam.radius).toBe(400); // planetRadius * 4
+        expect(cam.center).toEqual({ x: 100, y: 0, z: 0 });
+
+        // position = center - lookAt*radius, lookAt ≈ -up = (-1,0,~0).
+        expect(cam.position.x).toBeCloseTo(500, 1);
+        expect(cam.position.y).toBeCloseTo(0, 3);
+        expect(Math.abs(cam.position.z)).toBeLessThan(1);
+
+        // worldMatrix translation column equals the eye position (Float32 precision).
+        const w = cam.worldMatrix as unknown as number[];
+        expect(w[12]).toBeCloseTo(cam.position.x, 3);
+        expect(w[13]).toBeCloseTo(cam.position.y, 3);
+        expect(w[14]).toBeCloseTo(cam.position.z, 3);
+        expect(w[15]).toBe(1);
+    });
+
+    it("keeps the eye outside the planet at a sample tilted pose", () => {
+        const cam = createGeospatialCamera({ planetRadius: 100 });
+        cam.radius = 150; // within full-pitch range
+        cam.pitch = 0.6;
+        cam.yaw = 0.4;
+        expect(len(cam.position)).toBeGreaterThan(100);
+        expect(len(cam.upVector)).toBeCloseTo(1, 6);
+    });
+});
+
+describe("geospatial limits", () => {
+    it("getEffectivePitchMax disables pitch as the camera zooms out", () => {
+        const limits = createGeospatialLimits(100);
+        expect(getEffectivePitchMax(limits, 150)).toBeCloseTo(limits.pitchMax, 9); // ≤ 2·R
+        expect(getEffectivePitchMax(limits, 400)).toBeCloseTo(limits.pitchMin, 9); // ≥ 4·R
+        const mid = getEffectivePitchMax(limits, 300); // halfway between 2R and 4R
+        expect(mid).toBeGreaterThan(limits.pitchMin);
+        expect(mid).toBeLessThan(limits.pitchMax);
+        expect(mid).toBeCloseTo((limits.pitchMax + limits.pitchMin) / 2, 9);
+    });
+
+    it("clampZoomDistance respects the radius bounds in both directions", () => {
+        const limits = createGeospatialLimits(100); // radiusMin 10, radiusMax 400
+        // Zoom in cannot pass radiusMin given a distance to the target.
+        expect(clampZoomDistance(limits, 1000, 50, 50)).toBeCloseTo(40, 9); // 50 - 10
+        // Zoom out cannot pass radiusMax.
+        expect(clampZoomDistance(limits, -1000, 380)).toBeCloseTo(-20, 9); // -(400 - 380)
+        // A modest in-range zoom passes through unchanged.
+        expect(clampZoomDistance(limits, 5, 200, 200)).toBeCloseTo(5, 9);
+    });
+});

--- a/tests/lite/unit/geospatial-movement.test.ts
+++ b/tests/lite/unit/geospatial-movement.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    frameDecay,
+    integrateInertialVelocity,
+    computePanSpeedMultiplier,
+    computeZoomSpeedMultiplier,
+    REFERENCE_FRAME_RATE,
+} from "../../../packages/babylon-lite/src/camera/geospatial-movement";
+import type { Vec3 } from "../../../packages/babylon-lite/src/math/types";
+
+const REF_MS = 1000 / REFERENCE_FRAME_RATE;
+
+describe("frameDecay", () => {
+    it("is the identity at the reference frame time and 1 for a zero-length frame", () => {
+        expect(frameDecay(0.9, REF_MS)).toBeCloseTo(0.9, 9);
+        expect(frameDecay(0.9, 0)).toBe(1); // x^0 = 1
+    });
+
+    it("is frame-rate normalized: a double-length frame decays like two frames", () => {
+        const single = frameDecay(0.9, REF_MS);
+        const doubleFrame = frameDecay(0.9, 2 * REF_MS);
+        expect(doubleFrame).toBeCloseTo(single * single, 12);
+    });
+});
+
+describe("integrateInertialVelocity", () => {
+    it("decays velocity by frameDecay when there is no input", () => {
+        const v = integrateInertialVelocity(10, 0, 0.9, REF_MS, false);
+        expect(v).toBeCloseTo(9, 9);
+    });
+
+    it("returns the velocity unchanged for a zero-length frame", () => {
+        expect(integrateInertialVelocity(7, 100, 0.9, 0, true)).toBe(7);
+    });
+
+    it("snaps a tiny coasting velocity to exactly 0 (no input)", () => {
+        expect(integrateInertialVelocity(1e-7, 0, 0.9, REF_MS, false)).toBe(0);
+    });
+
+    it("decay is frame-rate independent over equal wall-clock time", () => {
+        // Two 16.67 ms steps vs one 33.33 ms step, starting from the same velocity.
+        const oneStep = integrateInertialVelocity(100, 0, 0.9, 2 * REF_MS, false);
+        const twoSteps = integrateInertialVelocity(integrateInertialVelocity(100, 0, 0.9, REF_MS, false), 0, 0.9, REF_MS, false);
+        expect(twoSteps).toBeCloseTo(oneStep, 9);
+    });
+
+    it("injects fresh pixel input on top of the decayed velocity", () => {
+        const decayedOnly = integrateInertialVelocity(10, 0, 0.9, REF_MS, false);
+        const withInput = integrateInertialVelocity(10, 30, 0.9, REF_MS, false);
+        expect(withInput).toBeGreaterThan(decayedOnly);
+    });
+});
+
+describe("computePanSpeedMultiplier", () => {
+    it("is 1 at the equator close to the surface (no damping)", () => {
+        const center: Vec3 = { x: 100, y: 0, z: 0 };
+        const position: Vec3 = { x: 110, y: 0, z: 0 };
+        expect(computePanSpeedMultiplier(center, position)).toBeCloseTo(1, 9);
+    });
+
+    it("applies sqrt(cos(lat)) latitude damping when altitude scale is 1", () => {
+        // sin(lat) = 0.8 → cos(lat) = 0.6; height == centreRadius so altitudeScale = 1.
+        const center: Vec3 = { x: 60, y: 0, z: 80 }; // mag 100
+        const position: Vec3 = { x: 120, y: 0, z: 160 }; // mag 200, height 100
+        const expected = Math.sqrt(0.6); // sqrt(|cos lat|), cos lat = 0.6
+        expect(computePanSpeedMultiplier(center, position)).toBeCloseTo(expected, 6);
+    });
+
+    it("pans slower at high latitude than at the equator for the same altitude", () => {
+        const equatorCenter: Vec3 = { x: 100, y: 0, z: 0 };
+        const equatorPos: Vec3 = { x: 200, y: 0, z: 0 };
+        const polarCenter: Vec3 = { x: 60, y: 0, z: 80 };
+        const polarPos: Vec3 = { x: 120, y: 0, z: 160 };
+        expect(computePanSpeedMultiplier(polarCenter, polarPos)).toBeLessThan(computePanSpeedMultiplier(equatorCenter, equatorPos));
+    });
+});
+
+describe("computeZoomSpeedMultiplier", () => {
+    it("scales linearly with distance to the target (0.01×)", () => {
+        expect(computeZoomSpeedMultiplier(500)).toBeCloseTo(5, 9);
+        expect(computeZoomSpeedMultiplier(0)).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Implements and validates the remaining `GeospatialCamera` milestones from #14 (touch, keyboard, and the missing tests).

### M6 — Touch
- Two-finger pinch zooms toward the centroid (analytic ray-sphere pick).
- Pinch promotes to a pan once the centroid drifts >= 20 px.
- Pointer-driven pan/rotate is suppressed while two fingers are down.
- iOS gesture* / native page pinch-zoom are prevented.

### M6 — Keyboard (aligned to the BJS spec)
- Arrows **pan**, Ctrl+arrows **tilt** (pitch/yaw), +/- **zoom along the look vector**.
- Updated `docs/lite/architecture/38-geospatial-camera.md` to match.

### M4 — Movement pipeline (now testable)
- Extracted the inertial physics into pure `camera/geospatial-movement.ts`
  (frame-rate-normalized decay `inertia^(dt/16.67)`, latitude/altitude pan
  damping, distance-based zoom scaling). Controls behaviour is unchanged.

### Tests (M2 / M3 / M4 / M5 / M6)
35 new Vitest unit + plumbing tests under `tests/lite/unit`:
- `geospatial-math.test.ts` — basis orthonormality + pole fallback, yaw/pitch <-> lookAt round-trip, straight-down yaw preservation, pole clamp, default pose / world matrix, limits.
- `geospatial-movement.test.ts` — frame-rate-independent decay, inertia integration, lat/altitude pan damping, zoom scaling.
- `geospatial-controls.test.ts` — drag-plane pan + anchor cancellation, wheel zoom, keyboard pan/tilt/zoom, pinch zoom + 20 px pan threshold + dispose.

## Validation
- `vitest run --project unit`: **452 passed** (incl. the 35 new).
- `tsc -p tests/lite/tsconfig.json`: clean.
- Scene 225 parity: **MAD = 0.000** (static parity scene tree-shakes out the controls, so bundle size is unaffected).
- `bundle-size` gate: ceilings hold; ceiling spec & golden refs unchanged.

## Out of scope
The deferred **M7** items (clipping behavior, advanced `flyTo`, non-spherical up-vector hook) remain for a follow-up.
