### PR TITLE
fix(deps): repair broken pnpm-lock.yaml on master (stale tsx@4.21.0 refs)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,10 +196,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.3(@types/node@25.9.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.3(@types/node@25.9.1)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@25.9.1)(rollup@4.62.0)(typescript@5.9.3)(vite@6.4.3(@types/node@25.9.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.5.4(@types/node@25.9.1)(rollup@4.62.0)(typescript@5.9.3)(vite@6.4.3(@types/node@25.9.1)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 


### PR DESCRIPTION
## Problem

master's `pnpm-lock.yaml` fails `pnpm install --frozen-lockfile`:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
'vite@6.4.3(@types/node@25.9.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)' in pnpm-lock.yaml
```

This breaks the **API Report** PR-validation job on every open PR, because that job builds a baseline from the master merge-base with `--frozen-lockfile`.

## Root cause

#237 (`chore(deps): clear dev-dependency security advisories`) bumped `tsx 4.21.0 -> 4.22.4`. It was green in isolation, but it was squash-merged onto a master that had since gained the `babylon-lite-compat` importer (#238, #250). git's textual 3-way merge of the lockfile kept master's old `tsx@4.21.0` text on two lines in that importer block, while the bump updated everything else — including removing the `tsx@4.21.0` snapshot. The result references a snapshot that no longer exists, which pnpm itself would never emit. No CI re-validated the post-squash commit, so it landed silently.

## Fix

Regenerated the lockfile (`pnpm install --no-frozen-lockfile`). Only the two stale refs change to `tsx@4.22.4`; `--frozen-lockfile` now passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>