### PR TITLE
feat(texture): add loadKtx2Texture2D for standalone KTX2 textures

### DIFF
--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -186,7 +186,7 @@ export { createTexture2DFromPixels, updateTexture2DFromPixels, createRenderTextu
 export type { PixelsTexture2DOptions, RenderTexture2DOptions } from "./texture/pixels-texture.js";
 export { loadKtxTexture2D } from "./texture/ktx-loader.js";
 export { loadBasisTexture2D } from "./texture/basis-loader.js";
-export { setKtx2DecoderUrl } from "./texture/ktx2-loader.js";
+export { setKtx2DecoderUrl, loadKtx2Texture2D } from "./texture/ktx2-loader.js";
 
 // ─── Materials ───────────────────────────────────────────────────────
 export { createStandardMaterial } from "./material/standard/create-standard-material.js";

--- a/packages/babylon-lite/src/texture/ktx2-loader.ts
+++ b/packages/babylon-lite/src/texture/ktx2-loader.ts
@@ -303,6 +303,20 @@ export async function uploadKtx2Texture2D(engine: EngineContext, buffer: ArrayBu
     throw new Error(`KTX2: unsupported transcoded format 0x${decoded.transcodedFormat.toString(16)}`);
 }
 
+/** Fetch and decode a standalone KTX2 (Basis Universal) texture from a URL into a Texture2D, transcoded to the
+ *  device's best GPU-compressed format (BC7/ETC2/ASTC) so it STAYS compressed in VRAM (a few times less than the
+ *  uncompressed RGBA8 `loadTexture2D` always uploads). Mirrors `loadKtxTexture2D` (KTX1) for app textures that
+ *  live outside a glTF. Requires the KTX2 decoder (configure self-hosting via `setKtx2DecoderUrl`). `sRGB`
+ *  selects the `*-srgb` GPU format (default false: raw/linear sampling, matching `loadTexture2D`'s `srgb:false`).
+ *  The decoder uploads the stored mips as-is (no V-flip), so author the .ktx2 in the orientation you want. */
+export async function loadKtx2Texture2D(engine: EngineContext, url: string, sRGB = false): Promise<Texture2D> {
+    const resp = await fetch(url);
+    if (!resp.ok) {
+        throw new Error(`KTX2 fetch failed: ${resp.status} for ${url}`);
+    }
+    return uploadKtx2Texture2D(engine, await resp.arrayBuffer(), sRGB);
+}
+
 /** Decode the first mip level of a KTX2 texture into an ImageBitmap so glTF
  *  material extensions can reuse the core image upload path. */
 export async function decodeKtx2ImageBitmapFromBuffer(buffer: ArrayBuffer): Promise<ImageBitmap> {


### PR DESCRIPTION
## Summary

Adds a public `loadKtx2Texture2D(engine, url, sRGB?)` that fetches and decodes a standalone KTX2 (Basis Universal) texture from a URL into a `Texture2D`, transcoded to the device's best GPU-compressed format (BC7/ETC2/ASTC) so it stays compressed in VRAM (a few times smaller than the uncompressed RGBA8 `loadTexture2D` always uploads).

This mirrors the existing `loadKtxTexture2D` (KTX1) entry point for app textures that live outside a glTF. It simply wraps the already-existing `uploadKtx2Texture2D` decode path with a `fetch`.

## Details

- `sRGB` selects the `*-srgb` GPU format (default `false`: raw/linear, matching `loadTexture2D`'s `srgb:false`).
- Requires the KTX2 decoder (self-host via `setKtx2DecoderUrl`).
- The decoder uploads stored mips as-is (no V-flip), so author the `.ktx2` in the orientation you want.

## Type of change

Non-breaking `feat` (purely additive public export). No scene uses it, so no parity or bundle-size movement.

## Validation

- `pnpm lint` (eslint + tsc x3): pass
- `pnpm docs:check` (TypeDoc): pass
- Bundle-size spec (183 tests): pass

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
