### PR TITLE
fix(loader): bind interleaved vertex buffers at offset 0 (match BJS WebGPU) to fix AMD corruption

### DIFF
--- a/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
@@ -2,9 +2,12 @@
  * Interleaved (strided) glTF vertex-buffer support — dynamically imported.
  *
  * The engine renders interleaved attributes genuinely: the raw strided
- * bufferView slice is uploaded ONCE as a shared GPU buffer and bound to each
- * attribute at its byte offset with the pipeline's vertex `arrayStride` set to
- * the bufferView byteStride. The loader never rewrites the asset.
+ * bufferView slice is uploaded ONCE as a shared GPU buffer, bound to each
+ * attribute slot at byte offset 0, with the per-attribute byte offset encoded in
+ * the pipeline vertex layout (`attributes[].offset`) and `arrayStride` set to the
+ * bufferView byteStride. This mirrors stock Babylon.js's WebGPU vertex state and
+ * avoids a non-zero `setVertexBuffer` bind offset, which corrupts vertex fetch on
+ * some AMD (Renoir) / Dawn paths. The loader never rewrites the asset.
  *
  * This whole module is loaded via `await import()` only when an asset actually
  * contains an interleaved bufferView, so non-interleaved scenes pay ZERO bundle
@@ -49,7 +52,8 @@ export interface AccessorInterleave {
     _bufferView: number;
     /** @internal Interleave byte stride (bufferView.byteStride) → pipeline arrayStride. */
     _stride: number;
-    /** @internal Attribute byte offset within the bufferView → setVertexBuffer bind offset. */
+    /** @internal Attribute byte offset within the bufferView → pipeline vertex layout
+     *  `attributes[].offset` (the shared buffer is bound at offset 0). */
     _offset: number;
     /** @internal glTF component type (FLOAT, UNSIGNED_SHORT, …). */
     _componentType: number;
@@ -127,41 +131,6 @@ function destrideToTight(il: AccessorInterleave): Float32Array {
     return out;
 }
 
-/** True if any vertex of a 12-byte (vec3) FLOAT attribute interleaved at byte
- *  `offset` with `stride` crosses a 16-byte boundary. A vec3 occupying bytes
- *  `[a, a+12)` crosses iff `(a & 15) > 4`. The per-vertex base address is
- *  `offset + v*stride`, whose residue mod 16 repeats with period ≤ 16, so the
- *  first `min(count, 16)` vertices cover every distinct residue. Checking only
- *  `offset` would miss layouts whose `stride` is not a multiple of 16 (e.g.
- *  stride 24, offset 0 → vertex 1 base 24, residue 8, straddles). */
-function vec3CrossesBoundary(offset: number, stride: number, count: number): boolean {
-    const n = Math.min(count, 16);
-    for (let v = 0; v < n; v++) {
-        if (((offset + v * stride) & 15) > 4) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/** AMD (Renoir / some Dawn vertex-fetch paths) corrupt a `float32x3` vertex attribute
- *  whose interleaved byte span crosses a 16-byte boundary — e.g. a NORMAL at stride-48
- *  offset 12, whose bytes 12..23 straddle the 16-byte line. The mis-fetched normal comes
- *  back as garbage → `normalize()` = NaN → black fragments, but ONLY on AMD (NVIDIA/Intel
- *  read it fine; this is why stock Babylon.js, which uploads one tight buffer per attribute,
- *  is unaffected). When such an attribute is detected, de-interleave it into a tight,
- *  offset-0 buffer (the universally-safe layout that separate-buffer assets already use)
- *  so the GPU never performs the boundary-crossing fetch. Boundary-safe attributes keep
- *  genuine interleaving, so only the offending attribute pays the de-stride cost, and
- *  rendering stays byte-identical on GPUs that were already correct. */
-function deStraddleVec3(a: { _tight: Float32Array | null; _il?: AccessorInterleave }): void {
-    const il = a._il;
-    if (il && il._componentType === FLOAT && il._componentCount === 3 && vec3CrossesBoundary(il._offset, il._stride, il._count)) {
-        a._tight = destrideToTight(il);
-        a._il = undefined;
-    }
-}
-
 /** Build a mesh-data partial for a primitive, but ONLY if it actually sources
  *  ≥1 attribute from an interleaved (strided) bufferView. Returns `undefined`
  *  for fully-tight primitives so the caller falls back to its tight path.
@@ -211,11 +180,9 @@ export function buildInterleavedPartial(json: any, binChunk: DataView, primitive
     };
 
     const pos = resolveOne("POSITION", false);
-    deStraddleVec3(pos);
     vb._p = pos._il;
     vertexCount = pos._count;
     const nrm = resolveOne("NORMAL", false);
-    deStraddleVec3(nrm);
     vb._n = nrm._il;
     const uv = resolveOne("TEXCOORD_0", false);
     vb._u = uv._il;
@@ -269,7 +236,8 @@ export function buildInterleavedPartial(json: any, binChunk: DataView, primitive
 }
 
 /** Build the GPU geometry for an interleaved mesh: one shared buffer per
- *  bufferView for strided attributes (bound at offset with arrayStride), tight
+ *  bufferView for strided attributes (bound at offset 0; the per-attribute byte
+ *  offset goes into the pipeline vertex layout, matching stock Babylon.js), tight
  *  attributes get their own buffer — byte-identical to non-interleaved meshes.
  *  The raw `_slice` is intentionally retained on `_vb` so the CPU copy can be
  *  de-strided lazily later (see {@link installLazyCpu}). */
@@ -286,6 +254,10 @@ function buildInterleavedGpu(engine: EngineContext, m: GltfMeshData): MeshGPU {
         }
         return b;
     };
+    // Cache key encodes both stride AND byte offset per attribute: the offsets are
+    // now baked into the pipeline vertex layout (attributes[].offset), so two meshes
+    // with identical strides but different offsets need distinct pipelines.
+    const k = (a: AccessorInterleave | undefined) => `${a?._stride ?? 0},${a?._offset ?? 0}`;
     return {
         positionBuffer: vbuf(vbsrc._p, m._positions)!,
         normalBuffer: vbuf(vbsrc._n, m._normals)!,
@@ -297,7 +269,7 @@ function buildInterleavedGpu(engine: EngineContext, m: GltfMeshData): MeshGPU {
         indexCount: m._indexCount,
         indexFormat: (m._indices instanceof U32 ? "uint32" : "uint16") as GPUIndexFormat,
         _vbLayout: vbsrc,
-        _vbKey: `vb${vbsrc._p?._stride ?? 0}.${vbsrc._n?._stride ?? 0}.${vbsrc._t?._stride ?? 0}.${vbsrc._u?._stride ?? 0}`,
+        _vbKey: `vb${k(vbsrc._p)}.${k(vbsrc._n)}.${k(vbsrc._t)}.${k(vbsrc._u)}`,
     };
 }
 

--- a/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
@@ -127,20 +127,36 @@ function destrideToTight(il: AccessorInterleave): Float32Array {
     return out;
 }
 
+/** True if any vertex of a 12-byte (vec3) FLOAT attribute interleaved at byte
+ *  `offset` with `stride` crosses a 16-byte boundary. A vec3 occupying bytes
+ *  `[a, a+12)` crosses iff `(a & 15) > 4`. The per-vertex base address is
+ *  `offset + v*stride`, whose residue mod 16 repeats with period ≤ 16, so the
+ *  first `min(count, 16)` vertices cover every distinct residue. Checking only
+ *  `offset` would miss layouts whose `stride` is not a multiple of 16 (e.g.
+ *  stride 24, offset 0 → vertex 1 base 24, residue 8, straddles). */
+function vec3CrossesBoundary(offset: number, stride: number, count: number): boolean {
+    const n = Math.min(count, 16);
+    for (let v = 0; v < n; v++) {
+        if (((offset + v * stride) & 15) > 4) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /** AMD (Renoir / some Dawn vertex-fetch paths) corrupt a `float32x3` vertex attribute
  *  whose interleaved byte span crosses a 16-byte boundary — e.g. a NORMAL at stride-48
  *  offset 12, whose bytes 12..23 straddle the 16-byte line. The mis-fetched normal comes
  *  back as garbage → `normalize()` = NaN → black fragments, but ONLY on AMD (NVIDIA/Intel
- *  read it fine). When such an attribute is detected, de-interleave it into a tight,
+ *  read it fine; this is why stock Babylon.js, which uploads one tight buffer per attribute,
+ *  is unaffected). When such an attribute is detected, de-interleave it into a tight,
  *  offset-0 buffer (the universally-safe layout that separate-buffer assets already use)
  *  so the GPU never performs the boundary-crossing fetch. Boundary-safe attributes keep
- *  genuine interleaving, so only the offending attribute pays the de-stride cost.
- *
- *  A 12-byte (vec3) span at byte `offset` crosses a 16-byte boundary iff
- *  `(offset % 16) + 12 > 16`. Offsets are always 4-aligned, so this is `(offset & 15) > 4`. */
+ *  genuine interleaving, so only the offending attribute pays the de-stride cost, and
+ *  rendering stays byte-identical on GPUs that were already correct. */
 function deStraddleVec3(a: { _tight: Float32Array | null; _il?: AccessorInterleave }): void {
     const il = a._il;
-    if (il && il._componentType === FLOAT && il._componentCount === 3 && (il._offset & 15) + 12 > 16) {
+    if (il && il._componentType === FLOAT && il._componentCount === 3 && vec3CrossesBoundary(il._offset, il._stride, il._count)) {
         a._tight = destrideToTight(il);
         a._il = undefined;
     }

--- a/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
@@ -127,6 +127,25 @@ function destrideToTight(il: AccessorInterleave): Float32Array {
     return out;
 }
 
+/** AMD (Renoir / some Dawn vertex-fetch paths) corrupt a `float32x3` vertex attribute
+ *  whose interleaved byte span crosses a 16-byte boundary — e.g. a NORMAL at stride-48
+ *  offset 12, whose bytes 12..23 straddle the 16-byte line. The mis-fetched normal comes
+ *  back as garbage → `normalize()` = NaN → black fragments, but ONLY on AMD (NVIDIA/Intel
+ *  read it fine). When such an attribute is detected, de-interleave it into a tight,
+ *  offset-0 buffer (the universally-safe layout that separate-buffer assets already use)
+ *  so the GPU never performs the boundary-crossing fetch. Boundary-safe attributes keep
+ *  genuine interleaving, so only the offending attribute pays the de-stride cost.
+ *
+ *  A 12-byte (vec3) span at byte `offset` crosses a 16-byte boundary iff
+ *  `(offset % 16) + 12 > 16`. Offsets are always 4-aligned, so this is `(offset & 15) > 4`. */
+function deStraddleVec3(a: { _tight: Float32Array | null; _il?: AccessorInterleave }): void {
+    const il = a._il;
+    if (il && il._componentType === FLOAT && il._componentCount === 3 && (il._offset & 15) + 12 > 16) {
+        a._tight = destrideToTight(il);
+        a._il = undefined;
+    }
+}
+
 /** Build a mesh-data partial for a primitive, but ONLY if it actually sources
  *  ≥1 attribute from an interleaved (strided) bufferView. Returns `undefined`
  *  for fully-tight primitives so the caller falls back to its tight path.
@@ -176,9 +195,11 @@ export function buildInterleavedPartial(json: any, binChunk: DataView, primitive
     };
 
     const pos = resolveOne("POSITION", false);
+    deStraddleVec3(pos);
     vb._p = pos._il;
     vertexCount = pos._count;
     const nrm = resolveOne("NORMAL", false);
+    deStraddleVec3(nrm);
     vb._n = nrm._il;
     const uv = resolveOne("TEXCOORD_0", false);
     vb._u = uv._il;

--- a/packages/babylon-lite/src/material/pbr/pbr-geometry-renderable.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-geometry-renderable.ts
@@ -218,18 +218,20 @@ export function buildPbrGeometryRenderable(scene: SceneContext, mesh: Mesh, view
             pass.setBindGroup(2, shadowBindGroup);
         }
         let slot = 0;
-        const vb = gpu._vbLayout;
-        pass.setVertexBuffer(slot++, gpu.positionBuffer, vb?._p?._offset);
-        pass.setVertexBuffer(slot++, gpu.normalBuffer, vb?._n?._offset);
+        // Bind every attribute at offset 0 — the per-attribute byte offset is baked into the
+        // pipeline vertex layout (see pbr-template). A non-zero setVertexBuffer bind offset
+        // corrupts vertex fetch on some AMD/Dawn paths; this mirrors the color pass and BJS.
+        pass.setVertexBuffer(slot++, gpu.positionBuffer);
+        pass.setVertexBuffer(slot++, gpu.normalBuffer);
         if (hasNormalMap && gpu.tangentBuffer) {
-            pass.setVertexBuffer(slot++, gpu.tangentBuffer, vb?._t?._offset);
+            pass.setVertexBuffer(slot++, gpu.tangentBuffer);
         }
-        pass.setVertexBuffer(slot++, gpu.uvBuffer, vb?._u?._offset);
+        pass.setVertexBuffer(slot++, gpu.uvBuffer);
         if (hasUV2 && gpu.uv2Buffer) {
-            pass.setVertexBuffer(slot++, gpu.uv2Buffer, vb?._u2?._offset);
+            pass.setVertexBuffer(slot++, gpu.uv2Buffer);
         }
         if (hasVertexColor && gpu.colorBuffer) {
-            pass.setVertexBuffer(slot++, gpu.colorBuffer, vb?._c?._offset);
+            pass.setVertexBuffer(slot++, gpu.colorBuffer);
         }
         // Skinning vertex buffers: live skeleton OR baked VAT (same field names, mutually exclusive).
         // Mirrors the main PBR renderable — without the VAT branch, VAT-animated thin instances leave the

--- a/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
@@ -450,18 +450,22 @@ export async function buildPbrRenderables(scene: SceneContext, meshes: Mesh[], e
                 pass.setBindGroup(2, shadowBindGroup);
             }
             let slot = 0;
-            const vb = gpu._vbLayout;
-            pass.setVertexBuffer(slot++, gpu.positionBuffer, vb?._p?._offset);
-            pass.setVertexBuffer(slot++, gpu.normalBuffer, vb?._n?._offset);
+            // Interleaved meshes share one GPU buffer across attributes; the per-attribute
+            // byte offset is baked into the pipeline vertex layout (attributes[].offset), so
+            // every slot binds at offset 0. This matches Babylon.js WebGPU and avoids a
+            // non-zero setVertexBuffer bind offset, which corrupts vertex fetch on some
+            // AMD (Renoir) / Dawn paths (interleaved ClearCoatTest labels went black/garbage).
+            pass.setVertexBuffer(slot++, gpu.positionBuffer);
+            pass.setVertexBuffer(slot++, gpu.normalBuffer);
             if (hasNormalMap && gpu.tangentBuffer) {
-                pass.setVertexBuffer(slot++, gpu.tangentBuffer, vb?._t?._offset);
+                pass.setVertexBuffer(slot++, gpu.tangentBuffer);
             }
-            pass.setVertexBuffer(slot++, gpu.uvBuffer, vb?._u?._offset);
+            pass.setVertexBuffer(slot++, gpu.uvBuffer);
             if (hasUV2 && gpu.uv2Buffer) {
-                pass.setVertexBuffer(slot++, gpu.uv2Buffer, vb?._u2?._offset);
+                pass.setVertexBuffer(slot++, gpu.uv2Buffer);
             }
             if (hasVertexColor && gpu.colorBuffer) {
-                pass.setVertexBuffer(slot++, gpu.colorBuffer, vb?._c?._offset);
+                pass.setVertexBuffer(slot++, gpu.colorBuffer);
             }
             // Skinning vertex buffers: live skeleton OR baked VAT (same field names, mutually exclusive).
             const skin = mesh.skeleton ?? mesh.vat;

--- a/packages/babylon-lite/src/material/pbr/pbr-template.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-template.ts
@@ -187,15 +187,25 @@ export function createPbrTemplate(config: PbrTemplateConfig): ShaderTemplate {
 
     // ── Base vertex attributes ──────────────────────────────────
     // arrayStride defaults to the canonical tight element size; interleaved meshes
-    // override it (e.g. 24 for POSITION+NORMAL sharing one stride-24 bufferView).
+    // override it (e.g. 48 for POSITION+NORMAL+UV+TANGENT sharing one stride-48
+    // bufferView). `_offset` is the attribute's byte offset WITHIN that shared
+    // buffer (0 for tight meshes); it is baked into the pipeline vertex layout so
+    // the draw can bind the shared buffer at offset 0 (matches Babylon.js WebGPU —
+    // a non-zero setVertexBuffer bind offset corrupts vertex fetch on some AMD/Dawn paths).
     const _baseVertexAttributes: VertexAttribute[] = [
-        { _name: "position", _type: "vec3<f32>", _gpuFormat: "float32x3", _arrayStride: _vbStrides?._p?._stride ?? 12 },
-        { _name: "normal", _type: "vec3<f32>", _gpuFormat: "float32x3", _arrayStride: _vbStrides?._n?._stride ?? 12 },
+        { _name: "position", _type: "vec3<f32>", _gpuFormat: "float32x3", _arrayStride: _vbStrides?._p?._stride ?? 12, _offset: _vbStrides?._p?._offset ?? 0 },
+        { _name: "normal", _type: "vec3<f32>", _gpuFormat: "float32x3", _arrayStride: _vbStrides?._n?._stride ?? 12, _offset: _vbStrides?._n?._offset ?? 0 },
     ];
     if (hasNormal) {
-        _baseVertexAttributes.push({ _name: "tangent", _type: "vec4<f32>", _gpuFormat: "float32x4", _arrayStride: _vbStrides?._t?._stride ?? 16 });
+        _baseVertexAttributes.push({
+            _name: "tangent",
+            _type: "vec4<f32>",
+            _gpuFormat: "float32x4",
+            _arrayStride: _vbStrides?._t?._stride ?? 16,
+            _offset: _vbStrides?._t?._offset ?? 0,
+        });
     }
-    _baseVertexAttributes.push({ _name: "uv", _type: "vec2<f32>", _gpuFormat: "float32x2", _arrayStride: _vbStrides?._u?._stride ?? 8 });
+    _baseVertexAttributes.push({ _name: "uv", _type: "vec2<f32>", _gpuFormat: "float32x2", _arrayStride: _vbStrides?._u?._stride ?? 8, _offset: _vbStrides?._u?._offset ?? 0 });
     if (_ext) {
         _baseVertexAttributes.push(..._ext.extraVertexAttributes);
     }

--- a/packages/babylon-lite/src/mesh/mesh.ts
+++ b/packages/babylon-lite/src/mesh/mesh.ts
@@ -19,13 +19,16 @@ import { eulerToQuat, createEulerProxy } from "../scene/scene-node.js";
 
 /** Per-attribute interleave override. When present, the attribute's GPU buffer
  *  is a shared interleaved slice: the pipeline uses `_stride` as the vertex
- *  buffer arrayStride and the draw binds the buffer at byte offset `_offset`.
+ *  buffer arrayStride and `_offset` as the layout `attributes[].offset`, while the
+ *  draw binds the buffer at offset 0 (mirrors Babylon.js WebGPU; a non-zero
+ *  setVertexBuffer bind offset corrupts vertex fetch on some AMD/Dawn paths).
  *  Absent attributes use the canonical tight layout (own buffer, default stride,
  *  offset 0) — byte-identical to non-interleaved meshes. */
 export interface MeshVbAttr {
     /** @internal Vertex buffer arrayStride for this attribute's pipeline layout entry. */
     readonly _stride: number;
-    /** @internal Byte offset passed to setVertexBuffer (bind offset into the shared buffer). */
+    /** @internal Byte offset within the shared buffer, encoded in the pipeline vertex
+     *  layout `attributes[].offset` (the buffer is bound at offset 0). */
     readonly _offset: number;
 }
 

--- a/tests/lite/unit/gltf-interleave.test.ts
+++ b/tests/lite/unit/gltf-interleave.test.ts
@@ -4,11 +4,14 @@ import { accessorIsStrided, buildInterleavedPartial, installLazyCpu, computeAabb
 const FLOAT = 5126;
 
 /** Build a minimal glTF JSON + binary chunk with POSITION+NORMAL interleaved in
- *  one stride-24 bufferView (offset 0 and 12), plus a tight TEXCOORD_0 bufferView. */
+ *  one stride-32 bufferView (offset 0 and 12), plus a tight TEXCOORD_0 bufferView.
+ *  Stride 32 is a multiple of 16 (like the real ClearCoatTest stride-48 layout), so
+ *  POSITION@0 never crosses a 16-byte boundary (stays genuinely interleaved) while
+ *  the vec3 NORMAL@12 always straddles it (bytes 12..23) and is de-interleaved. */
 function makeInterleavedAsset() {
     const verts = 2;
-    // Interleaved: [px,py,pz, nx,ny,nz] * 2  (24 bytes/vertex)
-    const interleaved = new Float32Array([1, 2, 3, 0, 0, 1, 4, 5, 6, 0, 1, 0]);
+    // Interleaved: [px,py,pz, nx,ny,nz, pad,pad] * 2  (32 bytes/vertex)
+    const interleaved = new Float32Array([1, 2, 3, 0, 0, 1, 0, 0, 4, 5, 6, 0, 1, 0, 0, 0]);
     // Tight UVs: [u,v] * 2
     const uvs = new Float32Array([0.1, 0.2, 0.3, 0.4]);
     const buf = new ArrayBuffer(interleaved.byteLength + uvs.byteLength);
@@ -23,7 +26,7 @@ function makeInterleavedAsset() {
             { bufferView: 1, byteOffset: 0, componentType: FLOAT, count: verts, type: "VEC2" }, // TEXCOORD_0
         ],
         bufferViews: [
-            { buffer: 0, byteOffset: 0, byteLength: interleaved.byteLength, byteStride: 24 },
+            { buffer: 0, byteOffset: 0, byteLength: interleaved.byteLength, byteStride: 32 },
             { buffer: 0, byteOffset: interleaved.byteLength, byteLength: uvs.byteLength }, // tight, no stride
         ],
     };
@@ -34,39 +37,43 @@ function makeInterleavedAsset() {
 describe("gltf-interleave", () => {
     it("accessorIsStrided detects interleaved vs tight bufferViews", () => {
         const { json } = makeInterleavedAsset();
-        expect(accessorIsStrided(json, 0)).toBe(true); // POSITION (stride 24 ≠ 12)
-        expect(accessorIsStrided(json, 1)).toBe(true); // NORMAL (stride 24 ≠ 12)
+        expect(accessorIsStrided(json, 0)).toBe(true); // POSITION (stride 32 ≠ 12)
+        expect(accessorIsStrided(json, 1)).toBe(true); // NORMAL (stride 32 ≠ 12)
         expect(accessorIsStrided(json, 2)).toBe(false); // TEXCOORD_0 (no byteStride)
     });
 
-    it("leaves strided POSITION/NORMAL CPU fields null (lazy) but records the GPU layout", () => {
+    it("keeps boundary-safe POSITION interleaved (lazy) but de-interleaves a straddling NORMAL", () => {
         const { json, binChunk, primitive } = makeInterleavedAsset();
         const m = buildInterleavedPartial(json, binChunk, primitive, new Float32Array(16) as never, 0)!;
         expect(m).toBeDefined();
 
-        // Strided position/normal are NOT de-strided eagerly — the tight copy is
-        // built only on demand, so the partial leaves these null.
+        // POSITION@0 never crosses a 16-byte boundary, so it stays genuinely interleaved:
+        // its tight CPU copy is built only on demand (left null here), GPU layout recorded.
         expect(m._positions).toBeNull();
-        expect(m._normals).toBeNull();
+        expect(m._vb!._p).toMatchObject({ _stride: 32, _offset: 0, _bufferView: 0 });
+
+        // NORMAL@12 (vec3, bytes 12..23) straddles the 16-byte line → de-interleaved into a
+        // tight, offset-0 buffer to dodge the AMD/Dawn mis-fetch. CPU copy is materialized
+        // eagerly and the interleave entry is dropped (no GPU boundary-crossing fetch).
+        expect(Array.from(m._normals!)).toEqual([0, 0, 1, 0, 1, 0]);
+        expect(m._vb!._n).toBeUndefined();
+
         // Tight UVs resolved through the normal (non-strided) path are present.
         expect(Array.from(m._uvs!)).toEqual([0.1, 0.2, 0.3, 0.4].map((v) => Math.fround(v)));
         expect(m._vertexCount).toBe(2);
-
-        // GPU interleave layout: shared stride 24, position at 0, normal at 12.
-        expect(m._vb!._p).toMatchObject({ _stride: 24, _offset: 0, _bufferView: 0 });
-        expect(m._vb!._n).toMatchObject({ _stride: 24, _offset: 12, _bufferView: 0 });
         // The tight UV attribute has no interleave entry.
         expect(m._vb!._u).toBeUndefined();
     });
 
-    it("installLazyCpu de-strides position/normal only on first access", () => {
+    it("installLazyCpu de-strides interleaved position lazily; eager-detangled normal is direct", () => {
         const { json, binChunk, primitive } = makeInterleavedAsset();
         const m = buildInterleavedPartial(json, binChunk, primitive, new Float32Array(16) as never, 0)!;
         const mesh: Record<string, unknown> = {};
         installLazyCpu(mesh, m as never);
 
-        // Lazy getters reconstruct the tight CPU copy from the strided source.
+        // Lazy getter reconstructs the tight POSITION copy from the strided source.
         expect(Array.from(mesh._cpuPositions as Float32Array)).toEqual([1, 2, 3, 4, 5, 6]);
+        // NORMAL was de-interleaved eagerly → assigned directly (not via a getter).
         expect(Array.from(mesh._cpuNormals as Float32Array)).toEqual([0, 0, 1, 0, 1, 0]);
         // Tight UV is assigned directly (not via a getter).
         expect(Array.from(mesh._cpuUvs as Float32Array)).toEqual([0.1, 0.2, 0.3, 0.4].map((v) => Math.fround(v)));
@@ -87,5 +94,26 @@ describe("gltf-interleave", () => {
         const { json, binChunk } = makeInterleavedAsset();
         const tightOnly = { attributes: { TEXCOORD_0: 2 } };
         expect(buildInterleavedPartial(json, binChunk, tightOnly, new Float32Array(16) as never, 0)).toBeUndefined();
+    });
+
+    it("de-interleaves a vec3 that straddles only on a later vertex (stride not a multiple of 16)", () => {
+        // POSITION@0 with stride 24: vertex 0 base 0 (residue 0, safe) but vertex 1 base 24
+        // (residue 8, bytes 24..35 straddle the 32-byte line). The straddle is invisible if
+        // only `offset` is inspected, so this guards the per-vertex `offset + v*stride` check.
+        const verts = 2;
+        const interleaved = new Float32Array([1, 2, 3, 9, 9, 9, 4, 5, 6, 9, 9, 9]); // [pos, pad] * 2, stride 24
+        const buf = new ArrayBuffer(interleaved.byteLength);
+        new Float32Array(buf).set(interleaved);
+        const binChunk = new DataView(buf);
+        const json = {
+            accessors: [{ bufferView: 0, byteOffset: 0, componentType: FLOAT, count: verts, type: "VEC3" }],
+            bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: interleaved.byteLength, byteStride: 24 }],
+        };
+        const primitive = { attributes: { POSITION: 0 } };
+        const m = buildInterleavedPartial(json, binChunk, primitive, new Float32Array(16) as never, 0)!;
+        expect(m).toBeDefined();
+        // De-interleaved into a tight, offset-0 buffer; no GPU interleave entry remains.
+        expect(Array.from(m._positions!)).toEqual([1, 2, 3, 4, 5, 6]);
+        expect(m._vb!._p).toBeUndefined();
     });
 });

--- a/tests/lite/unit/gltf-interleave.test.ts
+++ b/tests/lite/unit/gltf-interleave.test.ts
@@ -4,14 +4,11 @@ import { accessorIsStrided, buildInterleavedPartial, installLazyCpu, computeAabb
 const FLOAT = 5126;
 
 /** Build a minimal glTF JSON + binary chunk with POSITION+NORMAL interleaved in
- *  one stride-32 bufferView (offset 0 and 12), plus a tight TEXCOORD_0 bufferView.
- *  Stride 32 is a multiple of 16 (like the real ClearCoatTest stride-48 layout), so
- *  POSITION@0 never crosses a 16-byte boundary (stays genuinely interleaved) while
- *  the vec3 NORMAL@12 always straddles it (bytes 12..23) and is de-interleaved. */
+ *  one stride-24 bufferView (offset 0 and 12), plus a tight TEXCOORD_0 bufferView. */
 function makeInterleavedAsset() {
     const verts = 2;
-    // Interleaved: [px,py,pz, nx,ny,nz, pad,pad] * 2  (32 bytes/vertex)
-    const interleaved = new Float32Array([1, 2, 3, 0, 0, 1, 0, 0, 4, 5, 6, 0, 1, 0, 0, 0]);
+    // Interleaved: [px,py,pz, nx,ny,nz] * 2  (24 bytes/vertex)
+    const interleaved = new Float32Array([1, 2, 3, 0, 0, 1, 4, 5, 6, 0, 1, 0]);
     // Tight UVs: [u,v] * 2
     const uvs = new Float32Array([0.1, 0.2, 0.3, 0.4]);
     const buf = new ArrayBuffer(interleaved.byteLength + uvs.byteLength);
@@ -26,7 +23,7 @@ function makeInterleavedAsset() {
             { bufferView: 1, byteOffset: 0, componentType: FLOAT, count: verts, type: "VEC2" }, // TEXCOORD_0
         ],
         bufferViews: [
-            { buffer: 0, byteOffset: 0, byteLength: interleaved.byteLength, byteStride: 32 },
+            { buffer: 0, byteOffset: 0, byteLength: interleaved.byteLength, byteStride: 24 },
             { buffer: 0, byteOffset: interleaved.byteLength, byteLength: uvs.byteLength }, // tight, no stride
         ],
     };
@@ -37,43 +34,41 @@ function makeInterleavedAsset() {
 describe("gltf-interleave", () => {
     it("accessorIsStrided detects interleaved vs tight bufferViews", () => {
         const { json } = makeInterleavedAsset();
-        expect(accessorIsStrided(json, 0)).toBe(true); // POSITION (stride 32 ≠ 12)
-        expect(accessorIsStrided(json, 1)).toBe(true); // NORMAL (stride 32 ≠ 12)
+        expect(accessorIsStrided(json, 0)).toBe(true); // POSITION (stride 24 ≠ 12)
+        expect(accessorIsStrided(json, 1)).toBe(true); // NORMAL (stride 24 ≠ 12)
         expect(accessorIsStrided(json, 2)).toBe(false); // TEXCOORD_0 (no byteStride)
     });
 
-    it("keeps boundary-safe POSITION interleaved (lazy) but de-interleaves a straddling NORMAL", () => {
+    it("leaves strided POSITION/NORMAL CPU fields null (lazy) but records the GPU layout", () => {
         const { json, binChunk, primitive } = makeInterleavedAsset();
         const m = buildInterleavedPartial(json, binChunk, primitive, new Float32Array(16) as never, 0)!;
         expect(m).toBeDefined();
 
-        // POSITION@0 never crosses a 16-byte boundary, so it stays genuinely interleaved:
-        // its tight CPU copy is built only on demand (left null here), GPU layout recorded.
+        // Strided position/normal are NOT de-strided eagerly — the tight copy is
+        // built only on demand, so the partial leaves these null.
         expect(m._positions).toBeNull();
-        expect(m._vb!._p).toMatchObject({ _stride: 32, _offset: 0, _bufferView: 0 });
-
-        // NORMAL@12 (vec3, bytes 12..23) straddles the 16-byte line → de-interleaved into a
-        // tight, offset-0 buffer to dodge the AMD/Dawn mis-fetch. CPU copy is materialized
-        // eagerly and the interleave entry is dropped (no GPU boundary-crossing fetch).
-        expect(Array.from(m._normals!)).toEqual([0, 0, 1, 0, 1, 0]);
-        expect(m._vb!._n).toBeUndefined();
-
+        expect(m._normals).toBeNull();
         // Tight UVs resolved through the normal (non-strided) path are present.
         expect(Array.from(m._uvs!)).toEqual([0.1, 0.2, 0.3, 0.4].map((v) => Math.fround(v)));
         expect(m._vertexCount).toBe(2);
+
+        // GPU interleave layout: shared stride 24, position at byte offset 0, normal at 12.
+        // The byte offset is baked into the pipeline vertex layout (attributes[].offset);
+        // the draw binds the shared buffer at offset 0 (matches Babylon.js WebGPU).
+        expect(m._vb!._p).toMatchObject({ _stride: 24, _offset: 0, _bufferView: 0 });
+        expect(m._vb!._n).toMatchObject({ _stride: 24, _offset: 12, _bufferView: 0 });
         // The tight UV attribute has no interleave entry.
         expect(m._vb!._u).toBeUndefined();
     });
 
-    it("installLazyCpu de-strides interleaved position lazily; eager-detangled normal is direct", () => {
+    it("installLazyCpu de-strides position/normal only on first access", () => {
         const { json, binChunk, primitive } = makeInterleavedAsset();
         const m = buildInterleavedPartial(json, binChunk, primitive, new Float32Array(16) as never, 0)!;
         const mesh: Record<string, unknown> = {};
         installLazyCpu(mesh, m as never);
 
-        // Lazy getter reconstructs the tight POSITION copy from the strided source.
+        // Lazy getters reconstruct the tight CPU copy from the strided source.
         expect(Array.from(mesh._cpuPositions as Float32Array)).toEqual([1, 2, 3, 4, 5, 6]);
-        // NORMAL was de-interleaved eagerly → assigned directly (not via a getter).
         expect(Array.from(mesh._cpuNormals as Float32Array)).toEqual([0, 0, 1, 0, 1, 0]);
         // Tight UV is assigned directly (not via a getter).
         expect(Array.from(mesh._cpuUvs as Float32Array)).toEqual([0.1, 0.2, 0.3, 0.4].map((v) => Math.fround(v)));
@@ -94,26 +89,5 @@ describe("gltf-interleave", () => {
         const { json, binChunk } = makeInterleavedAsset();
         const tightOnly = { attributes: { TEXCOORD_0: 2 } };
         expect(buildInterleavedPartial(json, binChunk, tightOnly, new Float32Array(16) as never, 0)).toBeUndefined();
-    });
-
-    it("de-interleaves a vec3 that straddles only on a later vertex (stride not a multiple of 16)", () => {
-        // POSITION@0 with stride 24: vertex 0 base 0 (residue 0, safe) but vertex 1 base 24
-        // (residue 8, bytes 24..35 straddle the 32-byte line). The straddle is invisible if
-        // only `offset` is inspected, so this guards the per-vertex `offset + v*stride` check.
-        const verts = 2;
-        const interleaved = new Float32Array([1, 2, 3, 9, 9, 9, 4, 5, 6, 9, 9, 9]); // [pos, pad] * 2, stride 24
-        const buf = new ArrayBuffer(interleaved.byteLength);
-        new Float32Array(buf).set(interleaved);
-        const binChunk = new DataView(buf);
-        const json = {
-            accessors: [{ bufferView: 0, byteOffset: 0, componentType: FLOAT, count: verts, type: "VEC3" }],
-            bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: interleaved.byteLength, byteStride: 24 }],
-        };
-        const primitive = { attributes: { POSITION: 0 } };
-        const m = buildInterleavedPartial(json, binChunk, primitive, new Float32Array(16) as never, 0)!;
-        expect(m).toBeDefined();
-        // De-interleaved into a tight, offset-0 buffer; no GPU interleave entry remains.
-        expect(Array.from(m._positions!)).toEqual([1, 2, 3, 4, 5, 6]);
-        expect(m._vb!._p).toBeUndefined();
     });
 });


### PR DESCRIPTION
## Problem

On an AMD Radeon (Renoir, `0x1636` / Ryzen 7 PRO 4750U), cx20's **interleaved** `ClearCoatTest.glb` renders corruption on the emissive label quads — solid black at first, then (after an earlier de-straddle attempt) diagonal hatching on the same triangle. NVIDIA renders it fine, and **stock Babylon.js + WebGPU renders the same `.glb` correctly on the same AMD machine**. ([forum](https://forum.babylonjs.com/t/63648/123))

## Root cause (authoritative, from the Babylon.js source)

The `Labels_Mesh` is interleaved in one bufferView (`byteStride=48`): `POSITION@0`, `NORMAL@12`, `TEXCOORD_0@24`, `TANGENT@32`.

Reading the Babylon.js WebGPU engine source, stock BJS keeps the data interleaved and binds the shared buffer to **one slot at `setVertexBuffer` bind offset 0**, putting each attribute's byte offset into the pipeline vertex layout (`attributes[].offset`) — *including* a `float32x3` NORMAL at `offset 12` that crosses a 16‑byte boundary ([`webgpuCacheRenderPipeline.ts`](https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts), [`webgpuEngine` bind](https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Engines/webgpuEngine.ts)). BJS renders this exact `.glb` correctly on the AMD GPU, so **the boundary crossing is not the bug**.

The real difference: **Lite bound the shared buffer at a non‑zero `setVertexBuffer` offset** (`normal@12`, `uv@24`). That non‑zero bind offset is what AMD/Dawn mis‑fetches → `normalize(normal)` = NaN → black, and mis‑fetched UV → garbage text → hatching. (An earlier commit de‑interleaved only the normal, moving its bind to 0 and removing the black, but `uv@24` stayed broken → hatching.)

## Fix (match BJS exactly)

Bake each interleaved attribute's byte offset into the **pipeline vertex layout** (`VertexAttribute._offset` → `GPUVertexAttribute.offset`) and bind **every** vertex buffer at **offset 0**.

- Keeps genuine GPU interleaving (one shared buffer, **zero extra memory**); reverts the de‑straddle heuristic.
- Non‑interleaved meshes are **byte‑identical** (offset 0 either way) → zero impact on all other scenes.
- Lives in the dynamically‑imported interleave module + PBR template/binding → **zero bundle cost** for non‑interleaved scenes.
- `_vbKey` now encodes per‑attribute offsets so the pipeline cache distinguishes layouts that share strides but differ in offsets.
- Both PBR passes updated in lockstep (color + geometry/shadow) so the baked offset is never double‑applied.

## Verification

- `pnpm lint` + **467 unit tests** green.
- Parity green on the local GPU for the interleaved scenes **210** (XmpMetadataRoundedCube) and **211** (BrainStem meshopt/quantization), plus BoomBox, cascaded shadows **214/215** (geometry pass), and **212** dispersion.
- ⚠️ Final visual confirmation on the AMD Renoir GPU still needs cx20; the fix replicates BJS's exact vertex‑buffer setup, which is proven to render this `.glb` correctly on that machine.