### PR TITLE
fix(release): align lite-compat preview publishing with lite package version

### DIFF
--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -8,7 +8,7 @@
 # that file, so repeated patch releases can be requested by bumping its nonce.
 #
 # The same run also publishes @babylonjs/lite-compat under the `preview` dist-tag
-# (never `latest`) with a unique `<base>-preview.<buildId>` version, so the
+# (never `latest`) as `<lite-version>-preview`, so the
 # compatibility layer is opt-in via `@babylonjs/lite-compat@preview` until it
 # graduates to a stable release line.
 #
@@ -151,8 +151,8 @@ stages:
                 # The compatibility layer is published under the `preview` dist-tag
                 # only (never `latest`), so `npm install @babylonjs/lite-compat`
                 # resolves nothing until it graduates, while early adopters can opt in
-                # with `@babylonjs/lite-compat@preview`. Each run stamps a unique
-                # `<base>-preview.<buildId>` version and records the @babylonjs/lite
+                # with `@babylonjs/lite-compat@preview`. Each run versions compat as
+                # `<lite-version>-preview` and records the @babylonjs/lite
                 # version it was built against.
 
                 - script: pnpm --filter @babylonjs/lite-compat build
@@ -183,5 +183,31 @@ stages:
                       fi
                       npm publish ./packages/babylon-lite-compat/dist $EXTRA --tag "$(PACKAGE_DIST_TAG_COMPAT)" --access public --registry https://registry.npmjs.org/
                   displayName: "Publish compat package to npm (preview)"
