### PR TITLE
feat!: add hierarchy instance pools

### DIFF
--- a/docs/lite/architecture/17-thin-instances.md
+++ b/docs/lite/architecture/17-thin-instances.md
@@ -57,6 +57,29 @@ export function setThinInstanceColors(mesh: Mesh, colors: Float32Array): void;
 export function enableThinInstanceGpuCulling(mesh: Mesh, enabled?: boolean): void;
 ```
 
+### Functions — Hierarchy Instance Pools (`hierarchy-instance-pool.ts`)
+
+For the old Babylon.js `parentNode.instantiateHierarchy()` prop workflow, Lite exposes a small opt-in helper that keeps the rendering path thin-instance based while preserving child mesh offsets/rotations/scales:
+
+```typescript
+/** Build a fixed-capacity pool from a template hierarchy. Call before registerScene(). */
+export function createHierarchyInstancePool(root: SceneNode, capacity: number): HierarchyInstancePool;
+
+/** Add one logical hierarchy instance and return its slot index. */
+export function addHierarchyInstance(pool: HierarchyInstancePool, matrix: Mat4): number;
+
+/** Update one logical hierarchy instance root matrix. */
+export function setHierarchyInstanceMatrix(pool: HierarchyInstancePool, index: number, matrix: Mat4): void;
+
+/** Remove one logical hierarchy instance via swap-remove. */
+export function removeHierarchyInstance(pool: HierarchyInstancePool, index: number): void;
+
+/** Change active logical count without reallocating buffers. */
+export function setHierarchyInstanceCount(pool: HierarchyInstancePool, count: number): void;
+```
+
+`createHierarchyInstancePool()` walks all descendant meshes and assigns each one its own thin-instance matrix buffer at the requested capacity, then sets active count to zero. The source meshes therefore become render carriers for the pool: they do not draw the template by themselves, but they must stay `visible !== false` so their thin instances can draw. Do not hide a hierarchy pool with `setSubtreeVisible(root, false)`; clear it with `setHierarchyInstanceCount(pool, 0)` instead. When growing, prefer `addHierarchyInstance(pool, matrix)` so the newly visible slot has a defined matrix before the next frame.
+
 ### Functions — GPU Sync (`thin-instance-gpu.ts`)
 
 ```typescript
