### PR TITLE
fix: reduce sprite bundle size

### DIFF
--- a/lab/public/bundle/manifest/scene205.json
+++ b/lab/public/bundle/manifest/scene205.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 62.8,
-  "gzipKB": 25.6,
+  "rawKB": 61.9,
+  "gzipKB": 25.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene205-_mat4-storage-f64-BubVEbOW.js",
-    "scene205-billboard-renderable-Dbju5IaX.js",
+    "scene205-billboard-renderable-C3WQ2iBX.js",
     "scene205-floating-origin-BpHUAtCM.js",
     "scene205-pack-mat4-with-offset-BS-Lz8k7.js",
     "scene205-scene-uniforms-FTYH6Ct0.js",

--- a/lab/public/bundle/manifest/scene206.json
+++ b/lab/public/bundle/manifest/scene206.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 63.2,
-  "gzipKB": 25.7,
+  "rawKB": 62.3,
+  "gzipKB": 25.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene206-_mat4-storage-f64-FI8ZUjRd.js",
-    "scene206-billboard-renderable-ZrCxTbJQ.js",
+    "scene206-billboard-renderable-BgiMSK_u.js",
     "scene206-floating-origin-B3Cmn-Fn.js",
     "scene206-pack-mat4-with-offset-BS-Lz8k7.js",
     "scene206-scene-uniforms-FTYH6Ct0.js",

--- a/lab/public/bundle/manifest/scene50.json
+++ b/lab/public/bundle/manifest/scene50.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 16.7,
-  "gzipKB": 7.2,
+  "rawKB": 16.1,
+  "gzipKB": 7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene50.js"

--- a/lab/public/bundle/manifest/scene51.json
+++ b/lab/public/bundle/manifest/scene51.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 17.1,
-  "gzipKB": 7.4,
+  "rawKB": 16.6,
+  "gzipKB": 7.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene51.js"

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 58.4,
-  "gzipKB": 23.4,
+  "rawKB": 57.8,
+  "gzipKB": 23.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene52-standard-renderable-DXnTjsje.js",

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 58.6,
-  "gzipKB": 23.3,
+  "rawKB": 58,
+  "gzipKB": 23.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene53-standard-renderable-BwQeEm6J.js",

--- a/lab/public/bundle/manifest/scene54.json
+++ b/lab/public/bundle/manifest/scene54.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 60.8,
-  "gzipKB": 24.5,
+  "rawKB": 59.9,
+  "gzipKB": 24.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene54-billboard-renderable-2zrELk2k.js",
+    "scene54-billboard-renderable-BeTxDz7N.js",
     "scene54-scene-uniforms-FTYH6Ct0.js",
     "scene54-standard-renderable-gymiA78h.js",
     "scene54-wgsl-helpers-CwHFFXvt.js",

--- a/lab/public/bundle/manifest/scene55.json
+++ b/lab/public/bundle/manifest/scene55.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 32.1,
-  "gzipKB": 13.2,
+  "rawKB": 31.3,
+  "gzipKB": 13,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene55-billboard-renderable-D63qXGhg.js",
+    "scene55-billboard-renderable-5MnzUtlV.js",
     "scene55.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene56.json
+++ b/lab/public/bundle/manifest/scene56.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 61.1,
-  "gzipKB": 24.6,
+  "rawKB": 60.2,
+  "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene56-billboard-renderable-CxXl5OPv.js",
+    "scene56-billboard-renderable-rwL30tEO.js",
     "scene56-scene-uniforms-FTYH6Ct0.js",
     "scene56-standard-renderable-DLV9jNG_.js",
     "scene56-wgsl-helpers-CwHFFXvt.js",

--- a/lab/public/bundle/manifest/scene57.json
+++ b/lab/public/bundle/manifest/scene57.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 60.9,
-  "gzipKB": 24.4,
+  "rawKB": 60,
+  "gzipKB": 24.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene57-billboard-renderable--WkWkGbr.js",
+    "scene57-billboard-renderable-CUrr_OIJ.js",
     "scene57-scene-uniforms-FTYH6Ct0.js",
     "scene57-standard-renderable-Cv1M5x8s.js",
     "scene57-wgsl-helpers-CwHFFXvt.js",

--- a/lab/public/bundle/manifest/scene58.json
+++ b/lab/public/bundle/manifest/scene58.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 19.8,
-  "gzipKB": 8.2,
+  "rawKB": 19.3,
+  "gzipKB": 8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene58.js"

--- a/lab/public/bundle/manifest/scene59.json
+++ b/lab/public/bundle/manifest/scene59.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 64,
-  "gzipKB": 25.5,
+  "rawKB": 63.1,
+  "gzipKB": 25.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene59-billboard-renderable-CDjCX9_V.js",
+    "scene59-billboard-renderable-KN9gLXsu.js",
     "scene59-scene-uniforms-FTYH6Ct0.js",
     "scene59-standard-renderable-DnLmB7RO.js",
     "scene59-wgsl-helpers-CwHFFXvt.js",

--- a/lab/public/bundle/manifest/scene92.json
+++ b/lab/public/bundle/manifest/scene92.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 19.7,
-  "gzipKB": 8.2,
+  "rawKB": 19.1,
+  "gzipKB": 8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene92.js"

--- a/lab/public/bundle/manifest/scene93.json
+++ b/lab/public/bundle/manifest/scene93.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 20.8,
-  "gzipKB": 8.5,
+  "rawKB": 20.2,
+  "gzipKB": 8.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene93.js"

--- a/lab/public/bundle/manifest/scene94.json
+++ b/lab/public/bundle/manifest/scene94.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 65,
-  "gzipKB": 25.4,
+  "rawKB": 63.8,
+  "gzipKB": 25.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene94-billboard-renderable-BgBdc7uu.js",

