### PR TITLE
fix(release): soften breaking-change guard to a warning for non-major releases

### DIFF
--- a/scripts/prepare-npm-release.ts
+++ b/scripts/prepare-npm-release.ts
@@ -152,7 +152,9 @@ const previousReleaseTag = getPreviousReleaseTag(latestPublishedVersion);
 const breakingChangesDetected = hasBreakingChanges(previousReleaseTag);
 
 if (breakingChangesDetected && requestedReleaseType !== "auto" && requestedReleaseType !== "major") {
-    console.warn(
+    // Azure Pipelines parses `##vso[task.logissue ...]` from stdout, so use console.log (not
+    // console.warn, which writes to stderr and may not be picked up as an annotation).
+    console.log(
         `##vso[task.logissue type=warning]Breaking changes were detected since ${previousReleaseTag || "the start of history"}. ` +
             `A ${requestedReleaseType} release will hide those changes from the next auto release. ` +
             `This is currently allowed to avoid premature major releases; request a major release or remove the breaking-change marker if it is incorrect.`

--- a/scripts/prepare-npm-release.ts
+++ b/scripts/prepare-npm-release.ts
@@ -152,9 +152,10 @@ const previousReleaseTag = getPreviousReleaseTag(latestPublishedVersion);
 const breakingChangesDetected = hasBreakingChanges(previousReleaseTag);
 
 if (breakingChangesDetected && requestedReleaseType !== "auto" && requestedReleaseType !== "major") {
-    throw new Error(
-        `Breaking changes were detected since ${previousReleaseTag || "the start of history"}. ` +
-            `A ${requestedReleaseType} release would hide those changes from the next auto release; request a major release or remove the breaking-change marker if it is incorrect.`
+    console.warn(
+        `##vso[task.logissue type=warning]Breaking changes were detected since ${previousReleaseTag || "the start of history"}. ` +
+            `A ${requestedReleaseType} release will hide those changes from the next auto release. ` +
+            `This is currently allowed to avoid premature major releases; request a major release or remove the breaking-change marker if it is incorrect.`
     );
 }
 


### PR DESCRIPTION
## Summary

To avoid premature major version releases while we hold the publish default at `minor`, this changes the breaking-change safeguard in `scripts/prepare-npm-release.ts` from a hard failure into a warning.

Previously, when breaking-change markers were detected and a non-`major`/non-`auto` release was requested, the script would `throw` and abort the publish. Now it emits an Azure Pipelines warning (`##vso[task.logissue type=warning]`) and lets the `minor`/`patch` release proceed.

## Why

We want to prevent major versions from being released in the very near future, so the publish default was changed to `minor`. The existing safeguard blocked those releases whenever a breaking-change marker was present. Softening it to a warning unblocks releases while still surfacing the risk that those changes are hidden from the next auto release.

## Notes

- This is intentionally temporary; reverting to a hard error later is a one-line change.
- The warning message still flags the previous release tag and the recommendation to request a major release or remove an incorrect breaking-change marker.