@@ -461,7 +484,7 @@ Scene 16 chunk breakdown: `scene16.js` (18.1 KB) + `standard-renderable` (22.5 K
 
 ### Initialization
 
-1. User calls `setThinInstances(mesh, matrices, count)` or `addThinInstance(mesh, matrix)`.
+1. User calls `setThinInstances(mesh, matrices, count)` / `addThinInstance(mesh, matrix)` for a single mesh, or `createHierarchyInstancePool(root, capacity)` for a prop hierarchy.
 2. `ThinInstanceData` is created on `mesh.thinInstances` with initial capacity.
 3. Optionally, user calls `setThinInstanceColors(mesh, colors)` for per-instance RGBA.
 4. Optionally, user calls `enableThinInstanceGpuCulling(mesh)` before `registerScene()`.
@@ -489,6 +512,9 @@ Scene 16 chunk breakdown: `scene16.js` (18.1 KB) + `standard-renderable` (22.5 K
 - `setThinInstanceMatrix` → overwrites 16 floats in-place, bumps `_version`.
 - `flushThinInstances` → bumps `_version` only (for direct array manipulation).
 - `setThinInstanceColors` → replaces colors array, bumps `_colorVersion`.
+- `addHierarchyInstance` → writes one logical root matrix into every descendant mesh buffer and bumps all counts.
+- `removeHierarchyInstance` → swap-removes the same logical slot from every descendant mesh buffer.
+- `setHierarchyInstanceCount` → changes the active logical count on every descendant mesh without reallocating.
 
 ---
 

--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -2722,8 +2722,8 @@
     ]
   },
   "scene222": {
-    "rawKB": 109.1,
-    "gzipKB": 40.2,
+    "rawKB": 109.6,
+    "gzipKB": 40.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene222-gpu-pool-CHlSfwGp.js",

--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -751,8 +751,8 @@
     ]
   },
   "scene49": {
-    "rawKB": 91.8,
-    "gzipKB": 34.6,
+    "rawKB": 91.3,
+    "gzipKB": 34.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene49-standard-renderable-C3IPeUHN.js",
@@ -1698,8 +1698,8 @@
     ]
   },
   "scene113": {
-    "rawKB": 62.4,
-    "gzipKB": 24.1,
+    "rawKB": 61.9,
+    "gzipKB": 23.9,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene113-standard-renderable-D5DFpJqg.js",
@@ -1708,8 +1708,8 @@
     ]
   },
   "scene114": {
-    "rawKB": 80.3,
-    "gzipKB": 31,
+    "rawKB": 79.8,
+    "gzipKB": 30.8,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene114-morph-fragment-Dk2lIIy7.js",
@@ -1722,8 +1722,8 @@
     ]
   },
   "scene115": {
-    "rawKB": 122.4,
-    "gzipKB": 49.7,
+    "rawKB": 121.9,
+    "gzipKB": 49.4,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene115-create-morph-targets-_ECgIusp.js",
@@ -1840,8 +1840,8 @@
     ]
   },
   "scene129": {
-    "rawKB": 82.2,
-    "gzipKB": 31.3,
+    "rawKB": 81.7,
+    "gzipKB": 31,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene129-gs-picking-pipeline-wk9cVMav.js",
@@ -2709,8 +2709,8 @@
     ]
   },
   "scene221": {
-    "rawKB": 99.2,
-    "gzipKB": 37.6,
+    "rawKB": 98.7,
+    "gzipKB": 37.3,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene221-shader-renderable-D9GHG1j9.js",
@@ -2723,7 +2723,7 @@
   },
   "scene222": {
     "rawKB": 109.2,
-    "gzipKB": 40.3,
+    "gzipKB": 40.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene222-gpu-pool-CHlSfwGp.js",
@@ -2747,8 +2747,8 @@
     ]
   },
   "scene224": {
-    "rawKB": 81.2,
-    "gzipKB": 30.2,
+    "rawKB": 80.7,
+    "gzipKB": 30,
     "ignoredRawKB": 0,
     "runtimeChunks": [
       "scene224-standard-renderable-ZqgL6_fO.js",

--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -2722,7 +2722,7 @@
     ]
   },
   "scene222": {
-    "rawKB": 108.9,
+    "rawKB": 109.1,
     "gzipKB": 40.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [

--- a/lab/public/bundle/manifest.json
+++ b/lab/public/bundle/manifest.json
@@ -2722,7 +2722,7 @@
     ]
   },
   "scene222": {
-    "rawKB": 109.2,
+    "rawKB": 108.9,
     "gzipKB": 40.2,
     "ignoredRawKB": 0,
     "runtimeChunks": [

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -307,6 +307,14 @@ export {
     setThinInstanceColor,
     enableThinInstanceGpuCulling,
 } from "./mesh/thin-instance.js";
+export {
+    addHierarchyInstance,
+    createHierarchyInstancePool,
+    removeHierarchyInstance,
+    setHierarchyInstanceCount,
+    setHierarchyInstanceMatrix,
+} from "./mesh/hierarchy-instance-pool.js";
+export type { HierarchyInstancePool } from "./mesh/hierarchy-instance-pool.js";
 export type { ThinInstanceData } from "./mesh/thin-instance.js";
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -386,7 +394,7 @@ export { CAP_NONE, CAP_START, CAP_END, CAP_ALL } from "./mesh/create-tube.js";
 
 // ─── Picking ─────────────────────────────────────────────────────────
 export { createGpuPicker, pickAsync, disposePicker } from "./picking/gpu-picker.js";
-export type { GpuPicker, PickOptions } from "./picking/gpu-picker.js";
+export type { GpuPicker, PickDiscardRule, PickOptions } from "./picking/gpu-picker.js";
 export type { PickingInfo } from "./picking/picking-info.js";
 export { enableDetailedPicking } from "./picking/detailed-picking.js";
 export { getPickedNormal, getPickedUV } from "./picking/picking-helpers.js";

--- a/packages/babylon-lite/src/mesh/hierarchy-instance-pool.ts
+++ b/packages/babylon-lite/src/mesh/hierarchy-instance-pool.ts
@@ -1,0 +1,241 @@
+import { F32 } from "../engine/typed-arrays.js";
+import { mat4Invert } from "../math/mat4-invert.js";
+import { mat4MultiplyInto } from "../math/mat4-multiply-into.js";
+import type { Mat4, Mat4Storage } from "../math/types.js";
+import type { SceneNode } from "../scene/scene-node.js";
+import type { Mesh } from "./mesh.js";
+import { setThinInstanceCount, setThinInstances } from "./thin-instance.js";
+
+/** @internal */
+export interface HierarchyInstancePoolBinding {
+    mesh: Mesh;
+    matrices: Float32Array;
+    /** @internal */
+    _meshWorldInverse: Mat4Storage;
+    /** @internal */
+    _rootRelativeMeshWorld: Mat4Storage;
+}
+
+/**
+ * A fixed-capacity thin-instance pool for a transform-node hierarchy.
+ *
+ * The source meshes become the render carriers for the pool: each descendant
+ * mesh receives its own thin-instance matrix buffer, and one logical hierarchy
+ * instance updates the matching slot in every buffer.
+ */
+export interface HierarchyInstancePool {
+    /** Template hierarchy root used to build the pool. */
+    readonly root: SceneNode;
+    /** Maximum number of logical hierarchy instances that can be active. */
+    readonly capacity: number;
+    /** Descendant meshes driven by this pool. */
+    readonly meshes: readonly Mesh[];
+    /**
+     * Current active logical hierarchy instance count.
+     * Prefer {@link addHierarchyInstance}, {@link removeHierarchyInstance}, and
+     * {@link setHierarchyInstanceCount} over mutating this field directly.
+     */
+    count: number;
+    /** @internal */
+    readonly _bindings: readonly HierarchyInstancePoolBinding[];
+    /** @internal */
+    readonly _scratch: Float32Array;
+}
+
+/**
+ * Build a fixed-capacity thin-instance pool from a template hierarchy.
+ *
+ * Call before `registerScene()`, after the hierarchy's parent links are
+ * established. Fresh `loadGltf()` hierarchies are also supported: this helper
+ * materializes child parent links from the `children` arrays before snapshotting
+ * template world matrices.
+ *
+ * The template meshes are converted to thin-instanced meshes with an active
+ * count of zero, so they do not draw until instances are added.
+ *
+ * @param root - Root transform node or mesh for the template hierarchy.
+ * @param capacity - Maximum number of active logical hierarchy instances.
+ */
+export function createHierarchyInstancePool(root: SceneNode, capacity: number): HierarchyInstancePool {
+    if (!Number.isInteger(capacity) || capacity < 0) {
+        throw new Error("createHierarchyInstancePool capacity must be a non-negative integer");
+    }
+
+    const meshes: Mesh[] = [];
+    collectMeshes(root, meshes);
+    if (meshes.length === 0) {
+        throw new Error("createHierarchyInstancePool requires at least one mesh in the source hierarchy");
+    }
+
+    const rootWorld = copyMat4(root.worldMatrix);
+    const rootWorldInverse = mat4Invert(rootWorld as unknown as Mat4);
+    if (!rootWorldInverse) {
+        throw new Error("createHierarchyInstancePool requires an invertible root world matrix");
+    }
+    const rootWorldInverseStorage = rootWorldInverse as unknown as Mat4Storage;
+
+    const bindings: HierarchyInstancePoolBinding[] = [];
+    for (const mesh of meshes) {
+        if (mesh.thinInstances) {
+            throw new Error(`createHierarchyInstancePool mesh "${mesh.name}" already has thin instances`);
+        }
+
+        const meshWorld = copyMat4(mesh.worldMatrix);
+        const meshWorldInverse = mat4Invert(meshWorld as unknown as Mat4);
+        if (!meshWorldInverse) {
+            throw new Error(`createHierarchyInstancePool requires an invertible world matrix for mesh "${mesh.name}"`);
+        }
+
+        const rootRelativeMeshWorld = new F32(16);
+        mat4MultiplyInto(rootRelativeMeshWorld, 0, rootWorldInverseStorage, 0, meshWorld, 0);
+
+        const matrices = new F32(capacity * 16);
+        setThinInstances(mesh, matrices, capacity);
+        setThinInstanceCount(mesh, 0);
+        bindings.push({
+            mesh,
+            matrices,
+            _meshWorldInverse: meshWorldInverse as unknown as Mat4Storage,
+            _rootRelativeMeshWorld: rootRelativeMeshWorld,
+        });
+    }
+
+    return {
+        root,
+        capacity,
+        meshes,
+        count: 0,
+        _bindings: bindings,
+        _scratch: new F32(16),
+    };
+}
+
+/**
+ * Add one logical hierarchy instance and return its slot index.
+ *
+ * The same root matrix is expanded into each descendant mesh's thin-instance
+ * buffer so child offsets, rotations, and scales are preserved.
+ *
+ * @param pool - Pool created by {@link createHierarchyInstancePool}.
+ * @param matrix - Desired world matrix for the hierarchy root instance.
+ */
+export function addHierarchyInstance(pool: HierarchyInstancePool, matrix: Mat4): number {
+    const index = pool.count;
+    if (index >= pool.capacity) {
+        throw new Error("addHierarchyInstance exceeded pool capacity");
+    }
+
+    for (const binding of pool._bindings) {
+        writeBindingMatrix(pool, binding, index, matrix);
+    }
+    setHierarchyInstanceCount(pool, index + 1);
+    return index;
+}
+
+/**
+ * Update one logical hierarchy instance's root matrix.
+ *
+ * @param pool - Pool created by {@link createHierarchyInstancePool}.
+ * @param index - Active logical instance index to update.
+ * @param matrix - Desired world matrix for the hierarchy root instance.
+ */
+export function setHierarchyInstanceMatrix(pool: HierarchyInstancePool, index: number, matrix: Mat4): void {
+    assertActiveIndex(pool, index, "setHierarchyInstanceMatrix");
+    for (const binding of pool._bindings) {
+        writeBindingMatrix(pool, binding, index, matrix);
+        markMatrixDirty(binding, index);
+    }
+}
+
+/**
+ * Remove one logical hierarchy instance with O(1) swap-remove semantics.
+ *
+ * If `index` is not the last active slot, the last logical instance moves into
+ * `index` in every descendant mesh buffer.
+ *
+ * @param pool - Pool created by {@link createHierarchyInstancePool}.
+ * @param index - Active logical instance index to remove.
+ */
+export function removeHierarchyInstance(pool: HierarchyInstancePool, index: number): void {
+    assertActiveIndex(pool, index, "removeHierarchyInstance");
+
+    const last = pool.count - 1;
+    if (index !== last) {
+        const dst = index * 16;
+        const src = last * 16;
+        for (const binding of pool._bindings) {
+            binding.matrices.copyWithin(dst, src, src + 16);
+        }
+    }
+    setHierarchyInstanceCount(pool, last);
+}
+
+/**
+ * Set the active logical hierarchy instance count without reallocating buffers.
+ *
+ * This mirrors {@link setThinInstanceCount}: it only changes how many existing
+ * slots draw. Newly exposed slots are not initialized here; use
+ * {@link addHierarchyInstance} when growing with a new matrix, or immediately
+ * call {@link setHierarchyInstanceMatrix} before the next frame.
+ *
+ * @param pool - Pool created by {@link createHierarchyInstancePool}.
+ * @param count - New active logical instance count, from 0 to `pool.capacity`.
+ */
+export function setHierarchyInstanceCount(pool: HierarchyInstancePool, count: number): void {
+    if (!Number.isInteger(count) || count < 0 || count > pool.capacity) {
+        throw new Error("setHierarchyInstanceCount count must be an integer within pool capacity");
+    }
+    for (const binding of pool._bindings) {
+        if (!binding.mesh.thinInstances) {
+            throw new Error(`setHierarchyInstanceCount mesh "${binding.mesh.name}" is missing thin instance data`);
+        }
+        setThinInstanceCount(binding.mesh, count);
+    }
+    pool.count = count;
+}
+
+function collectMeshes(node: SceneNode, meshes: Mesh[]): void {
+    if (isMesh(node)) {
+        meshes.push(node);
+    }
+    const kids = node.children;
+    for (let i = 0; i < kids.length; i++) {
+        const child = kids[i]!;
+        if (child.parent !== node) {
+            child.parent = node;
+        }
+        collectMeshes(child, meshes);
+    }
+}
+
+function isMesh(node: SceneNode): node is Mesh {
+    return "_gpu" in node && "material" in node;
+}
+
+function copyMat4(src: Mat4): Float32Array {
+    const dst = new F32(16);
+    dst.set(src as unknown as Mat4Storage);
+    return dst;
+}
+
+function writeBindingMatrix(pool: HierarchyInstancePool, binding: HierarchyInstancePoolBinding, index: number, rootMatrix: Mat4): void {
+    const rootStorage = rootMatrix as unknown as Mat4Storage;
+    mat4MultiplyInto(pool._scratch, 0, rootStorage, 0, binding._rootRelativeMeshWorld, 0);
+    mat4MultiplyInto(binding.matrices, index * 16, binding._meshWorldInverse, 0, pool._scratch, 0);
+}
+
+function markMatrixDirty(binding: HierarchyInstancePoolBinding, index: number): void {
+    const ti = binding.mesh.thinInstances;
+    if (!ti) {
+        throw new Error(`HierarchyInstancePool mesh "${binding.mesh.name}" is missing thin instance data`);
+    }
+    ti._version++;
+    ti._dirtyMin = Math.min(ti._dirtyMin, index);
+    ti._dirtyMax = Math.max(ti._dirtyMax, index + 1);
+}
+
+function assertActiveIndex(pool: HierarchyInstancePool, index: number, caller: string): void {
+    if (!Number.isInteger(index) || index < 0 || index >= pool.count) {
+        throw new Error(`${caller} index must reference an active hierarchy instance`);
+    }
+}

--- a/packages/babylon-lite/src/mesh/mesh.ts
+++ b/packages/babylon-lite/src/mesh/mesh.ts
@@ -69,15 +69,6 @@ export interface MeshGPU {
     readonly _vbKey?: string;
 }
 
-/** Optional GPU-picking discard volume. The picker clips fragments in a bounded local frame:
- *  `a=(origin.x, origin.z, tangent.x, tangent.z)`, `b=(baseY, halfWidth, springY, rise)`,
- *  `c=(ringT, depthHalf, flatFlag, _)`. */
-export interface PickingClipVolume {
-    readonly a: readonly [number, number, number, number];
-    readonly b: readonly [number, number, number, number];
-    readonly c: readonly [number, number, number, number];
-}
-
 // ─── Mesh ────────────────────────────────────────────────────────────
 
 /** A renderable mesh — plain data with transform, material, and GPU geometry.
@@ -112,8 +103,6 @@ export interface Mesh extends SceneNode {
     /** When `false`, the GPU picker skips this mesh.  Defaults to `true`
      *  (undefined behaves as pickable).  Mirrors BJS `AbstractMesh.isPickable`. */
     pickable?: boolean;
-    /** Optional per-mesh GPU-picking clip volumes. Fragments inside any volume are ignored by the GPU picker. */
-    pickingClipVolumes?: readonly PickingClipVolume[] | null;
     // name, children, position, rotation, rotationQuaternion, scaling,
     // parent, worldMatrix, worldMatrixVersion — all inherited from SceneNode
 

--- a/packages/babylon-lite/src/picking/gpu-picker.ts
+++ b/packages/babylon-lite/src/picking/gpu-picker.ts
@@ -135,14 +135,14 @@ export interface PickOptions {
      *
      *  The input exposes only generic picker data: `worldPos`, `pickId`, `thinInstanceIndex`,
      *  `hasThinInstance`, and `instanceExtras` (the original thin-instance matrix w lanes, zero for
-     *  non-instanced meshes). */
+     *  non-instanced meshes). Storage entries are uploaded and bound by Lite for the current pick only. */
     discard?: PickDiscardRule;
     /** Dev-only diagnostics: logs the pick ray, pixel, pick id/depth and resolved mesh. */
     debugLabel?: string;
 }
 
 /**
- * Optional WGSL discard rule for {@link pickAsync}.
+ * Optional GPU-side discard rule for {@link pickAsync}.
  *
  * This lets apps remove pick hits with custom WGSL while keeping the main scene
  * render untouched. The WGSL must define
@@ -153,21 +153,40 @@ export interface PickDiscardRule {
     readonly key: string;
     /** WGSL source that defines `shouldDiscardPick(input: PickDiscardInput) -> bool`. */
     readonly wgsl: string;
-    /** @internal Optional group-2 bind group layout entries consumed by the discard WGSL. */
-    readonly _bindGroupLayoutEntries?: readonly GPUBindGroupLayoutEntry[];
-    /** @internal Optional per-mesh group-2 entries. Return `null` to use the default non-discard picker for that mesh. */
-    readonly _bindGroupEntries?: (mesh: Mesh) => readonly GPUBindGroupEntry[] | null;
+    /** Optional typed-array storage inputs exposed to the discard WGSL at group 2. */
+    readonly storage?: readonly PickDiscardStorage[];
 }
 
