### PR TITLE
fix(engine): GPU frame timer uses standard timestampWrites pass attachments

### DIFF
--- a/packages/babylon-lite/src/engine/gpu-timer.ts
+++ b/packages/babylon-lite/src/engine/gpu-timer.ts
@@ -1,21 +1,20 @@
 // engine/gpu-timer.ts — optional GPU frame-time measurement.
 //
-// Measures how long the GPU spends on a frame using a WebGPU `timestamp-query`. The opening and closing
-// timestamps are written *into the frame's own command encoder* (`gpuFrameTimerBegin` as the first
-// command, `gpuFrameTimerEnd` as the last), so the GPU runs them contiguously around exactly that frame's
-// passes — measuring the frame's GPU work, not the CPU time spent recording it. After the frame is
-// submitted, `gpuFrameTimerResolve` copies the pair into a mapped readback buffer ASYNCHRONOUSLY — off the
-// render critical path — so the measurement barely perturbs the number it reports (no pipeline stall, no
-// per-draw cost).
+// Measures how long the GPU spends on a frame using a WebGPU `timestamp-query`. Two EMPTY pass attachments
+// bracket the frame's recorded work: `gpuFrameTimerBegin` records an empty compute pass (as the encoder's first
+// command) whose BEGINNING timestamp is its slot-0 write, and `gpuFrameTimerEnd` records an empty compute pass
+// (as the last command) whose END timestamp is its slot-1 write — so the GPU runs them contiguously around
+// exactly that frame's passes, measuring the frame's GPU work, not the CPU time spent recording it. This uses
+// the STANDARD `timestampWrites` pass attachments (NOT the legacy `GPUCommandEncoder.writeTimestamp`, which
+// Chromium exposes only behind `--enable-unsafe-webgpu`), so it works in stock Chrome/Edge whenever the adapter
+// offers the `timestamp-query` feature. After the frame is submitted, `gpuFrameTimerResolve` copies the pair
+// into a mapped readback buffer ASYNCHRONOUSLY — off the render critical path — so the measurement barely
+// perturbs the number it reports (no pipeline stall, no per-draw cost).
 //
 // Entirely opt-in: the timer is only created on first enable, its per-frame hooks are installed only while
 // timing is on (so nothing is written while disabled), and the whole feature degrades to a no-op on
-// adapters lacking the `timestamp-query` feature (or the `GPUCommandEncoder.writeTimestamp` method).
-// renderFrame ships only three optional-chain short-circuits. Pure state + free functions (no methods, no
-// import side effects) per the engine's data-oriented style.
-
-/** Minimal structural type for the `writeTimestamp` method (not in every \@webgpu/types version). */
-type TimestampWriter = { writeTimestamp(querySet: GPUQuerySet, queryIndex: number): void };
+// adapters lacking the `timestamp-query` feature. renderFrame ships only three optional-chain short-circuits.
+// Pure state + free functions (no methods, no import side effects) per the engine's data-oriented style.
 
 export interface GpuFrameTimer {
     readonly device: GPUDevice;
@@ -31,9 +30,10 @@ export interface GpuFrameTimer {
     inFlight: number;
 }
 
-/** Whether a device can measure GPU time (has `timestamp-query` and the encoder write method). */
+/** Whether a device can measure GPU time — it offered the `timestamp-query` feature (which also enables the
+ *  standard `timestampWrites` pass attachments this timer uses; no `--enable-unsafe-webgpu` flag required). */
 export function gpuTimingSupportedFor(device: GPUDevice): boolean {
-    return device.features.has("timestamp-query") && typeof (GPUCommandEncoder.prototype as Partial<TimestampWriter>).writeTimestamp === "function";
+    return device.features.has("timestamp-query");
 }
 
 /** Create a GPU frame timer, or null when the device can't support timestamp queries. */
@@ -50,15 +50,18 @@ export function createGpuFrameTimer(device: GPUDevice): GpuFrameTimer | null {
 }
 
 /** Write the frame's opening timestamp into the frame encoder (call right after it is created, before any
- *  passes are recorded), so it is the first command the GPU runs for this frame. */
+ *  passes are recorded), so it bookends the start of this frame's GPU work. Uses the STANDARD `timestampWrites`
+ *  attachment (no `GPUCommandEncoder.writeTimestamp`, which Chromium gates behind `--enable-unsafe-webgpu`): an
+ *  EMPTY compute pass whose BEGINNING timestamp lands in slot 0. Empty pass = no dispatch, negligible cost. */
 export function gpuFrameTimerBegin(timer: GpuFrameTimer, encoder: GPUCommandEncoder): void {
-    (encoder as unknown as TimestampWriter).writeTimestamp(timer.querySet, 0);
+    encoder.beginComputePass({ timestampWrites: { querySet: timer.querySet, beginningOfPassWriteIndex: 0 } }).end();
 }
 
-/** Write the frame's closing timestamp into the frame encoder (call right before it is finished/submitted),
- *  so it is the last command — bracketing exactly this frame's recorded GPU work. */
+/** Write the frame's closing timestamp into the frame encoder (call right before it is finished/submitted), so
+ *  it bookends the end of this frame's GPU work — an EMPTY compute pass whose END timestamp lands in slot 1.
+ *  slot1 − slot0 is then the GPU time of exactly the passes recorded between the two empty passes. */
 export function gpuFrameTimerEnd(timer: GpuFrameTimer, encoder: GPUCommandEncoder): void {
-    (encoder as unknown as TimestampWriter).writeTimestamp(timer.querySet, 1);
+    encoder.beginComputePass({ timestampWrites: { querySet: timer.querySet, endOfPassWriteIndex: 1 } }).end();
 }
 
 /** Resolve the just-submitted timestamp pair and update `lastMs` when the readback maps. Submitted as its


### PR DESCRIPTION
Switches the optional GPU frame timer from the legacy `GPUCommandEncoder.writeTimestamp` — which Chromium only exposes behind `--enable-unsafe-webgpu` — to the **standard** `timestampWrites` compute-pass attachments.

## What changed
- `gpuFrameTimerBegin` / `gpuFrameTimerEnd` now record two empty compute passes that bracket the frame's recorded work: the begin pass writes its *beginning* timestamp into slot 0, the end pass writes its *end* timestamp into slot 1. An empty pass = no dispatch, negligible cost.
- `gpuTimingSupportedFor` no longer probes for the `writeTimestamp` method (and the `TimestampWriter` structural type is removed); it just checks for the `timestamp-query` adapter feature, which is all the standard attachments require.

## Why
With this change GPU frame timing works in **stock Chrome/Edge** whenever the adapter offers `timestamp-query`, instead of requiring the unsafe-webgpu flag.

## Compatibility
- Public function signatures are unchanged.
- Feature remains entirely opt-in (dynamic-imported on first `setGpuTimingEnabled`); zero bundle/parity impact on scenes that don't use it.

Follow-up to #219.