### PR TITLE
docs: use pnpm exec in command examples

### DIFF
--- a/.github/copilot/skills/update-compat-layer.md
+++ b/.github/copilot/skills/update-compat-layer.md
@@ -328,11 +328,11 @@ For every wrapper you add or extend, add or update a test in
 Run the suite and the typecheck before finishing:
 
 ```
-npx vitest run --project compat
-npx tsc -p packages/babylon-lite-compat/tsconfig.json --noEmit
-npx tsc -p packages/babylon-lite-compat/tests/tsconfig.json --noEmit
-npx eslint packages/babylon-lite-compat
-npx prettier --check "packages/babylon-lite-compat/**/*.ts"
+pnpm exec vitest run --project compat
+pnpm exec tsc -p packages/babylon-lite-compat/tsconfig.json --noEmit
+pnpm exec tsc -p packages/babylon-lite-compat/tests/tsconfig.json --noEmit
+pnpm exec eslint packages/babylon-lite-compat
+pnpm exec prettier --check "packages/babylon-lite-compat/**/*.ts"
 ```
 
 All must pass.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ Run the BJS reference page and capture a screenshot:
 pnpm dev:lab
 
 # In another terminal, capture the golden
-npx tsx scripts/capture-golden.ts --scene N
+pnpm exec tsx scripts/capture-golden.ts --scene N
 ```
 
 Or manually screenshot the canvas at `http://localhost:5174/babylon-ref-sceneN.html` and save as:
