### PR TITLE
feat(demos): rebrand demos page + show engine/asset size on loading screens

### DIFF
--- a/lab/lite/demo-platformer.html
+++ b/lab/lite/demo-platformer.html
@@ -1,41 +1,110 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <title>Babylon Lite — Demo: Platformer</title>
-  <style>
-    html, body { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #6aa0f5; }
-    canvas { width: 100%; height: 100%; display: block; touch-action: none; image-rendering: pixelated; }
-    .loading-overlay {
-      position: fixed; inset: 0; z-index: 10000;
-      display: flex; align-items: center; justify-content: center;
-      background: #1d2a44; color: #eaf2fb;
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      transition: opacity 0.5s ease;
-    }
-    .loading-overlay.is-hidden { opacity: 0; pointer-events: none; }
-    .loading-box { display: flex; flex-direction: column; align-items: center; gap: 1rem; text-align: center; padding: 0 1rem; }
-    .loading-spinner {
-      width: 54px; height: 54px; border-radius: 50%;
-      border: 4px solid rgba(120, 175, 235, 0.25); border-top-color: #6fb0ff;
-      animation: lite-spin 0.9s linear infinite;
-    }
-    .loading-label { font-size: 1.05rem; font-weight: 600; }
-    .loading-sub { font-size: 0.8rem; color: #9fb6d0; }
-    @keyframes lite-spin { to { transform: rotate(360deg); } }
-    @media (prefers-reduced-motion: reduce) { .loading-spinner { animation-duration: 2.4s; } }
-    .hint {
-      position: fixed; left: 12px; bottom: 12px; z-index: 50;
-      padding: 6px 10px; border-radius: 6px;
-      background: rgba(14, 33, 56, 0.72); color: #cfe0f5;
-      font: 12px system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-      pointer-events: none; user-select: none;
-    }
-  </style>
-</head>
-<body>
-  <!--
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+        <title>Babylon Lite — Demo: Platformer</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #6aa0f5;
+            }
+            canvas {
+                width: 100%;
+                height: 100%;
+                display: block;
+                touch-action: none;
+                image-rendering: pixelated;
+            }
+            .loading-overlay {
+                position: fixed;
+                inset: 0;
+                z-index: 10000;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                background: #1d2a44;
+                color: #eaf2fb;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    "Segoe UI",
+                    Roboto,
+                    sans-serif;
+                transition: opacity 0.5s ease;
+            }
+            .loading-overlay.is-hidden {
+                opacity: 0;
+                pointer-events: none;
+            }
+            .loading-box {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                gap: 1rem;
+                text-align: center;
+                padding: 0 1rem;
+            }
+            .loading-spinner {
+                width: 54px;
+                height: 54px;
+                border-radius: 50%;
+                border: 4px solid rgba(120, 175, 235, 0.25);
+                border-top-color: #6fb0ff;
+                animation: lite-spin 0.9s linear infinite;
+            }
+            .loading-label {
+                font-size: 1.05rem;
+                font-weight: 600;
+            }
+            .loading-sub {
+                font-size: 0.8rem;
+                color: #9fb6d0;
+            }
+            .loading-size {
+                font-size: 0.78rem;
+                color: #9fb6d0;
+                margin-top: 0.4rem;
+                min-height: 1em;
+                letter-spacing: 0.01em;
+            }
+            @keyframes lite-spin {
+                to {
+                    transform: rotate(360deg);
+                }
+            }
+            @media (prefers-reduced-motion: reduce) {
+                .loading-spinner {
+                    animation-duration: 2.4s;
+                }
+            }
+            .hint {
+                position: fixed;
+                left: 12px;
+                bottom: 12px;
+                z-index: 50;
+                padding: 6px 10px;
+                border-radius: 6px;
+                background: rgba(14, 33, 56, 0.72);
+                color: #cfe0f5;
+                font:
+                    12px system-ui,
+                    -apple-system,
+                    "Segoe UI",
+                    Roboto,
+                    sans-serif;
+                pointer-events: none;
+                user-select: none;
+            }
+        </style>
+    </head>
+    <body>
+        <!--
     This page loads the production-BUNDLED demo (tree-shaken + minified) from
     /lite/bundle/demos/, NOT the raw TypeScript source. Run `pnpm build:bundle-demo
     platformer` (fast, this demo only) or `pnpm build:bundle-demos` (all demos; also
@@ -44,37 +113,52 @@
     Assets are a committed CC0 subset of Kenney's Platformer Art Deluxe pack under
     lab/public/platformer/ — no runtime fetch required.
   -->
-  <canvas id="renderCanvas"></canvas>
-  <div class="hint">← → move · Z / Space jump · ↓ duck · X / Shift run / shoot · P pause · C CRT</div>
-  <div id="loadingOverlay" class="loading-overlay" role="status" aria-live="polite">
-    <div class="loading-box">
-      <div class="loading-spinner" aria-hidden="true"></div>
-      <div class="loading-label">Loading level…</div>
-      <div class="loading-sub">Preparing World 1-1.</div>
-    </div>
-  </div>
-  <script>
-    (function () {
-      var overlay = document.getElementById("loadingOverlay");
-      var canvas = document.getElementById("renderCanvas");
-      if (!overlay || !canvas) return;
-      var done = false;
-      function hide() {
-        if (done) return;
-        done = true;
-        overlay.classList.add("is-hidden");
-        setTimeout(function () { if (overlay.parentNode) overlay.parentNode.removeChild(overlay); }, 600);
-      }
-      function check() {
-        if (canvas.dataset.ready === "true" || canvas.dataset.error) { hide(); return true; }
-        return false;
-      }
-      if (!check()) {
-        new MutationObserver(check).observe(canvas, { attributes: true, attributeFilter: ["data-ready", "data-error"] });
-        setTimeout(hide, 45000);
-      }
-    })();
-  </script>
-  <script type="module" src="/lite/bundle/demos/platformer.js"></script>
-</body>
+        <canvas id="renderCanvas"></canvas>
+        <div class="hint">← → move · Z / Space jump · ↓ duck · X / Shift run / shoot · P pause · C CRT</div>
+        <div id="loadingOverlay" class="loading-overlay" role="status" aria-live="polite">
+            <div class="loading-box">
+                <div class="loading-spinner" aria-hidden="true"></div>
+                <div class="loading-label">Loading level…</div>
+                <div class="loading-sub">Preparing World 1-1.</div>
+                <div class="loading-size" aria-hidden="true"></div>
+            </div>
+        </div>
+        <script>
+            (function () {
+                var overlay = document.getElementById("loadingOverlay");
+                var canvas = document.getElementById("renderCanvas");
+                if (!overlay || !canvas) return;
+                var size = overlay.querySelector(".loading-size");
+                var done = false;
+                function syncSize() {
+                    var sz = canvas.dataset.loadingSize;
+                    if (sz !== undefined && sz !== "" && size) size.textContent = sz;
+                }
+                function hide() {
+                    if (done) return;
+                    done = true;
+                    overlay.classList.add("is-hidden");
+                    setTimeout(function () {
+                        if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+                    }, 600);
+                }
+                function check() {
+                    if (canvas.dataset.ready === "true" || canvas.dataset.error) {
+                        hide();
+                        return true;
+                    }
+                    return false;
+                }
+                syncSize();
+                if (!check()) {
+                    new MutationObserver(function () {
+                        syncSize();
+                        check();
+                    }).observe(canvas, { attributes: true, attributeFilter: ["data-ready", "data-error", "data-loading-size"] });
+                    setTimeout(hide, 45000);
+                }
+            })();
+        </script>
+        <script type="module" src="/lite/bundle/demos/platformer.js"></script>
+    </body>
 </html>

--- a/lab/lite/src/demos/loading-progress.ts
+++ b/lab/lite/src/demos/loading-progress.ts
@@ -10,10 +10,13 @@
  *                                      removed entirely while indeterminate.
  *   - `canvas.dataset.loadingDetail` — the current phase, e.g. "Downloading
  *                                      assets…" or "Preparing scene…".
- *   - `canvas.dataset.loadingSize`   — a static, code-set estimate of the demo's
- *                                      asset payload on its own line, e.g.
- *                                      "Estimated demo assets: 28 MB". Set once
- *                                      from `estimatedBytes` and never updated.
+ *   - `canvas.dataset.loadingSize`   — a static, code-set size line that
+ *                                      reiterates the measured engine/code size
+ *                                      (the same KB shown on the demos gallery
+ *                                      card) next to the demo's asset estimate,
+ *                                      e.g. "Engine 126.6 KB · Assets 28 MB". Set
+ *                                      once from `engineKB` and `estimatedBytes`
+ *                                      and never updated.
  *
  * The per-page overlay script (in each `demo-*.html`) renders a determinate bar
  * from `data-progress` (hidden when absent, leaving the spinner as the
@@ -46,6 +49,13 @@ export interface InstallFetchProgressOptions {
      * `Content-Length` header.
      */
     estimatedBytes?: number;
+    /**
+     * The measured engine + demo-code size in KB — the same number shown on the
+     * demos gallery card. When provided, or injected at build time as the global
+     * `window.__DEMO_ENGINE_KB`, the loading overlay reiterates it next to the
+     * asset estimate so the page states its full footprint.
+     */
+    engineKB?: number;
 }
 
 function formatBytes(bytes: number): string {
@@ -60,6 +70,7 @@ function formatBytes(bytes: number): string {
 
 export function installFetchProgress(canvas: HTMLElement, options: InstallFetchProgressOptions = {}): LoadProgressHandle {
     const estimate = Math.max(0, Math.round(options.estimatedBytes ?? 0));
+    const engineKB = Math.max(0, options.engineKB ?? (globalThis as { __DEMO_ENGINE_KB?: number }).__DEMO_ENGINE_KB ?? 0);
     const original = globalThis.fetch.bind(globalThis);
     const tasks: Task[] = [];
     let started = 0;
@@ -206,10 +217,18 @@ export function installFetchProgress(canvas: HTMLElement, options: InstallFetchP
 
     globalThis.fetch = wrapped;
 
-    // Static, code-set size line: a constant estimate of the demo's asset payload
-    // shown for the whole load and never updated dynamically.
-    if (estimate > 0) {
-        canvas.dataset.loadingSize = "Estimated demo assets: " + formatBytes(estimate);
+    // Static, code-set size line shown for the whole load and never updated by the
+    // progress stream: the measured engine/code size (matching the gallery card)
+    // reiterated next to the demo's asset estimate, e.g. "Engine 126.6 KB · Assets
+    // 28 MB". `engineKB` comes from `window.__DEMO_ENGINE_KB`, injected next to the
+    // demo HTML by both the build (deployed flat site) and the lab dev server, so it
+    // resolves synchronously in every environment. Built with string concatenation
+    // (not template literals) because the demo bundler's WGSL minify pass trims
+    // leading whitespace from template-literal tails.
+    if (estimate > 0 || engineKB > 0) {
+        const assets = estimate > 0 ? formatBytes(estimate) : "";
+        const engine = engineKB > 0 ? "Engine " + engineKB + " KB" : "";
+        canvas.dataset.loadingSize = engine ? (assets ? engine + " · Assets " + assets : engine) : "Estimated demo assets: " + assets;
         schedule();
     }
 

--- a/lab/lite/src/demos/platformer.ts
+++ b/lab/lite/src/demos/platformer.ts
@@ -21,11 +21,14 @@
 
 import { createEngine } from "babylon-lite";
 import { startGame } from "./platformer/game.js";
+import { installFetchProgress } from "./loading-progress.js";
 
 async function main(): Promise<void> {
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+    const progress = installFetchProgress(canvas, { estimatedBytes: 1_000_000 });
     const engine = await createEngine(canvas);
     await startGame(canvas, engine);
+    progress.done();
 }
 
 main().catch((error: unknown) => {

--- a/lab/lite/src/demos/torus-states.ts
+++ b/lab/lite/src/demos/torus-states.ts
@@ -19,6 +19,7 @@ import {
     setUniformEffectUniforms,
     startEngine,
 } from "babylon-lite";
+import { installFetchProgress } from "./loading-progress.js";
 
 const FRAGMENT_WGSL = /* wgsl */ `
 struct U {
@@ -169,6 +170,7 @@ const lerpState = (a: MorphState, b: MorphState, n: number): MorphState => ({
 
 async function main(): Promise<void> {
     const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+    const progress = installFetchProgress(canvas);
     const engine = await createEngine(canvas, { maxDevicePixelRatio: 1 });
 
     const effect = createUniformEffectWrapper(engine, {
@@ -259,6 +261,7 @@ async function main(): Promise<void> {
 
     registerFrameGraphContext(context);
     await startEngine(engine);
+    progress.done();
     canvas.dataset.ready = "true";
 }
 

--- a/lab/vite.config.ts
+++ b/lab/vite.config.ts
@@ -27,10 +27,31 @@ function escapeHtml(value: string): string {
     return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
+/**
+ * Inject the measured engine/code size (the same KB shown on the demos gallery
+ * card) into a source demo HTML page so its loading overlay can reiterate it next
+ * to the asset estimate. Mirrors the build-time injection used for the deployed
+ * flat demo site (scripts/bundle-demos-core.ts) so dev and prod behave the same:
+ * `installFetchProgress` reads `window.__DEMO_ENGINE_KB`, and the pre-hydration
+ * `.loading-size` text is rewritten to match.
+ */
+function injectDemoEngineSize(html: string, slug: string): string {
+    const sizes = readJson<Record<string, DemoSize>>(resolve(__dirname, "public/bundle/demos-manifest.json"), {});
+    const rawKB = sizes[slug]?.rawKB;
+    if (rawKB == null) {
+        return html;
+    }
+    const tag = `<script>window.__DEMO_ENGINE_KB=${rawKB};</script>`;
+    const withTag = html.includes("</head>") ? html.replace("</head>", `  ${tag}\n</head>`) : `${tag}\n${html}`;
+    return withTag.replace(/Estimated demo assets:\s*/g, `Engine ${rawKB} KB · Assets `);
+}
+
 function renderPagesDemoCard(demo: DemoConfigEntry, size: DemoSize | undefined): string {
     const tagList = demo.tags ?? [];
     const tags = tagList.map((t) => `<span class="tag">${escapeHtml(t)}</span>`).join("");
-    const sizeRow = size ? `<div class="size" title="Engine + demo code only — excludes external assets (textures, game data, etc.)"><strong>${size.rawKB} KB</strong> · ${size.gzipKB} KB gzip</div>` : "";
+    const sizeRow = size
+        ? `<div class="size" title="Engine + demo code only — excludes external assets (textures, game data, etc.)"><strong>${size.rawKB} KB</strong> · ${size.gzipKB} KB gzip</div>`
+        : "";
     return [
         `<a class="card" href="/demo-${demo.slug}.html" data-tags="${escapeHtml(tagList.join(" "))}" data-mobile="${demo.mobile === false ? "false" : "true"}">`,
         `<div class="card-image">`,
@@ -141,11 +162,19 @@ function serveReferenceImages(): Plugin {
                     /^\/((?:scene|bundle-scene|bundle-bjs-scene|babylon-ref-scene|bundle-baseline-scene)\d+|demo-[^/]+|dispose-test|leak-test|material-swap-test|picking-test)\.html$/
                 );
                 if (liteHtmlCompat) {
-                    const filePath = resolve(__dirname, "lite", `${liteHtmlCompat[1]}.html`);
+                    const name = liteHtmlCompat[1];
+                    const filePath = resolve(__dirname, "lite", `${name}.html`);
                     if (existsSync(filePath)) {
                         res.setHeader("Content-Type", "text/html; charset=utf-8");
                         res.setHeader("Cache-Control", "no-cache");
-                        createReadStream(filePath).pipe(res);
+                        // Demo pages: inject the measured engine size so the loading
+                        // overlay reiterates it next to the asset estimate, mirroring
+                        // the build-time injection on the deployed flat demo site.
+                        if (name.startsWith("demo-")) {
+                            res.end(injectDemoEngineSize(readFileSync(filePath, "utf-8"), name.slice("demo-".length)));
+                        } else {
+                            createReadStream(filePath).pipe(res);
+                        }
                         return;
                     }
                 }

--- a/pages/index.template.html
+++ b/pages/index.template.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Babylon.lite demos</title>
+        <title>Babylon Lite demos</title>
         <meta name="description" content="Standalone showcase demos built on Babylon Lite, a WebGPU-exclusive, tree-shakable, minimal-footprint rendering engine." />
         <style>
             :root {
@@ -440,10 +440,11 @@
         <div class="wrap">
             <header>
                 <img class="logo" src="babylon-logo.svg" alt="Babylon logo" />
-                <h1><span class="brand">Babylon</span><span class="lite">.lite</span> <span class="dot">demos</span></h1>
+                <h1><span class="brand">Babylon</span><span class="lite">Lite</span> <span class="dot">demos</span></h1>
                 <p>
                     Standalone showcase pages built on Babylon&nbsp;Lite, a WebGPU-exclusive, fully tree-shakable rendering engine. Each demo is production-bundled, so the size it
-                    actually ships is shown right on its card. Sizes cover the <strong>engine and demo code only</strong>. External assets (textures, game data, etc.) aren’t included.
+                    actually ships is shown right on its card. Sizes cover the <strong>engine and demo code only</strong>. External assets (textures, game data, etc.) aren’t
+                    included.
                 </p>
             </header>
             <!--FILTERS-->
@@ -489,13 +490,21 @@
 
                 function apply() {
                     var active = pills
-                        .filter(function (p) { return p !== allPill && p.classList.contains("is-active"); })
-                        .map(function (p) { return p.getAttribute("data-filter"); });
+                        .filter(function (p) {
+                            return p !== allPill && p.classList.contains("is-active");
+                        })
+                        .map(function (p) {
+                            return p.getAttribute("data-filter");
+                        });
                     // No tag selected -> behave as "All".
                     if (allPill) setActive(allPill, active.length === 0);
                     cards.forEach(function (card) {
                         var tags = (card.getAttribute("data-tags") || "").split(" ");
-                        var show = active.length === 0 || active.some(function (f) { return tags.indexOf(f) !== -1; });
+                        var show =
+                            active.length === 0 ||
+                            active.some(function (f) {
+                                return tags.indexOf(f) !== -1;
+                            });
                         card.classList.toggle("is-hidden", !show);
                     });
                 }
@@ -504,7 +513,9 @@
                     pill.addEventListener("click", function () {
                         if (pill === allPill) {
                             // Reset: clear every tag selection.
-                            pills.forEach(function (p) { if (p !== allPill) setActive(p, false); });
+                            pills.forEach(function (p) {
+                                if (p !== allPill) setActive(p, false);
+                            });
                         } else {
                             setActive(pill, !pill.classList.contains("is-active"));
                         }
@@ -532,7 +543,9 @@
                 if (!isMobile()) return;
                 document.body.classList.add("is-mobile");
                 var cards = Array.prototype.slice.call(document.querySelectorAll("a.card"));
-                var compatible = cards.filter(function (c) { return c.getAttribute("data-mobile") !== "false"; });
+                var compatible = cards.filter(function (c) {
+                    return c.getAttribute("data-mobile") !== "false";
+                });
                 if (compatible.length === 0) {
                     document.body.classList.add("no-compatible-demos");
                 } else if (compatible.length < cards.length) {

--- a/scripts/bundle-demos-core.ts
+++ b/scripts/bundle-demos-core.ts
@@ -100,6 +100,18 @@ function rewriteDemoHtmlForBundle(html: string): string {
     return html.replace(/(["'])\/(?:lite\/)?bundle\/demos\//g, "$1./");
 }
 
+/**
+ * Inject the measured engine/code size (the same KB shown on the gallery card)
+ * into a built demo page so its loading overlay can reiterate it next to the
+ * asset estimate. `installFetchProgress` reads `window.__DEMO_ENGINE_KB`; the
+ * pre-hydration `.loading-size` text is rewritten to match.
+ */
+function injectDemoEngineSize(html: string, rawKB: number): string {
+    const tag = `<script>window.__DEMO_ENGINE_KB=${rawKB};</script>`;
+    const out = html.includes("</head>") ? html.replace("</head>", `  ${tag}\n</head>`) : `${tag}\n${html}`;
+    return out.replace(/Estimated demo assets:\s*/g, `Engine ${rawKB} KB · Assets `);
+}
+
 function renderCard(demo: DemoConfigEntry, size: DemoManifestEntry | undefined): string {
     const tagList = demo.tags ?? [];
     const tags = tagList.map((tag) => `<span class="tag">${escapeHtml(tag)}</span>`).join("");
@@ -233,7 +245,9 @@ function writeDemoHtml(demos: DemoConfigEntry[], manifest: Record<string, DemoMa
         if (!existsSync(source)) {
             throw new Error(`Missing demo HTML: ${source}`);
         }
-        writeFileSync(resolve(demosDir, `demo-${demo.slug}.html`), rewriteDemoHtmlForBundle(readFileSync(source, "utf-8")));
+        const html = rewriteDemoHtmlForBundle(readFileSync(source, "utf-8"));
+        const rawKB = manifest[demo.slug]?.rawKB;
+        writeFileSync(resolve(demosDir, `demo-${demo.slug}.html`), rawKB != null ? injectDemoEngineSize(html, rawKB) : html);
     }
     copyDemoIndexAssets(demos);
     copyDemoRuntimeAssets(demos);
@@ -347,11 +361,6 @@ export async function buildSingleDemo(slug: string, options: { measure?: boolean
     await buildDemo(slug);
     copyDemoRuntimeAssets([demo]);
 
-    const source = resolve(labDir, "lite", `demo-${slug}.html`);
-    if (existsSync(source)) {
-        writeFileSync(resolve(demosDir, `demo-${slug}.html`), rewriteDemoHtmlForBundle(readFileSync(source, "utf-8")));
-    }
-
     if (options.measure) {
         const { chromium } = await import("@playwright/test");
         const { server, port } = await startStaticServer(labDir);
@@ -371,6 +380,16 @@ export async function buildSingleDemo(slug: string, options: { measure?: boolean
         } finally {
             server.close();
         }
+    }
+
+    const source = resolve(labDir, "lite", `demo-${slug}.html`);
+    if (existsSync(source)) {
+        const html = rewriteDemoHtmlForBundle(readFileSync(source, "utf-8"));
+        const manifest: Record<string, DemoManifestEntry> = existsSync(DEMOS_MANIFEST_FILE)
+            ? (JSON.parse(readFileSync(DEMOS_MANIFEST_FILE, "utf-8")) as Record<string, DemoManifestEntry>)
+            : {};
+        const rawKB = manifest[slug]?.rawKB;
+        writeFileSync(resolve(demosDir, `demo-${slug}.html`), rawKB != null ? injectDemoEngineSize(html, rawKB) : html);
     }
 
     console.log(`Demo "${slug}" ready → lab/public/bundle/demos/${slug}.js`);


### PR DESCRIPTION
Two demos-page improvements:

**1. Rebrand the demos page title** to `Babylon Lite` (was `Babylon.lite`) in `pages/index.template.html`.

**2. Show engine + asset size on every demo's loading screen.** Each demo's loading overlay now reiterates the measured engine/code size (the same KB shown on the gallery card) next to its asset estimate, e.g. `Engine 126.6 KB · Assets 27 MB` (engine-only for asset-less demos like Torus States).

- Engine size comes from `demos-manifest.json` via `window.__DEMO_ENGINE_KB`, injected both at build time (`scripts/bundle-demos-core.ts` for the deployed flat site) and by the lab dev server (`lab/vite.config.ts`), so prod and dev behave identically.
- The loader (`lab/lite/src/demos/loading-progress.ts`) renders the combined line.
- Also wires up `torus-states` and `platformer`, which previously did not call the loader.

Verified visually across all 11 demos in both prod and dev. Lint + typechecks green. Gallery cards are unchanged.