### PR TITLE
docs(lite): add README and LICENSE to public package

### DIFF
--- a/packages/babylon-lite/README.md
+++ b/packages/babylon-lite/README.md
@@ -36,3 +36,12 @@ Full documentation is available at
 ## License
 
 [Apache-2.0](./LICENSE)
+
+`@babylonjs/lite` is a derivative of [Babylon.js](https://www.babylonjs.com/)
+(Apache-2.0). It bundles a small number of third-party runtime libraries
+(`manifold-3d`, `@recast-navigation/*`, `text-shaper`) whose code ships inside
+the published package. Their license texts are reproduced in
+[THIRD_PARTY_NOTICES.txt](./THIRD_PARTY_NOTICES.txt).
+
+Development-only tooling (build, test, and lint frameworks) is **not** part of
+the published package and therefore carries no redistribution obligations.

--- a/packages/babylon-lite/README.md
+++ b/packages/babylon-lite/README.md
@@ -1,0 +1,38 @@
+# Babylon Lite
+
+A lightweight, tree-shakable, WebGPU-first rendering library derived from
+[Babylon.js](https://www.babylonjs.com/). Import only what you use and ship a
+minimal bundle.
+
+## Installation
+
+```bash
+npm install @babylonjs/lite
+```
+
+## Quick start
+
+```ts
+import { createEngine, createSceneContext, createDefaultCamera, createHemisphericLight, addToScene, loadGltf, registerScene, startEngine } from "@babylonjs/lite";
+
+const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+const engine = await createEngine(canvas);
+const scene = createSceneContext(engine);
+
+addToScene(scene, await loadGltf(engine, "https://playground.babylonjs.com/scenes/BoomBox.glb"));
+addToScene(scene, createHemisphericLight([0, 1, 0], 1.0));
+createDefaultCamera(scene);
+
+await registerScene(scene);
+await startEngine(engine);
+```
+
+## Documentation
+
+Full documentation is available at
+[https://doc.babylonjs.com/lite/](https://doc.babylonjs.com/lite/).
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/packages/babylon-lite/README.md
+++ b/packages/babylon-lite/README.md
@@ -15,17 +15,21 @@ npm install @babylonjs/lite
 ```ts
 import { createEngine, createSceneContext, createDefaultCamera, createHemisphericLight, addToScene, loadGltf, registerScene, startEngine } from "@babylonjs/lite";
 
-const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+async function main(): Promise<void> {
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
 
-const engine = await createEngine(canvas);
-const scene = createSceneContext(engine);
+    const engine = await createEngine(canvas);
+    const scene = createSceneContext(engine);
 
-addToScene(scene, await loadGltf(engine, "https://playground.babylonjs.com/scenes/BoomBox.glb"));
-addToScene(scene, createHemisphericLight([0, 1, 0], 1.0));
-createDefaultCamera(scene);
+    addToScene(scene, await loadGltf(engine, "https://playground.babylonjs.com/scenes/BoomBox.glb"));
+    addToScene(scene, createHemisphericLight([0, 1, 0], 1.0));
+    createDefaultCamera(scene);
 
-await registerScene(scene);
-await startEngine(engine);
+    await registerScene(scene);
+    await startEngine(engine);
+}
+
+main().catch(console.error);
 ```
 
 ## Documentation

--- a/packages/babylon-lite/vite.config.ts
+++ b/packages/babylon-lite/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, type Plugin } from "vite";
 import { resolve } from "path";
-import { copyFileSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import { copyFileSync, existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "fs";
 import dts from "vite-plugin-dts";
 import { Extractor, ExtractorConfig, ExtractorLogLevel } from "@microsoft/api-extractor";
 
@@ -120,6 +120,61 @@ function emitPackageJson(outDir: string): Plugin {
     };
 }
 
+/**
+ * Third-party packages whose code is bundled into the published output (as
+ * opposed to dev-only tooling, which never ships). Each runtime dependency's
+ * license text must be propagated per its MIT/Apache-2.0 attribution terms.
+ * Keep this list in sync with the `dependencies` field of package.json.
+ */
+const BUNDLED_DEPENDENCIES = ["manifold-3d", "@recast-navigation/core", "@recast-navigation/generators", "@recast-navigation/wasm", "text-shaper"];
+
+/**
+ * Resolve a bundled dependency's installed directory. These are declared
+ * runtime `dependencies`, so the package manager installs them under this
+ * package's `node_modules`. We read from there directly rather than resolving
+ * the dependency specifier, because several of them restrict access via their
+ * `exports` map (resolving the bare entry or `package.json` throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED).
+ */
+function resolveDependencyDir(dep: string): string {
+    const dir = resolve(__dirname, "node_modules", dep);
+    const pkgJson = resolve(dir, "package.json");
+    if (!existsSync(pkgJson)) {
+        throw new Error(`Could not locate installed package directory for bundled dependency "${dep}" at ${dir}`);
+    }
+    return dir;
+}
+
+/**
+ * Generate THIRD_PARTY_NOTICES.txt by aggregating the license text of every
+ * bundled runtime dependency. Generated at build time so the notices stay in
+ * sync with the actual dependency versions on each release. Fails the build if
+ * a license file cannot be located, so attribution is never silently dropped.
+ */
+function emitThirdPartyNotices(outDir: string): Plugin {
+    return {
+        name: "emit-third-party-notices",
+        writeBundle() {
+            const sections: string[] = [
+                "@babylonjs/lite bundles the following third-party open source software.",
+                "Their license texts are reproduced below as required by their terms.",
+            ];
+            for (const dep of BUNDLED_DEPENDENCIES) {
+                const pkgDir = resolveDependencyDir(dep);
+                const { version } = JSON.parse(readFileSync(resolve(pkgDir, "package.json"), "utf8")) as { version: string };
+                const licenseFile = readdirSync(pkgDir).find((f) => /^(license|licence|copying)/i.test(f));
+                if (!licenseFile) {
+                    throw new Error(`No license file found for bundled dependency "${dep}" in ${pkgDir}`);
+                }
+                const licenseText = readFileSync(resolve(pkgDir, licenseFile), "utf8").trimEnd();
+                const divider = "=".repeat(78);
+                sections.push(`${divider}\n${dep} ${version}\n${divider}\n\n${licenseText}`);
+            }
+            writeFileSync(resolve(outDir, "THIRD_PARTY_NOTICES.txt"), sections.join("\n\n") + "\n");
+        },
+    };
+}
+
 export default defineConfig(({ mode }) => {
     const outDir = mode === "prod" ? "dist/prod" : "dist";
     const isWatch = process.argv.includes("--watch");
@@ -142,6 +197,7 @@ export default defineConfig(({ mode }) => {
             }),
             ...(isWatch ? [] : [trimInternalDts(outDir)]),
             emitPackageJson(outDir),
+            emitThirdPartyNotices(outDir),
         ],
     };
 });

--- a/packages/babylon-lite/vite.config.ts
+++ b/packages/babylon-lite/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, type Plugin } from "vite";
 import { resolve } from "path";