-function createPickDiscardBindGroup(device: GPUDevice, layout: GPUBindGroupLayout, discard: PickDiscardRule, mesh: Mesh): GPUBindGroup | null {
-    const entries = discard._bindGroupEntries?.(mesh);
-    if (entries === undefined || entries === null) {
+/** Storage data for a pick discard rule. Lite injects the WGSL declaration and owns the GPU buffer upload. */
+export interface PickDiscardStorage {
+    /** WGSL variable name declared at `@group(2) @binding(index)`; must be unique within the rule. */
+    readonly name: string;
+    /** WGSL storage type, for example `array<vec4<f32>>`. */
+    readonly type: string;
+    /** Per-mesh data for the current pick. Return `null` to draw that mesh with the default picker. */
+    readonly data: (mesh: Mesh) => ArrayBufferView | null | undefined;
+}
+
+function createPickDiscardBindGroup(engine: EngineContext, layout: GPUBindGroupLayout, discard: PickDiscardRule, mesh: Mesh, tempBuffers: GPUBuffer[]): GPUBindGroup | null {
+    const storage = discard.storage;
+    if (!storage || storage.length === 0) {
         return null;
     }
+    const entries: GPUBindGroupEntry[] = [];
+    for (let i = 0; i < storage.length; i++) {
+        const data = storage[i]!.data(mesh);
+        if (!data) {
+            return null;
+        }
+        const buffer = createMappedBuffer(engine, data, BU.STORAGE);
+        tempBuffers.push(buffer);
+        entries.push({ binding: i, resource: { buffer } });
+    }
+    const device = engine._device;
     return device.createBindGroup({
         label: `pick-discard-${discard.key}-bg`,
         layout,
-        entries: [...entries],
+        entries,
     });
 }
 
@@ -260,7 +279,7 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
         }
         const gpu = mesh._gpu;
         const ti = mesh.thinInstances;
-        const discardBG = pickDiscard && discardPipelines?.discardBGL ? createPickDiscardBindGroup(device, discardPipelines.discardBGL, pickDiscard, mesh) : null;
+        const discardBG = pickDiscard && discardPipelines?.discardBGL ? createPickDiscardBindGroup(engine, discardPipelines.discardBGL, pickDiscard, mesh, tempBuffers) : null;
         const pipelines = discardPipelines && (!discardPipelines.discardBGL || discardBG) ? discardPipelines : defaultPipelines;
 
         if (ti) {

--- a/packages/babylon-lite/src/picking/gpu-picker.ts
+++ b/packages/babylon-lite/src/picking/gpu-picker.ts
@@ -142,7 +142,7 @@ export interface PickOptions {
 }
 
 /**
- * Optional WGSL-only discard rule for {@link pickAsync}.
+ * Optional WGSL discard rule for {@link pickAsync}.
  *
  * This lets apps remove pick hits with custom WGSL while keeping the main scene
  * render untouched. The WGSL must define
@@ -153,6 +153,22 @@ export interface PickDiscardRule {
     readonly key: string;
     /** WGSL source that defines `shouldDiscardPick(input: PickDiscardInput) -> bool`. */
     readonly wgsl: string;
+    /** @internal Optional group-2 bind group layout entries consumed by the discard WGSL. */
+    readonly _bindGroupLayoutEntries?: readonly GPUBindGroupLayoutEntry[];
+    /** @internal Optional per-mesh group-2 entries. Return `null` to use the default non-discard picker for that mesh. */
+    readonly _bindGroupEntries?: (mesh: Mesh) => readonly GPUBindGroupEntry[] | null;
+}
+
+function createPickDiscardBindGroup(device: GPUDevice, layout: GPUBindGroupLayout, discard: PickDiscardRule, mesh: Mesh): GPUBindGroup | null {
+    const entries = discard._bindGroupEntries?.(mesh);
+    if (entries === undefined || entries === null) {
+        return null;
+    }
+    return device.createBindGroup({
+        label: `pick-discard-${discard.key}-bg`,
+        layout,
+        entries: [...entries],
+    });
 }
 
 /** Pick the mesh at CSS-space canvas coordinates, matching Babylon.js Scene.pick. Returns a PickingInfo. */
@@ -244,7 +260,8 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
         }
         const gpu = mesh._gpu;
         const ti = mesh.thinInstances;
-        const pipelines = discardPipelines ?? defaultPipelines;
+        const discardBG = pickDiscard && discardPipelines?.discardBGL ? createPickDiscardBindGroup(device, discardPipelines.discardBGL, pickDiscard, mesh) : null;
+        const pipelines = discardPipelines && (!discardPipelines.discardBGL || discardBG) ? discardPipelines : defaultPipelines;
 
         if (ti) {
             if (ti.count <= 0 || !ti._gpuBuffer) {
@@ -266,6 +283,9 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
                     ],
                 })
             );
+            if (discardBG) {
+                pass.setBindGroup(2, discardBG);
+            }
             pass.setVertexBuffer(0, gpu.positionBuffer);
             pass.setIndexBuffer(gpu.indexBuffer, gpu.indexFormat);
             pass.drawIndexed(gpu.indexCount, ti.count);
@@ -293,6 +313,9 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
                     entries: [{ binding: 0, resource: { buffer: meshUbo } }],
                 })
             );
+            if (discardBG) {
+                pass.setBindGroup(2, discardBG);
+            }
             pass.setVertexBuffer(0, positionBuffer);
             pass.setIndexBuffer(gpu.indexBuffer, gpu.indexFormat);
             pass.drawIndexed(gpu.indexCount);

--- a/packages/babylon-lite/src/picking/gpu-picker.ts
+++ b/packages/babylon-lite/src/picking/gpu-picker.ts
@@ -10,7 +10,7 @@ import type { GaussianSplattingMesh } from "../mesh/GaussianSplatting/gaussian-s
 import { createEmptyPickingInfo } from "./picking-info.js";
 import { createPickingRay } from "./ray.js";
 import { mat4Invert } from "../math/mat4-invert.js";
-import { getPickingPipeline, getPickingTIPipeline, getPickingSceneBGL, getPickingMeshBGL, getPickingTIMeshBGL } from "./picking-pipeline.js";
+import { getPickingPipelineSet, getPickingSceneBGL } from "./picking-pipeline.js";
 import { getViewProjectionMatrix, getCameraPosition } from "../camera/camera.js";
 import { resolveCameraViewport } from "../camera/viewport.js";
 import { createEmptyUniformBuffer, createMappedBuffer, createUniformBuffer } from "../resource/gpu-buffers.js";
@@ -27,22 +27,6 @@ const _uboView = new U8(_uboScratch);
 const _tiUboScratch = new ArrayBuffer(PICK_TI_UBO_BYTES);
 const _tiUboU32 = new U32(_tiUboScratch);
 const _tiUboView = new U8(_tiUboScratch);
-
-function createPickClipBuffer(engine: EngineContext, mesh: Mesh, tempBuffers: GPUBuffer[]): GPUBuffer {
-    const clips = mesh.pickingClipVolumes;
-    const count = clips?.length ?? 0;
-    const data = new F32((1 + count * 3) * 4);
-    data[0] = count;
-    for (let i = 0; i < count; i++) {
-        const off = 4 + i * 12;
-        data.set(clips![i]!.a, off);
-        data.set(clips![i]!.b, off + 4);
-        data.set(clips![i]!.c, off + 8);
-    }
-    const buf = createMappedBuffer(engine, data, BU.STORAGE);
-    tempBuffers.push(buf);
-    return buf;
-}
 
 /** GPU-based picker — pure state. Use pickAsync() and disposePicker() standalone functions. */
 export interface GpuPicker {
@@ -143,14 +127,56 @@ export interface PickOptions {
      *  structure behind/around them. When omitted, every mesh is pickable (previous behaviour). Applied
      *  identically to the id-assignment and id-resolve passes so ids stay consistent. */
     filter?: (mesh: Mesh) => boolean;
+    /** Optional GPU fragment-discard extension for app-specific pick removal.
+     *
+     *  `wgsl` is injected into the regular and thin-instance picking shaders and must define:
+     *
+     *  `fn shouldDiscardPick(input: PickDiscardInput) -> bool`
+     *
+     *  The input exposes only generic picker data: `worldPos`, `pickId`, `thinInstanceIndex`,
+     *  `hasThinInstance`, and `instanceExtras` (the original thin-instance matrix w lanes, zero for
+     *  non-instanced meshes). If `bindGroupLayoutEntries` are supplied, they are bound as group 2;
+     *  return `null` from `bindGroupEntries(mesh)` to draw that mesh with the default picker shader. */
+    discard?: PickDiscardRule;
     /** Dev-only diagnostics: logs the pick ray, pixel, pick id/depth and resolved mesh. */
     debugLabel?: string;
+}
+
+/**
+ * Optional GPU-side discard rule for {@link pickAsync}.
+ *
+ * This lets apps remove pick hits with custom WGSL while keeping the main scene
+ * render untouched. The WGSL must define
+ * `fn shouldDiscardPick(input: PickDiscardInput) -> bool`.
+ */
+export interface PickDiscardRule {
+    /** Stable cache key for the generated picking pipeline set. Change it when the WGSL or layout changes. */
+    readonly key: string;
+    /** WGSL source that defines `shouldDiscardPick(input: PickDiscardInput) -> bool`. */
+    readonly wgsl: string;
+    /** Optional group-2 bind group layout entries consumed by the discard WGSL. */
+    readonly bindGroupLayoutEntries?: readonly GPUBindGroupLayoutEntry[];
+    /** Optional per-mesh group-2 entries. Return `null` to use the default non-discard picker for that mesh. */
+    readonly bindGroupEntries?: (mesh: Mesh) => readonly GPUBindGroupEntry[] | null;
+}
+
+function createPickDiscardBindGroup(device: GPUDevice, layout: GPUBindGroupLayout, discard: PickDiscardRule, mesh: Mesh): GPUBindGroup | null {
+    const entries = discard.bindGroupEntries ? discard.bindGroupEntries(mesh) : [];
+    if (entries === null) {
+        return null;
+    }
+    return device.createBindGroup({
+        label: `pick-discard-${discard.key}-bg`,
+        layout,
+        entries: [...entries],
+    });
 }
 
 /** Pick the mesh at CSS-space canvas coordinates, matching Babylon.js Scene.pick. Returns a PickingInfo. */
 export async function pickAsync(picker: GpuPicker, x: number, y: number, options?: PickOptions): Promise<PickingInfo> {
     const scene = picker._scene;
     const pickFilter = options?.filter ?? null;
+    const pickDiscard = options?.discard ?? null;
     const debugLabel = options?.debugLabel;
     const engine = scene.surface.engine;
     const device = engine._device;
@@ -217,10 +243,8 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
         depthStencilAttachment: { view: rt.depthView, depthClearValue: 0, depthLoadOp: "clear", depthStoreOp: "discard" },
     });
 
-    const regularPipeline = getPickingPipeline(engine);
-    const tiPipeline = getPickingTIPipeline(engine);
-    const meshBGL = getPickingMeshBGL(engine);
-    const tiMeshBGL = getPickingTIMeshBGL(engine);
+    const defaultPipelines = getPickingPipelineSet(engine);
+    const discardPipelines = pickDiscard ? getPickingPipelineSet(engine, pickDiscard) : null;
 
     const tempBuffers: GPUBuffer[] = [];
     for (let mi = 0; mi < meshCount; mi++) {
@@ -237,6 +261,8 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
         }
         const gpu = mesh._gpu;
         const ti = mesh.thinInstances;
+        const discardBG = pickDiscard && discardPipelines?.discardBGL ? createPickDiscardBindGroup(device, discardPipelines.discardBGL, pickDiscard, mesh) : null;
+        const pipelines = discardBG ? discardPipelines! : defaultPipelines;
 
         if (ti) {
             if (ti.count <= 0 || !ti._gpuBuffer) {
@@ -244,22 +270,23 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
             }
             _tiUboU32[0] = nextId;
             const tiUbo = createUniformBuffer(engine, _tiUboView);
-            const clipBuffer = createPickClipBuffer(engine, mesh, tempBuffers);
             tempBuffers.push(tiUbo);
 
-            pass.setPipeline(tiPipeline);
+            pass.setPipeline(pipelines.thinInstancePipeline);
             pass.setBindGroup(0, picker._sceneBG!);
             pass.setBindGroup(
                 1,
                 device.createBindGroup({
-                    layout: tiMeshBGL,
+                    layout: pipelines.thinInstancePipeline.getBindGroupLayout(1),
                     entries: [
                         { binding: 0, resource: { buffer: tiUbo } },
                         { binding: 1, resource: { buffer: ti._gpuBuffer } },
-                        { binding: 2, resource: { buffer: clipBuffer } },
                     ],
                 })
             );
+            if (discardBG) {
+                pass.setBindGroup(2, discardBG);
+            }
             pass.setVertexBuffer(0, gpu.positionBuffer);
             pass.setIndexBuffer(gpu.indexBuffer, gpu.indexFormat);
             pass.drawIndexed(gpu.indexCount, ti.count);
@@ -268,7 +295,6 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
             _uboF32.set(mesh.worldMatrix, 0);
             _uboU32[16] = nextId;
             const meshUbo = createUniformBuffer(engine, _uboView);
-            const clipBuffer = createPickClipBuffer(engine, mesh, tempBuffers);
             tempBuffers.push(meshUbo);
             let positionBuffer = gpu.positionBuffer;
             if (deformedGeometry && (mesh.morphTargets || mesh.skeleton) && mesh._cpuPositions) {
@@ -279,18 +305,18 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
                 }
             }
 
