### PR TITLE
Freeciv demo: smooth continuous zoom via render-to-texture

### DIFF
--- a/lab/lite/src/demos/freeciv.ts
+++ b/lab/lite/src/demos/freeciv.ts
@@ -13,7 +13,7 @@
  * and no tileset bytes are committed to this repo.
  */
 
-import { createEngine, createSprite2DLayer, createSpriteRenderer, registerSpriteRenderer, startEngine, type EngineContext, type Sprite2DLayer } from "babylon-lite";
+import { createEngine, createSprite2DLayer, createSpriteRenderer, registerSpriteRenderer, startEngine, type EngineContext } from "babylon-lite";
 import { loadFreecivSheet } from "./freeciv/atlas.js";
 import { createAtmosphere } from "./freeciv/atmosphere.js";
 import { createBackdrop } from "./freeciv/backdrop.js";
@@ -29,6 +29,7 @@ import { createGlints } from "./freeciv/glints.js";
 import { createLiveSim } from "./freeciv/live.js";
 import { createPicker } from "./freeciv/pick.js";
 import { createMinimap } from "./freeciv/minimap.js";
+import { createPresent } from "./freeciv/present.js";
 import { DIR8, DIR_DELTA, TILE_H, TILE_W, isoCentre, worldToTile } from "./freeciv/iso.js";
 import { demoAssetUrl } from "./demo-asset-url.js";
 import { installFetchProgress } from "./loading-progress.js";
@@ -154,12 +155,21 @@ async function main(): Promise<void> {
     };
 
     const view: View = { x: 0, y: 0, zoom: 1, userMoved: false };
+    // Recomputes the seam-safe RUNG render view + present scale from `view`. Assigned once the
+    // render target + present pass exist (just after the world renderer is built, below).
+    let syncView: () => void = () => {};
+    // Smooth wheel zoom: the wheel only nudges `zoomCtl.target` (+ records the world point under
+    // the cursor); the tick eases `view.zoom` toward it over several frames, so a notched mouse
+    // glides instead of stepping. Pan / minimap cancel the ease by snapping the target to live
+    // zoom. All view→render syncing happens in the tick so tiles and world FX move in lockstep.
+    const zoomCtl = { target: 1, wx: 0, wy: 0, sx: 0, sy: 0 };
     // Start pointed at Babylon (the player's capital) rather than the geometric
     // centre of the map bounds, which sits further south.
     const capital = world.cities.find((c) => c.name === "Babylon") ?? world.cities[0];
     const recenter = (): void => {
         if (view.userMoved) return;
         fitView(view, engine, bounds);
+        zoomCtl.target = view.zoom;
         if (capital) {
             const [wx, wy] = isoCentre(capital.x, capital.y);
             const w = engine.canvas.width || 1;
@@ -167,7 +177,7 @@ async function main(): Promise<void> {
             view.x = wx - w / 2 / view.zoom;
             view.y = wy - h / 2 / view.zoom;
         }
-        applyView(view, layers);
+        syncView();
     };
 
     // Subdued public-domain Mercator 1569 world map behind the playfield, plus a
@@ -181,6 +191,44 @@ async function main(): Promise<void> {
         clearValue: { r: 0.149, g: 0.29, b: 0.451, a: 1 }, // deep ocean blue
     });
     registerSpriteRenderer(sr);
+
+    // Smooth zoom: redirect the whole world renderer into a supersampled offscreen render
+    // target and present it scaled (see present.ts). `render` is the seam-safe RUNG view the
+    // tiles actually rasterise at — integer zoom + pixel-snapped origin + the RT size — while
+    // the fractional zoom lives in the present scale. World-anchored effects render into the
+    // same RT, so they are driven by `render`, not the continuous `view`.
+    const present = createPresent(engine, sr);
+    present.resize(engine.canvas.width || 1, engine.canvas.height || 1);
+    const render: RenderView = { x: 0, y: 0, zoom: 1, w: engine.canvas.width || 1, h: engine.canvas.height || 1, dz: 1 };
+    syncView = (): void => {
+        const cw = engine.canvas.width || 1;
+        const ch = engine.canvas.height || 1;
+        const z = view.zoom;
+        const R = ceilRung(z); // smallest seam-safe rung ≥ the continuous zoom
+        // The engine SpriteRenderer always projects at the CANVAS size even when targeting an
+        // offscreen RT (it reads the surface, not the target). So rendering into the SS×-sized RT
+        // stretches the canvas projection by SS. We pre-divide the projection zoom by SS so the
+        // stretch lands the tiles at exactly effective scale R in the RT (seam-safe), and size the
+        // fullscreen-FX quads to the canvas (the SS× stretch then fills the RT).
+        const ss = present.width / cw; // supersample factor (RT px per canvas px), exactly 2
+        render.zoom = R / ss; //          canvas-projection zoom; ×ss stretch ⇒ effective RT scale R
+        render.dz = z; //                 continuous display zoom (for the atmosphere altitude fade)
+        render.w = cw; //                 FX quads size to the canvas; the ×ss stretch fills the RT
+        render.h = ch;
+        // Snap the RT origin to the rung's (effective-scale-R) device-pixel grid so the alpha-baked
+        // diamonds tessellate crack-free; the sub-rung remainder is carried in the present offset.
+        render.x = Math.round(view.x * R) / R;
+        render.y = Math.round(view.y * R) / R;
+        for (const layer of layers) {
+            layer.view.positionPx[0] = render.x;
+            layer.view.positionPx[1] = render.y;
+            layer.view.zoom = render.zoom;
+        }
+        // Present the RT sub-rect matching the viewport. RT pixel of world W = (W − render.x)·R
+        // (effective scale R after the ×ss stretch); the viewport spans cw·R/z RT px. This composite
+        // exactly reproduces `world = view.x + screenPx/zoom`, so all inverse math uses raw `view`.
+        present.sync(cw, ch, (view.x - render.x) * R, (view.y - render.y) * R, (cw * R) / z, (ch * R) / z);
+    };
 
     // Drifting clouds over the parchment backdrop, behind the map (subtle).
     const atmosphere = createAtmosphere(engine, sr);