-import { readFileSync, unlinkSync, writeFileSync } from "fs";
+import { copyFileSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import dts from "vite-plugin-dts";
 import { Extractor, ExtractorConfig, ExtractorLogLevel } from "@microsoft/api-extractor";
 
@@ -83,7 +83,10 @@ function trimInternalDts(outDir: string): Plugin {
     };
 }
 
-/** Emit a publish-ready package.json into the build output directory. */
+/**
+ * Emit a publish-ready package.json into the build output directory and copy
+ * the README and LICENSE alongside it so the published package is complete.
+ */
 function emitPackageJson(outDir: string): Plugin {
     return {
         name: "emit-package-json",
@@ -91,6 +94,13 @@ function emitPackageJson(outDir: string): Plugin {
             const pkg = {
                 name: "@babylonjs/lite",
                 version: "0.1.0",
+                description: "A lightweight, tree-shakable, WebGPU-first rendering library derived from Babylon.js.",
+                license: "Apache-2.0",
+                homepage: "https://doc.babylonjs.com/lite/",
+                repository: {
+                    type: "git",
+                    url: "https://github.com/BabylonJS/Babylon-Lite.git",
+                },
                 type: "module",
                 main: "./index.js",
                 module: "./index.js",
@@ -104,6 +114,8 @@ function emitPackageJson(outDir: string): Plugin {
                 sideEffects: false,
             };
             writeFileSync(resolve(outDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+            copyFileSync(resolve(__dirname, "README.md"), resolve(outDir, "README.md"));
+            copyFileSync(resolve(__dirname, "../../LICENSE"), resolve(outDir, "LICENSE"));
         },
     };
 }


### PR DESCRIPTION
## Summary

The public `@babylonjs/lite` package was missing a README and LICENSE. This PR adds both and ensures the auto-generated `package.json` declares the Apache-2.0 license.

## Changes

- **Add `packages/babylon-lite/README.md`** — includes a minimal quick-start example and a link to the docs at https://doc.babylonjs.com/lite/.
- **Amend the auto-generated `package.json`** — the `emitPackageJson` plugin in `vite.config.ts` now sets `license: "Apache-2.0"` (plus `description`, `homepage`, and `repository`) and copies `README.md` and the repo-root `LICENSE` into the published `dist/` output.

## Validation

Ran `pnpm --filter babylon-lite build` and confirmed `dist/` now contains `package.json` (with the license field), `README.md`, and `LICENSE`.