@@ -189,7 +189,7 @@ test("Scene 23 — My Feature matches Babylon.js reference", async ({ page }) =>
 
 ```bash
 # Run the parity test for your scene
-npx playwright test tests/lite/parity/scenes/sceneN-my-feature.spec.ts
+pnpm exec playwright test tests/lite/parity/scenes/sceneN-my-feature.spec.ts
 
 # Run the full suite to check for regressions
 pnpm test
@@ -216,7 +216,7 @@ Plumbing tests validate engine internals (dispose, material-swap, etc.) using Pl
 
 1. Create a test page in `lab/` (HTML + TS)
 2. Create the spec in `tests/lite/plumbing/`
-3. Run: `npx playwright test tests/lite/plumbing/my-test.spec.ts`
+3. Run: `pnpm exec playwright test tests/lite/plumbing/my-test.spec.ts`
 
 > **Note:** CI uses Chrome's SwiftShader Vulkan backend for WebGPU — no real GPU needed.
 
@@ -226,7 +226,7 @@ For pure logic (shader composition, math) that doesn't need a browser:
 
 1. Create `tests/lite/unit/my-feature.test.ts`
 2. Use vitest: `describe`, `it`, `expect`
-3. Run: `npx vitest run`
+3. Run: `pnpm exec vitest run`
 
 ## Code Quality
 

--- a/GUIDANCE.md
+++ b/GUIDANCE.md
@@ -146,11 +146,11 @@ async function main(): Promise<void> {
 ### 0c. Agent Test Commands (Strict)
 
 - **Agents MUST NOT run `pnpm test:perf`.** Performance tests are machine-sensitive and reserved for the user / CI; running them from an agent session wastes time and produces unreliable signal.
-- **Agents run only:** `pnpm build:bundle-scenes` and `pnpm test:parity` (or the individual spec via `npx playwright test tests/lite/parity/scenes/<spec>.spec.ts`). These cover parity MAD + bundle-size ceilings, which are the agent-enforceable guardrails.
+- **Agents run only:** `pnpm build:bundle-scenes` and `pnpm test:parity` (or the individual spec via `pnpm exec playwright test tests/lite/parity/scenes/<spec>.spec.ts`). These cover parity MAD + bundle-size ceilings, which are the agent-enforceable guardrails.
 - `pnpm test` chains build + parity (no perf), which is acceptable.
 - **The parity suite is slow (many minutes). Only run it when the Lite engine changed.** Run `pnpm test` / `pnpm test:parity` **only if you modified `packages/babylon-lite/src/**`** (the engine/runtime). Changes confined to **demos** (`lab/lite/src/demos/**`), **scenes** (`lab/lite/src/scenes/**`), **lab UI**, thumbnails, docs, manifests, or other static lab assets **do not require** running parity or any test suite — they cannot move engine parity. Skip the suites in those cases unless the user explicitly asks.
 - **Lab-only UI changes do not require parity/test suites.** When a task only changes the lab UI or static lab presentation, do not run parity or other test suites unless explicitly requested; use lightweight static inspection or a lab build only if validation is needed.
-- **Iterate on one scene first.** When working on a specific scene, run only that scene's parity spec during the edit/test loop (e.g. `npx playwright test tests/lite/parity/scenes/scene36-basis-texture.spec.ts`) instead of the full `pnpm test:parity` suite. This dramatically cuts iteration time. Only run the full suite + `pnpm build:bundle-scenes` as the final guardrail check before declaring success.
+- **Iterate on one scene first.** When working on a specific scene, run only that scene's parity spec during the edit/test loop (e.g. `pnpm exec playwright test tests/lite/parity/scenes/scene36-basis-texture.spec.ts`) instead of the full `pnpm test:parity` suite. This dramatically cuts iteration time. Only run the full suite + `pnpm build:bundle-scenes` as the final guardrail check before declaring success.
 - If perf validation is needed, ask the user to run `pnpm test:perf` locally.
 
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For pure logic tests (shaders, math, composition) that don't need a browser or G
 
 1. Create `tests/lite/unit/my-feature.test.ts`
 2. Use vitest APIs (`describe`, `it`, `expect`)
-3. Run: `npx vitest run`
+3. Run: `pnpm exec vitest run`
 
 ### Plumbing Tests (Playwright + WebGPU)
 
@@ -83,7 +83,7 @@ For GPU integration tests (dispose, material-swap, lifecycle):
 1. Create a test page: `lab/lite/my-test.html` + `lab/lite/src/my-test.ts`
 2. Add the HTML entry to `lab/vite.config.ts` (auto-detected if in root)
 3. Create `tests/lite/plumbing/my-test.spec.ts`
-4. Run: `npx playwright test tests/lite/plumbing/my-test.spec.ts`
+4. Run: `pnpm exec playwright test tests/lite/plumbing/my-test.spec.ts`
 
 > CI uses Chrome's SwiftShader Vulkan backend — WebGPU works without a real GPU.
 
@@ -99,7 +99,7 @@ For pixel-diff visual regression tests against Babylon.js golden references:
 6. Add scene config to `scene-config.json` with `id`, `slug`, `name`, `maxMad`
 7. Create `tests/lite/parity/scenes/sceneN-<slug>.spec.ts` using `compare-utils.ts` helpers
 8. Add a bundle-size ceiling in `tests/lite/parity/bundle-size.spec.ts` (never raise without approval)
-9. Run: `npx playwright test tests/lite/parity/scenes/sceneN-<slug>.spec.ts`
+9. Run: `pnpm exec playwright test tests/lite/parity/scenes/sceneN-<slug>.spec.ts`
 
 ### CI Workflows
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -32,8 +32,8 @@ jobs on every PR targeting `master`.
 Standard unit tests for core logic (shader composer, shader integration, etc.).
 
 ```sh
-pnpm test:watch   # interactive
-npx vitest run     # single run
+pnpm test:watch        # interactive
+pnpm exec vitest run   # single run
 ```
 
 ---
@@ -51,7 +51,7 @@ Browser-based integration tests that exercise engine lifecycle:
 - `picking.spec.ts` — GPU picking
 
 ```sh
-npx playwright test tests/lite/plumbing/
+pnpm exec playwright test tests/lite/plumbing/
 ```
 
 ---
@@ -302,8 +302,8 @@ Report locations after a run:
 To view the HTML report locally:
 
 ```sh
-npx playwright show-report test-results/parity-report
-npx playwright show-report test-results/perf-report
+pnpm exec playwright show-report test-results/parity-report
+pnpm exec playwright show-report test-results/perf-report
 ```
 
 In CI, test artifacts (including the HTML report) are uploaded as pipeline

--- a/docs/lite/architecture/16-animation-parity-testing.md
+++ b/docs/lite/architecture/16-animation-parity-testing.md
@@ -130,7 +130,7 @@ test('Scene N — Animated model matches reference', async ({ page }) => {
 `scripts/capture-golden.ts` is a CLI tool that captures golden reference PNGs:
 
 ```bash
-npx tsx scripts/capture-golden.ts 5   # Capture scene 5 golden
+pnpm exec tsx scripts/capture-golden.ts 5   # Capture scene 5 golden
 ```
 
 For animated scenes it:

--- a/packages/babylon-lite-compat/CONTRIBUTING.md
+++ b/packages/babylon-lite-compat/CONTRIBUTING.md
@@ -130,10 +130,10 @@ The prompt is assembled by
 
 ```sh
 # Unit tests (GPU-free): math, observables, engine/scene APIs, bundler resolver
-npx vitest run --project compat
+pnpm exec vitest run --project compat
 
 # Typecheck the package against the linked babylon-lite types
-npx tsc -p packages/babylon-lite-compat/tsconfig.json --noEmit
+pnpm exec tsc -p packages/babylon-lite-compat/tsconfig.json --noEmit
 
 # Build the publishable dist (ESM + .d.ts)
 pnpm --filter @babylonjs/lite-compat build


### PR DESCRIPTION
## Summary

- Update Markdown command examples to use `pnpm exec` instead of `npx` for local workspace tools.
- Keep Playwright, Vitest, tsx, and tsc examples consistent with the repo's pnpm-managed setup and README troubleshooting guidance.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm lint`
- `git diff --check`
- `rg -n 'npx ' -g '*.md'` (no matches)
