### PR TITLE
fix: destroy mesh vertex colorBuffer on dispose to stop GPU leak

### DIFF
--- a/packages/babylon-lite/src/mesh/mesh-dispose.ts
+++ b/packages/babylon-lite/src/mesh/mesh-dispose.ts
@@ -9,6 +9,7 @@ export function disposeMeshGpu(mesh: Mesh): void {
     g.indexBuffer.destroy();
     g.tangentBuffer?.destroy();
     g.uv2Buffer?.destroy();
+    g.colorBuffer?.destroy();
     mesh.thinInstances?._gpuBuffer?.destroy();
     mesh.thinInstances?._colorGpuBuffer?.destroy();
     const sk = mesh.skeleton;


### PR DESCRIPTION
## What

`disposeMeshGpu` destroyed every owned vertex buffer (positions / normals / uv / index / tangent / uv2) **except** the per-vertex `colorBuffer` created in `mesh.ts`. Any disposed mesh that carried vertex colors leaked its color `GPUBuffer`. This adds the missing `g.colorBuffer?.destroy()` alongside its sibling vertex buffers.

## Why

Follow-up to #287 (thin-instance / CSM GPU-state leak cleanup). `colorBuffer` ownership/teardown is already expected elsewhere (`mesh-factories.ts` destroys `old.colorBuffer` on a buffer swap), so disposal should free it too.

## Impact

- Dispose-only change: cannot affect render output (runs at teardown, after frame capture).
- **Zero bundle movement**: the dispose path is tree-shaken out of the render-only bundle scenes, so `manifest.json` is byte-identical (no rebuild delta, no ceiling change).
- Non-breaking.

## Validation

- `pnpm build:bundle-scenes` -> manifest byte-identical (zero delta).
- `pnpm test:parity` (full scene parity + bundle-size ceilings).
