### PR TITLE
feat(playground): loading screen, compile metadata, centered save dialog, new examples

### DIFF
--- a/playground/examples/grid-studio.ts
+++ b/playground/examples/grid-studio.ts
@@ -1,0 +1,93 @@
+/**
+ * Grid Studio — an infinite reference grid (the built-in grid material) under a
+ * trio of PBR shapes, lit by an image-based environment. The kind of clean,
+ * neutral staging ground you'd use to inspect a material or model. Shows off
+ * `createGridMaterial`, PBR metalness/roughness, and IBL together. Public assets
+ * only.
+ */
+import {
+    addToScene,
+    attachControl,
+    createArcRotateCamera,
+    createBox,
+    createEngine,
+    createGridMaterial,
+    createGround,
+    createPbrMaterial,
+    createSceneContext,
+    createSolidTexture2D,
+    createSphere,
+    createTorusKnot,
+    loadEnvironment,
+    onBeforeRender,
+    registerScene,
+    startEngine,
+} from "@babylonjs/lite";
+
+async function main(): Promise<void> {
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    const engine = await createEngine(canvas);
+    const scene = createSceneContext(engine);
+    scene.clearColor = { r: 0.03, g: 0.04, b: 0.06, a: 1 };
+
+    const camera = createArcRotateCamera(-Math.PI / 2.6, 1.15, 9, { x: 0, y: 0.6, z: 0 });
+    scene.camera = camera;
+    attachControl(camera, canvas, scene);
+
+    // IBL for the PBR shapes; no skybox/ground so the grid stays the backdrop.
+    await loadEnvironment(scene, "https://assets.babylonjs.com/core/environments/environmentSpecular.env", {
+        skipSkybox: true,
+        skipGround: true,
+        brdfUrl: "/brdf-lut.png",
+    });
+
+    // Infinite grid floor, Babylon-brand teal lines.
+    const ground = createGround(engine, { width: 60, height: 60 });
+    ground.material = createGridMaterial({
+        mainColor: [0.05, 0.06, 0.08],
+        lineColor: [0.22, 0.55, 0.6],
+        gridRatio: 0.5,
+        majorUnitFrequency: 8,
+    });
+    addToScene(scene, ground);
+
+    // A polished metal torus knot centre stage.
+    const knot = createTorusKnot(engine, { radius: 0.8, tube: 0.26, radialSegments: 128, tubularSegments: 32 });
+    knot.position.set(0, 0.9, 0);
+    knot.material = createPbrMaterial({
+        baseColorTexture: createSolidTexture2D(engine, 0.95, 0.78, 0.4),
+        ormTexture: createSolidTexture2D(engine, 1.0, 0.2, 1.0), // glossy metal
+        environmentIntensity: 1.0,
+    });
+    addToScene(scene, knot);
+
+    // A matte dielectric sphere and a glossy box flanking it.
+    const sphere = createSphere(engine, { diameter: 1.1, segments: 32 });
+    sphere.position.set(-2.4, 0.55, 0.4);
+    sphere.material = createPbrMaterial({
+        baseColorTexture: createSolidTexture2D(engine, 0.85, 0.27, 0.27),
+        ormTexture: createSolidTexture2D(engine, 1.0, 0.55, 0.0),
+        environmentIntensity: 1.0,
+    });
+    addToScene(scene, sphere);
+
+    const box = createBox(engine, 1.1);
+    box.position.set(2.4, 0.55, -0.4);
+    box.material = createPbrMaterial({
+        baseColorTexture: createSolidTexture2D(engine, 0.3, 0.5, 0.85),
+        ormTexture: createSolidTexture2D(engine, 1.0, 0.15, 0.0),
+        environmentIntensity: 1.0,
+    });
+    addToScene(scene, box);
+
+    // Slowly turn the knot so its reflections shift.
+    onBeforeRender(scene, (deltaMs) => {
+        knot.rotation.y += (deltaMs / 1000) * 0.5;
+    });
+
+    await registerScene(scene);
+    await startEngine(engine);
+}
+
+void main().catch((err) => console.error(err));