--- a/lab/public/bundle/manifest/scene95.json
+++ b/lab/public/bundle/manifest/scene95.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 66.1,
-  "gzipKB": 25.7,
+  "rawKB": 64.9,
+  "gzipKB": 25.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene95-billboard-renderable-D1Ojksz4.js",

--- a/lab/public/bundle/manifest/scene96.json
+++ b/lab/public/bundle/manifest/scene96.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 16.4,
-  "gzipKB": 7,
+  "rawKB": 15.8,
+  "gzipKB": 6.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene96.js"

--- a/lab/public/bundle/manifest/scene97.json
+++ b/lab/public/bundle/manifest/scene97.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 16.8,
-  "gzipKB": 7.2,
+  "rawKB": 16.3,
+  "gzipKB": 7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene97.js"

--- a/lab/public/bundle/manifest/scene98.json
+++ b/lab/public/bundle/manifest/scene98.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 61,
-  "gzipKB": 24.6,
+  "rawKB": 60.2,
+  "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene98-billboard-renderable-D3gVfZGM.js",
+    "scene98-billboard-renderable-jlPUXki_.js",
     "scene98-scene-uniforms-FTYH6Ct0.js",
     "scene98-standard-renderable-uFFg5Orm.js",
     "scene98-wgsl-helpers-CwHFFXvt.js",