-            pass.setPipeline(regularPipeline);
+            pass.setPipeline(pipelines.regularPipeline);
             pass.setBindGroup(0, picker._sceneBG!);
             pass.setBindGroup(
                 1,
                 device.createBindGroup({
-                    layout: meshBGL,
-                    entries: [
-                        { binding: 0, resource: { buffer: meshUbo } },
-                        { binding: 1, resource: { buffer: clipBuffer } },
-                    ],
+                    layout: pipelines.regularPipeline.getBindGroupLayout(1),
+                    entries: [{ binding: 0, resource: { buffer: meshUbo } }],
                 })
             );
+            if (discardBG) {
+                pass.setBindGroup(2, discardBG);
+            }
             pass.setVertexBuffer(0, positionBuffer);
             pass.setIndexBuffer(gpu.indexBuffer, gpu.indexFormat);
             pass.drawIndexed(gpu.indexCount);

--- a/packages/babylon-lite/src/picking/gpu-picker.ts
+++ b/packages/babylon-lite/src/picking/gpu-picker.ts
@@ -135,15 +135,14 @@ export interface PickOptions {
      *
      *  The input exposes only generic picker data: `worldPos`, `pickId`, `thinInstanceIndex`,
      *  `hasThinInstance`, and `instanceExtras` (the original thin-instance matrix w lanes, zero for
-     *  non-instanced meshes). If `bindGroupLayoutEntries` are supplied, they are bound as group 2;
-     *  return `null` from `bindGroupEntries(mesh)` to draw that mesh with the default picker shader. */
+     *  non-instanced meshes). */
     discard?: PickDiscardRule;
     /** Dev-only diagnostics: logs the pick ray, pixel, pick id/depth and resolved mesh. */
     debugLabel?: string;
 }
 
 /**
- * Optional GPU-side discard rule for {@link pickAsync}.
+ * Optional WGSL-only discard rule for {@link pickAsync}.
  *
  * This lets apps remove pick hits with custom WGSL while keeping the main scene
  * render untouched. The WGSL must define
@@ -154,22 +153,6 @@ export interface PickDiscardRule {
     readonly key: string;
     /** WGSL source that defines `shouldDiscardPick(input: PickDiscardInput) -> bool`. */
     readonly wgsl: string;
-    /** Optional group-2 bind group layout entries consumed by the discard WGSL. */
-    readonly bindGroupLayoutEntries?: readonly GPUBindGroupLayoutEntry[];
-    /** Optional per-mesh group-2 entries. Return `null` to use the default non-discard picker for that mesh. */
-    readonly bindGroupEntries?: (mesh: Mesh) => readonly GPUBindGroupEntry[] | null;
-}
-
-function createPickDiscardBindGroup(device: GPUDevice, layout: GPUBindGroupLayout, discard: PickDiscardRule, mesh: Mesh): GPUBindGroup | null {
-    const entries = discard.bindGroupEntries ? discard.bindGroupEntries(mesh) : [];
-    if (entries === null) {
-        return null;
-    }
-    return device.createBindGroup({
-        label: `pick-discard-${discard.key}-bg`,
-        layout,
-        entries: [...entries],
-    });
 }
 
 /** Pick the mesh at CSS-space canvas coordinates, matching Babylon.js Scene.pick. Returns a PickingInfo. */
@@ -261,8 +244,7 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
         }
         const gpu = mesh._gpu;
         const ti = mesh.thinInstances;
-        const discardBG = pickDiscard && discardPipelines?.discardBGL ? createPickDiscardBindGroup(device, discardPipelines.discardBGL, pickDiscard, mesh) : null;
-        const pipelines = discardBG ? discardPipelines! : defaultPipelines;
+        const pipelines = discardPipelines ?? defaultPipelines;
 
         if (ti) {
             if (ti.count <= 0 || !ti._gpuBuffer) {
@@ -284,9 +266,6 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
                     ],
                 })
             );
-            if (discardBG) {
-                pass.setBindGroup(2, discardBG);
-            }
             pass.setVertexBuffer(0, gpu.positionBuffer);
             pass.setIndexBuffer(gpu.indexBuffer, gpu.indexFormat);
             pass.drawIndexed(gpu.indexCount, ti.count);
@@ -314,9 +293,6 @@ export async function pickAsync(picker: GpuPicker, x: number, y: number, options
                     entries: [{ binding: 0, resource: { buffer: meshUbo } }],
                 })
             );
-            if (discardBG) {
-                pass.setBindGroup(2, discardBG);
-            }
             pass.setVertexBuffer(0, positionBuffer);
             pass.setIndexBuffer(gpu.indexBuffer, gpu.indexFormat);
             pass.drawIndexed(gpu.indexCount);

