### PR TITLE
fix(demos): load loose-file glTF models from CDN to fix caching

### DIFF
--- a/lab/lite/src/demos/mosquito-amber.ts
+++ b/lab/lite/src/demos/mosquito-amber.ts
@@ -13,14 +13,12 @@ import {
     createPbrMaterial,
     createSceneContext,
     createSolidTexture2D,
-    getFrameGraph,
     loadEnvironment,
     loadGltf,
     onBeforeRender,
     registerScene,
     setCameraLimits,
     startEngine,
-    type RenderTask,
 } from "babylon-lite";
 import { configureDemoDecoderBases, demoAssetUrl } from "./demo-asset-url.js";
 import { installFetchProgress } from "./loading-progress.js";
@@ -46,8 +44,6 @@ async function main(): Promise<void> {
 
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);
-    // Transmissive amber requires the frame-graph scene-texture transmission copy.
-    (getFrameGraph(scene)._tasks[0] as RenderTask)._config.transmission = { copyCount: 1 };
 
     const cam = createArcRotateCamera(CAM.alpha, CAM.beta, CAM.radius, CAM.target);
     cam.fov = CAM.fov;

--- a/lab/lite/src/demos/mosquito-amber.ts
+++ b/lab/lite/src/demos/mosquito-amber.ts
@@ -25,7 +25,7 @@ import {
 import { configureDemoDecoderBases, demoAssetUrl } from "./demo-asset-url.js";
 import { installFetchProgress } from "./loading-progress.js";
 
-const MODEL_URL = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/MosquitoInAmber/glTF/MosquitoInAmber.gltf";
+const MODEL_URL = "https://assets.babylonjs.com/meshes/MosquitoInAmber/glTF/MosquitoInAmber.gltf";
 const ENV_URL = "https://assets.babylonjs.com/environments/studio.env";
 
 // Fixed camera pose framing the amber from the sandbox cameraPosition

--- a/lab/lite/src/demos/offscreen-scene.ts
+++ b/lab/lite/src/demos/offscreen-scene.ts
@@ -23,14 +23,12 @@ import {
     createSceneContext,
     createDefaultCamera,
     createHemisphericLight,
-    getFrameGraph,
     loadGltf,
     loadEnvironment,
     onBeforeRender,
     registerScene,
     type EngineContext,
     type RenderCanvas,
-    type RenderTask,
 } from "babylon-lite";
 import { configureDemoDecoderBases, demoAssetUrl } from "./demo-asset-url.js";
 
@@ -62,11 +60,6 @@ export async function startOffscreenScene(canvas: RenderCanvas, brdfUrl: string 
 
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);
-
-    // The latest Flight Helmet uses KHR_materials_transmission for the glass
-    // lenses; transmissive materials need the frame-graph scene-texture copy to
-    // refract what's behind them.
-    (getFrameGraph(scene)._tasks[0] as RenderTask)._config.transmission = { copyCount: 1 };
 
     // PBR model + studio environment (IBL, DDS skybox, reflective ground). All the
     // asset I/O below uses fetch + createImageBitmap, which work identically on the

--- a/lab/lite/src/demos/offscreen-scene.ts
+++ b/lab/lite/src/demos/offscreen-scene.ts
@@ -23,18 +23,27 @@ import {
     createSceneContext,
     createDefaultCamera,
     createHemisphericLight,
+    getFrameGraph,
     loadGltf,
     loadEnvironment,
     onBeforeRender,
     registerScene,
     type EngineContext,
     type RenderCanvas,
+    type RenderTask,
 } from "babylon-lite";
 import { configureDemoDecoderBases, demoAssetUrl } from "./demo-asset-url.js";
 
-// Same CDN assets used by the existing Flight Helmet scene (lab scene 14):
-// PBR model, .env IBL, DDS skybox and a reflective ground texture.
-const MODEL_URL = "https://assets.babylonjs.com/meshes/flightHelmet.glb";
+// Same Flight Helmet model + studio environment as lab scene 14 (PBR model,
+// .env IBL, DDS skybox, reflective ground).
+//
+// The model is the loose-file glTF (.gltf + .bin + per-material textures) rather
+// than the single ~55 MB flightHelmet.glb. A 55 MB resource exceeds Chromium's
+// per-cache-entry size cap, so the .glb is never stored in the HTTP cache and
+// re-downloads on every load — including this demo's second (worker) load. Split
+// into small per-texture files, each stays under the cap and is cached normally,
+// so the worker's load and reloads are served from cache.
+const MODEL_URL = "https://assets.babylonjs.com/meshes/FlightHelmet/glTF/FlightHelmet.gltf";
 const ENV_URL = "https://assets.babylonjs.com/core/environments/environmentSpecular.env";
 const SKYBOX_URL = "https://assets.babylonjs.com/core/environments/backgroundSkybox.dds";
 const GROUND_URL = "https://assets.babylonjs.com/core/environments/backgroundGround.png";
@@ -53,6 +62,11 @@ export async function startOffscreenScene(canvas: RenderCanvas, brdfUrl: string 
 
     const engine = await createEngine(canvas);
     const scene = createSceneContext(engine);
+
+    // The latest Flight Helmet uses KHR_materials_transmission for the glass
+    // lenses; transmissive materials need the frame-graph scene-texture copy to
+    // refract what's behind them.
+    (getFrameGraph(scene)._tasks[0] as RenderTask)._config.transmission = { copyCount: 1 };
 
     // PBR model + studio environment (IBL, DDS skybox, reflective ground). All the
     // asset I/O below uses fetch + createImageBitmap, which work identically on the

--- a/lab/lite/src/demos/offscreen.ts
+++ b/lab/lite/src/demos/offscreen.ts
@@ -36,8 +36,10 @@ async function main(): Promise<void> {
     const slowButton = document.getElementById("slowButton") as HTMLButtonElement | null;
 
     // The main-thread (left) engine performs the real asset downloads (glTF +
-    // environment); the worker re-uses the warm HTTP cache. Report that download.
-    const progress = installFetchProgress(leftCanvas, { estimatedBytes: 55_700_000 });
+    // environment); the worker mostly re-uses the warm HTTP cache, now that the
+    // model is a loose-file glTF whose small per-texture files are individually
+    // cacheable. Report that download.
+    const progress = installFetchProgress(leftCanvas, { estimatedBytes: 49_000_000 });
 
     let leftReady = false;
     let rightReady = false;


### PR DESCRIPTION
Migrates the `offscreen` and `mosquito-amber` demos off the single ~55 MB `flightHelmet.glb` / raw GitHub and onto loose-file glTF models on `assets.babylonjs.com`.

**Bug:** `offscreen` loaded `flightHelmet.glb` (~55 MB) on both the main thread and a worker. A response that large exceeds Chromium's per-cache-entry cap (~1/8 of the budget), so it's never cached and re-downloads every load (including the concurrent worker load); sequential reloads showed no speedup.

**Fix:**
- `offscreen` → `FlightHelmet/glTF` on the CDN.
- `mosquito-amber` → `MosquitoInAmber/glTF` on the CDN (was `raw.githubusercontent.com`).

Loose files keep every resource under the cache cap (largest ~5.4 MB), so worker loads and reloads hit cache.

**Behavioral:** Both models use `KHR_materials_transmission` (lenses / amber); transmission auto-enables when the glTF loads, so the demos need no manual frame-graph config. Verified rendering on the main thread and in the worker. `offscreen.ts` download estimate updated (~55.7 → ~49 MB).

**Depends on BabylonJS/Assets#150** (adds the models). Assets won't load until #150 merges and syncs to the CDN — kept as a **draft** until then and pending review.

[Created by Copilot on behalf of @bghgary]
