### PR TITLE
fix(ci): diff API report against merge base, not target tip

### DIFF
--- a/scripts/report-api-changes.ts
+++ b/scripts/report-api-changes.ts
@@ -177,10 +177,21 @@ async function normalizeApiReport(reportPath: string, prettierConfig: PrettierOp
     }
 }
 
-function createTargetWorktree(rootDir: string, targetRef: string): string {
+function createBaselineWorktree(rootDir: string, targetRef: string): string {
     const worktreeDir = mkdtempSync(resolve(tmpdir(), "babylon-lite-api-baseline-"));
     run("git", ["fetch", "origin", `${targetRef}:refs/remotes/origin/${targetRef}`], rootDir, { inheritStdio: true });
-    run("git", ["worktree", "add", "--detach", worktreeDir, `origin/${targetRef}`], rootDir, { inheritStdio: true });
+
+    // Build the baseline at the point where this branch diverged from the target
+    // branch, not at the target branch tip. Otherwise public API that landed on
+    // the target branch *after* this PR branched off is reported as "removed" by
+    // the PR — a false breaking-change positive for branches that are merely
+    // behind (e.g. a demo-only PR that never touched the framework). The merge
+    // base is the exact framework state the PR started from, so the diff reflects
+    // only what this PR itself changed. Fall back to the target tip if the merge
+    // base cannot be resolved (e.g. a shallow clone with unrelated histories).
+    const mergeBase = run("git", ["merge-base", "HEAD", `origin/${targetRef}`], rootDir, { allowFailure: true });
+    const baselineRef = mergeBase || `origin/${targetRef}`;
+    run("git", ["worktree", "add", "--detach", worktreeDir, baselineRef], rootDir, { inheritStdio: true });
     return worktreeDir;
 }
 
@@ -468,8 +479,8 @@ async function main(): Promise<void> {
         const currentReport = generateApiReport(rootDir, currentOutputDir);
         await normalizeApiReport(currentReport, prettierConfig);
 
-        console.log(`Building target branch package from origin/${targetBranch}...`);
-        targetWorktree = createTargetWorktree(rootDir, targetBranch);
+        console.log(`Building baseline package from the merge base with origin/${targetBranch}...`);
+        targetWorktree = createBaselineWorktree(rootDir, targetBranch);
         buildPackage(targetWorktree, { installDependencies: true });
         const targetReport = generateApiReport(targetWorktree, targetOutputDir);
         await normalizeApiReport(targetReport, prettierConfig);


### PR DESCRIPTION
## Problem

The API report breaking-change gate (`scripts/report-api-changes.ts`, run by the **API Report** CI job) built its baseline from the **tip of the target branch** (`origin/master`).

As a result, any public API that landed on `master` **after** a PR diverged was reported as "removed" by that PR — a false breaking-change positive for branches that are merely behind master and never touched the framework.

Concretely, demo-only [#220](https://github.com/BabylonJS/Babylon-Lite/pull/220) was flagged as breaking `createCapsule`, `createCapsuleData`, `createHeightFieldShape`, `getRenderTaskGpuTimings`, etc. — none of which the PR changed. Those symbols simply landed on `master` in #226 (Physics scenes 47–49) after #220 branched off.

## Root cause

This is **not** an api-extractor scope problem — the extractor already analyzes only the rolled-up `packages/babylon-lite/dist/index.d.ts` (verified: its TypeScript program loads exactly that file plus `@webgpu/types`, no demos/lab/scenes). The bug is the **baseline choice**: comparing against the target tip instead of the divergence point.

## Fix

Build the baseline at the **merge base** of `HEAD` and the target branch, so the diff reflects only what the PR itself changed:

```ts
const mergeBase = run("git", ["merge-base", "HEAD", `origin/${targetRef}`], rootDir, { allowFailure: true });
const baselineRef = mergeBase || `origin/${targetRef}`;
run("git", ["worktree", "add", "--detach", worktreeDir, baselineRef], rootDir, { inheritStdio: true });
```

- Demo-only / behind-master PRs no longer produce phantom "removed" lines.
- PRs that genuinely remove or change public API are still caught.
- Falls back to the target tip when the merge base can't be resolved (e.g. shallow clone / unrelated histories). The **API Report** job uses `fetchDepth: 0`, so the merge base resolves in CI.

## Testing

- Type-check clean (`tsc --noEmit` on the script).
- Existing unit tests pass: `tests/lite/unit/report-api-changes.test.ts` (6/6).
- `scripts/` is eslint-ignored by repo config; no lint changes needed.

Not a breaking change (CI tooling only).