--- a/playground/examples/pbr-material-grid.ts
+++ b/playground/examples/pbr-material-grid.ts
@@ -12,7 +12,6 @@ import {
     createEngine,
     createPbrMaterial,
     createSceneContext,
-    createSolidTexture2D,
     createSphere,
     loadEnvironment,
     onBeforeRender,
@@ -43,8 +42,6 @@ async function main(): Promise<void> {
         brdfUrl: "/brdf-lut.png",
     });
 
-    const baseColorTexture = createSolidTexture2D(engine, BASE[0], BASE[1], BASE[2]);
-
     for (let row = 0; row < GRID; row++) {
         const metallic = row / (GRID - 1);
         for (let col = 0; col < GRID; col++) {
@@ -53,10 +50,12 @@ async function main(): Promise<void> {
 
             const sphere = createSphere(engine, { diameter: 1, segments: 32 });
             sphere.position.set((col - (GRID - 1) / 2) * SPACING, (row - (GRID - 1) / 2) * SPACING, 0);
+            // No per-sphere textures: factors multiply the shared 1×1 white fallback,
+            // so all 36 materials reuse the same GPU textures (no allocations in the loop).
             sphere.material = createPbrMaterial({
-                baseColorTexture,
-                // ORM packed: R=occlusion, G=roughness, B=metallic.
-                ormTexture: createSolidTexture2D(engine, 1.0, roughness, metallic),
+                baseColorFactor: [BASE[0], BASE[1], BASE[2], 1],
+                metallicFactor: metallic,
+                roughnessFactor: roughness,
                 environmentIntensity: 1.0,
             });
             addToScene(scene, sphere);

--- a/playground/examples/pbr-material-grid.ts
+++ b/playground/examples/pbr-material-grid.ts
@@ -1,0 +1,75 @@
+/**
+ * PBR Material Grid — the classic metalness × roughness sweep. A 6×6 grid of
+ * spheres where metalness increases up each column and roughness increases across
+ * each row, all lit purely by an image-based environment (IBL). The camera slowly
+ * auto-orbits so you can watch the reflections move. A great way to get a feel for
+ * how the two core PBR parameters interact. Uses only public Babylon.js assets.
+ */
+import {
+    addToScene,
+    attachControl,
+    createArcRotateCamera,
+    createEngine,
+    createPbrMaterial,
+    createSceneContext,
+    createSolidTexture2D,
+    createSphere,
+    loadEnvironment,
+    onBeforeRender,
+    registerScene,
+    startEngine,
+} from "@babylonjs/lite";
+
+const GRID = 6;
+const SPACING = 1.35;
+
+// A warm copper base colour so the dielectric → metal transition reads clearly.
+const BASE: [number, number, number] = [0.95, 0.64, 0.54];
+
+async function main(): Promise<void> {
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    const engine = await createEngine(canvas);
+    const scene = createSceneContext(engine);
+
+    const span = (GRID - 1) * SPACING;
+    const camera = createArcRotateCamera(-Math.PI / 2, Math.PI / 2.2, span * 1.9, { x: 0, y: 0, z: 0 });
+    scene.camera = camera;
+    attachControl(camera, canvas, scene);
+
+    // Image-based lighting + a matching blurred skybox for reflections.
+    await loadEnvironment(scene, "https://assets.babylonjs.com/core/environments/environmentSpecular.env", {
+        skyboxSize: 1000,
+        brdfUrl: "/brdf-lut.png",
+    });
+
+    const baseColorTexture = createSolidTexture2D(engine, BASE[0], BASE[1], BASE[2]);
+
+    for (let row = 0; row < GRID; row++) {
+        const metallic = row / (GRID - 1);
+        for (let col = 0; col < GRID; col++) {
+            // Clamp roughness away from 0 so the smoothest spheres still resolve.
+            const roughness = Math.max(0.04, col / (GRID - 1));
+
+            const sphere = createSphere(engine, { diameter: 1, segments: 32 });
+            sphere.position.set((col - (GRID - 1) / 2) * SPACING, (row - (GRID - 1) / 2) * SPACING, 0);
+            sphere.material = createPbrMaterial({
+                baseColorTexture,
+                // ORM packed: R=occlusion, G=roughness, B=metallic.
+                ormTexture: createSolidTexture2D(engine, 1.0, roughness, metallic),
+                environmentIntensity: 1.0,
+            });
+            addToScene(scene, sphere);
+        }
+    }
+
+    // Gentle auto-orbit (≈ one revolution every 40s); user drag still works.
+    onBeforeRender(scene, (deltaMs) => {
+        camera.alpha += (deltaMs / 1000) * 0.157;
+    });
+
+    await registerScene(scene);
+    await startEngine(engine);
+}
+
+void main().catch((err) => console.error(err));

--- a/playground/examples/spinning-polyhedra.ts
+++ b/playground/examples/spinning-polyhedra.ts
@@ -1,0 +1,98 @@
+/**
+ * Spinning Polyhedra — a ring of the five Platonic-ish solids orbiting a central
+ * pillar, each tumbling on its own axis while the whole carousel rotates. Pure
+ * procedural geometry and standard materials, so it loads instantly with no
+ * external assets — a compact tour of the mesh factories and the per-frame
+ * `onBeforeRender` hook.
+ */
+import {
+    addToScene,
+    attachControl,
+    createArcRotateCamera,
+    createCylinder,
+    createDirectionalLight,
+    createGround,
+    createHemisphericLight,
+    createPolyhedron,
+    createSceneContext,
+    createStandardMaterial,
+    createEngine,
+    onBeforeRender,
+    registerScene,
+    startEngine,
+    type Mesh,
+} from "@babylonjs/lite";
+
+// Polyhedron preset indices (see createPolyhedron docs) and a brand-ish palette.
+const SOLIDS = [0, 1, 2, 3, 4, 7];
+const COLORS: [number, number, number][] = [
+    [0.86, 0.27, 0.29], // red
+    [0.88, 0.41, 0.29], // coral
+    [0.95, 0.77, 0.35], // amber
+    [0.35, 0.72, 0.55], // green
+    [0.31, 0.55, 0.86], // blue
+    [0.6, 0.45, 0.85], // violet
+];
+
+async function main(): Promise<void> {
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    const engine = await createEngine(canvas);
+    const scene = createSceneContext(engine);
+    scene.clearColor = { r: 0.04, g: 0.05, b: 0.08, a: 1 };
+
+    const camera = createArcRotateCamera(-Math.PI / 2, 1.05, 12, { x: 0, y: 0.8, z: 0 });
+    scene.camera = camera;
+    attachControl(camera, canvas, scene);
+
+    addToScene(scene, createHemisphericLight([0, 1, 0], 0.6));
+    addToScene(scene, createDirectionalLight([-0.5, -1, -0.4], 1.2));
+
+    // Dark reflective-ish floor.
+    const ground = createGround(engine, { width: 24, height: 24 });
+    const groundMat = createStandardMaterial();
+    groundMat.diffuseColor = [0.12, 0.14, 0.18];
+    groundMat.specularColor = [0.05, 0.05, 0.05];
+    ground.material = groundMat;
+    ground.position.set(0, -1.4, 0);
+    addToScene(scene, ground);
+
+    // Central pillar the ring revolves around.
+    const pillar = createCylinder(engine, { height: 2.6, diameter: 0.5, tessellation: 32 });
+    const pillarMat = createStandardMaterial();
+    pillarMat.diffuseColor = [0.5, 0.52, 0.58];
+    pillarMat.specularColor = [0.6, 0.6, 0.6];
+    pillar.material = pillarMat;
+    pillar.position.set(0, 0.1, 0);
+    addToScene(scene, pillar);
+
+    const radius = 4;
+    const solids: { mesh: Mesh; spin: number }[] = [];
+    for (let i = 0; i < SOLIDS.length; i++) {
+        const mesh = createPolyhedron(engine, { type: SOLIDS[i]!, size: 0.7 });
+        const mat = createStandardMaterial();
+        mat.diffuseColor = COLORS[i % COLORS.length]!;
+        mat.specularColor = [0.4, 0.4, 0.4];
+        mesh.material = mat;
+        mesh.position.set(0, 0.6, 0);
+        addToScene(scene, mesh);
+        solids.push({ mesh, spin: 0.6 + i * 0.18 });
+    }
+
+    let t = 0;
+    onBeforeRender(scene, (deltaMs) => {
+        const dt = deltaMs / 1000;
+        t += dt;
+        for (let i = 0; i < solids.length; i++) {
+            const { mesh, spin } = solids[i]!;
+            const angle = t * 0.4 + (i / solids.length) * Math.PI * 2;
+            mesh.position.set(Math.cos(angle) * radius, 0.6 + Math.sin(t * 1.5 + i) * 0.35, Math.sin(angle) * radius);
+            mesh.rotation.set(t * spin, t * spin * 1.3, 0);
+        }
+    });
+
+    await registerScene(scene);
+    await startEngine(engine);
+}
+
+void main().catch((err) => console.error(err));

--- a/playground/examples/spinning-polyhedra.ts
+++ b/playground/examples/spinning-polyhedra.ts
@@ -1,5 +1,5 @@
 /**
- * Spinning Polyhedra — a ring of the five Platonic-ish solids orbiting a central
+ * Spinning Polyhedra — a ring of six solids orbiting a central
  * pillar, each tumbling on its own axis while the whole carousel rotates. Pure
  * procedural geometry and standard materials, so it loads instantly with no
  * external assets — a compact tour of the mesh factories and the per-frame

--- a/playground/index.html
+++ b/playground/index.html
@@ -44,6 +44,16 @@
                 <div class="splitter" id="splitter" role="separator" aria-orientation="vertical" aria-label="Resize editor and preview" tabindex="0"></div>
                 <section class="pane pane-preview">
                     <div class="preview-host" id="previewHost">
+                        <div class="preview-loader" id="previewLoader">
+                            <div class="loader-spinner">
+                                <img class="loader-logo" src="/favicon.svg" alt="" width="52" height="52" />
+                                <svg class="loader-ring" viewBox="0 0 100 100" aria-hidden="true">
+                                    <circle class="loader-ring-track" cx="50" cy="50" r="46" />
+                                    <circle class="loader-ring-arc" cx="50" cy="50" r="46" />
+                                </svg>
+                            </div>
+                            <span class="loader-text" id="previewLoaderText">Loading…</span>
+                        </div>
                         <div class="preview-overlay">
                             <span id="fpsCounter" class="fps-counter" title="Frames per second" hidden>0 FPS</span>
                             <button id="fullscreenBtn" class="overlay-btn" title="Toggle fullscreen" aria-label="Toggle fullscreen">

--- a/playground/index.html
+++ b/playground/index.html
@@ -52,7 +52,7 @@
                                     <circle class="loader-ring-arc" cx="50" cy="50" r="46" />
                                 </svg>
                             </div>
-                            <span class="loader-text" id="previewLoaderText">Loading…</span>
+                            <span class="loader-text" id="previewLoaderText" role="status" aria-live="polite">Loading…</span>
                         </div>
                         <div class="preview-overlay">
                             <span id="fpsCounter" class="fps-counter" title="Frames per second" hidden>0 FPS</span>

--- a/playground/src/examples.ts
+++ b/playground/src/examples.ts
@@ -14,6 +14,9 @@ import TORUS_STATES from "../examples/torus-states.ts?raw";
 import NEON_RIBBONS from "../examples/neon-ribbons.ts?raw";
 import MOSQUITO_AMBER from "../examples/mosquito-amber.ts?raw";
 import HAVOK_PHYSICS from "../examples/havok-physics.ts?raw";
+import PBR_MATERIAL_GRID from "../examples/pbr-material-grid.ts?raw";
+import SPINNING_POLYHEDRA from "../examples/spinning-polyhedra.ts?raw";
+import GRID_STUDIO from "../examples/grid-studio.ts?raw";
 
 const BOOMBOX = `import {
     addToScene,
@@ -162,6 +165,9 @@ export function buildScene(engine: EngineContext, scene: SceneContext) {
 export const EXAMPLES: Example[] = [
     { id: "boombox", label: "glTF — BoomBox (PBR + environment)", code: BOOMBOX },
     { id: "primitives", label: "Primitives — box + ground", code: PRIMITIVES },
+    { id: "spinning-polyhedra", label: "Animation — Spinning Polyhedra", code: SPINNING_POLYHEDRA },
+    { id: "pbr-material-grid", label: "PBR — Metalness × Roughness grid", code: PBR_MATERIAL_GRID },
+    { id: "grid-studio", label: "Grid material — Studio staging", code: GRID_STUDIO },
     {
         id: "multifile",
         label: "Multi-file — index + scene module",

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -24,6 +24,8 @@ import { NIGHTLY, engineUrlForVersion, fetchPublishedVersions } from "./versions
 const editorContainer = document.getElementById("editor") as HTMLElement;
 const fileTabsContainer = document.getElementById("fileTabs") as HTMLElement;
 const previewHost = document.getElementById("previewHost") as HTMLElement;
+const previewLoader = document.getElementById("previewLoader") as HTMLElement;
+const previewLoaderText = document.getElementById("previewLoaderText") as HTMLElement;
 const consoleEl = document.getElementById("console") as HTMLElement;
 const splitEl = document.getElementById("split") as HTMLElement;
 const splitter = document.getElementById("splitter") as HTMLElement;
@@ -76,6 +78,30 @@ function clearConsole(): void {
     consoleEl.replaceChildren();
 }
 
+/** Show/hide the preview loading screen, optionally updating its label. */
+function setLoading(on: boolean, label?: string): void {
+    previewLoader.hidden = !on;
+    if (label) {
+        previewLoaderText.textContent = label;
+    }
+}
+
+/** Human-readable byte size, e.g. `48.2 KB`. */
+function formatBytes(bytes: number): string {
+    if (bytes < 1024) {
+        return `${bytes} B`;
+    }
+    if (bytes < 1024 * 1024) {
+        return `${(bytes / 1024).toFixed(1)} KB`;
+    }
+    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+/** Human-readable duration, e.g. `820 ms` or `1.24 s`. */
+function formatDuration(ms: number): string {
+    return ms < 1000 ? `${Math.round(ms)} ms` : `${(ms / 1000).toFixed(2)} s`;
+}
+
 /** Append a clickable build error that jumps the editor to the offending location. */
 function appendBuildError(file: string, line: number, column: number, text: string): void {
     const lineEl = document.createElement("div");
@@ -106,6 +132,8 @@ const runner = new Runner(previewHost, (message: RunnerMessage) => {
             embedHost?.emit({ channel: "babylon-lite-playground", type: "console", level: message.level, text: message.text });
             break;
         case "error":
+            setLoading(false);
+            runStartedAt = null;
             appendConsole("error", message.text);
             embedHost?.emit({ channel: "babylon-lite-playground", type: "error", text: message.text });
             break;
@@ -115,6 +143,11 @@ const runner = new Runner(previewHost, (message: RunnerMessage) => {
             embedHost?.emit({ channel: "babylon-lite-playground", type: "stats", fps: message.fps });
             break;
         case "ran":
+            setLoading(false);
+            if (runStartedAt !== null) {
+                appendConsole("system", `Scene ready in ${formatDuration(performance.now() - runStartedAt)}`);
+                runStartedAt = null;
+            }
             embedHost?.emit({ channel: "babylon-lite-playground", type: "ran" });
             break;
         default:
@@ -124,6 +157,9 @@ const runner = new Runner(previewHost, (message: RunnerMessage) => {
 
 let running = false;
 let rerunPending = false;
+// When the transpiled module was handed to the runner, so we can report how long
+// the scene took to become ready (the runner posts `ran` once it finishes).
+let runStartedAt: number | null = null;
 
 async function run(): Promise<void> {
     // Coalesce concurrent requests: remember that another run was asked for and
@@ -135,13 +171,22 @@ async function run(): Promise<void> {
     running = true;
     runBtn.disabled = true;
     clearConsole();
+    setLoading(true, "Compiling…");
     appendConsole("system", "Compiling…");
     try {
+        const compileStart = performance.now();
         const code = await transpile(editor.getFiles(), editor.getEntry());
+        const compileMs = performance.now() - compileStart;
+        const size = new Blob([code]).size;
         editor.clearBuildMarkers();
+        appendConsole("system", `Compiled ${formatBytes(size)} in ${formatDuration(compileMs)}`);
+        setLoading(true, "Running…");
         appendConsole("system", "Running…");
+        runStartedAt = performance.now();
         await runner.run(code, engineUrlForVersion(currentVersion));
     } catch (err) {
+        setLoading(false);
+        runStartedAt = null;
         if (err instanceof TranspileError) {
             editor.setBuildMarkers(err.diagnostics);
             for (const diag of err.diagnostics) {

--- a/playground/src/styles.css
+++ b/playground/src/styles.css
@@ -361,6 +361,95 @@ body {
     background: rgba(1, 4, 9, 0.85);
 }
 
+/* Loading screen over the preview while booting / compiling a scene.
+   A Babylon logo with a spinning ring around it (à la the Babylon.js playground). */
+.preview-loader {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    background: rgba(1, 4, 9, 0.82);
+    backdrop-filter: blur(2px);
+}
+
+.preview-loader[hidden] {
+    display: none;
+}
+
+.loader-spinner {
+    position: relative;
+    width: 92px;
+    height: 92px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.loader-logo {
+    width: 50px;
+    height: 50px;
+    display: block;
+    animation: loader-pulse 1.6s ease-in-out infinite;
+}
+
+.loader-ring {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    transform-origin: center;
+    animation: loader-spin 1s linear infinite;
+}
+
+.loader-ring-track {
+    fill: none;
+    stroke: var(--border);
+    stroke-width: 4;
+}
+
+.loader-ring-arc {
+    fill: none;
+    stroke: var(--accent);
+    stroke-width: 4;
+    stroke-linecap: round;
+    stroke-dasharray: 70 220;
+}
+
+.loader-text {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    letter-spacing: 0.04em;
+}
+
+@keyframes loader-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes loader-pulse {
+    0%,
+    100% {
+        opacity: 0.85;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 1;
+        transform: scale(1.06);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .loader-ring,
+    .loader-logo {
+        animation: none;
+    }
+}
+
 .console {
     flex: 0 0 auto;
     height: 9rem;
@@ -430,6 +519,9 @@ body {
 
 /* Save dialog */
 .dialog {
+    /* Native modal dialogs center via `margin: auto`, which the global reset
+       (`* { margin: 0 }`) clobbers — restore it so the dialog is centered. */
+    margin: auto;
     border: 1px solid var(--border);
     border-radius: 10px;
     background: var(--bg-elevated);


### PR DESCRIPTION
## Summary

A batch of Lite Playground improvements.

### 1. Loading screen
A Babylon.js-style loading screen — the brand logo with a spinning ring around it — now covers the preview pane on first boot and during every compile/run. It cycles through status labels (`Compiling…` → `Running…`) and hides once the scene reports ready (or on error). Respects `prefers-reduced-motion`.

### 2. Compile metadata in the console
Each run now logs build metrics to the console panel:
- `Compiled <size> in <time>` — transpiled bundle byte size + esbuild time.
- `Scene ready in <time>` — from handing code to the runner until the scene is up.

### 3. Centered save dialog
The **Save with details…** dialog was pinned to the top-left. Root cause: the global `* { margin: 0 }` reset clobbered the native `<dialog>`'s `margin: auto` centering. Restored `margin: auto` on `.dialog`.

### 4. Three new examples
Non-proprietary, using only public Babylon.js CDN assets (or none):
- **Animation — Spinning Polyhedra**: a ring of Platonic solids orbiting + tumbling via `onBeforeRender`. No assets → instant load.
- **PBR — Metalness × Roughness grid**: the classic 6×6 sphere sweep under IBL with an auto-orbit camera.
- **Grid material — Studio staging**: infinite reference grid (`createGridMaterial`) under glossy/matte PBR shapes with IBL.

## Validation
- `tsc --noEmit` on the playground (`src`) — clean.
- Strict `tsc` of the three new example files against the real engine declaration (`packages/babylon-lite/build/index.d.ts`) — clean; every API call resolves.
- Vite client build succeeds; dev server serves all three new raw example modules (HTTP 200).
- No engine/runtime code touched — playground-only changes.