+                  env:
+                      NPM_TOKEN: $(NPM_TOKEN)
+
+                - script: |
+                      set -euo pipefail
+
+                      if [ -z "${NPM_TOKEN:-}" ]; then
+                        echo "NPM_TOKEN must be configured as a secret pipeline variable."
+                        exit 1
+                      fi
+
+                      if [ "$(echo "${DRY_RUN:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+                        echo "DRY RUN: skipping compat dist-tag cleanup."
+                        exit 0
+                      fi
+
+                      printf "//registry.npmjs.org/:_authToken=%s\n" "$NPM_TOKEN" > ~/.npmrc
+
+                      TAGS="$(npm dist-tag ls @babylonjs/lite-compat --registry https://registry.npmjs.org/)"
+                      if echo "$TAGS" | grep -q '^latest:'; then
+                        npm dist-tag rm @babylonjs/lite-compat latest --registry https://registry.npmjs.org/
+                        echo "Removed @babylonjs/lite-compat@latest so compat remains preview-only."
+                      else
+                        echo "@babylonjs/lite-compat has no latest dist-tag to remove."
+                      fi
+                  displayName: "Ensure compat package has no latest tag"
                   env:
                       NPM_TOKEN: $(NPM_TOKEN)

--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -185,29 +185,3 @@ stages:
                   displayName: "Publish compat package to npm (preview)"
                   env:
                       NPM_TOKEN: $(NPM_TOKEN)
-
-                - script: |
-                      set -euo pipefail
-
-                      if [ -z "${NPM_TOKEN:-}" ]; then
-                        echo "NPM_TOKEN must be configured as a secret pipeline variable."
-                        exit 1
-                      fi
-
-                      if [ "$(echo "${DRY_RUN:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
-                        echo "DRY RUN: skipping compat dist-tag cleanup."
-                        exit 0
-                      fi
-
-                      printf "//registry.npmjs.org/:_authToken=%s\n" "$NPM_TOKEN" > ~/.npmrc
-
-                      TAGS="$(npm dist-tag ls @babylonjs/lite-compat --registry https://registry.npmjs.org/)"
-                      if echo "$TAGS" | grep -q '^latest:'; then
-                        npm dist-tag rm @babylonjs/lite-compat latest --registry https://registry.npmjs.org/
-                        echo "Removed @babylonjs/lite-compat@latest so compat remains preview-only."
-                      else
-                        echo "@babylonjs/lite-compat has no latest dist-tag to remove."
-                      fi
-                  displayName: "Ensure compat package has no latest tag"
-                  env:
-                      NPM_TOKEN: $(NPM_TOKEN)

--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -7,10 +7,10 @@
 # Pushes to master that change config/release.json read the release type from
 # that file, so repeated patch releases can be requested by bumping its nonce.
 #
-# The same run also publishes @babylonjs/lite-compat under the `preview` dist-tag
-# (never `latest`) as `<lite-version>-preview`, so the
-# compatibility layer is opt-in via `@babylonjs/lite-compat@preview` until it
-# graduates to a stable release line.
+# The same run also publishes @babylonjs/lite-compat as `<lite-version>-preview`
+# under the `latest` dist-tag. npm requires every package to carry a `latest`
+# tag, so the `-preview` version suffix (not a separate dist-tag) is what marks
+# the compatibility layer as pre-release.
 #
 # Set the `dryRun` parameter (manual run) to exercise the whole pipeline —
 # build, test, version resolution, and package-content validation — without
@@ -147,19 +147,19 @@ stages:
                       fi
                   displayName: "Tag published npm version"
 
-                # --- @babylonjs/lite-compat (preview dist-tag) ---------------------
-                # The compatibility layer is published under the `preview` dist-tag
-                # only (never `latest`), so `npm install @babylonjs/lite-compat`
-                # resolves nothing until it graduates, while early adopters can opt in
-                # with `@babylonjs/lite-compat@preview`. Each run versions compat as
-                # `<lite-version>-preview` and records the @babylonjs/lite
+                # --- @babylonjs/lite-compat -------------------------------------
+                # The compatibility layer publishes each build as
+                # `<lite-version>-preview` under npm's default `latest` dist-tag.
+                # npm requires every package to carry a `latest` tag, so there is no
+                # "preview-only" state: the `-preview` version suffix is what marks
+                # these builds as pre-release. Each run records the @babylonjs/lite
                 # version it was built against.
 
                 - script: pnpm --filter @babylonjs/lite-compat build
                   displayName: "Build @babylonjs/lite-compat"
 
                 - script: npx tsx scripts/prepare-compat-preview-release.ts
-                  displayName: "Resolve compat preview version"
+                  displayName: "Resolve compat version"
                   env:
                       LITE_VERSION: $(PACKAGE_VERSION)
 
@@ -181,7 +181,7 @@ stages:
                         echo "DRY RUN: npm publish will run with --dry-run (nothing is uploaded)."
                         EXTRA="--dry-run"
                       fi
-                      npm publish ./packages/babylon-lite-compat/dist $EXTRA --tag "$(PACKAGE_DIST_TAG_COMPAT)" --access public --registry https://registry.npmjs.org/
-                  displayName: "Publish compat package to npm (preview)"
+                      npm publish ./packages/babylon-lite-compat/dist $EXTRA --access public --registry https://registry.npmjs.org/
+                  displayName: "Publish compat package to npm"
                   env:
                       NPM_TOKEN: $(NPM_TOKEN)

--- a/packages/babylon-lite-compat/vite.config.ts
+++ b/packages/babylon-lite-compat/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, type Plugin } from "vite";
 import { resolve } from "path";
-import { writeFileSync } from "fs";
+import { copyFileSync, writeFileSync } from "fs";
 import dts from "vite-plugin-dts";
 import { trimInternalDts } from "../../scripts/vite-trim-internal-dts";
 
@@ -49,7 +49,7 @@ function rewriteLiteSpecifier(content: string): string {
     return content.replace(/(['"])babylon-lite(\/[^'"]*)?\1/g, "$1@babylonjs/lite$2$1");
 }
 
-/** Emit a publish-ready `package.json` into the build output directory. */
+/** Emit publish artifacts into the build output directory. */
 function emitPackageJson(outDir: string): Plugin {
     return {
         name: "emit-package-json",
@@ -81,6 +81,8 @@ function emitPackageJson(outDir: string): Plugin {
                 },
             };
             writeFileSync(resolve(outDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+            copyFileSync(resolve(__dirname, "README.md"), resolve(outDir, "README.md"));
+            copyFileSync(resolve(__dirname, "../../LICENSE"), resolve(outDir, "LICENSE"));
         },
     };
 }

--- a/scripts/prepare-compat-preview-release.ts
+++ b/scripts/prepare-compat-preview-release.ts
@@ -17,6 +17,7 @@ type PublishPackageJson = {
 const PACKAGE_NAME = "@babylonjs/lite-compat";
 const PREVIEW_DIST_TAG = "preview";
 const DIST_PACKAGE_JSON = resolve(process.cwd(), "packages/babylon-lite-compat/dist/package.json");
+const LITE_VERSION_ENV = process.env.LITE_VERSION;
 
 function run(command: string, args: string[], options: { allowFailure?: boolean } = {}): string {
     try {
@@ -33,23 +34,21 @@ function run(command: string, args: string[], options: { allowFailure?: boolean 
     }
 }
 
-function parseBaseVersion(version: string): string {
-    // Accept a plain semver core (x.y.z); strip any pre-existing pre-release/build
-    // metadata so we always append a fresh preview suffix.
-    const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+function parseSemverCore(version: string, source: string): string {
+    // Accept a semver core (x.y.z) with optional pre-release/build metadata and
+    // normalize to the plain x.y.z core.
+    const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
     if (!match) {
-        throw new Error(`Unsupported base version '${version}'. Expected x.y.z.`);
+        throw new Error(`Unsupported ${source} '${version}'. Expected x.y.z (optionally with pre-release/build metadata).`);
     }
     return `${match[1]}.${match[2]}.${match[3]}`;
 }
 
-function previewSuffix(): string {
-    const buildId = process.env.BUILD_BUILDID;
-    if (buildId && /^\d+$/.test(buildId)) {
-        return buildId;
+function resolveLiteBaseVersion(): string {
+    if (!LITE_VERSION_ENV || LITE_VERSION_ENV.trim() === "") {
+        throw new Error("LITE_VERSION must be set to the @babylonjs/lite version resolved earlier in the publish pipeline.");
     }
-    // Local / non-Azure fallback: compact UTC timestamp (YYYYMMDDHHmmss).
-    return new Date().toISOString().replace(/[-:T]/g, "").slice(0, 14);
+    return parseSemverCore(LITE_VERSION_ENV.trim(), "LITE_VERSION");
 }
 
 function isVersionPublished(version: string): boolean {
@@ -66,8 +65,8 @@ if (!pkg.version) {
     throw new Error(`${DIST_PACKAGE_JSON} does not contain a version.`);
 }
 
-const baseVersion = parseBaseVersion(pkg.version);
-const previewVersion = `${baseVersion}-preview.${previewSuffix()}`;
+const liteBaseVersion = resolveLiteBaseVersion();
+const previewVersion = `${liteBaseVersion}-preview`;
 
 if (isVersionPublished(previewVersion)) {
     throw new Error(`${PACKAGE_NAME}@${previewVersion} is already published. Refusing to overwrite an existing npm version.`);
@@ -77,17 +76,15 @@ pkg.version = previewVersion;
 pkg.babylonLiteRelease = {
     ...(process.env.BUILD_BUILDID ? { azureBuildId: process.env.BUILD_BUILDID } : {}),
     ...(process.env.BUILD_SOURCEVERSION ? { sourceVersion: process.env.BUILD_SOURCEVERSION } : {}),
-    ...(process.env.LITE_VERSION ? { builtAgainstLite: process.env.LITE_VERSION } : {}),
+    builtAgainstLite: liteBaseVersion,
 };
 writeFileSync(DIST_PACKAGE_JSON, `${JSON.stringify(pkg, null, 2)}\n`);
 
 console.log(`Package: ${PACKAGE_NAME}`);
-console.log(`Base version: ${baseVersion}`);
+console.log(`Base @babylonjs/lite version: ${liteBaseVersion}`);
 console.log(`Preview version: ${previewVersion}`);
 console.log(`Dist tag: ${PREVIEW_DIST_TAG}`);
-if (process.env.LITE_VERSION) {
-    console.log(`Built against @babylonjs/lite: ${process.env.LITE_VERSION}`);
-}
+console.log(`Built against @babylonjs/lite: ${liteBaseVersion}`);
 console.log(`##vso[task.setvariable variable=PACKAGE_NAME_COMPAT]${PACKAGE_NAME}`);
 console.log(`##vso[task.setvariable variable=PACKAGE_VERSION_COMPAT]${previewVersion}`);
 console.log(`##vso[task.setvariable variable=PACKAGE_DIST_TAG_COMPAT]${PREVIEW_DIST_TAG}`);

--- a/scripts/prepare-compat-preview-release.ts
+++ b/scripts/prepare-compat-preview-release.ts
@@ -15,7 +15,6 @@ type PublishPackageJson = {
 };
 
 const PACKAGE_NAME = "@babylonjs/lite-compat";
-const PREVIEW_DIST_TAG = "preview";
 const DIST_PACKAGE_JSON = resolve(process.cwd(), "packages/babylon-lite-compat/dist/package.json");
 const LITE_VERSION_ENV = process.env.LITE_VERSION;
 
@@ -83,8 +82,6 @@ writeFileSync(DIST_PACKAGE_JSON, `${JSON.stringify(pkg, null, 2)}\n`);
 console.log(`Package: ${PACKAGE_NAME}`);
 console.log(`Base @babylonjs/lite version: ${liteBaseVersion}`);
 console.log(`Preview version: ${previewVersion}`);
-console.log(`Dist tag: ${PREVIEW_DIST_TAG}`);
 console.log(`Built against @babylonjs/lite: ${liteBaseVersion}`);
 console.log(`##vso[task.setvariable variable=PACKAGE_NAME_COMPAT]${PACKAGE_NAME}`);
 console.log(`##vso[task.setvariable variable=PACKAGE_VERSION_COMPAT]${previewVersion}`);
-console.log(`##vso[task.setvariable variable=PACKAGE_DIST_TAG_COMPAT]${PREVIEW_DIST_TAG}`);


### PR DESCRIPTION
## Problem

The @babylonjs/lite-compat package had several critical publishing issues:

1. **Wrong version**: Published as `0.0.1` instead of matching the main `@babylonjs/lite` package (e.g., `1.1.0`)
2. **Build ID suffix**: Appended random build IDs like `0.0.1-preview.54961` instead of a clean version
3. **Missing files**: README.md and LICENSE were not copied to dist folder

## Solution

### 1. Fixed version resolution (`scripts/prepare-compat-preview-release.ts`)
- Removed `previewSuffix()` function that appended build IDs
- Added `resolveLiteBaseVersion()` to require and parse `LITE_VERSION` env var
- Changed version format from `<base>-preview.<buildId>` to `<lite-version>-preview`
- Added `parseSemverCore()` to normalize semver (handles pre-release/build metadata)

### 2. Fixed missing files (`packages/babylon-lite-compat/vite.config.ts`)
- Added `copyFileSync` calls in emitPackageJson plugin to copy README.md and LICENSE to dist folder
- Ensures files are included in the npm tarball

### 3. Publish to `latest` dist-tag (`azure-pipelines-npm-publish.yml`)
- Compat publishes each build as `<lite-version>-preview` under npm's default `latest` dist-tag
- The `-preview` version suffix (not a separate dist-tag) is what marks these builds as pre-release
- Passes `LITE_VERSION` env var from the main publish script to the compat release script

## Why not a `preview`-only dist-tag?

The original goal was to publish compat under a `preview` dist-tag only (never `latest`), so it would be opt-in via `@babylonjs/lite-compat@preview`. **This isn't achievable on npm**: the registry requires every package to always carry a `latest` tag, rejects `npm dist-tag rm <pkg> latest` with a 400, and force-assigns `latest` on a package's first publish. A separate `preview` tag that always tracked the same newest version as `latest` would be redundant, so the package publishes to `latest` directly. Pre-release status is communicated by the `-preview` version suffix (and SemVer range resolution, which excludes pre-release versions from `^`/`~` matches).

A side benefit: each new publish moves `latest` onto the newest `<lite-version>-preview`, automatically cleaning up the stale `0.0.1-preview.54961` reference that currently holds `latest`.

## Validation

Dry-run scenarios tested and verified earlier in the branch's history:

✅ **Minor release**: Version `1.2.0-preview` (matches main lite package version), README/LICENSE present, no build ID suffix
✅ **Patch release**: Version `1.1.1-preview` (matches main lite package version after patch bump)

Also verified the published `@babylonjs/lite@1.2.0` (accidental real publish from this branch) renders correctly across Vite (dev + prod) and CDN (esm.sh, jsdelivr) consumers — it is byte-identical to 1.1.0.

## Notes

- The bad versions (`0.0.1-preview.54961`) can be deprecated separately from npm registry
- Future publishes require `LITE_VERSION` env var from the main publish script