### PR TITLE
fix(shader): avoid rebinding unchanged shader resources

### DIFF
--- a/packages/babylon-lite/src/material/shader/shader-material.ts
+++ b/packages/babylon-lite/src/material/shader/shader-material.ts
@@ -386,7 +386,7 @@ export function setShaderTexture(material: ShaderMaterial, name: string, texture
         throw new Error(`ShaderMaterial: sampler "${name}" was not declared.`);
     }
     if (texture) {
-        const expectsDepth = slot.decl.sampleType === "depth" || slot.decl.comparison === true;
+        const expectsDepth = slot.decl.comparison || slot.decl.sampleType === "depth";
         const isDepthTexture = texture._sampleType === "depth";
         if (expectsDepth && !isDepthTexture) {
             throw new Error(`ShaderMaterial: sampler "${name}" expects a depth Texture2D.`);

--- a/packages/babylon-lite/src/material/shader/shader-material.ts
+++ b/packages/babylon-lite/src/material/shader/shader-material.ts
@@ -395,8 +395,17 @@ export function setShaderTexture(material: ShaderMaterial, name: string, texture
             throw new Error(`ShaderMaterial: sampler "${name}" cannot use a depth Texture2D.`);
         }
     }
-    slot.current = texture;
-    material._resourceVersion++;
+    // Only invalidate the cached bind groups when the bound texture HANDLE actually changes. The bind group
+    // references the texture's view + sampler (see createShaderBindGroup), so re-binding the SAME Texture2D (the
+    // common "keep my shadow map / scene-depth bound every frame" pattern) leaves those identical. Bumping the
+    // resource version unconditionally therefore forced a BRAND-NEW bind group every frame (per material, for every
+    // packet using it), churning the D3D12 descriptor heap until it OOMed on content-heavy scenes (e.g. reloading
+    // a big save). A texture's CONTENTS can change freely without a new bind group (the bound view is live), so
+    // identity comparison is correct.
+    if (slot.current !== texture) {
+        slot.current = texture;
+        material._resourceVersion++;
+    }
 }
 
 /** Bind (or clear) a declared read-only storage buffer. */
@@ -405,8 +414,12 @@ export function setShaderStorageBuffer(material: ShaderMaterial, name: string, b
     if (!slot) {
         throw new Error(`ShaderMaterial: storage buffer "${name}" was not declared.`);
     }
-    slot.current = buffer;
-    material._resourceVersion++;
+    // See setShaderTexture: only invalidate the bind groups when the bound buffer HANDLE changes; re-binding the
+    // same GPUBuffer is a no-op (contents update live), so an unconditional bump churned the descriptor heap.
+    if (slot.current !== buffer) {
+        slot.current = buffer;
+        material._resourceVersion++;
+    }
 }
 
 /** Set a declared `f32` uniform. Convenience wrapper over `setShaderUniform()`. */


### PR DESCRIPTION
## Summary
- Avoid bumping `ShaderMaterial._resourceVersion` when `setShaderTexture` or `setShaderStorageBuffer` rebinds the same resource handle.
- Keep the `setShaderTexture` depth validation compact so ShaderMaterial bundle ceilings stay green without raising thresholds.

## Validation
- `pnpm run lint`
- `pnpm build:bundle-scenes`
- `pnpm exec playwright test tests/lite/parity/scenes/scene159-shader-material-basic.spec.ts tests/lite/parity/scenes/scene160-shader-material-texture.spec.ts tests/lite/parity/scenes/scene161-shader-material-uniform.spec.ts tests/lite/parity/scenes/scene162-shader-material-defines.spec.ts tests/lite/parity/scenes/scene163-shader-material-alpha.spec.ts tests/lite/parity/scenes/scene165-shader-material-thin-instances.spec.ts`
- `pnpm exec playwright test tests/lite/parity/bundle-size.spec.ts --grep "Scene 159|Scene 160|Scene 161|Scene 162|Scene 163|Scene 165"`

Note: full `pnpm test` was executed locally, but the local parity server refused connections late in the run after the bundle build completed. PR CI is the authoritative full-suite check.