--- a/packages/babylon-lite/src/sprite/billboard-custom-shader.ts
+++ b/packages/babylon-lite/src/sprite/billboard-custom-shader.ts
@@ -72,52 +72,52 @@ export interface BillboardCustomShader {
 function makeCustomBillboardWgsl(orientation: BillboardOrientation, extraTextures: readonly BillboardCustomTexture[], fragment: string): string {
     const fxBinding = 3 + extraTextures.length * 2;
     return `${SCENE_UBO_WGSL}
-struct BillboardSystem {
-opacityMul: vec4<f32>,
-axisAndCutoff: vec4<f32>,
+struct S {
+opacityMul: vec4f,
+axisAndCutoff: vec4f,
 };
-@group(1) @binding(0) var<uniform> billboards: BillboardSystem;
+@group(1) @binding(0) var<uniform> billboards: S;
 @group(1) @binding(1) var atlasTex: texture_2d<f32>;
 @group(1) @binding(2) var atlasSamp: sampler;
 ${makeExtraBindingsWgsl(1, 3, extraTextures)}${makeFxStructWgsl(1, fxBinding)}
 ${makeBillboardBasisWgsl(orientation)}
-struct VIn {
+struct I {
 @builtin(vertex_index) vid: u32,
-@location(0) iPos: vec3<f32>,
-@location(1) iSize: vec2<f32>,
-@location(2) iUvMin: vec2<f32>,
-@location(3) iUvMax: vec2<f32>,
-@location(4) iRot: f32,
-@location(5) iPivot: vec2<f32>,
-@location(6) iColor: vec4<f32>,
+@location(0) p: vec3f,
+@location(1) s: vec2f,
+@location(2) a: vec2f,
+@location(3) b: vec2f,
+@location(4) r: f32,
+@location(5) o: vec2f,
+@location(6) c: vec4f,
 };
-struct VOut {
-@builtin(position) pos: vec4<f32>,
-@location(0) uv: vec2<f32>,
-@location(1) tint: vec4<f32>,
+struct O {
+@builtin(position) p: vec4f,
+@location(0) uv: vec2f,
+@location(1) tint: vec4f,
 @location(2) viewDist: f32,
-@location(3) vWorldPos: vec3<f32>,
+@location(3) vWorldPos: vec3f,
 };
 @vertex
-fn vs(in: VIn) -> VOut {
-let corner = vec2<f32>(select(0.0, 1.0, in.vid == 1u || in.vid == 2u), select(0.0, 1.0, in.vid >= 2u));
-let local = (corner - in.iPivot) * in.iSize;
-let cosRot = cos(in.iRot);
-let sinRot = sin(in.iRot);
-let rotated = vec2<f32>(local.x * cosRot - local.y * sinRot, local.x * sinRot + local.y * cosRot);
-let basis = getBillboardBasis(in.iPos);
-let worldPos = in.iPos + basis.right * rotated.x + basis.up * rotated.y;
-var out: VOut;
-out.pos = scene.viewProjection * vec4<f32>(worldPos, 1.0);
-out.uv = mix(in.iUvMin, in.iUvMax, corner);
-out.tint = in.iColor;
-let viewCenter = scene.view * vec4<f32>(in.iPos, 1.0);
+fn vs(in: I) -> O {
+let q = vec2f(select(0.0, 1.0, in.vid == 1u || in.vid == 2u), select(0.0, 1.0, in.vid >= 2u));
+let l = (q - in.o) * in.s;
+let cr = cos(in.r);
+let sr = sin(in.r);
+let r = vec2f(l.x * cr - l.y * sr, l.x * sr + l.y * cr);
+let b = basis(in.p);
+let wp = in.p + b.r * r.x + b.u * r.y;
+var out: O;
+out.p = scene.viewProjection * vec4f(wp, 1);
+out.uv = mix(in.a, in.b, q);
+out.tint = in.c;
+let viewCenter = scene.view * vec4f(in.p, 1);
 out.viewDist = length(viewCenter.xyz);
-out.vWorldPos = worldPos;
+out.vWorldPos = wp;
 return out;
 }
 @fragment
-fn fs(in: VOut) -> @location(0) vec4<f32> {
+fn fs(in: O) -> @location(0) vec4f {
 ${fragment}
 }`;
 }

--- a/packages/babylon-lite/src/sprite/billboard-pipeline.ts
+++ b/packages/babylon-lite/src/sprite/billboard-pipeline.ts
@@ -56,31 +56,29 @@ function getDepthModeEntry(depthMode: BillboardDepthMode): (typeof DEPTH_MODE_TA
 export function makeBillboardBasisWgsl(orientation: BillboardOrientation): string {
     switch (orientation) {
         case "facing":
-            return `struct BillboardBasis {
-right: vec3<f32>,
-up: vec3<f32>,
+            return `struct B {
+r: vec3f,
+u: vec3f,
 };
-fn getBillboardBasis(_anchor: vec3<f32>) -> BillboardBasis {
-let cameraRight = normalize(vec3<f32>(scene.view[0][0], scene.view[1][0], scene.view[2][0]));
-let cameraUp = normalize(vec3<f32>(scene.view[0][1], scene.view[1][1], scene.view[2][1]));
-return BillboardBasis(cameraRight, -cameraUp);
+fn basis(_a: vec3f) -> B {
+let r = normalize(vec3f(scene.view[0][0], scene.view[1][0], scene.view[2][0]));
+let u = normalize(vec3f(scene.view[0][1], scene.view[1][1], scene.view[2][1]));
+return B(r, -u);
 }`;
         case "axis-locked":
-            return `struct BillboardBasis {
-right: vec3<f32>,
-up: vec3<f32>,
+            return `struct B {
+r: vec3f,
+u: vec3f,
 };
-fn getBillboardBasis(_anchor: vec3<f32>) -> BillboardBasis {
-let lockAxis = normalize(billboards.axisAndCutoff.xyz);
-let cameraRight = normalize(vec3<f32>(scene.view[0][0], scene.view[1][0], scene.view[2][0]));
-let projectedRight = cameraRight - lockAxis * dot(cameraRight, lockAxis);
-let projectedRightLen = length(projectedRight);
-let safeProjectedRightLen = max(projectedRightLen, 1e-4);
-let fallbackSeed = select(vec3<f32>(0.0, 0.0, 1.0), vec3<f32>(1.0, 0.0, 0.0), abs(lockAxis.z) > 0.999);
-let fallbackRightRaw = cross(lockAxis, fallbackSeed);
-let fallbackRight = fallbackRightRaw / max(length(fallbackRightRaw), 1e-4);
-let right = select(fallbackRight, projectedRight / safeProjectedRightLen, projectedRightLen > 1e-4);
-return BillboardBasis(right, -lockAxis);
+fn basis(_a: vec3f) -> B {
+let a = normalize(billboards.axisAndCutoff.xyz);
+let cr = normalize(vec3f(scene.view[0][0], scene.view[1][0], scene.view[2][0]));
+let pr = cr - a * dot(cr, a);
+let pl = length(pr);
+let f = select(vec3f(0, 0, 1), vec3f(1, 0, 0), abs(a.z) > 0.999);
+let fr = cross(a, f);
+let r = select(fr / max(length(fr), 1e-4), pr / max(pl, 1e-4), pl > 1e-4);
+return B(r, -a);
 }`;
     }
 }
@@ -88,59 +86,59 @@ return BillboardBasis(right, -lockAxis);
 function makeBillboardFragmentWgsl(depthMode: BillboardDepthMode): string {
     if (depthMode === "cutout") {
         return `@fragment
-fn fs(in: VOut) -> @location(0) vec4<f32> {
-let sampleColor = textureSample(atlasTex, atlasSamp, in.uv);
-if (sampleColor.a < billboards.axisAndCutoff.w) {
+fn fs(in: O) -> @location(0) vec4f {
+let s = textureSample(atlasTex, atlasSamp, in.uv);
+if (s.a < billboards.axisAndCutoff.w) {
 discard;
 }
-return sampleColor * in.tint * billboards.opacityMul;
+return s * in.tint * billboards.opacityMul;
 }`;
     }
     return `@fragment
-fn fs(in: VOut) -> @location(0) vec4<f32> {
-let sampleColor = textureSample(atlasTex, atlasSamp, in.uv);
-return sampleColor * in.tint * billboards.opacityMul;
+fn fs(in: O) -> @location(0) vec4f {
+let s = textureSample(atlasTex, atlasSamp, in.uv);
+return s * in.tint * billboards.opacityMul;
 }`;
 }
 
 function makeBillboardWgsl(orientation: BillboardOrientation, depthMode: BillboardDepthMode): string {
     return `${SCENE_UBO_WGSL}
-struct BillboardSystem {
-opacityMul: vec4<f32>,
-axisAndCutoff: vec4<f32>,
+struct S {
+opacityMul: vec4f,
+axisAndCutoff: vec4f,
 };
-@group(1) @binding(0) var<uniform> billboards: BillboardSystem;
+@group(1) @binding(0) var<uniform> billboards: S;
 @group(1) @binding(1) var atlasTex: texture_2d<f32>;
 @group(1) @binding(2) var atlasSamp: sampler;
 ${makeBillboardBasisWgsl(orientation)}
-struct VIn {
+struct I {
 @builtin(vertex_index) vid: u32,
-@location(0) iPos: vec3<f32>,
-@location(1) iSize: vec2<f32>,
-@location(2) iUvMin: vec2<f32>,
-@location(3) iUvMax: vec2<f32>,
-@location(4) iRot: f32,
-@location(5) iPivot: vec2<f32>,
-@location(6) iColor: vec4<f32>,
+@location(0) p: vec3f,
+@location(1) s: vec2f,
+@location(2) a: vec2f,
+@location(3) b: vec2f,
+@location(4) r: f32,
+@location(5) o: vec2f,
+@location(6) c: vec4f,
 };
-struct VOut {
-@builtin(position) pos: vec4<f32>,
-@location(0) uv: vec2<f32>,
-@location(1) tint: vec4<f32>,
+struct O {
+@builtin(position) p: vec4f,
+@location(0) uv: vec2f,
+@location(1) tint: vec4f,
 };
 @vertex
-fn vs(in: VIn) -> VOut {
-let corner = vec2<f32>(select(0.0, 1.0, in.vid == 1u || in.vid == 2u), select(0.0, 1.0, in.vid >= 2u));
-let local = (corner - in.iPivot) * in.iSize;
-let cosRot = cos(in.iRot);
-let sinRot = sin(in.iRot);
-let rotated = vec2<f32>(local.x * cosRot - local.y * sinRot, local.x * sinRot + local.y * cosRot);
-let basis = getBillboardBasis(in.iPos);
-let worldPos = in.iPos + basis.right * rotated.x + basis.up * rotated.y;
-var out: VOut;
-out.pos = scene.viewProjection * vec4<f32>(worldPos, 1.0);
-out.uv = mix(in.iUvMin, in.iUvMax, corner);
-out.tint = in.iColor;
+fn vs(in: I) -> O {
+let q = vec2f(select(0.0, 1.0, in.vid == 1u || in.vid == 2u), select(0.0, 1.0, in.vid >= 2u));
+let l = (q - in.o) * in.s;
+let cr = cos(in.r);
+let sr = sin(in.r);
+let r = vec2f(l.x * cr - l.y * sr, l.x * sr + l.y * cr);
+let b = basis(in.p);
+let wp = in.p + b.r * r.x + b.u * r.y;
+var out: O;
+out.p = scene.viewProjection * vec4f(wp, 1);
+out.uv = mix(in.a, in.b, q);
+out.tint = in.c;
 return out;
 }
 ${makeBillboardFragmentWgsl(depthMode)}`;

--- a/packages/babylon-lite/src/sprite/custom-shader-core.ts
+++ b/packages/babylon-lite/src/sprite/custom-shader-core.ts
@@ -94,7 +94,7 @@ time: f32,
 _p0: f32,
 _p1: f32,
 _p2: f32,
-params: vec4<f32>,
+params: vec4f,
 };
 @group(${group}) @binding(${binding}) var<uniform> fx: SpriteFx;`;
 }

--- a/packages/babylon-lite/src/sprite/shared/sprite-atlas.ts
+++ b/packages/babylon-lite/src/sprite/shared/sprite-atlas.ts
@@ -144,10 +144,10 @@ export function createGridSpriteAtlas(texture: Texture2D, options: GridAtlasOpti
  */
 export async function loadSpriteAtlas(engine: EngineContext, textureUrl: string, options: LoadAtlasOptions = {}): Promise<SpriteAtlas> {
     if (options.metadataUrl !== undefined) {
-        throw new Error("loadSpriteAtlas: metadataUrl is not implemented in PR 1.");
+        throw new Error("loadSpriteAtlas: metadataUrl unsupported.");
     }
     if (!options.gridSize) {
-        throw new Error("loadSpriteAtlas: options.gridSize is required in PR 1.");
+        throw new Error("loadSpriteAtlas: gridSize required.");
     }
 
     const texOpts: Texture2DOptions = {

--- a/packages/babylon-lite/src/sprite/sprite-2d.ts
+++ b/packages/babylon-lite/src/sprite/sprite-2d.ts
@@ -549,7 +549,7 @@ function markDirty(layer: Sprite2DLayer, lo: number, hi: number): void {
 /** Add one sprite. Returns its index. Grows capacity as needed. */
 export function addSprite2DIndex(layer: Sprite2DLayer, props: Sprite2DProps): number {
     if (props.positionPx === undefined) {
-        throw new Error("addSprite2DIndex: props.positionPx is required.");
+        throw new Error("addSprite2DIndex: positionPx required.");
     }
     const idx = layer.count;
     if (idx >= layer._capacity) {

--- a/packages/babylon-lite/src/sprite/sprite-custom-shader.ts
+++ b/packages/babylon-lite/src/sprite/sprite-custom-shader.ts
@@ -73,7 +73,7 @@ function makeCustomSpriteWgsl(hasDepth: boolean, spriteGroupIndex: 0 | 1, extraT
     return `${makeSpritePrologueWgsl(hasDepth, spriteGroupIndex, uvScroll)}
 ${makeExtraBindingsWgsl(spriteGroupIndex, 3, extraTextures)}${makeFxStructWgsl(spriteGroupIndex, fxBinding)}
 @fragment
-fn fs(in: VOut) -> @location(0) vec4<f32> {
+fn fs(in: O) -> @location(0) vec4f {
 ${fragment}
 }`;
 }

--- a/packages/babylon-lite/src/sprite/sprite-pipeline.ts
+++ b/packages/babylon-lite/src/sprite/sprite-pipeline.ts
@@ -36,10 +36,10 @@ function makeSpriteWgsl(hasDepth: boolean, spriteGroupIndex: 0 | 1, uvScroll: bo
     // Coverage gamma (opt-in, text layers): raise sampled alpha to 1/coverageGamma (L.aa.x) so
     // anti-aliased glyph edges composite heavier, mimicking gamma-space stem darkening. Gated at
     // shader-build time — non-gamma layers ship the trivial textured fragment with no `pow`.
-    const coverageLine = coverageGamma ? `\nlet a = pow(s.a, L.aa.x);\nreturn vec4<f32>(s.rgb, a) * in.tint * L.opacityMul;` : `\nreturn s * in.tint * L.opacityMul;`;
+    const coverageLine = coverageGamma ? `\nlet a = pow(s.a, L.aa.x);\nreturn vec4f(s.rgb, a) * in.tint * L.opacityMul;` : `\nreturn s * in.tint * L.opacityMul;`;
     return `${makeSpritePrologueWgsl(hasDepth, spriteGroupIndex, uvScroll)}
 @fragment
-fn fs(in: VOut) -> @location(0) vec4<f32> {
+fn fs(in: O) -> @location(0) vec4f {
 let s = textureSample(atlasTex, atlasSamp, in.uv);${coverageLine}
 }`;
 }
@@ -54,62 +54,53 @@ let s = textureSample(atlasTex, atlasSamp, in.uv);${coverageLine}
  */
 export function makeSpritePrologueWgsl(hasDepth: boolean, spriteGroupIndex: 0 | 1, uvScroll = false): string {
     const group = `@group(${spriteGroupIndex})`;
-    const zAttribute = hasDepth ? `,\n@location(6) iZ: f32` : "";
-    const uvOffsetAttribute = uvScroll ? `,\n@location(7) iUvOffset: vec2<f32>` : "";
-    const zPosition = hasDepth ? "1.0 - in.iZ" : "0.0";
-    return `struct Layer {
-viewPos: vec2<f32>,
+    const zAttribute = hasDepth ? `,\n@location(6) z: f32` : "";
+    const uvOffsetAttribute = uvScroll ? `,\n@location(7) o: vec2f` : "";
+    const zPosition = hasDepth ? "1 - in.z" : "0";
+    return `struct Lr {
+viewPos: vec2f,
 viewScale: f32,
 viewRot: f32,
-screenSize: vec2<f32>,
-pivot: vec2<f32>,
-// Per-layer opacity, pre-shaped for the layer's blend mode (CPU-side):
-//   straight-alpha:  (1, 1, 1, opacity)  — only alpha is scaled
-//   premultiplied:   (opacity, opacity, opacity, opacity) — RGB and A scale together
-// One uniform, no shader branch.
-opacityMul: vec4<f32>,
-// Coverage-gamma controls (text layers): .x = 1/coverageGamma applied to sampled alpha by the
-// coverage-gamma shader permutation. .yzw reserved. Always present (UBO is a fixed 64 bytes);
-// unused by the base shader permutation.
-aa: vec4<f32>,
+screenSize: vec2f,
+pivot: vec2f,
+opacityMul: vec4f,
+aa: vec4f,
 };
-${group} @binding(0) var<uniform> L: Layer;
+${group} @binding(0) var<uniform> L: Lr;
 ${group} @binding(1) var atlasTex: texture_2d<f32>;
 ${group} @binding(2) var atlasSamp: sampler;
-struct VIn {
+struct I {
 @builtin(vertex_index) vid: u32,
-@location(0) iPos: vec2<f32>,
-@location(1) iSize: vec2<f32>,
-@location(2) iUvMin: vec2<f32>,
-@location(3) iUvMax: vec2<f32>,
-@location(4) iRot: f32,
-@location(5) iColor: vec4<f32>${zAttribute}${uvOffsetAttribute}
+@location(0) p: vec2f,
+@location(1) s: vec2f,
+@location(2) a: vec2f,
+@location(3) b: vec2f,
+@location(4) r: f32,
+@location(5) c: vec4f${zAttribute}${uvOffsetAttribute}
 };
-struct VOut {
-@builtin(position) pos: vec4<f32>,
-@location(0) uv: vec2<f32>,
-@location(1) tint: vec4<f32>,
+struct O {
+@builtin(position) p: vec4f,
+@location(0) uv: vec2f,
+@location(1) tint: vec4f,
 };
 @vertex
-fn vs(in: VIn) -> VOut {
-var corners = array<vec2<f32>, 4>(vec2<f32>(0.0, 0.0), vec2<f32>(1.0, 0.0), vec2<f32>(1.0, 1.0), vec2<f32>(0.0, 1.0));
-let c = corners[in.vid];
-let local = (c - L.pivot) * in.iSize;
-let cr = cos(in.iRot);
-let sr = sin(in.iRot);
-let rotated = vec2<f32>(local.x * cr - local.y * sr, local.x * sr + local.y * cr);
-let layerPx = in.iPos + rotated;
-let centered = layerPx - L.viewPos;
+fn vs(in: I) -> O {
+var q = array<vec2f, 4>(vec2f(0, 0), vec2f(1, 0), vec2f(1, 1), vec2f(0, 1));
+let c = q[in.vid];
+let l = (c - L.pivot) * in.s;
+let cr = cos(in.r);
+let sr = sin(in.r);
+let r = vec2f(l.x * cr - l.y * sr, l.x * sr + l.y * cr);
+let p = in.p + r - L.viewPos;
 let lc = cos(L.viewRot);
 let ls = sin(L.viewRot);
-let viewRot = vec2<f32>(centered.x * lc - centered.y * ls, centered.x * ls + centered.y * lc);
-let screenPx = viewRot * L.viewScale;
-let ndc = vec2<f32>(screenPx.x / L.screenSize.x * 2.0 - 1.0, 1.0 - screenPx.y / L.screenSize.y * 2.0);
-let uv = mix(in.iUvMin, in.iUvMax, c)${uvScroll ? " + in.iUvOffset" : ""};
-var out: VOut;
-out.pos = vec4<f32>(ndc, ${zPosition}, 1.0);
+let v = vec2f(p.x * lc - p.y * ls, p.x * ls + p.y * lc) * L.viewScale;
+let n = vec2f(v.x / L.screenSize.x * 2 - 1, 1 - v.y / L.screenSize.y * 2);
+let uv = mix(in.a, in.b, c)${uvScroll ? " + in.o" : ""};
+var out: O;
+out.p = vec4f(n, ${zPosition}, 1);
 out.uv = uv;
-out.tint = in.iColor;
+out.tint = in.c;
 return out;
 }`;
 }

--- a/packages/babylon-lite/src/sprite/sprite-renderable.ts
+++ b/packages/babylon-lite/src/sprite/sprite-renderable.ts
@@ -100,13 +100,13 @@ interface SpriteRenderableInternal extends Renderable {
  */
 export function buildSpriteRenderable(engine: EngineContext, layer: Sprite2DLayer): { renderable: Renderable; dispose: () => void } {
     if (layer.depth === "none") {
-        throw new Error('Sprite2DLayer with depth: "none" must be rendered via createSpriteRenderer, not addDepthHostedSpriteLayer.');
+        throw new Error('Depth-hosted sprites require depth != "none".');
     }
     const indexBuffer = createMappedBuffer(engine, SHARED_SPRITE_INDEX_DATA, BU.INDEX);
-    const uniformBuffer = createEmptyUniformBuffer(engine, LAYER_UBO_BYTES, "sprite-depth-hosted-ubo");
+    const uniformBuffer = createEmptyUniformBuffer(engine, LAYER_UBO_BYTES);
     const cap = layer._capacity;
-    const instanceBuffer = createSpriteInstanceBuffer(engine._device, layer, "sprite-depth-hosted-instances");
-    const fx = _getSpriteFxHook()?.createLayerFx(engine, "sprite-depth-hosted-fx-ubo", layer) ?? null;
+    const instanceBuffer = createSpriteInstanceBuffer(engine._device, layer);
+    const fx = _getSpriteFxHook()?.createLayerFx(engine, "", layer) ?? null;
 
     const isTransparent = layer.depth === "test";
     const isDirect = layer.depth === "test-write";
@@ -192,7 +192,7 @@ function uploadLayer(r: SpriteRenderableInternal, target: DrawUpdateContext): vo
     if (r._fx) {
         _getSpriteFxHook()!.updateFx(r._fx, r._layer, r._engine._currentDelta);
     }
-    const grown = ensureSpriteInstanceBuffer(r._engine._device, r._layer, r._instanceBuffer, r._instanceBufferCapacity, "sprite-depth-hosted-instances");
+    const grown = ensureSpriteInstanceBuffer(r._engine._device, r._layer, r._instanceBuffer, r._instanceBufferCapacity);
     if (grown.reallocated) {
         r._instanceBuffer = grown.buffer;
         r._instanceBufferCapacity = grown.capacity;

--- a/packages/babylon-lite/src/sprite/sprite-renderer.ts
+++ b/packages/babylon-lite/src/sprite/sprite-renderer.ts
@@ -155,8 +155,8 @@ function ensureLayerGpu(rr: SpriteRenderer, layer: Sprite2DLayer): LayerGpu {
     let lg = rr._layerGpu.get(layer);
     if (!lg) {
         const cap = layer._capacity;
-        const instanceBuffer = createSpriteInstanceBuffer(rr._surface.engine._device, layer, "sprite-layer-instances");
-        const uniformBuffer = createEmptyUniformBuffer(rr._surface.engine, LAYER_UBO_BYTES, "sprite-layer-ubo");
+        const instanceBuffer = createSpriteInstanceBuffer(rr._surface.engine._device, layer);
+        const uniformBuffer = createEmptyUniformBuffer(rr._surface.engine, LAYER_UBO_BYTES);
         const fx = _getSpriteFxHook()?.createLayerFx(rr._surface.engine, "sprite-layer-fx-ubo", layer) ?? null;
         lg = {
             layer,
@@ -174,7 +174,7 @@ function ensureLayerGpu(rr: SpriteRenderer, layer: Sprite2DLayer): LayerGpu {
         };
         rr._layerGpu.set(layer, lg);
     }
-    const grown = ensureSpriteInstanceBuffer(rr._surface.engine._device, layer, lg.instanceBuffer, lg.instanceBufferCapacity, "sprite-layer-instances");
+    const grown = ensureSpriteInstanceBuffer(rr._surface.engine._device, layer, lg.instanceBuffer, lg.instanceBufferCapacity);
     if (grown.reallocated) {
         lg.instanceBuffer = grown.buffer;
         lg.instanceBufferCapacity = grown.capacity;
@@ -284,7 +284,7 @@ function assertSpriteRendererLayers(layers: readonly Sprite2DLayer[]): void {
 
 function assertSpriteRendererLayer(layer: Sprite2DLayer): void {
     if (layer.depth !== "none") {
-        throw new Error('SpriteRenderer only supports Sprite2DLayer with depth: "none". Use addDepthHostedSpriteLayer(scene, layer) for depth-hosted sprites.');
+        throw new Error('SpriteRenderer requires depth: "none".');
     }
 }
 

--- a/packages/babylon-lite/src/sprite/sprite-scene.ts
+++ b/packages/babylon-lite/src/sprite/sprite-scene.ts
@@ -10,7 +10,7 @@ import { buildSpriteRenderable } from "./sprite-renderable.js";
  */
 export function addDepthHostedSpriteLayer(scene: SceneContext, layer: Sprite2DLayer): void {
     if (layer.depth === "none") {
-        throw new Error('Sprite2DLayer with depth: "none" must be rendered via createSpriteRenderer, not addDepthHostedSpriteLayer.');
+        throw new Error('Depth-hosted sprites require depth != "none".');
     }
     addDeferredSceneRenderables(scene, (engine) => {
         const built = buildSpriteRenderable(engine, layer);

--- a/tests/lite/unit/billboard-sprite.test.ts
+++ b/tests/lite/unit/billboard-sprite.test.ts
@@ -381,10 +381,10 @@ describe("addFacingBillboardSystem", () => {
         expect((vertexBuffer.attributes as GPUVertexAttribute[]).map((attribute) => attribute.shaderLocation)).toEqual([0, 1, 2, 3, 4, 5, 6]);
 
         const shaderDescriptor = device.createShaderModule.mock.calls.find((call) =>
-            (call[0] as GPUShaderModuleDescriptor).code.includes("cameraRight")
+            (call[0] as GPUShaderModuleDescriptor).code.includes("basis")
         )![0] as GPUShaderModuleDescriptor;
         expect(shaderDescriptor.code).toContain("scene.viewProjection");
-        expect(shaderDescriptor.code).toContain("getBillboardBasis");
+        expect(shaderDescriptor.code).toContain("basis");
         expect(shaderDescriptor.code).toContain("scene.view[0][0]");
 
         device.queue.writeBuffer.mockClear();
@@ -422,7 +422,7 @@ describe("addFacingBillboardSystem", () => {
         const shaderDescriptor = device.createShaderModule.mock.calls.find((call) =>
             (call[0] as GPUShaderModuleDescriptor).code.includes("discard")
         )![0] as GPUShaderModuleDescriptor;
-        expect(shaderDescriptor.code).toContain("sampleColor.a < billboards.axisAndCutoff.w");
+        expect(shaderDescriptor.code).toContain("s.a < billboards.axisAndCutoff.w");
         expect(shaderDescriptor.code).toContain("discard");
 
         device.queue.writeBuffer.mockClear();
@@ -595,7 +595,7 @@ describe("AxisLockedBillboardSpriteSystem", () => {
         expect(scene._renderables[0]!.isTransparent).toBe(true);
     });
 
-    it("generates axis-locked shader with billboards.axisAndCutoff and projectedRight", async () => {
+    it("generates axis-locked shader with billboards.axisAndCutoff and projected right basis", async () => {
         const engine = makeMockEngine();
         const scene = createSceneContext(engine);
         const system = createAxisLockedBillboardSystem(makeMockAtlas(), [0, 1, 0], { capacity: 1 });
@@ -618,9 +618,9 @@ describe("AxisLockedBillboardSpriteSystem", () => {
             (call[0] as GPUShaderModuleDescriptor).code.includes("billboards.axisAndCutoff")
         )![0] as GPUShaderModuleDescriptor;
         expect(shaderDescriptor.code).toContain("billboards.axisAndCutoff");
-        expect(shaderDescriptor.code).toContain("projectedRight");
-        expect(shaderDescriptor.code).toContain("lockAxis");
-        expect(shaderDescriptor.code).toContain("getBillboardBasis");
+        expect(shaderDescriptor.code).toContain("let pr = cr - a * dot(cr, a)");
+        expect(shaderDescriptor.code).toContain("cross(a, f)");
+        expect(shaderDescriptor.code).toContain("basis");
     });
 
     it("writes axis data to UBO after opacity", async () => {
@@ -677,18 +677,18 @@ return vec4<f32>(base.rgb * (0.5 + 0.5 * sin(fx.time + fx.params.x)), base.a);`;
 
         const facing = cs._composeWgsl("facing", "transparent");
         expect(facing).toContain("@group(1) @binding(3) var<uniform> fx: SpriteFx");
-        expect(facing).toContain("fn fs(in: VOut) -> @location(0) vec4<f32>");
+        expect(facing).toContain("fn fs(in: O) -> @location(0) vec4f");
         expect(facing).toContain(FX_FRAGMENT);
-        expect(facing).toContain("@location(3) vWorldPos: vec3<f32>");
-        expect(facing).toContain("out.vWorldPos = worldPos;");
-        expect(facing).toContain("getBillboardBasis");
-        expect(facing).toContain("cameraRight");
+        expect(facing).toContain("@location(3) vWorldPos: vec3f");
+        expect(facing).toContain("out.vWorldPos = wp;");
+        expect(facing).toContain("basis");
+        expect(facing).toContain("scene.view[0][0]");
 
         // Axis-locked uses a different basis but the same fragment contract.
         const axisLocked = cs._composeWgsl("axis-locked", "transparent");
-        expect(axisLocked).toContain("projectedRight");
-        expect(axisLocked).toContain("lockAxis");
-        expect(axisLocked).toContain("@location(3) vWorldPos: vec3<f32>");
+        expect(axisLocked).toContain("let pr = cr - a * dot(cr, a)");
+        expect(axisLocked).toContain("cross(a, f)");
+        expect(axisLocked).toContain("@location(3) vWorldPos: vec3f");
     });
 
     it("places the fx UBO after extra textures and binds them at group 1", () => {

--- a/tests/lite/unit/sprite-depth-hosted-routing.test.ts
+++ b/tests/lite/unit/sprite-depth-hosted-routing.test.ts
@@ -171,8 +171,8 @@ describe("addDepthHostedSpriteLayer", () => {
         const device = engine._device as unknown as { createRenderPipeline: ReturnType<typeof vi.fn>; createShaderModule: ReturnType<typeof vi.fn> };
         const depthShaderDescriptor = device.createShaderModule.mock.calls
             .map((call) => call[0] as GPUShaderModuleDescriptor)
-            .find((descriptor) => descriptor.code.includes("@location(6) iZ: f32"));
-        expect(depthShaderDescriptor?.code).toContain("vec4<f32>(ndc, 1.0 - in.iZ, 1.0)");
+            .find((descriptor) => descriptor.code.includes("@location(6) z: f32"));
+        expect(depthShaderDescriptor?.code).toContain("vec4f(n, 1 - in.z, 1)");
         device.createRenderPipeline.mockClear();
         const renderable = scene._renderables[0]!;
 
@@ -203,7 +203,7 @@ describe("addDepthHostedSpriteLayer", () => {
         await registerScene(scene);
 
         const device = engine._device as unknown as { createBuffer: ReturnType<typeof vi.fn>; queue: { writeBuffer: ReturnType<typeof vi.fn> } };
-        const instanceBufferCreate = device.createBuffer.mock.calls.find((call) => (call[0] as GPUBufferDescriptor).label === "sprite-depth-hosted-instances");
+        const instanceBufferCreate = device.createBuffer.mock.calls.find((call) => (call[0] as GPUBufferDescriptor).size === DEPTH_INSTANCE_STRIDE_BYTES);
         expect((instanceBufferCreate![0] as GPUBufferDescriptor).size).toBe(DEPTH_INSTANCE_STRIDE_BYTES);
 
         const binding = scene._renderables[0]!.bind(engine, { _colorFormat: "bgra8unorm", _depthStencilFormat: "depth24plus-stencil8", _sampleCount: 1 });

--- a/tests/lite/unit/sprite-renderer.test.ts
+++ b/tests/lite/unit/sprite-renderer.test.ts
@@ -200,7 +200,7 @@ describe("createSpriteRenderer", () => {
         const shaderDescriptor = device.createShaderModule.mock.calls[0]![0] as GPUShaderModuleDescriptor;
         expect(shaderDescriptor.code).not.toContain("iZ");
         expect(shaderDescriptor.code).not.toContain("iUvOffset");
-        expect(shaderDescriptor.code).toContain("vec4<f32>(ndc, 0.0, 1.0)");
+        expect(shaderDescriptor.code).toContain("vec4f(n, 0, 1)");
     });
 
     it("converts depth-hosted sprite NDC Z to reverse-Z clip depth", () => {
@@ -213,7 +213,7 @@ describe("createSpriteRenderer", () => {
         const device = engine._device as unknown as { createRenderPipeline: ReturnType<typeof vi.fn>; createShaderModule: ReturnType<typeof vi.fn> };
         const shaderDescriptor = device.createShaderModule.mock.calls[0]![0] as GPUShaderModuleDescriptor;
         const descriptor = device.createRenderPipeline.mock.calls[0]![0] as GPURenderPipelineDescriptor;
-        expect(shaderDescriptor.code).toContain("vec4<f32>(ndc, 1.0 - in.iZ, 1.0)");
+        expect(shaderDescriptor.code).toContain("vec4f(n, 1 - in.z, 1)");
         expect(descriptor.depthStencil?.depthCompare).toBe("greater-equal");
     });
 });
@@ -239,7 +239,7 @@ describe("uvScroll (per-sprite uvOffset)", () => {
         expect(DEPTH_UVSCROLL_STRIDE_BYTES).toBe(64);
     });
 
-    it("builds a pure-2D uvScroll pipeline with a 60-byte stride and a location-7 iUvOffset attribute", () => {
+    it("builds a pure-2D uvScroll pipeline with a 60-byte stride and a location-7 uvOffset attribute", () => {
         const { engine } = makeMockEngine();
         const cache = createSpritePipelineCache();
         const layer = createSprite2DLayer(makeMockAtlas(), { uvScroll: true });
@@ -258,8 +258,8 @@ describe("uvScroll (per-sprite uvOffset)", () => {
         expect(uvAttr.format).toBe("float32x2");
 
         const shaderDescriptor = device.createShaderModule.mock.calls[0]![0] as GPUShaderModuleDescriptor;
-        expect(shaderDescriptor.code).toContain("@location(7) iUvOffset: vec2<f32>");
-        expect(shaderDescriptor.code).toContain("+ in.iUvOffset");
+        expect(shaderDescriptor.code).toContain("@location(7) o: vec2f");
+        expect(shaderDescriptor.code).toContain("+ in.o");
     });
 
     it("builds a depth-hosted uvScroll pipeline with a 64-byte stride and uvOffset at byte offset 56", () => {
@@ -512,7 +512,7 @@ describe("pure-2D instance layout", () => {
 
         sr._update();
 
-        const instanceBufferCreate = device.createBuffer.mock.calls.find((call) => (call[0] as GPUBufferDescriptor).label === "sprite-layer-instances");
+        const instanceBufferCreate = device.createBuffer.mock.calls.find((call) => (call[0] as GPUBufferDescriptor).size === PURE_2D_INSTANCE_STRIDE_BYTES);
         expect((instanceBufferCreate![0] as GPUBufferDescriptor).size).toBe(PURE_2D_INSTANCE_STRIDE_BYTES);
         expect(device.queue.writeBuffer.mock.calls.some((call) => call[4] === PURE_2D_INSTANCE_STRIDE_BYTES)).toBe(true);
         expect(device.queue.writeBuffer.mock.calls.some((call) => call[4] === DEPTH_INSTANCE_STRIDE_BYTES)).toBe(false);
@@ -544,10 +544,10 @@ describe("Sprite2D custom shader", () => {
         const cs = createSprite2DCustomShader({ fragment: FX_FRAGMENT });
         const wgsl = cs._composeWgsl(false, 0, false);
         expect(wgsl).toContain("@binding(3) var<uniform> fx: SpriteFx");
-        expect(wgsl).toContain("fn fs(in: VOut) -> @location(0) vec4<f32>");
+        expect(wgsl).toContain("fn fs(in: O) -> @location(0) vec4f");
         expect(wgsl).toContain(FX_FRAGMENT);
         // The vertex prologue must still be present.
-        expect(wgsl).toContain("fn vs(in: VIn)");
+        expect(wgsl).toContain("fn vs(in: I)");
         expect(wgsl).toContain("var atlasTex");
     });
 


### PR DESCRIPTION
## Summary
- compact sprite and billboard WGSL wrappers to reduce runtime JS string payload
- remove nonessential sprite GPU debug labels and shorten rare sprite error strings
- refresh sprite scene bundle manifests, every sprite-tagged scene drops at least 551 bytes

## Validation
- pnpm lint
- pnpm validate:bundle-manifest
- pnpm test:bundle-size (with LAB_TEST_PORT=5189 because 5179 was occupied by another local checkout)
- focused sprite parity specs for scenes 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 92, 93, 94, 95, 96, 97, 98, 205, 206

Note: I also ran full pnpm test before the final billboard literal fix; it exposed the existing local parity baseline failures plus the fixed billboard regression, so I reran all sprite parity coverage after the fix.