@@ -204,27 +252,32 @@ async function main(): Promise<void> {
     // forward `commandFx` declared above so the click handler can fire pings.
     commandFx = createCommandFx(engine, sr);
 
-    // Slow day/night cycle: a full-screen multiply grade plus warm additive city
-    // lights that bloom after sunset. Above the clouds, below the vignette/HUD.
+    // Slow day/night cycle: a full-screen alpha grade plus warm additive city lights that
+    // bloom after sunset. World-anchored, so it renders into the RT with the map.
     const dayNight = createDayNight(engine, sr, world);
 
-    // Screen-space vignette: darkens the corners so the void around the island
-    // fades to shadow instead of exposing the Mercator backdrop at the edges.
-    const vignette = createVignette(engine, sr);
+    // Screen-space vignette: darkens the corners so the void around the island fades to
+    // shadow. HUD layer — drawn on the present's swapchain pass, on top of the scaled map.
+    const vignette = createVignette(engine, present.screen);
 
-    installControls(engine, view, layers, picker.hover, onMapClick);
+    installControls(engine, view, zoomCtl, picker.hover, onMapClick);
     recenter();
-    window.addEventListener("resize", recenter);
+    const onResize = (): void => {
+        present.resize(engine.canvas.width || 1, engine.canvas.height || 1);
+        recenter(); // re-fits only if the user hasn't panned/zoomed
+        syncView(); // always re-anchor for the new RT size
+    };
+    window.addEventListener("resize", onResize);
 
     const labels = createCityLabels(world.cities);
 
-    // Overview minimap (corner). Its viewport box inverts the SAME snapped view the
-    // tiles render with; clicking/dragging recentres the main view on that tile.
-    const minimap = createMinimap(engine, sr, world, {
+    // Overview minimap (corner). A HUD layer on the present's swapchain pass; its viewport
+    // box inverts the continuous `view` the map is presented at.
+    const minimap = createMinimap(engine, present.screen, world, {
         viewportCorners: () => viewportTileCorners(view, engine),
         panToTile: (tx, ty) => {
             centreViewOnTile(view, engine, tx, ty);
-            applyView(view, layers);
+            zoomCtl.target = view.zoom; // cancel any in-flight zoom ease
         },
     });
 
@@ -234,26 +287,47 @@ async function main(): Promise<void> {
 
     // Animation loop: advance the live sim and reposition floating city labels.
     let last = performance.now();
+    // The GPU map is drawn by the engine's render loop, which runs a frame AFTER `syncView` sets
+    // its transform (the engine rAF was registered before this tick rAF). So the map you see this
+    // frame reflects the PREVIOUS tick's view. The DOM city labels paint the same frame the tick
+    // runs, so to keep them glued to the map we drive them from this one-frame-old snapshot —
+    // otherwise they lead the map by a frame and visibly bump when the zoom accelerates/decelerates.
+    const presentedView: View = { x: view.x, y: view.y, zoom: view.zoom, userMoved: false };
     const tick = (now: number): void => {
         const dt = Math.min(100, now - last);
         last = now;
         sim.step(dt);
+        // Ease the continuous zoom toward the wheel target, holding the cursor's world point
+        // fixed, so notched wheels glide. Driving it here (not in the wheel event) keeps the
+        // tiles and all world-anchored FX in lockstep — they all read the SAME `view` this frame.
+        if (Math.abs(zoomCtl.target - view.zoom) > 1e-4) {
+            view.zoom += (zoomCtl.target - view.zoom) * 0.25;
+            if (Math.abs(zoomCtl.target - view.zoom) <= 1e-4) view.zoom = zoomCtl.target;
+            view.x = zoomCtl.wx - zoomCtl.sx / view.zoom;
+            view.y = zoomCtl.wy - zoomCtl.sy / view.zoom;
+            view.userMoved = true;
+        }
+        syncView(); // recompute the seam-safe render view + present scale for this frame
         const [scoutX, scoutY] = sim.scoutTile();
-        fog.update(view, scoutX, scoutY);
-        dayNight.update(view);
-        glints.update(view, dayNight.daylight());
+        fog.update(render, scoutX, scoutY);
+        dayNight.update(render);
+        glints.update(render, dayNight.daylight());
         const [scoutWx, scoutWy] = sim.scoutWorld();
-        dust.update(view, scoutWx, scoutWy, sim.scoutMoving(), dt);
+        dust.update(render, scoutWx, scoutWy, sim.scoutMoving(), dt);
         // Clear the marching-ants destination once the scout reaches it (idle again).
         if (scoutDest && !sim.scoutMoving()) {
             const [stx, sty] = sim.scoutTile();
             if (stx === scoutDest[0] && sty === scoutDest[1]) scoutDest = null;
         }
-        commandFx?.update(view, { dest: scoutDest }, dt);
-        atmosphere.update(view, dayNight.daylight());
+        commandFx?.update(render, { dest: scoutDest }, dt);
+        atmosphere.update(render, dayNight.daylight());
         vignette.update();
         waterFx.update();
-        labels.update(view, engine);
+        labels.update(presentedView, engine);
+        // Snapshot the view the engine will composite the map from next frame (see presentedView).
+        presentedView.x = view.x;
+        presentedView.y = view.y;
+        presentedView.zoom = view.zoom;
         minimap.update();
         requestAnimationFrame(tick);
     };
@@ -314,14 +388,12 @@ function createCityLabels(cities: readonly { x: number; y: number; name: string;
         update(view: View, engine: EngineContext): void {
             const cv = engine.canvas as HTMLCanvasElement;
             const dpr = (cv.width || 1) / (cv.clientWidth || 1);
-            // Match the snapped transform the tiles render with so labels don't
-            // drift off their tiles by a fraction of a pixel.
-            const z = snapZoom(view.zoom);
-            const vx = Math.round(view.x * z) / z;
-            const vy = Math.round(view.y * z) / z;
+            // The present composite reproduces the world exactly at the continuous view
+            // (world = view.x + screenPx/zoom), so labels track the raw view — no rung snap.
+            const z = view.zoom;
             for (const a of anchors) {
-                const sx = ((a.wx - vx) * z) / dpr;
-                const sy = ((a.wy - vy) * z) / dpr;
+                const sx = ((a.wx - view.x) * z) / dpr;
+                const sy = ((a.wy - view.y) * z) / dpr;
                 a.el.style.transform = `translate(${sx}px, ${sy}px) translate(-50%, -100%)`;
             }
         },
@@ -335,88 +407,62 @@ interface View {
     userMoved: boolean;
 }
 
+/** The seam-safe RUNG view the world is rasterised at (integer zoom + pixel-snapped origin)
+ *  plus the render-target size in device pixels. World-anchored effects read this, not `view`. */
+interface RenderView {
+    x: number;
+    y: number;
+    zoom: number;
+    w: number;
+    h: number;
+    /** Continuous display zoom (the perceived zoom); `zoom` is the seam-safe rung. */
+    dz: number;
+}
+
+/** Continuous-zoom clamp = the rung ladder's extremes (the minimap owns the whole-map
+ *  overview, so the main canvas need not zoom out past ½). */
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 8;
+
 /** Fit the whole map into the viewport and centre it. */
 function fitView(view: View, engine: EngineContext, b: Bounds): void {
     const w = engine.canvas.width || 1;
     const h = engine.canvas.height || 1;
     const mapW = b.maxX - b.minX + TILE_W;
     const mapH = b.maxY - b.minY + TILE_H;
-    // Seed the zoom on the ladder so the very first frame is already crack-free and
-    // in lock-step with the wheel handler (snapped to ½, the widest rung).
-    view.zoom = snapZoom(Math.min(w / mapW, h / mapH) * 0.95);
+    // Seed continuous zoom, clamped to the rung range.
+    view.zoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Math.min(w / mapW, h / mapH) * 0.95));
     const cx = (b.minX + b.maxX) / 2;
     const cy = (b.minY + b.maxY) / 2;
     view.x = cx - w / 2 / view.zoom;
     view.y = cy - h / 2 / view.zoom;
 }
 
-function applyView(view: View, layers: readonly Sprite2DLayer[]): void {
-    // The iso tiles are alpha-baked diamonds that tessellate by sharing edges.
-    // With nearest filtering this is only seamless when one texel maps to a whole
-    // number of device pixels — i.e. at INTEGER zoom — and when the grid origin
-    // lands on the device-pixel grid (otherwise every diamond edge resamples at a
-    // fractional offset and a 1px crack appears between tiles). So we render with a
-    // snapped view: zoom rounded to an integer (when zoomed in) and the origin
-    // rounded to the nearest 1/zoom. The logical `view` stays unsnapped so panning
-    // and wheel-zoom still accumulate smoothly; only the per-layer view is snapped.
-    const z = snapZoom(view.zoom);
-    const snapX = Math.round(view.x * z) / z;
-    const snapY = Math.round(view.y * z) / z;
-    for (const layer of layers) {
-        layer.view.positionPx[0] = snapX;
-        layer.view.positionPx[1] = snapY;
-        layer.view.zoom = z;
-    }
-}
-
 /**
- * Discrete zoom ladder. Every rung is seam-safe for nearest-filtered diamond tiles:
- * the ≥1 rungs are integers (one texel maps to a whole number of device pixels, so
- * shared diamond edges never resample at a fractional offset — no 1px cracks), and
- * the ½ rung minifies the tiles enough that any sub-pixel seam is invisible. The
- * whole-map overview lives on the minimap, so the main canvas need not zoom out
- * past ½. Zoom is quantised to these rungs (see the wheel handler) so it can never
- * land on a crack-producing fractional scale — which is why the old render-time
- * integer snap is gone and `view.zoom` is always exactly one of these values.
+ * Seam-safe zoom rungs for nearest-filtered diamond tiles: the ≥1 rungs are integers (one
+ * texel maps to a whole number of device pixels, so shared diamond edges never resample — no
+ * 1px cracks), and the ½ rung minifies enough that any sub-pixel seam is invisible. The tiles
+ * are always rasterised at one of these (into the offscreen RT); the present pass then scales
+ * that crack-free image to the continuous on-screen zoom (see syncView / present.ts).
  */
-const ZOOM_LEVELS = [0.5, 1, 2, 4, 8] as const;
+const ZOOM_RUNGS = [0.5, 1, 2, 4, 8] as const;
 
-/** Index of the ladder rung nearest `zoom`, compared in log space so the
- *  power-of-two gaps feel perceptually even. */
-function nearestZoomLevel(zoom: number): number {
-    const target = Math.log(zoom);
-    let best = 0;
-    let bestErr = Infinity;
-    for (let i = 0; i < ZOOM_LEVELS.length; i++) {
-        const err = Math.abs(Math.log(ZOOM_LEVELS[i]!) - target);
-        if (err < bestErr) {
-            bestErr = err;
-            best = i;
-        }
+/** Smallest rung ≥ `zoom`, clamped to the ladder. Rendering at the CEILING rung and
+ *  down-scaling on present keeps the pixel art crisp (a floor rung would up-scale = blur). */
+function ceilRung(zoom: number): number {
+    for (const r of ZOOM_RUNGS) {
+        if (zoom <= r + 1e-6) return r;
     }
-    return best;
+    return ZOOM_RUNGS[ZOOM_RUNGS.length - 1]!;
 }
 
 /**
- * Snap an arbitrary zoom to its nearest ladder rung. Because the wheel handler keeps
- * `view.zoom` ON a rung at all times, this is effectively identity for the live view;
- * it only does real work for the one-off `fitView` seed. Kept as the single chokepoint
- * so `screenToTile`, the city labels and the minimap all read the same rendered scale.
- */
-function snapZoom(zoom: number): number {
-    return ZOOM_LEVELS[nearestZoomLevel(zoom)]!;
-}
-
-/**
- * Device-pixel cursor position → tile `(x, y)`. Inverts the SNAPPED view that is
- * actually rendered (same `snapZoom` + rounded origin as {@link applyView}), so the
- * tile under the highlight matches the tile under the pointer exactly.
+ * Device-pixel cursor position → tile `(x, y)`. The present composite reproduces the world
+ * exactly at the continuous view (`world = view.x + screenPx/zoom`), so this inverts the raw
+ * `view` directly — the tile under the highlight matches the tile under the pointer exactly.
  */
 function screenToTile(view: View, sxDevice: number, syDevice: number): [number, number] {
-    const z = snapZoom(view.zoom);
-    const vx = Math.round(view.x * z) / z;
-    const vy = Math.round(view.y * z) / z;
-    return worldToTile(vx + sxDevice / z, vy + syDevice / z);
+    return worldToTile(view.x + sxDevice / view.zoom, view.y + syDevice / view.zoom);
 }
 
 /**
@@ -426,9 +472,9 @@ function screenToTile(view: View, sxDevice: number, syDevice: number): [number, 
  * {@link screenToTile} but WITHOUT rounding (we want the exact sub-tile quad).
  */
 function viewportTileCorners(view: View, engine: EngineContext): Array<[number, number]> {
-    const z = snapZoom(view.zoom);
-    const vx = Math.round(view.x * z) / z;
-    const vy = Math.round(view.y * z) / z;
+    const z = view.zoom;
+    const vx = view.x;
+    const vy = view.y;
     const w = engine.canvas.width || 1;
     const h = engine.canvas.height || 1;
     const screen: ReadonlyArray<readonly [number, number]> = [
@@ -525,7 +571,17 @@ function findPath(world: GameMap, sx: number, sy: number, gx: number, gy: number
 /** Callback fired as the cursor moves over the map; `tileX = null` clears hover. */
 type HoverFn = (tileX: number | null, tileY: number | null, cssX: number, cssY: number) => void;
 
-function installControls(engine: EngineContext, view: View, layers: readonly Sprite2DLayer[], onHover?: HoverFn, onClick?: (tileX: number, tileY: number) => void): void {
+/** Smooth-zoom controller: the wheel writes a `target` + cursor anchor here; the tick eases
+ *  `view.zoom` toward it (see the tick loop). Pan / minimap cancel the ease by matching target. */
+interface ZoomCtl {
+    target: number;
+    wx: number;
+    wy: number;
+    sx: number;
+    sy: number;
+}
+
+function installControls(engine: EngineContext, view: View, zoomCtl: ZoomCtl, onHover?: HoverFn, onClick?: (tileX: number, tileY: number) => void): void {
     const canvas = engine.canvas as HTMLCanvasElement;
     const dpr = (): number => (canvas.width || 1) / (canvas.clientWidth || 1);
     let dragging = false;
@@ -548,7 +604,8 @@ function installControls(engine: EngineContext, view: View, layers: readonly Spr
             lastX = e.clientX;
             lastY = e.clientY;
             view.userMoved = true;
-            applyView(view, layers);
+            zoomCtl.target = view.zoom; // a pan cancels any in-flight zoom ease
+            // No syncView() here: the tick re-syncs every frame, keeping tiles + FX in lockstep.
         } else if (onHover) {
             const rect = canvas.getBoundingClientRect();
             const [tx, ty] = screenToTile(view, (e.clientX - rect.left) * dpr(), (e.clientY - rect.top) * dpr());
@@ -572,49 +629,25 @@ function installControls(engine: EngineContext, view: View, layers: readonly Spr
     });
     canvas.addEventListener("pointercancel", endDrag);
 
-    // Discrete, device-independent zoom: scroll accumulates until it crosses one
-    // notch's worth of delta, then steps exactly one ladder rung. This kills the old
-    // "dead zone then lurch" feel (continuous zoom rounded to an integer at render
-    // time) — every step is the same size and lands on a seam-safe rung. No tween:
-    // an animated transit would pass through fractional integer-zooms and flash the
-    // 1px tile cracks the ladder exists to avoid.
-    const WHEEL_NOTCH = 100; // device-px of scroll per zoom step (one mouse notch)
-    let wheelAccum = 0;
+    // Continuous, cursor-anchored wheel zoom. The wheel only nudges the eased TARGET (and records
+    // the world point under the cursor); the tick glides `view.zoom` toward it and re-anchors each
+    // frame, so a notched mouse zooms smoothly instead of jumping a step per notch. The seam-safe
+    // rung rasterisation + scaled present (syncView / present.ts) keep every fractional zoom
+    // crack-free along the way.
     canvas.addEventListener(
         "wheel",
         (e) => {
             e.preventDefault();
-            wheelAccum += e.deltaY;
-            let steps = 0; // +1 per notch = zoom IN (scroll up → negative deltaY)
-            while (wheelAccum <= -WHEEL_NOTCH) {
-                steps++;
-                wheelAccum += WHEEL_NOTCH;
-            }
-            while (wheelAccum >= WHEEL_NOTCH) {
-                steps--;
-                wheelAccum -= WHEEL_NOTCH;
-            }
-            if (steps === 0) return;
-
-            const idx = nearestZoomLevel(view.zoom);
-            const next = Math.min(ZOOM_LEVELS.length - 1, Math.max(0, idx + steps));
-            if (next === idx) return; // already at a rail
-
             const rect = canvas.getBoundingClientRect();
             const sx = (e.clientX - rect.left) * dpr();
             const sy = (e.clientY - rect.top) * dpr();
-            // Hold the world point under the cursor fixed across the step. Anchor on the
-            // SNAPPED origin that is actually rendered (matching `applyView`), else the
-            // target appears to orbit the corner instead of staying under the pointer.
-            const zBefore = snapZoom(view.zoom);
-            const wx = Math.round(view.x * zBefore) / zBefore + sx / zBefore;
-            const wy = Math.round(view.y * zBefore) / zBefore + sy / zBefore;
-            const zAfter = ZOOM_LEVELS[next]!;
-            view.zoom = zAfter;
-            view.x = wx - sx / zAfter;
-            view.y = wy - sy / zAfter;
-            view.userMoved = true;
-            applyView(view, layers);
+            // Anchor on the world point currently under the cursor (live zoom), so the ease holds
+            // it fixed even if more notches arrive mid-glide.
+            zoomCtl.wx = view.x + sx / view.zoom;
+            zoomCtl.wy = view.y + sy / view.zoom;
+            zoomCtl.sx = sx;
+            zoomCtl.sy = sy;
+            zoomCtl.target = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoomCtl.target * Math.pow(2, -e.deltaY / 500)));
         },
         { passive: false }
     );

--- a/lab/lite/src/demos/freeciv/atmosphere.ts
+++ b/lab/lite/src/demos/freeciv/atmosphere.ts
@@ -43,6 +43,11 @@ export interface AtmosphereView {
     x: number;
     y: number;
     zoom: number;
+    /** Render-target size in device pixels (the cloud/shadow quads fill it). Defaults to the canvas. */
+    w?: number;
+    h?: number;
+    /** Continuous display zoom for the altitude fade (`zoom` is the seam-safe rung). */
+    dz?: number;
 }
 
 export interface Atmosphere {
@@ -186,11 +191,13 @@ export function createAtmosphere(engine: EngineContext, sr: SpriteRenderer): Atm
 
     return {
         update(view: AtmosphereView, daylight: number): void {
-            const w = engine.canvas.width || 1;
-            const h = engine.canvas.height || 1;
-            // Clouds live at "altitude": visible only on the zoomed-out rungs, fading
-            // out as you zoom in past 1 so the camera drops below them.
-            const vis = Math.max(0, Math.min(1, (CLOUD_FADE_HI - view.zoom) / (CLOUD_FADE_HI - CLOUD_FADE_LO)));
+            const w = view.w ?? (engine.canvas.width || 1);
+            const h = view.h ?? (engine.canvas.height || 1);
+            // Clouds live at "altitude": visible only zoomed out, fading out as you zoom in
+            // past 1. Use the CONTINUOUS display zoom (`dz`) for the fade — `view.zoom` is the
+            // rung the world rasterises at, which would make clouds vanish abruptly at a rung.
+            const dz = view.dz ?? view.zoom;
+            const vis = Math.max(0, Math.min(1, (CLOUD_FADE_HI - dz) / (CLOUD_FADE_HI - CLOUD_FADE_LO)));
             // World rectangle on screen: a world point W draws at (W − view) · zoom, so
             // screen-left (uv 0) is world `view.x` and the span is `canvas / zoom`.
             const originX = view.x * CLOUD_SCALE;

--- a/lab/lite/src/demos/freeciv/daynight.ts
+++ b/lab/lite/src/demos/freeciv/daynight.ts
@@ -40,6 +40,9 @@ export interface DayNightView {
     x: number;
     y: number;
     zoom: number;
+    /** Render-target size in device pixels (the grade quad fills it). Defaults to the canvas. */
+    w?: number;
+    h?: number;
 }
 
 export interface DayNight {
@@ -175,9 +178,11 @@ export function createDayNight(engine: EngineContext, sr: SpriteRenderer, world:
             const og = 0.06;
             const ob = 0.18;
             const alpha = level * 0.62; // 0 at full day → 0.62 at midnight, linear in time
+            const gw = view.w ?? (engine.canvas.width || 1);
+            const gh = view.h ?? (engine.canvas.height || 1);
             updateSprite2DIndex(gradeLayer, gradeIndex, {
-                positionPx: [(engine.canvas.width || 1) / 2, (engine.canvas.height || 1) / 2],
-                sizePx: [engine.canvas.width || 1, engine.canvas.height || 1],
+                positionPx: [gw / 2, gh / 2],
+                sizePx: [gw, gh],
                 color: [or, og, ob, alpha],
             });
 

--- a/lab/lite/src/demos/freeciv/fog.ts
+++ b/lab/lite/src/demos/freeciv/fog.ts
@@ -53,6 +53,9 @@ export interface FogView {
     x: number;
     y: number;
     zoom: number;
+    /** Render-target size in device pixels (the haze quad fills it). Defaults to the canvas. */
+    w?: number;
+    h?: number;
 }
 
 export interface Fog {
@@ -237,8 +240,8 @@ export function createFog(engine: EngineContext, sr: SpriteRenderer, world: Game
             // Fullscreen quad centred on the canvas; the tint carries the world rectangle
             // currently on screen (a world point W draws at (W − view) · zoom, so screen
             // uv 0 is world `view` and the span is `canvas / zoom`).
-            const w = engine.canvas.width || 1;
-            const h = engine.canvas.height || 1;
+            const w = view.w ?? (engine.canvas.width || 1);
+            const h = view.h ?? (engine.canvas.height || 1);
             updateSprite2DIndex(layer, sprite, {
                 positionPx: [w * 0.5, h * 0.5],
                 sizePx: [w, h],

--- a/lab/lite/src/demos/freeciv/glints.ts
+++ b/lab/lite/src/demos/freeciv/glints.ts
@@ -52,6 +52,9 @@ export interface GlintsView {
     x: number;
     y: number;
     zoom: number;
+    /** Render-target size in device pixels (the sparkle quad fills it). Defaults to the canvas. */
+    w?: number;
+    h?: number;
 }
 
 export interface Glints {
@@ -156,8 +159,8 @@ export function createGlints(engine: EngineContext, sr: SpriteRenderer, world: G
             // Fullscreen quad centred on the canvas; the tint carries the world rectangle
             // currently on screen (a world point W draws at (W − view) · zoom, so screen uv 0
             // is world `view` and the span is `canvas / zoom`). `daylight` rides in fx.params.x.
-            const w = engine.canvas.width || 1;
-            const h = engine.canvas.height || 1;
+            const w = view.w ?? (engine.canvas.width || 1);
+            const h = view.h ?? (engine.canvas.height || 1);
             updateSprite2DIndex(layer, sprite, {
                 positionPx: [w * 0.5, h * 0.5],
                 sizePx: [w, h],

--- a/lab/lite/src/demos/freeciv/present.ts
+++ b/lab/lite/src/demos/freeciv/present.ts
@@ -1,0 +1,167 @@
+/**
+ * Smooth-zoom present pass for the Freeciv demo.
+ *
+ * The isometric tiles are alpha-baked diamonds that only tessellate crack-free when
+ * rasterised at an INTEGER zoom rung (one texel → a whole number of device pixels).
+ * That is why the demo's logical zoom used to be quantised to a ladder. To get smooth,
+ * continuous zoom we decouple the two scales:
+ *
+ *   1. The whole *world* `SpriteRenderer` is redirected to render into an offscreen
+ *      render texture (`worldRt`) at the nearest seam-safe rung — perfect tessellation,
+ *      no cracks. The render target is SUPERSAMPLED (≈2× the canvas) so that between
+ *      rungs we sample MORE than one RT texel per screen pixel and *down*-scale, which
+ *      keeps the pixel-art crisp instead of the blur an up-scale would give.
+ *   2. A "present" `SpriteRenderer` owns a single full-screen quad whose atlas IS that
+ *      render texture. Each frame it samples the sub-rectangle of the RT that corresponds
+ *      to the current viewport and scales it to the canvas (linear filtering), so the
+ *      *fractional* part of the zoom lives entirely in this image scale. One continuous
+ *      bitmap scaling smoothly → zero inter-tile seams at any zoom.
+ *   3. A third "HUD" `SpriteRenderer` draws screen-space overlays (vignette, minimap) onto
+ *      the swapchain AFTER the present quad — unscaled and uncropped, on top of the map.
+ *
+ * The three renderers run in registration order world → present → HUD, so each runs after
+ * the one before and composites over the finished result. Built entirely on the public
+ * sprite API plus the opt-in offscreen-target capability (`createRenderTexture2D` +
+ * `setSpriteRendererTarget`); no engine changes.
+ */
+
+import {
+    addSprite2DIndex,
+    createGridSpriteAtlas,
+    createRenderTexture2D,
+    createSprite2DCustomShader,
+    createSprite2DLayer,
+    createSpriteRenderer,
+    disposeSpriteRenderer,
+    registerSpriteRenderer,
+    setSprite2DShaderParams,
+    setSpriteRendererTarget,
+    unregisterSpriteRenderer,
+    updateSprite2DIndex,
+    type EngineContext,
+    type Sprite2DLayer,
+    type SpriteRenderer,
+    type Texture2D,
+} from "babylon-lite";
+
+/**
+ * Present fragment: sample the world render texture over a per-frame sub-rectangle.
+ * `fx.params` = (uvScaleX, uvScaleY, uvOffsetX, uvOffsetY); `in.uv` (0..1 across the
+ * full-screen quad) is remapped into the RT's UV space so only the viewport portion is
+ * shown, scaled to fill the canvas. Linear sampling (the RT's default) makes the between-
+ * rung down-scale smooth. `atlasTex`/`atlasSamp` are bound to the world RT.
+ */
+const PRESENT_FRAGMENT = `
+let uv = in.uv * vec2<f32>(fx.params.x, fx.params.y) + vec2<f32>(fx.params.z, fx.params.w);
+return textureSample(atlasTex, atlasSamp, uv) * in.tint * L.opacityMul;
+`;
+
+/** Supersample factor for the world render target (RT pixels per canvas pixel, each axis).
+ * 2 covers the worst case: just past a rung, R/zoom approaches 2, so the viewport occupies
+ * up to ~2× canvas RT pixels that are then down-scaled to the canvas. */
+const SUPERSAMPLE = 2;
+
+export interface Present {
+    /** Current world render-target size in device pixels (≈ canvas × SUPERSAMPLE). */
+    readonly width: number;
+    readonly height: number;
+    /** Swapchain HUD renderer (drawn last). Register screen-space overlay layers here. */
+    readonly screen: SpriteRenderer;
+    /** (Re)allocate the render target for a new canvas backing size and rewire the world renderer. */
+    resize: (canvasW: number, canvasH: number) => void;
+    /**
+     * Point the present quad at the RT sub-rectangle `[srcX, srcX+srcW) × [srcY, srcY+srcH)`
+     * (in RT device pixels) and stretch it across the whole canvas.
+     */
+    sync: (canvasW: number, canvasH: number, srcX: number, srcY: number, srcW: number, srcH: number) => void;
+    /** Tear down GPU resources (does not retarget the world renderer). */
+    dispose: () => void;
+}
+
+/**
+ * Wire smooth-zoom presentation onto `worldSr` (which must already be registered). Returns a
+ * {@link Present}; call {@link Present.resize} once with the initial canvas size, then
+ * {@link Present.sync} each frame. Register HUD layers on {@link Present.screen}.
+ */
+export function createPresent(engine: EngineContext, worldSr: SpriteRenderer): Present {
+    const shader = createSprite2DCustomShader({ fragment: PRESENT_FRAGMENT });
+
+    // HUD renderer: created once, kept across resizes. `clear: false` so it composites over
+    // the present quad (which already filled every pixel) instead of wiping it.
+    const hudSr = createSpriteRenderer(engine, { layers: [], clear: false });
+    let hudRegistered = false;
+
+    let worldRt: Texture2D | null = null;
+    let presentSr: SpriteRenderer | null = null;
+    let presentLayer: Sprite2DLayer | null = null;
+    let presentSprite = -1;
+    let rtW = 0;
+    let rtH = 0;
+
+    const build = (canvasW: number, canvasH: number): void => {
+        // Tear down the old present chain. The world renderer keeps rendering to the old RT
+        // until we retarget it below, so order of operations is safe.
+        if (presentSr) {
+            disposeSpriteRenderer(presentSr); // unregisters + frees the present layer GPU
+            presentSr = null;
+            presentLayer = null;
+            presentSprite = -1;
+        }
+        if (worldRt) {
+            worldRt.texture.destroy();
+            worldRt = null;
+        }
+        // Drop the HUD's registration so the rebuilt present pass re-inserts before it.
+        if (hudRegistered) {
+            unregisterSpriteRenderer(hudSr);
+            hudRegistered = false;
+        }
+
+        rtW = Math.max(1, Math.round(canvasW * SUPERSAMPLE));
+        rtH = Math.max(1, Math.round(canvasH * SUPERSAMPLE));
+        worldRt = createRenderTexture2D(engine, rtW, rtH);
+        const atlas = createGridSpriteAtlas(worldRt, { cellWidthPx: rtW, cellHeightPx: rtH, pivot: [0.5, 0.5] });
+        presentLayer = createSprite2DLayer(atlas, { capacity: 1, pivot: [0.5, 0.5], customShader: shader });
+        presentSprite = addSprite2DIndex(presentLayer, { positionPx: [canvasW / 2, canvasH / 2], sizePx: [canvasW, canvasH], frame: 0, visible: true });
+        presentSr = createSpriteRenderer(engine, { layers: [presentLayer] }); // default clear: wipes the swapchain, then the opaque present quad fills it
+
+        // Registration order is render order: worldSr (already first) → present → HUD.
+        registerSpriteRenderer(presentSr);
+        registerSpriteRenderer(hudSr);
+        hudRegistered = true;
+
+        setSpriteRendererTarget(worldSr, worldRt);
+        setSprite2DShaderParams(presentLayer, [1, 1, 0, 0]);
+    };
+
+    return {
+        get width(): number {
+            return rtW;
+        },
+        get height(): number {
+            return rtH;
+        },
+        get screen(): SpriteRenderer {
+            return hudSr;
+        },
+        resize(canvasW: number, canvasH: number): void {
+            if (canvasW < 1 || canvasH < 1) return;
+            if (worldRt && Math.round(canvasW * SUPERSAMPLE) === rtW && Math.round(canvasH * SUPERSAMPLE) === rtH) return;
+            build(canvasW, canvasH);
+        },
+        sync(canvasW: number, canvasH: number, srcX: number, srcY: number, srcW: number, srcH: number): void {
+            if (!presentLayer || presentSprite < 0) return;
+            updateSprite2DIndex(presentLayer, presentSprite, { positionPx: [canvasW / 2, canvasH / 2], sizePx: [canvasW, canvasH], visible: true });
+            setSprite2DShaderParams(presentLayer, [srcW / rtW, srcH / rtH, srcX / rtW, srcY / rtH]);
+        },
+        dispose(): void {
+            if (presentSr) disposeSpriteRenderer(presentSr);
+            if (hudRegistered) unregisterSpriteRenderer(hudSr);
+            disposeSpriteRenderer(hudSr);
+            if (worldRt) worldRt.texture.destroy();
+            presentSr = null;
+            presentLayer = null;
+            worldRt = null;
+        },
+    };
+}

--- a/lab/public/bundle/demos-manifest.json
+++ b/lab/public/bundle/demos-manifest.json
@@ -1,46 +1,46 @@
 {
   "offscreen": {
-    "rawKB": 179.3,
-    "gzipKB": 74.4
+    "rawKB": 180.3,
+    "gzipKB": 75.7
   },
   "torus-states": {
-    "rawKB": 25.2,
-    "gzipKB": 8.6
+    "rawKB": 25.1,
+    "gzipKB": 8.8
   },
   "doom": {
-    "rawKB": 123.9,
-    "gzipKB": 41.2
+    "rawKB": 126.6,
+    "gzipKB": 42.5
   },
   "quake": {
-    "rawKB": 126.5,
-    "gzipKB": 45.8
+    "rawKB": 127.8,
+    "gzipKB": 46.3
   },
   "minecraft": {
-    "rawKB": 105.9,
-    "gzipKB": 38
+    "rawKB": 107.2,
+    "gzipKB": 38.8
   },
   "freeciv": {
-    "rawKB": 64.1,
-    "gzipKB": 24.2
+    "rawKB": 67.1,
+    "gzipKB": 25.2
   },
   "tetris": {
-    "rawKB": 69.6,
-    "gzipKB": 25.3
+    "rawKB": 70.5,
+    "gzipKB": 26
   },
   "mosquito-amber": {
-    "rawKB": 104.2,
-    "gzipKB": 40.9
+    "rawKB": 105,
+    "gzipKB": 41.8
   },
   "littlest-tokyo": {
-    "rawKB": 58.5,
-    "gzipKB": 23.2
+    "rawKB": 59,
+    "gzipKB": 23.8
   },
   "bath-day": {
-    "rawKB": 177.7,
-    "gzipKB": 61
+    "rawKB": 178.5,
+    "gzipKB": 61.8
   },
   "platformer": {
-    "rawKB": 81.5,
-    "gzipKB": 28.7
+    "rawKB": 82.2,
+    "gzipKB": 29.1
   }
 }


### PR DESCRIPTION
Replaces the freeciv demo's discrete zoom ladder (`0.5, 1, 2, 4, 8`) with smooth, continuous, cursor-anchored zoom — built on the engine's offscreen render-target capability (`createRenderTexture2D` + `setSpriteRendererTarget`). No engine changes.

## The problem

The isometric tiles are alpha-baked diamonds that only tessellate crack-free when rasterised at an **integer** zoom (one texel → a whole number of device pixels). To avoid 1px seams, zoom was previously quantised to a fixed ladder, so it stepped.

## The approach

Decouple the *rasterisation* scale from the *display* scale (new `freeciv/present.ts`):

1. **World → offscreen RT.** The whole world `SpriteRenderer` renders into a supersampled (2×) render texture at the nearest seam-safe integer rung, so the diamonds always tessellate perfectly.
2. **Scaled present.** A second `SpriteRenderer` draws one full-screen quad that samples the RT sub-rectangle matching the viewport and scales it to the canvas (linear). The *fractional* zoom lives entirely in this image scale — one continuous bitmap scaling smoothly, so there are **zero inter-tile seams at any zoom**. Rendering at the ceiling rung + down-scaling keeps the pixel art crisp.
3. **HUD pass.** A third `SpriteRenderer` draws the screen-space overlays (vignette, minimap) on top, unscaled.

The composite exactly reproduces `world = view.x + screenPx / zoom`, so all the inverse-view math (picking, minimap box, city labels) reads the raw continuous view.

## Details worth noting

- **Eased zoom.** The wheel nudges a target; the tick eases `view.zoom` toward it while holding the cursor's world point fixed, so notched mice glide instead of stepping.
- **Lockstep updates.** All view→render syncing happens once per frame in the tick, so the tiles and every world-anchored effect (fog, sun-glints, clouds + shadows, day/night grade, dust, command FX) move together — no lag-and-snap.
- **Supersample compensation.** The engine's `SpriteRenderer` projects at the canvas size even when targeting an offscreen RT, so the world layers' projection zoom is pre-divided by the supersample factor to land tiles at the exact rung scale in the 2× RT.
- **One-frame label sync.** The GPU map is composited a frame after the tick sets its transform, so the DOM city labels are driven from a one-frame-old view snapshot to stay glued to the map through zoom accel/decel.