--- a/packages/babylon-lite/src/picking/picking-pipeline.ts
+++ b/packages/babylon-lite/src/picking/picking-pipeline.ts
@@ -14,8 +14,7 @@ let _pipelineSets: Map<string, PickingPipelineSet> | null = null;
 export interface PickingDiscardPipelineOptions {
     readonly key: string;
     readonly wgsl: string;
-    /** @internal */
-    readonly _bindGroupLayoutEntries?: readonly GPUBindGroupLayoutEntry[];
+    readonly storage?: readonly { readonly name: string; readonly type: string }[];
 }
 
 export interface PickingPipelineSet {
@@ -82,7 +81,11 @@ function getPickingTIMeshBGL(engine: EngineContext): GPUBindGroupLayout {
 function createDiscardBGL(engine: EngineContext, discard: PickingDiscardPipelineOptions): GPUBindGroupLayout {
     return engine._device.createBindGroupLayout({
         label: `picking-discard-${discard.key}-bgl`,
-        entries: [...(discard._bindGroupLayoutEntries ?? [])],
+        entries: (discard.storage ?? []).map((_, binding) => ({
+            binding,
+            visibility: SS.FRAGMENT,
+            buffer: { type: "read-only-storage" },
+        })),
     });
 }
 
@@ -149,8 +152,8 @@ export function getPickingPipelineSet(engine: EngineContext, discard?: PickingDi
         return cached;
     }
 
-    const discardBGL = discard?._bindGroupLayoutEntries?.length ? createDiscardBGL(engine, discard) : null;
-    const shaderOptions = discard ? { discardWgsl: discard.wgsl } : undefined;
+    const discardBGL = discard?.storage?.length ? createDiscardBGL(engine, discard) : null;
+    const shaderOptions = discard ? { discardWgsl: discard.wgsl, storage: discard.storage } : undefined;
     const regularPipeline = createPickingPipelineInternal(engine, {
         shader: pickingShaderSource(shaderOptions),
         meshBGL: getPickingMeshBGL(engine),

--- a/packages/babylon-lite/src/picking/picking-pipeline.ts
+++ b/packages/babylon-lite/src/picking/picking-pipeline.ts
@@ -14,7 +14,8 @@ let _pipelineSets: Map<string, PickingPipelineSet> | null = null;
 export interface PickingDiscardPipelineOptions {
     readonly key: string;
     readonly wgsl: string;
-    readonly bindGroupLayoutEntries?: readonly GPUBindGroupLayoutEntry[];
+    /** @internal */
+    readonly _bindGroupLayoutEntries?: readonly GPUBindGroupLayoutEntry[];
 }
 
 export interface PickingPipelineSet {
@@ -81,7 +82,7 @@ function getPickingTIMeshBGL(engine: EngineContext): GPUBindGroupLayout {
 function createDiscardBGL(engine: EngineContext, discard: PickingDiscardPipelineOptions): GPUBindGroupLayout {
     return engine._device.createBindGroupLayout({
         label: `picking-discard-${discard.key}-bgl`,
-        entries: [...(discard.bindGroupLayoutEntries ?? [])],
+        entries: [...(discard._bindGroupLayoutEntries ?? [])],
     });
 }
 
@@ -148,7 +149,7 @@ export function getPickingPipelineSet(engine: EngineContext, discard?: PickingDi
         return cached;
     }
 
-    const discardBGL = discard?.bindGroupLayoutEntries?.length ? createDiscardBGL(engine, discard) : null;
+    const discardBGL = discard?._bindGroupLayoutEntries?.length ? createDiscardBGL(engine, discard) : null;
     const shaderOptions = discard ? { discardWgsl: discard.wgsl } : undefined;
     const regularPipeline = createPickingPipelineInternal(engine, {
         shader: pickingShaderSource(shaderOptions),

--- a/packages/babylon-lite/src/picking/picking-pipeline.ts
+++ b/packages/babylon-lite/src/picking/picking-pipeline.ts
@@ -6,20 +6,30 @@ import { createSingleUniformBGL } from "../shader/bgl-helpers.js";
 // ─── Cache state (auto-invalidate on device change) ─────────────────
 
 let _cachedDevice: GPUDevice | null = null;
-let _pipeline: GPURenderPipeline | null = null;
-let _tiPipeline: GPURenderPipeline | null = null;
 let _sceneBGL: GPUBindGroupLayout | null = null;
 let _meshBGL: GPUBindGroupLayout | null = null;
 let _tiMeshBGL: GPUBindGroupLayout | null = null;
+let _pipelineSets = new Map<string, PickingPipelineSet>();
+
+export interface PickingDiscardPipelineOptions {
+    readonly key: string;
+    readonly wgsl: string;
+    readonly bindGroupLayoutEntries?: readonly GPUBindGroupLayoutEntry[];
+}
+
+export interface PickingPipelineSet {
+    readonly regularPipeline: GPURenderPipeline;
+    readonly thinInstancePipeline: GPURenderPipeline;
+    readonly discardBGL: GPUBindGroupLayout | null;
+}
 
 function invalidateIfNeeded(engine: EngineContext): void {
     const device = engine._device;
     if (device !== _cachedDevice) {
-        _pipeline = null;
-        _tiPipeline = null;
         _sceneBGL = null;
         _meshBGL = null;
         _tiMeshBGL = null;
+        _pipelineSets = new Map();
         _cachedDevice = device;
     }
 }
@@ -36,22 +46,16 @@ export function getPickingSceneBGL(engine: EngineContext): GPUBindGroupLayout {
 }
 
 /** Group 1: per-mesh world matrix + pickId uniform (regular meshes). */
-export function getPickingMeshBGL(engine: EngineContext): GPUBindGroupLayout {
+function getPickingMeshBGL(engine: EngineContext): GPUBindGroupLayout {
     invalidateIfNeeded(engine);
     if (!_meshBGL) {
-        _meshBGL = engine._device.createBindGroupLayout({
-            label: "picking-mesh-bgl",
-            entries: [
-                { binding: 0, visibility: SS.VERTEX | SS.FRAGMENT, buffer: { type: "uniform" } },
-                { binding: 1, visibility: SS.FRAGMENT, buffer: { type: "read-only-storage" } },
-            ],
-        });
+        _meshBGL = createSingleUniformBGL(engine, "picking-mesh-bgl", SS.VERTEX | SS.FRAGMENT);
     }
     return _meshBGL;
 }
 
 /** Group 1: per-mesh baseMeshPickId uniform + instance storage buffer (thin instances). */
-export function getPickingTIMeshBGL(engine: EngineContext): GPUBindGroupLayout {
+function getPickingTIMeshBGL(engine: EngineContext): GPUBindGroupLayout {
     const device = engine._device;
     invalidateIfNeeded(engine);
     if (!_tiMeshBGL) {
@@ -68,15 +72,17 @@ export function getPickingTIMeshBGL(engine: EngineContext): GPUBindGroupLayout {
                     visibility: SS.VERTEX,
                     buffer: { type: "read-only-storage" },
                 },
-                {
-                    binding: 2,
-                    visibility: SS.FRAGMENT,
-                    buffer: { type: "read-only-storage" },
-                },
             ],
         });
     }
     return _tiMeshBGL;
+}
+
+function createDiscardBGL(engine: EngineContext, discard: PickingDiscardPipelineOptions): GPUBindGroupLayout {
+    return engine._device.createBindGroupLayout({
+        label: `picking-discard-${discard.key}-bgl`,
+        entries: [...(discard.bindGroupLayoutEntries ?? [])],
+    });
 }
 
 // ─── Position-only vertex layout ────────────────────────────────────
@@ -91,15 +97,17 @@ const POSITION_VERTEX_LAYOUT: GPUVertexBufferLayout = {
 interface PickingPipelineOptions {
     shader: string;
     meshBGL: GPUBindGroupLayout;
+    discardBGL: GPUBindGroupLayout | null;
     label: string;
 }
 
 function createPickingPipelineInternal(engine: EngineContext, opts: PickingPipelineOptions): GPURenderPipeline {
     const device = engine._device;
     const module = device.createShaderModule({ label: `${opts.label}-shader`, code: opts.shader });
+    const bindGroupLayouts = opts.discardBGL ? [getPickingSceneBGL(engine), opts.meshBGL, opts.discardBGL] : [getPickingSceneBGL(engine), opts.meshBGL];
     const layout = device.createPipelineLayout({
         label: `${opts.label}-pipeline-layout`,
-        bindGroupLayouts: [getPickingSceneBGL(engine), opts.meshBGL],
+        bindGroupLayouts,
     });
     return device.createRenderPipeline({
         label: `${opts.label}-pipeline`,
@@ -123,38 +131,37 @@ function createPickingPipelineInternal(engine: EngineContext, opts: PickingPipel
             topology: "triangle-list",
             // Pick the NEAREST surface regardless of facing (matches Babylon.js Scene.pick, which intersects
             // both triangle sides). Culling back faces here would make any DOUBLE-SIDED mesh
-            // (material.backFaceCulling === false, e.g. foliage quads or a deck whose box winding isn't
-            // uniformly CCW) unpickable wherever the renderer shows its back face — scattered pick holes on a
-            // solid mesh. The reverse-Z depth test still resolves the front-most surface, so "none" is correct
-            // and also makes frontFace irrelevant (no winding assumption to get wrong).
+            // unpickable wherever the renderer shows its back face.
             cullMode: "none",
         },
         multisample: { count: 1 },
     });
 }
 
-/** Get (or create) the picking pipeline for regular meshes. */
-export function getPickingPipeline(engine: EngineContext): GPURenderPipeline {
+/** Get (or create) the picking pipeline set for the default path or a caller-provided discard rule. */
+export function getPickingPipelineSet(engine: EngineContext, discard?: PickingDiscardPipelineOptions | null): PickingPipelineSet {
     invalidateIfNeeded(engine);
-    if (!_pipeline) {
-        _pipeline = createPickingPipelineInternal(engine, {
-            shader: pickingShaderSource,
-            meshBGL: getPickingMeshBGL(engine),
-            label: "picking",
-        });
+    const key = discard ? `discard:${discard.key}` : "default";
+    const cached = _pipelineSets.get(key);
+    if (cached) {
+        return cached;
     }
-    return _pipeline;
-}
 
-/** Get (or create) the picking pipeline for thin-instanced meshes. */
-export function getPickingTIPipeline(engine: EngineContext): GPURenderPipeline {
-    invalidateIfNeeded(engine);
-    if (!_tiPipeline) {
-        _tiPipeline = createPickingPipelineInternal(engine, {
-            shader: pickingThinInstanceShaderSource,
-            meshBGL: getPickingTIMeshBGL(engine),
-            label: "picking-ti",
-        });
-    }
-    return _tiPipeline;
+    const discardBGL = discard ? createDiscardBGL(engine, discard) : null;
+    const shaderOptions = discard ? { discardWgsl: discard.wgsl } : undefined;
+    const regularPipeline = createPickingPipelineInternal(engine, {
+        shader: pickingShaderSource(shaderOptions),
+        meshBGL: getPickingMeshBGL(engine),
+        discardBGL,
+        label: discard ? `picking-${discard.key}` : "picking",
+    });
+    const thinInstancePipeline = createPickingPipelineInternal(engine, {
+        shader: pickingThinInstanceShaderSource(shaderOptions),
+        meshBGL: getPickingTIMeshBGL(engine),
+        discardBGL,
+        label: discard ? `picking-ti-${discard.key}` : "picking-ti",
+    });
+    const set = { regularPipeline, thinInstancePipeline, discardBGL };
+    _pipelineSets.set(key, set);
+    return set;
 }

--- a/packages/babylon-lite/src/picking/picking-pipeline.ts
+++ b/packages/babylon-lite/src/picking/picking-pipeline.ts
@@ -9,7 +9,7 @@ let _cachedDevice: GPUDevice | null = null;
 let _sceneBGL: GPUBindGroupLayout | null = null;
 let _meshBGL: GPUBindGroupLayout | null = null;
 let _tiMeshBGL: GPUBindGroupLayout | null = null;
-let _pipelineSets = new Map<string, PickingPipelineSet>();
+let _pipelineSets: Map<string, PickingPipelineSet> | null = null;
 
 export interface PickingDiscardPipelineOptions {
     readonly key: string;
@@ -29,7 +29,7 @@ function invalidateIfNeeded(engine: EngineContext): void {
         _sceneBGL = null;
         _meshBGL = null;
         _tiMeshBGL = null;
-        _pipelineSets = new Map();
+        _pipelineSets = null;
         _cachedDevice = device;
     }
 }
@@ -142,12 +142,13 @@ function createPickingPipelineInternal(engine: EngineContext, opts: PickingPipel
 export function getPickingPipelineSet(engine: EngineContext, discard?: PickingDiscardPipelineOptions | null): PickingPipelineSet {
     invalidateIfNeeded(engine);
     const key = discard ? `discard:${discard.key}` : "default";
-    const cached = _pipelineSets.get(key);
+    const pipelineSets = _pipelineSets ?? (_pipelineSets = new Map());
+    const cached = pipelineSets.get(key);
     if (cached) {
         return cached;
     }
 
-    const discardBGL = discard ? createDiscardBGL(engine, discard) : null;
+    const discardBGL = discard?.bindGroupLayoutEntries?.length ? createDiscardBGL(engine, discard) : null;
     const shaderOptions = discard ? { discardWgsl: discard.wgsl } : undefined;
     const regularPipeline = createPickingPipelineInternal(engine, {
         shader: pickingShaderSource(shaderOptions),
@@ -162,6 +163,6 @@ export function getPickingPipelineSet(engine: EngineContext, discard?: PickingDi
         label: discard ? `picking-ti-${discard.key}` : "picking-ti",
     });
     const set = { regularPipeline, thinInstancePipeline, discardBGL };
-    _pipelineSets.set(key, set);
+    pipelineSets.set(key, set);
     return set;
 }

--- a/packages/babylon-lite/src/picking/picking-shader.ts
+++ b/packages/babylon-lite/src/picking/picking-shader.ts
@@ -3,6 +3,7 @@
 
 export interface PickingShaderOptions {
     readonly discardWgsl?: string | null;
+    readonly storage?: readonly { readonly name: string; readonly type: string }[];
 }
 
 const PICK_DISCARD_INPUT = /* wgsl */ `
@@ -23,6 +24,14 @@ return false;
 
 function pickDiscardSource(opts?: PickingShaderOptions): string {
     return opts?.discardWgsl ?? DEFAULT_PICK_DISCARD;
+}
+
+function pickDiscardStorageDecls(opts?: PickingShaderOptions): string {
+    const storage = opts?.storage;
+    if (!storage || storage.length === 0) {
+        return "";
+    }
+    return storage.map((s, binding) => `@group(2) @binding(${binding}) var<storage, read> ${s.name}: ${s.type};`).join("\n");
 }
 
 // ─── Shared structs + fragment shader ───────────────────────────────
@@ -60,6 +69,7 @@ pickId: u32,
 @group(0) @binding(0) var<uniform> scene: SceneUniforms;
 @group(1) @binding(0) var<uniform> mesh: MeshUniforms;
 ${PICK_DISCARD_INPUT}
+${pickDiscardStorageDecls(opts)}
 ${pickDiscardSource(opts)}
 ${PICK_FS}
 @vertex fn vs(@location(0) position: vec3f) -> VsOut {
@@ -88,6 +98,7 @@ baseMeshPickId: u32,
 @group(1) @binding(0) var<uniform> tiMesh: TIMeshUniforms;
 @group(1) @binding(1) var<storage, read> instances: array<mat4x4f>;
 ${PICK_DISCARD_INPUT}
+${pickDiscardStorageDecls(opts)}
 ${pickDiscardSource(opts)}
 ${PICK_FS}
 @vertex fn vs(@location(0) position: vec3f, @builtin(instance_index) instanceIndex: u32) -> VsOut {

--- a/packages/babylon-lite/src/picking/picking-shader.ts
+++ b/packages/babylon-lite/src/picking/picking-shader.ts
@@ -1,33 +1,45 @@
 /** WGSL shaders for GPU pick-ID rendering.
  *  Outputs pick ID as rgba8unorm (location 0) and depth as r32float (location 1). */
 
-// ─── Shared structs + fragment shader ───────────────────────────────
+export interface PickingShaderOptions {
+    readonly discardWgsl?: string | null;
+}
 
-const PICK_SHARED = /* wgsl */ `
-fn pickClipOne(wp: vec3f, a: vec4f, b: vec4f, c: vec4f) -> bool {
-let q = wp.xz - a.xy;
-let ds = dot(q, a.zw);
-let dp = dot(q, vec2f(-a.w, a.z));
-if (abs(dp) > c.y) { return false; }
-let y = wp.y - b.x;
-let outerHW = b.y + c.x;
-if (c.z > 0.5) { return y <= b.z + c.x && abs(ds) <= outerHW; }
-if (y <= b.z) { return abs(ds) <= outerHW; }
-let outerRise = b.w + c.x;
-if (y > b.z + outerRise || outerRise <= 0.0) { return false; }
-let ex = ds / max(outerHW, 0.001);
-let ey = (y - b.z) / max(outerRise, 0.001);
-return ex * ex + ey * ey <= 1.0;
+const PICK_DISCARD_INPUT = /* wgsl */ `
+struct PickDiscardInput {
+worldPos: vec3f,
+pickId: u32,
+thinInstanceIndex: u32,
+hasThinInstance: u32,
+instanceExtras: vec4f,
+};
+`;
+
+const DEFAULT_PICK_DISCARD = /* wgsl */ `
+fn shouldDiscardPick(input: PickDiscardInput) -> bool {
+return false;
 }
 `;
+
+function pickDiscardSource(opts?: PickingShaderOptions): string {
+    return opts?.discardWgsl ?? DEFAULT_PICK_DISCARD;
+}
 
 // ─── Shared structs + fragment shader ───────────────────────────────
 
 const PICK_FS = /* wgsl */ `
-struct VsOut { @builtin(position) position: vec4f, @location(0) @interpolate(flat) pickId: u32, @location(1) worldPos: vec3f, @location(2) clipSkip: f32 };
+struct VsOut {
+@builtin(position) position: vec4f,
+@location(0) @interpolate(flat) pickId: u32,
+@location(1) worldPos: vec3f,
+@location(2) @interpolate(flat) thinInstanceIndex: u32,
+@location(3) @interpolate(flat) hasThinInstance: u32,
+@location(4) @interpolate(flat) instanceExtras: vec4f,
+};
 struct FsOut { @location(0) color: vec4f, @location(1) depth: vec4f };
 @fragment fn fs(input: VsOut) -> FsOut {
-if (input.clipSkip < 0.5 && pickClipHit(input.worldPos)) { discard; }
+let discardInput = PickDiscardInput(input.worldPos, input.pickId, input.thinInstanceIndex, input.hasThinInstance, input.instanceExtras);
+if (shouldDiscardPick(discardInput)) { discard; }
 let id = input.pickId;
 let r = f32((id >> 16u) & 0xFFu) / 255.0;
 let g = f32((id >> 8u) & 0xFFu) / 255.0;
@@ -38,7 +50,8 @@ return FsOut(vec4f(r, g, b, 1.0), vec4f(input.position.z, 0.0, 0.0, 0.0));
 
 // ─── Regular mesh picking shader ────────────────────────────────────
 
-export const pickingShaderSource = /* wgsl */ `
+export function pickingShaderSource(opts?: PickingShaderOptions): string {
+    return /* wgsl */ `
 struct SceneUniforms { viewProjection: mat4x4f };
 struct MeshUniforms {
 world: mat4x4f,
@@ -46,16 +59,8 @@ pickId: u32,
 };
 @group(0) @binding(0) var<uniform> scene: SceneUniforms;
 @group(1) @binding(0) var<uniform> mesh: MeshUniforms;
-@group(1) @binding(1) var<storage, read> clipData: array<vec4f>;
-${PICK_SHARED}
-fn pickClipHit(wp: vec3f) -> bool {
-let n = i32(clipData[0].x);
-for (var i = 0; i < n; i = i + 1) {
-let base = 1 + i * 3;
-if (pickClipOne(wp, clipData[base], clipData[base + 1], clipData[base + 2])) { return true; }
-}
-return false;
-}
+${PICK_DISCARD_INPUT}
+${pickDiscardSource(opts)}
 ${PICK_FS}
 @vertex fn vs(@location(0) position: vec3f) -> VsOut {
 var out: VsOut;
@@ -63,14 +68,18 @@ let wp = (mesh.world * vec4f(position, 1.0)).xyz;
 out.position = scene.viewProjection * vec4f(wp, 1.0);
 out.pickId = mesh.pickId;
 out.worldPos = wp;
-out.clipSkip = 0.0;
+out.thinInstanceIndex = 0xffffffffu;
+out.hasThinInstance = 0u;
+out.instanceExtras = vec4f(0.0);
 return out;
 }
 `;
+}
 
 // ─── Thin-instance picking shader ───────────────────────────────────
 
-export const pickingThinInstanceShaderSource = /* wgsl */ `
+export function pickingThinInstanceShaderSource(opts?: PickingShaderOptions): string {
+    return /* wgsl */ `
 struct SceneUniforms { viewProjection: mat4x4f };
 struct TIMeshUniforms {
 baseMeshPickId: u32,
@@ -78,24 +87,15 @@ baseMeshPickId: u32,
 @group(0) @binding(0) var<uniform> scene: SceneUniforms;
 @group(1) @binding(0) var<uniform> tiMesh: TIMeshUniforms;
 @group(1) @binding(1) var<storage, read> instances: array<mat4x4f>;
-@group(1) @binding(2) var<storage, read> clipData: array<vec4f>;
-${PICK_SHARED}
-fn pickClipHit(wp: vec3f) -> bool {
-let n = i32(clipData[0].x);
-for (var i = 0; i < n; i = i + 1) {
-let base = 1 + i * 3;
-if (pickClipOne(wp, clipData[base], clipData[base + 1], clipData[base + 2])) { return true; }
-}
-return false;
-}
+${PICK_DISCARD_INPUT}
+${pickDiscardSource(opts)}
 ${PICK_FS}
 @vertex fn vs(@location(0) position: vec3f, @builtin(instance_index) instanceIndex: u32) -> VsOut {
 let m = instances[instanceIndex];
 // Treat the instance placement as an AFFINE transform: force the basis columns' homogeneous w to 0 and the
 // translation column's w to 1. Thin-instanced ShaderMaterials may pack per-instance data in those spare w
 // lanes (a sanctioned pattern — Lite injects world0..world3 and the app's own vertex shader zeroes them
-// before transforming, e.g. a frozen anchor Y in world0.w). Picking only needs the transform, so any packed
-// value left in w would corrupt clip.w → wrong depth/rasterisation → the pick returns the wrong instance.
+// before transforming). Picking only needs the transform, so packed values are exposed separately.
 let world = mat4x4f(
 vec4f(m[0].xyz, 0.0),
 vec4f(m[1].xyz, 0.0),
@@ -107,7 +107,10 @@ let wp = (world * vec4f(position, 1.0)).xyz;
 out.position = scene.viewProjection * vec4f(wp, 1.0);
 out.pickId = tiMesh.baseMeshPickId + instanceIndex;
 out.worldPos = wp;
-out.clipSkip = clamp(floor(max(m[2].w, 0.0) * 0.25), 0.0, 1.0);
+out.thinInstanceIndex = instanceIndex;
+out.hasThinInstance = 1u;
+out.instanceExtras = vec4f(m[0].w, m[1].w, m[2].w, m[3].w);
 return out;
 }
 `;
+}

--- a/tests/lite/unit/hierarchy-instance-pool.test.ts
+++ b/tests/lite/unit/hierarchy-instance-pool.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    createHierarchyInstancePool,
+    addHierarchyInstance,
+    removeHierarchyInstance,
+    setHierarchyInstanceCount,
+    setHierarchyInstanceMatrix,
+} from "../../../packages/babylon-lite/src";
+import { initMeshTransform } from "../../../packages/babylon-lite/src/mesh/mesh";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
+import { createTransformNode } from "../../../packages/babylon-lite/src/scene/transform-node";
+import { mat4Compose } from "../../../packages/babylon-lite/src/math/mat4-compose";
+import { mat4Multiply } from "../../../packages/babylon-lite/src/math/mat4-multiply";
+import { mat4Translation } from "../../../packages/babylon-lite/src/math/mat4-translation";
+import type { Mat4 } from "../../../packages/babylon-lite/src/math/types";
+
+function makeMesh(name: string): Mesh {
+    const mesh = {
+        name,
+        material: {},
+        receiveShadows: false,
+        _gpu: {},
+    } as unknown as Mesh;
+    initMeshTransform(mesh);
+    return mesh;
+}
+
+function readMatrix(data: Float32Array, index: number): Mat4 {
+    return data.slice(index * 16, index * 16 + 16) as unknown as Mat4;
+}
+
+function expectMatrixClose(actual: Mat4, expected: Mat4): void {
+    for (let i = 0; i < 16; i++) {
+        expect(actual[i]).toBeCloseTo(expected[i]!, 5);
+    }
+}
+
+describe("hierarchy instance pool", () => {
+    it("initializes descendant meshes as zero-count thin-instanced render carriers", () => {
+        const root = createTransformNode("root");
+        const mesh = makeMesh("leaf");
+        root.children.push(mesh);
+
+        const pool = createHierarchyInstancePool(root, 4);
+
+        expect(pool.root).toBe(root);
+        expect(pool.count).toBe(0);
+        expect(pool.capacity).toBe(4);
+        expect(pool.meshes).toEqual([mesh]);
+        expect(mesh.parent).toBe(root);
+        expect(mesh.thinInstances?.count).toBe(0);
+        expect(mesh.thinInstances?._capacity).toBe(4);
+    });
+
+    it("expands one root instance matrix into each child mesh's local hierarchy space", () => {
+        const root = createTransformNode("root");
+        const child = createTransformNode("child", 2, 0, 0);
+        const mesh = makeMesh("leaf");
+        mesh.position.set(0, 1, 0);
+        root.children.push(child);
+        child.children.push(mesh);
+
+        const pool = createHierarchyInstancePool(root, 2);
+        const angle = Math.PI / 2;
+        const rootInstance = mat4Compose(5, 0, 0, 0, 0, Math.sin(angle / 2), Math.cos(angle / 2), 1, 1, 1);
+
+        const index = addHierarchyInstance(pool, rootInstance);
+
+        expect(index).toBe(0);
+        expect(pool.count).toBe(1);
+        const perMeshMatrix = readMatrix(mesh.thinInstances!.matrices as Float32Array, 0);
+        const actualFinalWorld = mat4Multiply(mesh.worldMatrix, perMeshMatrix);
+        const expectedFinalWorld = mat4Multiply(rootInstance, mesh.worldMatrix);
+        expectMatrixClose(actualFinalWorld, expectedFinalWorld);
+    });
+
+    it("updates and swap-removes logical hierarchy instance slots across meshes", () => {
+        const root = createTransformNode("root");
+        const mesh = makeMesh("leaf");
+        root.children.push(mesh);
+        const pool = createHierarchyInstancePool(root, 3);
+
+        addHierarchyInstance(pool, mat4Translation(1, 0, 0));
+        addHierarchyInstance(pool, mat4Translation(2, 0, 0));
+        addHierarchyInstance(pool, mat4Translation(3, 0, 0));
+
+        setHierarchyInstanceMatrix(pool, 0, mat4Translation(9, 0, 0));
+        expect(readMatrix(mesh.thinInstances!.matrices as Float32Array, 0)[12]).toBeCloseTo(9);
+
+        removeHierarchyInstance(pool, 1);
+        expect(pool.count).toBe(2);
+        expect(mesh.thinInstances?.count).toBe(2);
+        expect(readMatrix(mesh.thinInstances!.matrices as Float32Array, 1)[12]).toBeCloseTo(3);
+
+        setHierarchyInstanceCount(pool, 0);
+        expect(pool.count).toBe(0);
+        expect(mesh.thinInstances?.count).toBe(0);
+    });
+
+    it("rejects invalid counts and indices", () => {
+        const root = createTransformNode("root");
+        const mesh = makeMesh("leaf");
+        root.children.push(mesh);
+        const pool = createHierarchyInstancePool(root, 1);
+
+        expect(() => setHierarchyInstanceCount(pool, 2)).toThrow("within pool capacity");
+        expect(() => removeHierarchyInstance(pool, 0)).toThrow("active hierarchy instance");
+
+        addHierarchyInstance(pool, mat4Translation(0, 0, 0));
+        expect(() => addHierarchyInstance(pool, mat4Translation(1, 0, 0))).toThrow("exceeded pool capacity");
+        expect(() => setHierarchyInstanceMatrix(pool, 1, mat4Translation(1, 0, 0))).toThrow("active hierarchy instance");
+    });
+});

--- a/tests/lite/unit/picking-discard-api.test.ts
+++ b/tests/lite/unit/picking-discard-api.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
+import { createGpuPicker, pickAsync } from "../../../packages/babylon-lite/src/picking/gpu-picker";
 import { getPickingPipelineSet } from "../../../packages/babylon-lite/src/picking/picking-pipeline";
 import { pickingShaderSource, pickingThinInstanceShaderSource } from "../../../packages/babylon-lite/src/picking/picking-shader";
 import type { PickDiscardRule, PickOptions } from "../../../packages/babylon-lite/src";
+
+const IDENTITY = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
 
 function makeEngine(): {
     engine: EngineContext;
@@ -29,17 +33,133 @@ function makeEngine(): {
         },
         createPipelineLayout(descriptor: GPUPipelineLayoutDescriptor): GPUPipelineLayout {
             this.pipelineLayouts.push(descriptor);
-            return descriptor as unknown as GPUPipelineLayout;
+            return { descriptor, bindGroupLayouts: descriptor.bindGroupLayouts } as unknown as GPUPipelineLayout;
         },
         createRenderPipeline(descriptor: GPURenderPipelineDescriptor): GPURenderPipeline {
             this.renderPipelines.push(descriptor);
-            return descriptor as unknown as GPURenderPipeline;
+            const layout = descriptor.layout as unknown as { bindGroupLayouts?: readonly GPUBindGroupLayout[] };
+            return {
+                descriptor,
+                getBindGroupLayout(index: number): GPUBindGroupLayout {
+                    return layout.bindGroupLayouts?.[index] ?? ({ label: `layout-${index}` } as unknown as GPUBindGroupLayout);
+                },
+                _bindGroupLayoutCount: layout.bindGroupLayouts?.length ?? 0,
+            } as unknown as GPURenderPipeline;
         },
     };
 
     return {
         engine: { _device: device as unknown as GPUDevice } as unknown as EngineContext,
         device,
+    };
+}
+
+function makePickerEngine(): ReturnType<typeof makeEngine> & { pass: { drawCalls: { group2Bound: boolean }[] } } {
+    const base = makeEngine();
+    const passState = {
+        drawCalls: [] as { group2Bound: boolean }[],
+        pipeline: null as (GPURenderPipeline & { _bindGroupLayoutCount?: number }) | null,
+        bindGroups: new Set<number>(),
+        setPipeline(pipeline: GPURenderPipeline) {
+            this.pipeline = pipeline;
+            this.bindGroups.clear();
+        },
+        setBindGroup(index: number) {
+            this.bindGroups.add(index);
+        },
+        setVertexBuffer() {},
+        setIndexBuffer() {},
+        drawIndexed() {
+            if ((this.pipeline?._bindGroupLayoutCount ?? 0) > 2 && !this.bindGroups.has(2)) {
+                throw new Error("No bind group set at group index 2.");
+            }
+            this.drawCalls.push({ group2Bound: this.bindGroups.has(2) });
+        },
+        end() {},
+    };
+
+    const device = base.engine._device as unknown as {
+        createTexture: (descriptor: GPUTextureDescriptor) => GPUTexture;
+        createBuffer: (descriptor: GPUBufferDescriptor) => GPUBuffer;
+        createBindGroup: (descriptor: GPUBindGroupDescriptor) => GPUBindGroup;
+        createCommandEncoder: (descriptor?: GPUCommandEncoderDescriptor) => GPUCommandEncoder;
+        queue: { writeBuffer: GPUQueue["writeBuffer"]; submit: GPUQueue["submit"] };
+    };
+    device.queue = {
+        writeBuffer() {},
+        submit() {},
+    };
+    device.createTexture = () =>
+        ({
+            createView: () => ({}),
+            destroy() {},
+        }) as unknown as GPUTexture;
+    device.createBuffer = (descriptor) => {
+        const data = new ArrayBuffer(Math.max(256, descriptor.size));
+        if (descriptor.label === "pick-color-staging") {
+            new Uint8Array(data)[2] = 1;
+        } else if (descriptor.label === "pick-depth-staging") {
+            new Float32Array(data)[0] = 0.5;
+        }
+        return {
+            destroy() {},
+            getMappedRange: () => data,
+            mapAsync: async () => undefined,
+            unmap() {},
+        } as unknown as GPUBuffer;
+    };
+    device.createBindGroup = (descriptor) => descriptor as unknown as GPUBindGroup;
+    device.createCommandEncoder = () =>
+        ({
+            beginRenderPass: () => passState,
+            copyTextureToBuffer() {},
+            finish: () => ({}),
+        }) as unknown as GPUCommandEncoder;
+
+    (globalThis as unknown as { GPUMapMode: { READ: number } }).GPUMapMode ??= { READ: 1 };
+    return { ...base, pass: passState };
+}
+
+function makePickScene(engine: EngineContext): { scene: Parameters<typeof createGpuPicker>[0]; mesh: Mesh; discardBuffer: GPUBuffer } {
+    const discardBuffer = {} as GPUBuffer;
+    const mesh = {
+        name: "pickable",
+        material: {},
+        receiveShadows: false,
+        children: [],
+        worldMatrix: IDENTITY,
+        worldMatrixVersion: 1,
+        _gpu: {
+            positionBuffer: {},
+            normalBuffer: {},
+            uvBuffer: {},
+            indexBuffer: {},
+            indexCount: 3,
+            indexFormat: "uint32",
+        },
+    } as unknown as Mesh;
+    return {
+        mesh,
+        discardBuffer,
+        scene: {
+            surface: {
+                engine,
+                canvas: { width: 64, height: 64, clientWidth: 64, clientHeight: 64 },
+            },
+            camera: {
+                fov: Math.PI / 3,
+                nearPlane: 0.1,
+                farPlane: 100,
+                children: [],
+                worldMatrix: IDENTITY,
+                worldMatrixVersion: 1,
+                _viewCache: new Float32Array(16),
+                _projCache: new Float32Array(16),
+                _vpCache: new Float32Array(16),
+            },
+            meshes: [mesh],
+            _gsMeshes: [],
+        } as unknown as Parameters<typeof createGpuPicker>[0],
     };
 }
 
@@ -80,18 +200,21 @@ return input.hasThinInstance == 1u && input.instanceExtras.x > 4.0;
 });
 
 describe("picking discard pipeline API", () => {
-    it("keeps the public discard rule WGSL-only", () => {
+    it("supports internal discard rules with optional group-2 bind entries", () => {
+        const entry: GPUBindGroupLayoutEntry = {
+            binding: 0,
+            visibility: GPUShaderStage.FRAGMENT,
+            buffer: { type: "read-only-storage" },
+        };
         const discard: PickDiscardRule = {
-            key: "public-wgsl-only",
+            key: "public-bindings",
             wgsl: "fn shouldDiscardPick(input: PickDiscardInput) -> bool { return input.pickId == 1u; }",
+            _bindGroupLayoutEntries: [entry],
+            _bindGroupEntries: () => [{ binding: 0, resource: { buffer: {} as GPUBuffer } }],
         };
         const options: PickOptions = { discard };
 
-        // @ts-expect-error PickDiscardRule intentionally does not expose raw WebGPU bind-group layout entries.
-        const invalidPublicDiscardRule: PickDiscardRule = { key: "raw-webgpu", wgsl: discard.wgsl, bindGroupLayoutEntries: [] };
-
         expect(options.discard).toBe(discard);
-        void invalidPublicDiscardRule;
     });
 
     it("caches the default regular/thin pipeline set per device", () => {
@@ -117,7 +240,7 @@ describe("picking discard pipeline API", () => {
         const discard = {
             key: "clip-volume",
             wgsl: "fn shouldDiscardPick(input: PickDiscardInput) -> bool { return input.pickId == 7u; }",
-            bindGroupLayoutEntries: [entry],
+            _bindGroupLayoutEntries: [entry],
         };
 
         const set = getPickingPipelineSet(engine, discard);
@@ -130,6 +253,30 @@ describe("picking discard pipeline API", () => {
         expect(device.renderPipelines).toHaveLength(2);
         expect(device.shaderModules.every((module) => String(module.code).includes(discard.wgsl))).toBe(true);
         expect(device.pipelineLayouts.every((layout) => Array.from(layout.bindGroupLayouts).length === 3)).toBe(true);
+    });
+
+    it("binds discard group-2 resources before drawing a discard pipeline", async () => {
+        const { engine, pass } = makePickerEngine();
+        const { scene, mesh, discardBuffer } = makePickScene(engine);
+        const picker = createGpuPicker(scene);
+        const entry: GPUBindGroupLayoutEntry = {
+            binding: 0,
+            visibility: GPUShaderStage.FRAGMENT,
+            buffer: { type: "read-only-storage" },
+        };
+        const discard: PickDiscardRule = {
+            key: "storage-discard",
+            _bindGroupLayoutEntries: [entry],
+            wgsl: `
+@group(2) @binding(0) var<storage, read> data: array<vec4f>;
+fn shouldDiscardPick(input: PickDiscardInput) -> bool { return data[0].x > 1.0 && input.pickId == 0u; }`,
+            _bindGroupEntries: (m) => (m === mesh ? [{ binding: 0, resource: { buffer: discardBuffer } }] : null),
+        };
+
+        const info = await pickAsync(picker, 4, 4, { discard });
+
+        expect(info.hit).toBe(true);
+        expect(pass.drawCalls).toEqual([{ group2Bound: true }]);
     });
 
     it("invalidates cached pipeline sets when the WebGPU device changes", () => {

--- a/tests/lite/unit/picking-discard-api.test.ts
+++ b/tests/lite/unit/picking-discard-api.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import { getPickingPipelineSet } from "../../../packages/babylon-lite/src/picking/picking-pipeline";
+import { pickingShaderSource, pickingThinInstanceShaderSource } from "../../../packages/babylon-lite/src/picking/picking-shader";
+import type { PickDiscardRule, PickOptions } from "../../../packages/babylon-lite/src";
+
+function makeEngine(): {
+    engine: EngineContext;
+    device: {
+        bindGroupLayouts: GPUBindGroupLayoutDescriptor[];
+        shaderModules: GPUShaderModuleDescriptor[];
+        pipelineLayouts: GPUPipelineLayoutDescriptor[];
+        renderPipelines: GPURenderPipelineDescriptor[];
+    };
+} {
+    const device = {
+        bindGroupLayouts: [] as GPUBindGroupLayoutDescriptor[],
+        shaderModules: [] as GPUShaderModuleDescriptor[],
+        pipelineLayouts: [] as GPUPipelineLayoutDescriptor[],
+        renderPipelines: [] as GPURenderPipelineDescriptor[],
+        createBindGroupLayout(descriptor: GPUBindGroupLayoutDescriptor): GPUBindGroupLayout {
+            this.bindGroupLayouts.push(descriptor);
+            return descriptor as unknown as GPUBindGroupLayout;
+        },
+        createShaderModule(descriptor: GPUShaderModuleDescriptor): GPUShaderModule {
+            this.shaderModules.push(descriptor);
+            return descriptor as unknown as GPUShaderModule;
+        },
+        createPipelineLayout(descriptor: GPUPipelineLayoutDescriptor): GPUPipelineLayout {
+            this.pipelineLayouts.push(descriptor);
+            return descriptor as unknown as GPUPipelineLayout;
+        },
+        createRenderPipeline(descriptor: GPURenderPipelineDescriptor): GPURenderPipeline {
+            this.renderPipelines.push(descriptor);
+            return descriptor as unknown as GPURenderPipeline;
+        },
+    };
+
+    return {
+        engine: { _device: device as unknown as GPUDevice } as unknown as EngineContext,
+        device,
+    };
+}
+
+describe("picking discard shader API", () => {
+    it("keeps the default picker shader non-discarding", () => {
+        const regular = pickingShaderSource();
+        const thin = pickingThinInstanceShaderSource();
+
+        expect(regular).toContain("struct PickDiscardInput");
+        expect(regular).toContain("fn shouldDiscardPick(input: PickDiscardInput) -> bool");
+        expect(regular).toContain("return false;");
+        expect(regular).toContain("out.hasThinInstance = 0u;");
+        expect(regular).toContain("out.thinInstanceIndex = 0xffffffffu;");
+
+        expect(thin).toContain("fn shouldDiscardPick(input: PickDiscardInput) -> bool");
+        expect(thin).toContain("return false;");
+        expect(thin).toContain("out.hasThinInstance = 1u;");
+        expect(thin).toContain("out.thinInstanceIndex = instanceIndex;");
+        expect(thin).toContain("out.instanceExtras = vec4f(m[0].w, m[1].w, m[2].w, m[3].w);");
+    });
+
+    it("injects a custom discard rule into regular and thin-instance picking shaders", () => {
+        const discardWgsl = `
+fn shouldDiscardPick(input: PickDiscardInput) -> bool {
+return input.hasThinInstance == 1u && input.instanceExtras.x > 4.0;
+}`;
+
+        const regular = pickingShaderSource({ discardWgsl });
+        const thin = pickingThinInstanceShaderSource({ discardWgsl });
+
+        expect(regular).toContain(discardWgsl);
+        expect(thin).toContain(discardWgsl);
+        expect(regular).toContain("let discardInput = PickDiscardInput(input.worldPos, input.pickId, input.thinInstanceIndex, input.hasThinInstance, input.instanceExtras);");
+        expect(thin).toContain("let world = mat4x4f(");
+        expect(thin).toContain("vec4f(m[0].xyz, 0.0)");
+        expect(thin).toContain("vec4f(m[3].xyz, 1.0)");
+    });
+});
+
+describe("picking discard pipeline API", () => {
+    it("caches the default regular/thin pipeline set per device", () => {
+        const { engine, device } = makeEngine();
+
+        const first = getPickingPipelineSet(engine);
+        const second = getPickingPipelineSet(engine);
+
+        expect(second).toBe(first);
+        expect(first.discardBGL).toBeNull();
+        expect(device.renderPipelines).toHaveLength(2);
+        expect(device.shaderModules.map((m) => m.label)).toEqual(["picking-shader", "picking-ti-shader"]);
+        expect(device.pipelineLayouts.every((layout) => Array.from(layout.bindGroupLayouts).length === 2)).toBe(true);
+    });
+
+    it("creates a discard pipeline set with a group-2 layout and injected WGSL", () => {
+        const { engine, device } = makeEngine();
+        const entry: GPUBindGroupLayoutEntry = {
+            binding: 0,
+            visibility: GPUShaderStage.FRAGMENT,
+            buffer: { type: "read-only-storage" },
+        };
+        const discard: PickDiscardRule = {
+            key: "clip-volume",
+            wgsl: "fn shouldDiscardPick(input: PickDiscardInput) -> bool { return input.pickId == 7u; }",
+            bindGroupLayoutEntries: [entry],
+        };
+        const options: PickOptions = { discard };
+
+        const set = getPickingPipelineSet(engine, options.discard);
+
+        expect(set.discardBGL).not.toBeNull();
+        expect(device.bindGroupLayouts.find((layout) => layout.label === "picking-discard-clip-volume-bgl")).toMatchObject({
+            label: "picking-discard-clip-volume-bgl",
+            entries: [entry],
+        });
+        expect(device.renderPipelines).toHaveLength(2);
+        expect(device.shaderModules.every((module) => String(module.code).includes(discard.wgsl))).toBe(true);
+        expect(device.pipelineLayouts.every((layout) => Array.from(layout.bindGroupLayouts).length === 3)).toBe(true);
+    });
+
+    it("invalidates cached pipeline sets when the WebGPU device changes", () => {
+        const first = makeEngine();
+        const second = makeEngine();
+
+        getPickingPipelineSet(first.engine);
+        getPickingPipelineSet(second.engine);
+
+        expect(first.device.renderPipelines).toHaveLength(2);
+        expect(second.device.renderPipelines).toHaveLength(2);
+    });
+});

--- a/tests/lite/unit/picking-discard-api.test.ts
+++ b/tests/lite/unit/picking-discard-api.test.ts
@@ -200,17 +200,11 @@ return input.hasThinInstance == 1u && input.instanceExtras.x > 4.0;
 });
 
 describe("picking discard pipeline API", () => {
-    it("supports internal discard rules with optional group-2 bind entries", () => {
-        const entry: GPUBindGroupLayoutEntry = {
-            binding: 0,
-            visibility: GPUShaderStage.FRAGMENT,
-            buffer: { type: "read-only-storage" },
-        };
+    it("allows public discard rules to supply typed-array storage data", () => {
         const discard: PickDiscardRule = {
             key: "public-bindings",
             wgsl: "fn shouldDiscardPick(input: PickDiscardInput) -> bool { return input.pickId == 1u; }",
-            _bindGroupLayoutEntries: [entry],
-            _bindGroupEntries: () => [{ binding: 0, resource: { buffer: {} as GPUBuffer } }],
+            storage: [{ name: "clipData", type: "array<vec4<f32>>", data: () => new Float32Array(4) }],
         };
         const options: PickOptions = { discard };
 
@@ -232,15 +226,10 @@ describe("picking discard pipeline API", () => {
 
     it("creates a discard pipeline set with a group-2 layout and injected WGSL", () => {
         const { engine, device } = makeEngine();
-        const entry: GPUBindGroupLayoutEntry = {
-            binding: 0,
-            visibility: GPUShaderStage.FRAGMENT,
-            buffer: { type: "read-only-storage" },
-        };
         const discard = {
             key: "clip-volume",
-            wgsl: "fn shouldDiscardPick(input: PickDiscardInput) -> bool { return input.pickId == 7u; }",
-            _bindGroupLayoutEntries: [entry],
+            wgsl: "fn shouldDiscardPick(input: PickDiscardInput) -> bool { return clipData[0].x > 0.0 && input.pickId == 7u; }",
+            storage: [{ name: "clipData", type: "array<vec4<f32>>" }],
         };
 
         const set = getPickingPipelineSet(engine, discard);
@@ -248,29 +237,23 @@ describe("picking discard pipeline API", () => {
         expect(set.discardBGL).not.toBeNull();
         expect(device.bindGroupLayouts.find((layout) => layout.label === "picking-discard-clip-volume-bgl")).toMatchObject({
             label: "picking-discard-clip-volume-bgl",
-            entries: [entry],
+            entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: "read-only-storage" } }],
         });
         expect(device.renderPipelines).toHaveLength(2);
         expect(device.shaderModules.every((module) => String(module.code).includes(discard.wgsl))).toBe(true);
+        expect(device.shaderModules.every((module) => String(module.code).includes("@group(2) @binding(0) var<storage, read> clipData: array<vec4<f32>>;"))).toBe(true);
         expect(device.pipelineLayouts.every((layout) => Array.from(layout.bindGroupLayouts).length === 3)).toBe(true);
     });
 
     it("binds discard group-2 resources before drawing a discard pipeline", async () => {
         const { engine, pass } = makePickerEngine();
-        const { scene, mesh, discardBuffer } = makePickScene(engine);
+        const { scene, mesh } = makePickScene(engine);
         const picker = createGpuPicker(scene);
-        const entry: GPUBindGroupLayoutEntry = {
-            binding: 0,
-            visibility: GPUShaderStage.FRAGMENT,
-            buffer: { type: "read-only-storage" },
-        };
         const discard: PickDiscardRule = {
             key: "storage-discard",
-            _bindGroupLayoutEntries: [entry],
             wgsl: `
-@group(2) @binding(0) var<storage, read> data: array<vec4f>;
 fn shouldDiscardPick(input: PickDiscardInput) -> bool { return data[0].x > 1.0 && input.pickId == 0u; }`,
-            _bindGroupEntries: (m) => (m === mesh ? [{ binding: 0, resource: { buffer: discardBuffer } }] : null),
+            storage: [{ name: "data", type: "array<vec4f>", data: (m) => (m === mesh ? new Float32Array([2, 0, 0, 0]) : null) }],
         };
 
         const info = await pickAsync(picker, 4, 4, { discard });

--- a/tests/lite/unit/picking-discard-api.test.ts
+++ b/tests/lite/unit/picking-discard-api.test.ts
@@ -80,6 +80,20 @@ return input.hasThinInstance == 1u && input.instanceExtras.x > 4.0;
 });
 
 describe("picking discard pipeline API", () => {
+    it("keeps the public discard rule WGSL-only", () => {
+        const discard: PickDiscardRule = {
+            key: "public-wgsl-only",
+            wgsl: "fn shouldDiscardPick(input: PickDiscardInput) -> bool { return input.pickId == 1u; }",
+        };
+        const options: PickOptions = { discard };
+
+        // @ts-expect-error PickDiscardRule intentionally does not expose raw WebGPU bind-group layout entries.
+        const invalidPublicDiscardRule: PickDiscardRule = { key: "raw-webgpu", wgsl: discard.wgsl, bindGroupLayoutEntries: [] };
+
+        expect(options.discard).toBe(discard);
+        void invalidPublicDiscardRule;
+    });
+
     it("caches the default regular/thin pipeline set per device", () => {
         const { engine, device } = makeEngine();
 
@@ -100,14 +114,13 @@ describe("picking discard pipeline API", () => {
             visibility: GPUShaderStage.FRAGMENT,
             buffer: { type: "read-only-storage" },
         };
-        const discard: PickDiscardRule = {
+        const discard = {
             key: "clip-volume",
             wgsl: "fn shouldDiscardPick(input: PickDiscardInput) -> bool { return input.pickId == 7u; }",
             bindGroupLayoutEntries: [entry],
         };
-        const options: PickOptions = { discard };
 
-        const set = getPickingPipelineSet(engine, options.discard);
+        const set = getPickingPipelineSet(engine, discard);
 
         expect(set.discardBGL).not.toBeNull();
         expect(device.bindGroupLayouts.find((layout) => layout.label === "picking-discard-clip-volume-bgl")).toMatchObject({


### PR DESCRIPTION
## Summary
- add a tree-shakeable hierarchy instance pool API for transform-node/mesh prop hierarchies
- add WGSL-only picker discard-rule support for app-specific GPU pick filtering
- document hierarchy instance pools in the thin-instances architecture doc
- add unit coverage for the new hierarchy-pool and picking-discard APIs

## Breaking change
BREAKING CHANGE: `Mesh.pickingClipVolumes` and `PickingClipVolume` were removed; use `PickOptions.discard` for custom GPU-side pick filtering.

## Validation
- `pnpm test:unit -- tests\lite\unit\hierarchy-instance-pool.test.ts tests\lite\unit\picking-discard-api.test.ts`
- `pnpm lint`
- `pnpm test` (scene47 reported flaky but passed after retry)
- scene1 bundle delta vs master: 0.0 KB