### PR TITLE
ci: fix npm publish release zip path after lite build dir move

### DIFF
--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -156,13 +156,13 @@ stages:
 
                 # --- GitHub release ---------------------------------------------
                 # Publish a GitHub release for the just-pushed npm tag, attaching a
-                # zip of the built @babylonjs/lite package (dist/ contents). Skipped
+                # zip of the built @babylonjs/lite package (build/ contents). Skipped
                 # in dry-run mode because the underlying tag is never pushed.
                 - script: |
                       set -euo pipefail
 
                       ZIP_PATH="$(Build.ArtifactStagingDirectory)/babylonjs-lite-$(PACKAGE_VERSION).zip"
-                      ( cd ./packages/babylon-lite/dist && zip -r "$ZIP_PATH" . )
+                      ( cd ./packages/babylon-lite/build && zip -r "$ZIP_PATH" . )
                       echo "Created release archive: $ZIP_PATH"
                   displayName: "Zip @babylonjs/lite dist for release"
                   condition: and(succeeded(), ne(lower(variables['DRY_RUN']), 'true'))


### PR DESCRIPTION
## Problem
PR #276 moved the `@babylonjs/lite` publish output from `packages/babylon-lite/dist` to `packages/babylon-lite/build`.

The npm publish path was updated, but the later GitHub-release zip step still used:

```bash
cd ./packages/babylon-lite/dist
```

That caused publish run `20260624.1` to fail in the release-attachment stage after npm publish had already succeeded.

## Solution
- Updated `azure-pipelines-npm-publish.yml` zip step path from `./packages/babylon-lite/dist` to `./packages/babylon-lite/build`.
- Updated the adjacent comment to reflect that we zip `build/` contents.

## Why this was missed in the original PR
The stale path was in a separate post-publish GitHub release block, not in the main npm publish command that was updated in PR #276. So the primary publish flow looked correct, while the later zip step retained the old directory reference and only surfaced when that stage executed.