### PR TITLE
[compat-sync] Babylon.js compat-layer sync

### DIFF
--- a/packages/babylon-lite-compat/COMPAT-STATUS.md
+++ b/packages/babylon-lite-compat/COMPAT-STATUS.md
@@ -7,8 +7,8 @@ updated by the `update-compat-layer` skill.
 <!-- The two markers below are machine-read by the update-compat-layer skill.
      Do not rename them. Update the SHA after re-syncing against BJS master. -->
 
-- **Last synced BJS commit:** `608146f18dbf6ff9547f7b6ffe336cc3cbb5c33a`
-- **Last sync date:** 2026-06-24
+- **Last synced BJS commit:** `c729b94f2e36f2d915415620857452f7ad0ff731`
+- **Last sync date:** 2026-06-25
 - **Lite compat package version:** 0.0.1
 
 > The "Last synced BJS commit" is the `BabylonJS/Babylon.js` `master` HEAD that the
@@ -64,21 +64,21 @@ date` markers above record the `BabylonJS/Babylon.js` `master` HEAD the surface
 
 ## Math
 
-| BJS API                                            | Status     | Module                                                                                           |
-| -------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------ |
-| `Vector2` / `Vector3` / `Vector4`                  | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                             |
-| `Color3` / `Color4`                                | ✅ Full    | [math/color.ts](src/math/color.ts)                                                               |
+| BJS API                                            | Status     | Module                                                                                                                                                          |
+| -------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Vector2` / `Vector3` / `Vector4`                  | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
+| `Color3` / `Color4`                                | ✅ Full    | [math/color.ts](src/math/color.ts)                                                                                                                              |
 | `Quaternion`                                       | ✅ Full    | [math/quaternion.ts](src/math/quaternion.ts) (incl. `FromRotationMatrix` / `FromRotationMatrixToRef` / `fromRotationMatrix` over Lite `quatFromRotationMatrix`) |
-| `Matrix`                                           | ✅ Full    | [math/matrix.ts](src/math/matrix.ts) (incl. `decompose` — BJS-accurate scale/negative-determinant handling, rotation via Lite `quatFromRotationMatrix`)        |
-| `Vector3.TransformCoordinates` / `TransformNormal` | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                             |
-| `Vector3.Center` / `CenterToRef`                   | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                             |
-| `Matrix.copyToArray`                               | ✅ Full    | [math/matrix.ts](src/math/matrix.ts)                                                             |
-| `Scalar`                                           | ✅ Full    | [math/scalar.ts](src/math/scalar.ts)                                                             |
-| `Axis` / `Space` / `Epsilon`                       | ✅ Full    | [math/constants.ts](src/math/constants.ts)                                                       |
-| `Plane` / `Ray` / `Frustum`                        | ✅ Full    | [math/plane.ts](src/math/plane.ts), [ray.ts](src/math/ray.ts), [frustum.ts](src/math/frustum.ts) |
-| `Size` / `Viewport`                                | ✅ Full    | [math/size.ts](src/math/size.ts)                                                                 |
-| `Angle` / `Curve3` / `Path3D`                      | ⚡ Partial | [math/curve.ts](src/math/curve.ts)                                                               |
-| `Curve3` / `Path3D` / easing curves on math        | ⚡ Partial | curve + easing                                                                                   |
+| `Matrix`                                           | ✅ Full    | [math/matrix.ts](src/math/matrix.ts) (incl. `decompose` — BJS-accurate scale/negative-determinant handling, rotation via Lite `quatFromRotationMatrix`)         |
+| `Vector3.TransformCoordinates` / `TransformNormal` | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
+| `Vector3.Center` / `CenterToRef`                   | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
+| `Matrix.copyToArray`                               | ✅ Full    | [math/matrix.ts](src/math/matrix.ts)                                                                                                                            |
+| `Scalar`                                           | ✅ Full    | [math/scalar.ts](src/math/scalar.ts)                                                                                                                            |
+| `Axis` / `Space` / `Epsilon`                       | ✅ Full    | [math/constants.ts](src/math/constants.ts)                                                                                                                      |
+| `Plane` / `Ray` / `Frustum`                        | ✅ Full    | [math/plane.ts](src/math/plane.ts), [ray.ts](src/math/ray.ts), [frustum.ts](src/math/frustum.ts)                                                                |
+| `Size` / `Viewport`                                | ✅ Full    | [math/size.ts](src/math/size.ts)                                                                                                                                |
+| `Angle` / `Curve3` / `Path3D`                      | ⚡ Partial | [math/curve.ts](src/math/curve.ts)                                                                                                                              |
+| `Curve3` / `Path3D` / easing curves on math        | ⚡ Partial | curve + easing                                                                                                                                                  |
 
 ## Core
 
@@ -271,10 +271,10 @@ date` markers above record the `BabylonJS/Babylon.js` `master` HEAD the surface
 
 ## Bones / Skeletons / Morph
 
-| BJS API                              | Status           | Notes                                                                                                                                                             |
-| ------------------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BJS API                              | Status           | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Skeleton` / `Bone`                  | ❌ Not supported | throwing stub; produced by glTF loader, not constructed. Re-checked 2026-06-24: Lite's new opt-in bone-control API (`enableBoneControl` / `getBoneByName` / `setBone*` / `Skeleton` / `Bone`, #268) can read & pose a **loader-built** skeleton, but BJS `new Skeleton()/new Bone()` manual construction and sync skinned `scene.pick` (`applySkeleton`) are still absent, so scene 114 stays blocked and no compat wrapper is shippable yet |
-| `MorphTarget` / `MorphTargetManager` | ✅ Full          | morph ([morph/morph.ts](src/morph/morph.ts)) over Lite `createMorphTargets` / `setMorphTargetWeights` (absolute target positions → deltas, built at engine start) |
+| `MorphTarget` / `MorphTargetManager` | ✅ Full          | morph ([morph/morph.ts](src/morph/morph.ts)) over Lite `createMorphTargets` / `setMorphTargetWeights` (absolute target positions → deltas, built at engine start)                                                                                                                                                                                                                                                                            |
 
 ## Sprites
 
@@ -319,11 +319,32 @@ date` markers above record the `BabylonJS/Babylon.js` `master` HEAD the surface
 | ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `RecastJSPlugin` | ✅ Full | compat `@babylonjs/addons/navigation` wrapper ([navigation/navigation.ts](src/navigation/navigation.ts)) over Babylon Lite's native Recast-V2 API (navmesh + debug mesh + crowd + path + raycast + off-mesh connections + tile-cache obstacles via `addBoxObstacle`/`addCylinderObstacle`/`removeObstacle` + `WaitForFullTileCacheUpdate`) |
 
-## Audio
+## Audio (AudioV2)
 
-| BJS API                                   | Status           | Notes                                 |
-| ----------------------------------------- | ---------------- | ------------------------------------- |
-| `Sound` / `AudioEngine` / `WeightedSound` | ❌ Not supported | throwing stub; use Web Audio directly |
+Babylon Lite ships a full AudioV2 port (offline-capable Web Audio graph). The compat
+layer mirrors the Babylon.js `AudioV2` public surface 1:1 (exact class names,
+inheritance chain, factory functions, enums) on top of it — see
+[audio/audio.ts](src/audio/audio.ts) and [audio/audio-enums.ts](src/audio/audio-enums.ts).
+Added for issue #296.
+
+| BJS API                                                                               | Status           | Notes                                                                                                                                                                  |
+| ------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CreateAudioEngineAsync` / `AudioEngineV2`                                            | ✅ Full          | over Lite `createAudioEngineAsync`; volume, state, `unlockAsync`, `pause`/`resume`/`dispose`, `listener`, `defaultMainBus`                                             |
+| `LastCreatedAudioEngine` / `OnAudioEngineV2CreatedObservable`                         | ✅ Full          | module-level tracking, matches BJS                                                                                                                                     |
+| `CreateSoundAsync` / `StaticSound`                                                    | ✅ Full          | over Lite `createSoundAsync`; play/pause/resume/stop, `loop`/`startOffset`/`maxInstances`/`duration`/`loopStart`/`loopEnd`/`pitch`/`playbackRate`, `onEndedObservable` |
+| `CreateSoundBufferAsync` / `StaticSoundBuffer`                                        | ✅ Full          | over Lite `createSoundBufferAsync`                                                                                                                                     |
+| `CreateStreamingSoundAsync` / `StreamingSound`                                        | ✅ Full          | over Lite streaming-sound fns; preload counts, transport                                                                                                               |
+| `CreateAudioBusAsync` / `AudioBus`                                                    | ✅ Full          | over Lite `createAudioBusAsync`; volume, spatial/stereo/analyzer, `outBus`                                                                                             |
+| `MainAudioBus`                                                                        | ⚡ Partial       | `engine.defaultMainBus`; Lite main bus is not a spatial-graph host, so `spatial`/`stereo`/`analyzer` throw a discoverable error                                        |
+| `CreateMainAudioBusAsync`                                                             | ⚡ Partial       | Lite exposes only the default main bus; resolves to `engine.defaultMainBus` rather than constructing a second one                                                      |
+| `CreateSoundSourceAsync` / `CreateMicrophoneSoundSourceAsync` / `SoundSource`         | ✅ Full          | over Lite `createSoundSourceAsync` / `createMicrophoneSoundSourceAsync`                                                                                                |
+| `AbstractSound` / `AbstractSoundSource` / `AbstractAudioBus` / `AbstractAudioOutNode` | ✅ Full          | abstract base classes in the hierarchy                                                                                                                                 |
+| `AbstractAudioNode` / `AbstractNamedAudioNode`                                        | ✅ Full          | `onNameChangedObservable`, engine `onNodeAddedObservable`/`onNodeRemovedObservable`                                                                                    |
+| `AbstractSpatialAudio` / `AbstractSpatialAudioListener`                               | ⚡ Partial       | over Lite spatial feature fns; node attachment tracked by world position, not a live transform binding                                                                 |
+| `AbstractStereoAudio`                                                                 | ✅ Full          | over Lite stereo feature fns                                                                                                                                           |
+| `AbstractAudioAnalyzer`                                                               | ✅ Full          | over Lite analyzer feature fns; `getByteFrequencyData`/`getFloatFrequencyData`                                                                                         |
+| `SoundState` / `AudioParameterRampShape` / `SpatialAudioAttachmentType`               | ✅ Full          | enums mirror BJS string/number values exactly                                                                                                                          |
+| `Sound` / `AudioEngine` / `WeightedSound` (legacy v1)                                 | ❌ Not supported | throwing stub; superseded by the AudioV2 surface above                                                                                                                 |
 
 ## Not yet wrapped (Lite supports — wrappers planned)
 
@@ -342,7 +363,7 @@ candidate rows for the next audit passes — until wrapped they either carry a
 | `Inspector` / `NodeMaterialEditor`             | ⛔ Out of scope                            |
 | `ParticleSystem` / `GPUParticleSystem`         | ❌ Not supported (not in Lite)             |
 | `@babylonjs/gui`                               | ❌ Not supported (not in Lite)             |
-| `Sound` / `AudioEngine`                        | ❌ Not supported (no audio in Lite)        |
+| `Sound` / `AudioEngine` (legacy v1)            | ❌ Not supported (use AudioV2 — see Audio) |
 | WebXR                                          | ❌ Not supported (no XR in Lite)           |
 | `HighlightLayer` / `GlowLayer` / `Decal`       | ❌ Not supported (not in Lite)             |
 | `SceneSerializer`                              | ❌ Not supported                           |

--- a/packages/babylon-lite-compat/README.md
+++ b/packages/babylon-lite-compat/README.md
@@ -97,7 +97,7 @@ mismapping. Once migration is complete you can drop the plugin and import from
   module-level side effects, so it never bloats consumers that don't use it.
 - **Honest:** unsupported Babylon.js APIs throw `LiteCompatError` rather than
   rendering something subtly wrong.
-- **Not** a full Babylon.js reimplementation. Particles, GUI, WebXR, audio, decals,
+- **Not** a full Babylon.js reimplementation. Particles, GUI, WebXR, decals,
   and other features absent from Babylon Lite are out of scope.
 
 ## Supported APIs at a glance
@@ -132,7 +132,8 @@ overloads within a supported area may still be absent.
 | Sprites (`SpriteManager` / `Sprite`)                                                                    |   ⚡   | camera-facing billboards; `SpriteMap` / packed atlas unsupported                                         |
 | Behaviors / Actions (`AutoRotation`, `Framing`, `ActionManager`, conditions)                            |   ⚡   | `ActionManager` is manual-dispatch; drag behaviors need Lite core                                        |
 | Misc (`Observable`, `Tools`, `SmartArray`, `Tags`, gradients, `PerformanceMonitor`)                     |   ✅   |                                                                                                          |
-| Particles, post-processes, layers (glow/highlight), probes, physics, audio, WebXR                       |   ❌   | not in Babylon Lite — use native Lite `create*Task` / Havok-V2 functions                                 |
+| Audio V2 (`AudioEngineV2`, `StaticSound`, `StreamingSound`, `AudioBus`, buses/sources/analyzer)         |   ⚡   | over Lite's AudioV2 port; `MainAudioBus` spatial/analyzer and a second main bus unsupported              |
+| Particles, post-processes, layers (glow/highlight), probes, physics, WebXR                              |   ❌   | not in Babylon Lite — use native Lite `create*Task` / Havok-V2 functions                                 |
 
 ### `@babylonjs/loaders`
 

--- a/packages/babylon-lite-compat/src/audio/audio-enums.ts
+++ b/packages/babylon-lite-compat/src/audio/audio-enums.ts
@@ -1,0 +1,64 @@
+/**
+ * Babylon.js AudioV2 enums and small shared helpers.
+ *
+ * These mirror the `@babylonjs/core` `AudioV2` `const enum`s exactly (same member
+ * names and values) so ported code that reads e.g. `SoundState.Started` or
+ * `AudioParameterRampShape.Linear` resolves identically.
+ */
+
+import type { RampOptions as LiteRampOptions } from "babylon-lite";
+
+/** Playback state of a sound (mirrors `@babylonjs/core` `SoundState`). */
+export const SoundState = {
+    Stopping: 0,
+    Stopped: 1,
+    Starting: 2,
+    Started: 3,
+    FailedToStart: 4,
+    Paused: 5,
+} as const;
+export type SoundState = (typeof SoundState)[keyof typeof SoundState];
+
+/** Ramp shape used when changing an audio parameter (mirrors `AudioParameterRampShape`). */
+export const AudioParameterRampShape = {
+    Linear: "linear",
+    Exponential: "exponential",
+    Logarithmic: "logarithmic",
+    None: "none",
+} as const;
+export type AudioParameterRampShape = (typeof AudioParameterRampShape)[keyof typeof AudioParameterRampShape];
+
+/** Which transform components a spatial sound/listener follows (mirrors `SpatialAudioAttachmentType`). */
+export const SpatialAudioAttachmentType = {
+    Position: 1,
+    Rotation: 2,
+    PositionAndRotation: 3,
+} as const;
+export type SpatialAudioAttachmentType = (typeof SpatialAudioAttachmentType)[keyof typeof SpatialAudioAttachmentType];
+
+/** FFT window sizes accepted by the analyzer (mirrors `AudioAnalyzerFFTSizeType`). */
+export type AudioAnalyzerFFTSizeType = 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384 | 32768;
+
+/** Engine context state (mirrors `AudioEngineV2State`). */
+export type AudioEngineV2State = "closed" | "interrupted" | "running" | "suspended";
+
+/** Babylon.js `IAudioParameterRampOptions`. */
+export interface IAudioParameterRampOptions {
+    /** Ramp time, in seconds. */
+    duration: number;
+    /** Ramp shape. */
+    shape: AudioParameterRampShape;
+}
+
+/**
+ * Maps a Babylon.js ramp option bag to the Lite `RampOptions` shape. The shape
+ * string values are identical between the two APIs, so this is a structural pass
+ * through.
+ * @internal
+ */
+export function toLiteRamp(options?: Partial<IAudioParameterRampOptions> | null): LiteRampOptions | undefined {
+    if (!options) {
+        return undefined;
+    }
+    return { duration: options.duration, shape: options.shape };
+}

--- a/packages/babylon-lite-compat/src/audio/audio.ts
+++ b/packages/babylon-lite-compat/src/audio/audio.ts
@@ -106,6 +106,10 @@ function readNodePosition(node: SpatialNodeLike | null): { x: number; y: number;
     return node.getAbsolutePosition?.() ?? node.absolutePosition ?? node.position ?? null;
 }
 
+function readNodeRotation(node: SpatialNodeLike | null): { x: number; y: number; z: number; w: number } | null {
+    return node?.rotationQuaternion ?? null;
+}
+
 // ───────────────────────────── Options interfaces ────────────────────────────
 
 /** Babylon.js `IAudioEngineV2Options` (subset backed by Lite). */
@@ -642,11 +646,28 @@ export class AbstractSpatialAudio {
 
     /** Pulls the attached node's current world position/rotation into the source. */
     public update(): void {
-        const pos = readNodePosition(this._attachedNode);
-        if (pos) {
-            this._position = new Vector3(pos.x, pos.y, pos.z);
-            this._ensure();
-            setSpatialPosition(this._host, pos);
+        const node = this._attachedNode;
+        if (!node) {
+            return;
+        }
+        let dirty = false;
+        if ((this.attachmentType & SpatialAudioAttachmentType.Position) !== 0) {
+            const pos = readNodePosition(node);
+            if (pos) {
+                this._position = new Vector3(pos.x, pos.y, pos.z);
+                dirty = true;
+            }
+        }
+        if ((this.attachmentType & SpatialAudioAttachmentType.Rotation) !== 0) {
+            const quat = readNodeRotation(node);
+            if (quat) {
+                this._rotationQuaternion = new Quaternion(quat.x, quat.y, quat.z, quat.w);
+                dirty = true;
+            }
+        }
+        if (dirty) {
+            enableSpatial(this._host, this._options());
+            this._enabled = true;
         }
     }
 
@@ -750,12 +771,18 @@ export class AbstractSpatialAudioListener {
         this._attachedNode = null;
     }
 
-    /** Pulls the attached node's current world position into the listener. */
+    /** Pulls the attached node's current world position/rotation into the listener. */
     public update(): void {
-        const pos = readNodePosition(this._attachedNode);
+        const node = this._attachedNode;
+        const pos = readNodePosition(node);
         if (pos) {
             this._position = new Vector3(pos.x, pos.y, pos.z);
             setSpatialListenerPosition(this._engine, pos);
+        }
+        const quat = readNodeRotation(node);
+        if (quat) {
+            this._rotationQuaternion = new Quaternion(quat.x, quat.y, quat.z, quat.w);
+            setSpatialListener(this._engine, { rotationQuaternion: this._rotationQuaternion });
         }
         updateSpatialAudio(this._engine);
     }
@@ -775,10 +802,11 @@ export class AudioBus extends AbstractAudioBus {
     private _outBus: PrimaryAudioBus | null;
 
     /** @internal */
-    public constructor(engine: AudioEngineV2, lite: LiteAudioBus, outBus: PrimaryAudioBus | null) {
+    public constructor(engine: AudioEngineV2, lite: LiteAudioBus, outBus: PrimaryAudioBus | null, volume = 1) {
         super(lite.name, engine);
         this._lite = lite;
         this._outBus = outBus;
+        this._volume = volume;
     }
 
     /** The output bus this bus routes to. */
@@ -786,6 +814,10 @@ export class AudioBus extends AbstractAudioBus {
         return this._outBus;
     }
     public set outBus(value: PrimaryAudioBus | null) {
+        if (this._outBus === value) {
+            return;
+        }
+        rerouteLiteOutBus(this._lite, unwrapBus(value) ?? null);
         this._outBus = value;
     }
 
@@ -862,6 +894,10 @@ export abstract class AbstractSoundSource extends AbstractAudioOutNode {
         return this._outBus;
     }
     public set outBus(value: PrimaryAudioBus | null) {
+        if (this._outBus === value) {
+            return;
+        }
+        rerouteLiteOutBus(this._spatialHost(), unwrapBus(value) ?? null);
         this._outBus = value;
     }
 
@@ -882,9 +918,10 @@ export class SoundSource extends AbstractSoundSource {
     public readonly _lite: LiteAudioInputSource;
 
     /** @internal */
-    public constructor(engine: AudioEngineV2, lite: LiteAudioInputSource, outBus: PrimaryAudioBus | null) {
+    public constructor(engine: AudioEngineV2, lite: LiteAudioInputSource, outBus: PrimaryAudioBus | null, volume = 1) {
         super(lite.name, engine, outBus);
         this._lite = lite;
+        this._volume = volume;
     }
 
     public getClassName(): string {
@@ -1001,11 +1038,12 @@ export class StaticSound extends AbstractSound {
     private _buffer: StaticSoundBuffer;
 
     /** @internal */
-    public constructor(engine: AudioEngineV2, lite: LiteStaticSound, buffer: StaticSoundBuffer, outBus: PrimaryAudioBus | null, autoplay: boolean) {
-        super(lite.name ?? "Sound", engine, outBus);
+    public constructor(engine: AudioEngineV2, lite: LiteStaticSound, buffer: StaticSoundBuffer, outBus: PrimaryAudioBus | null, autoplay: boolean, name?: string, volume = 1) {
+        super(name ?? lite.name ?? "Sound", engine, outBus);
         this._lite = lite;
         this._buffer = buffer;
         this._autoplay = autoplay;
+        this._volume = volume;
         lite.onEnded.add(() => this.onEndedObservable.notifyObservers(this));
     }
 
@@ -1147,13 +1185,14 @@ export class StreamingSound extends AbstractSound {
     private _maxInstances: number;
 
     /** @internal */
-    public constructor(engine: AudioEngineV2, lite: LiteStreamingSound, outBus: PrimaryAudioBus | null, options: Partial<IStreamingSoundOptions>) {
-        super(lite.name ?? "Sound", engine, outBus);
+    public constructor(engine: AudioEngineV2, lite: LiteStreamingSound, outBus: PrimaryAudioBus | null, options: Partial<IStreamingSoundOptions>, name?: string) {
+        super(name ?? lite.name ?? "Sound", engine, outBus);
         this._lite = lite;
         this._autoplay = options.autoplay ?? false;
         this._loop = options.loop ?? false;
         this._startOffset = options.startOffset ?? 0;
         this._maxInstances = options.maxInstances ?? Infinity;
+        this._volume = options.volume ?? 1;
         lite.onEnded.add(() => this.onEndedObservable.notifyObservers(this));
     }
 
@@ -1274,6 +1313,35 @@ function unwrapBus(bus: PrimaryAudioBus | null | undefined): LitePrimaryAudioBus
         return undefined;
     }
     return (bus as AudioBus | MainAudioBus)._lite as LitePrimaryAudioBus;
+}
+
+/** The Web Audio input node a Lite primary bus exposes (mirrors Lite's internal `getBusInputNode`). */
+function liteBusInputNode(bus: LitePrimaryAudioBus): AudioNode {
+    return "_graph" in bus ? (bus as LiteAudioBus)._graph._in : (bus as LiteMainBus)._in;
+}
+
+/**
+ * Re-routes a Lite graph-bearing handle (sound, source, or generic bus) from its
+ * current output bus to `newOutBus`, mirroring AudioV2's `outBus` setter. Lite
+ * exposes no public re-route entry point, so this rewires the single stable tail
+ * link (the sub-graph's `_out` node to the target bus input) directly, exactly as
+ * Lite wires it at creation time.
+ */
+function rerouteLiteOutBus(host: LiteHost, newOutBus: LitePrimaryAudioBus | null): void {
+    const out = host._graph._out;
+    const oldOutBus = host._outBus;
+    if (oldOutBus) {
+        try {
+            out.disconnect(liteBusInputNode(oldOutBus));
+        } catch {
+            // The tail may not be connected yet (e.g. a microphone source created
+            // without an output bus); ignore.
+        }
+    }
+    if (newOutBus) {
+        out.connect(liteBusInputNode(newOutBus));
+    }
+    (host as { _outBus: LitePrimaryAudioBus | null })._outBus = newOutBus;
 }
 
 function unwrapBufferSource(source: StaticSoundSource): ArrayBuffer | AudioBuffer | LiteSoundBuffer | string | string[] {
@@ -1407,7 +1475,7 @@ export class AudioEngineV2 {
         const liteOptions = toLiteStaticSoundOptions(name, options);
         const lite = await createSoundAsync(this._lite, unwrapBufferSource(source), liteOptions);
         const buffer = new StaticSoundBuffer(this, lite.buffer, name);
-        return new StaticSound(this, lite, buffer, (options?.outBus as PrimaryAudioBus | undefined) ?? this.defaultMainBus, options?.autoplay ?? false);
+        return new StaticSound(this, lite, buffer, (options?.outBus as PrimaryAudioBus | undefined) ?? this.defaultMainBus, options?.autoplay ?? false, name, options?.volume ?? 1);
     }
 
     /** Creates a decoded sound buffer. */
@@ -1417,7 +1485,7 @@ export class AudioEngineV2 {
     }
 
     /** Creates a streaming, media-element-backed sound. */
-    public async createStreamingSoundAsync(_name: string, source: HTMLMediaElement | string | string[], options?: Partial<IStreamingSoundOptions>): Promise<StreamingSound> {
+    public async createStreamingSoundAsync(name: string, source: HTMLMediaElement | string | string[], options?: Partial<IStreamingSoundOptions>): Promise<StreamingSound> {
         const liteOptions: LiteStreamingSoundOptions = {
             autoplay: options?.autoplay,
             loop: options?.loop,
@@ -1428,7 +1496,7 @@ export class AudioEngineV2 {
             volume: options?.volume,
         };
         const lite = await createStreamingSoundAsync(this._lite, source, liteOptions);
-        return new StreamingSound(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? this.defaultMainBus, options ?? {});
+        return new StreamingSound(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? this.defaultMainBus, options ?? {}, name);
     }
 
     /** Creates a generic mixer bus. */
@@ -1437,7 +1505,7 @@ export class AudioEngineV2 {
             volume: options?.volume,
             outBus: unwrapBus(options?.outBus) as LitePrimaryAudioBus | undefined,
         });
-        return new AudioBus(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? this.defaultMainBus);
+        return new AudioBus(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? this.defaultMainBus, options?.volume ?? 1);
     }
 
     /**
@@ -1457,7 +1525,7 @@ export class AudioEngineV2 {
             outBusAutoDefault: options?.outBusAutoDefault,
             volume: options?.volume,
         });
-        return new SoundSource(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? null);
+        return new SoundSource(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? null, options?.volume ?? 1);
     }
 
     /** Creates a microphone-backed sound source. */
@@ -1468,7 +1536,7 @@ export class AudioEngineV2 {
             outBusAutoDefault: options?.outBusAutoDefault,
             volume: options?.volume,
         });
-        return new SoundSource(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? null);
+        return new SoundSource(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? null, options?.volume ?? 1);
     }
 
     /** Disposes the engine and all its sounds/buses. */

--- a/packages/babylon-lite-compat/src/audio/audio.ts
+++ b/packages/babylon-lite-compat/src/audio/audio.ts
@@ -79,6 +79,7 @@ import type {
     StaticSoundOptions as LiteStaticSoundOptions,
     StreamingSoundOptions as LiteStreamingSoundOptions,
     SpatialSoundOptions as LiteSpatialSoundOptions,
+    AudioGraphHost as LiteHost,
 } from "babylon-lite";
 
 import { Observable } from "../misc/observable.js";
@@ -87,14 +88,11 @@ import { Quaternion } from "../math/quaternion.js";
 import { unsupported } from "../error.js";
 import { SpatialAudioAttachmentType, toLiteRamp, type SoundState, type AudioAnalyzerFFTSizeType, type AudioEngineV2State, type IAudioParameterRampOptions } from "./audio-enums.js";
 
-/** Any Lite handle that can carry spatial / stereo / analyzer sub-nodes. @internal */
-type LiteHost = LiteStaticSound | LiteStreamingSound | LiteAudioBus | LiteAudioInputSource;
-
 /** A bus a sound or bus can output to (mirrors AudioV2 `PrimaryAudioBus`). */
 export type PrimaryAudioBus = MainAudioBus | AudioBus;
 
-/** A node that can have a world transform (subset of the compat `Node`). @internal */
-interface SpatialNodeLike {
+/** A node that can have a world transform (subset of the compat `Node`). */
+export interface SpatialNodeLike {
     getAbsolutePosition?: () => { x: number; y: number; z: number };
     absolutePosition?: { x: number; y: number; z: number };
     position?: { x: number; y: number; z: number };

--- a/packages/babylon-lite-compat/src/audio/audio.ts
+++ b/packages/babylon-lite-compat/src/audio/audio.ts
@@ -1,0 +1,1627 @@
+/**
+ * Babylon.js AudioV2 (`AudioEngineV2` and friends) implemented on top of the
+ * Babylon Lite audio port.
+ *
+ * The Lite audio API is pure state + standalone functions (`createAudioEngineAsync`,
+ * `playSound`, `setBusVolume`, …); Babylon.js AudioV2 is a class hierarchy of
+ * `AbstractAudioNode` subclasses with mutable properties. This module reproduces
+ * the BJS class names, inheritance chain, and public members exactly, holding the
+ * corresponding Lite handle as `_lite` and proxying property get/set + methods to
+ * the Lite functions.
+ *
+ * Inheritance chain mirrored from `@babylonjs/core`:
+ *
+ *   AbstractAudioNode
+ *     └─ AbstractNamedAudioNode
+ *          └─ AbstractAudioOutNode            (volume / analyzer)
+ *               ├─ AbstractAudioBus → AudioBus / MainAudioBus
+ *               └─ AbstractSoundSource
+ *                    └─ AbstractSound → StaticSound / StreamingSound
+ *
+ * No module-level Web Audio allocation happens at import time, so a consumer that
+ * never touches audio pays nothing.
+ */
+
+import {
+    createAudioEngineAsync,
+    disposeAudioEngine,
+    unlockAudioEngineAsync,
+    setMasterVolume,
+    getMasterVolume,
+    createSoundAsync,
+    playSound,
+    pauseSound,
+    resumeSound,
+    stopSound,
+    disposeSound,
+    setSoundVolume,
+    createStreamingSoundAsync,
+    preloadStreamingInstanceAsync,
+    preloadStreamingInstancesAsync,
+    playStreamingSound,
+    pauseStreamingSound,
+    resumeStreamingSound,
+    stopStreamingSound,
+    disposeStreamingSound,
+    setStreamingSoundVolume,
+    createAudioBusAsync,
+    disposeAudioBus,
+    setBusVolume,
+    createSoundBufferAsync,
+    createSoundSourceAsync,
+    createMicrophoneSoundSourceAsync,
+    setSoundSourceVolume,
+    disposeSoundSource,
+    enableSpatial,
+    setSpatialPosition,
+    setSpatialOrientation,
+    setSpatialListener,
+    setSpatialListenerPosition,
+    updateSpatialAudio,
+    enableStereo,
+    setStereoPan,
+    enableAnalyzer,
+    getByteFrequencyData,
+    getFloatFrequencyData,
+    getByteTimeDomainData,
+    getFloatTimeDomainData,
+} from "babylon-lite";
+import type {
+    AudioEngine as LiteAudioEngine,
+    AudioEngineOptions as LiteAudioEngineOptions,
+    StaticSound as LiteStaticSound,
+    StreamingSound as LiteStreamingSound,
+    AudioBus as LiteAudioBus,
+    MainBus as LiteMainBus,
+    SoundBuffer as LiteSoundBuffer,
+    AudioInputSource as LiteAudioInputSource,
+    PrimaryAudioBus as LitePrimaryAudioBus,
+    StaticSoundOptions as LiteStaticSoundOptions,
+    StreamingSoundOptions as LiteStreamingSoundOptions,
+    SpatialSoundOptions as LiteSpatialSoundOptions,
+} from "babylon-lite";
+
+import { Observable } from "../misc/observable.js";
+import { Vector3 } from "../math/vector.js";
+import { Quaternion } from "../math/quaternion.js";
+import { unsupported } from "../error.js";
+import { SpatialAudioAttachmentType, toLiteRamp, type SoundState, type AudioAnalyzerFFTSizeType, type AudioEngineV2State, type IAudioParameterRampOptions } from "./audio-enums.js";
+
+/** Any Lite handle that can carry spatial / stereo / analyzer sub-nodes. @internal */
+type LiteHost = LiteStaticSound | LiteStreamingSound | LiteAudioBus | LiteAudioInputSource;
+
+/** A bus a sound or bus can output to (mirrors AudioV2 `PrimaryAudioBus`). */
+export type PrimaryAudioBus = MainAudioBus | AudioBus;
+
+/** A node that can have a world transform (subset of the compat `Node`). @internal */
+interface SpatialNodeLike {
+    getAbsolutePosition?: () => { x: number; y: number; z: number };
+    absolutePosition?: { x: number; y: number; z: number };
+    position?: { x: number; y: number; z: number };
+    rotationQuaternion?: { x: number; y: number; z: number; w: number } | null;
+}
+
+function readNodePosition(node: SpatialNodeLike | null): { x: number; y: number; z: number } | null {
+    if (!node) {
+        return null;
+    }
+    return node.getAbsolutePosition?.() ?? node.absolutePosition ?? node.position ?? null;
+}
+
+// ───────────────────────────── Options interfaces ────────────────────────────
+
+/** Babylon.js `IAudioEngineV2Options` (subset backed by Lite). */
+export interface IAudioEngineV2Options {
+    /** Default parameter ramp duration, in seconds. Defaults to `0.01`. */
+    parameterRampDuration: number;
+    /** Initial output volume. Defaults to `1`. */
+    volume: number;
+}
+
+/** Babylon.js `IWebAudioEngineOptions`. */
+export interface IWebAudioEngineOptions extends IAudioEngineV2Options {
+    /** An existing audio context (pass an `OfflineAudioContext` for headless rendering). */
+    audioContext: BaseAudioContext;
+    /** Auto-resume the context on user interaction. Defaults to `true`. */
+    resumeOnInteraction: boolean;
+    /** Auto-resume the context if the browser pauses playback. Defaults to `true`. */
+    resumeOnPause: boolean;
+    /** Retry interval (ms) for `resumeOnPause`. Defaults to `1000`. */
+    resumeOnPauseRetryInterval: number;
+}
+
+/** Babylon.js `IVolumeAudioOptions`. */
+export interface IVolumeAudioOptions {
+    /** Volume / gain. Defaults to `1`. */
+    volume: number;
+}
+
+/** Babylon.js `IAudioAnalyzerOptions`. */
+export interface IAudioAnalyzerOptions {
+    /** Build the analyzer immediately. Defaults to `false`. */
+    analyzerEnabled: boolean;
+    /** FFT window size. Defaults to `2048`. */
+    analyzerFFTSize: AudioAnalyzerFFTSizeType;
+    /** Minimum dB. Defaults to `-100`. */
+    analyzerMinDecibels: number;
+    /** Maximum dB. Defaults to `-30`. */
+    analyzerMaxDecibels: number;
+    /** Time-averaging constant `[0, 1]`. Defaults to `0.8`. */
+    analyzerSmoothing: number;
+}
+
+/** Babylon.js `IStereoAudioOptions`. */
+export interface IStereoAudioOptions {
+    /** Build stereo immediately. Defaults to `false`. */
+    stereoEnabled: boolean;
+    /** Pan `-1` (left) to `1` (right). Defaults to `0`. */
+    stereoPan: number;
+}
+
+/** Babylon.js `ISpatialAudioOptions` (subset backed by Lite). */
+export interface ISpatialAudioOptions {
+    /** Build spatial immediately. */
+    spatialEnabled: boolean;
+    /** Cone inner angle, radians. */
+    spatialConeInnerAngle: number;
+    /** Cone outer angle, radians. */
+    spatialConeOuterAngle: number;
+    /** Volume outside the cone. */
+    spatialConeOuterVolume: number;
+    /** Distance attenuation model. */
+    spatialDistanceModel: DistanceModelType;
+    /** Max distance. */
+    spatialMaxDistance: number;
+    /** Reference / min distance. */
+    spatialMinDistance: number;
+    /** Source facing direction. */
+    spatialOrientation: Vector3;
+    /** Enable left/right panning. */
+    spatialPanningEnabled: boolean;
+    /** Panning algorithm. */
+    spatialPanningModel: PanningModelType;
+    /** Source world position. */
+    spatialPosition: Vector3;
+    /** Roll-off factor. */
+    spatialRolloffFactor: number;
+    /** Source rotation quaternion. */
+    spatialRotationQuaternion: Quaternion;
+}
+
+/** Babylon.js `IStaticSoundBufferOptions`. */
+export interface IStaticSoundBufferOptions {
+    /** Skip codec checks when the source is a URL list. Defaults to `false`. */
+    skipCodecCheck: boolean;
+}
+
+/** Babylon.js `IAbstractSoundOptions` (subset). */
+export interface IAbstractSoundOptions extends Partial<IVolumeAudioOptions> {
+    /** Play immediately once ready. Defaults to `false`. */
+    autoplay?: boolean;
+    /** Maximum simultaneous instances. Defaults to `Infinity`. */
+    maxInstances?: number;
+    /** Loop playback. Defaults to `false`. */
+    loop?: boolean;
+    /** Start offset in seconds. Defaults to `0`. */
+    startOffset?: number;
+    /** Output bus. */
+    outBus?: PrimaryAudioBus;
+}
+
+/** Babylon.js `IStaticSoundOptions`. */
+export interface IStaticSoundOptions extends IAbstractSoundOptions, Partial<IStaticSoundBufferOptions> {
+    /** Play duration in seconds (`0` = full). */
+    duration?: number;
+    /** Loop end, seconds. */
+    loopEnd?: number;
+    /** Loop start, seconds. */
+    loopStart?: number;
+    /** Detune in cents. */
+    pitch?: number;
+    /** Playback rate multiplier. */
+    playbackRate?: number;
+}
+
+/** Babylon.js `IStaticSoundPlayOptions`. */
+export interface IStaticSoundPlayOptions {
+    /** Loop playback. */
+    loop?: boolean;
+    /** Start offset in seconds. */
+    startOffset?: number;
+    /** Play duration in seconds. */
+    duration?: number;
+    /** Loop start, seconds. */
+    loopStart?: number;
+    /** Loop end, seconds. */
+    loopEnd?: number;
+    /** Per-instance volume. */
+    volume?: number;
+    /** Delay before playback, seconds. */
+    waitTime?: number;
+}
+
+/** Babylon.js `IStaticSoundStopOptions`. */
+export interface IStaticSoundStopOptions {
+    /** Delay before stopping, seconds. */
+    waitTime?: number;
+}
+
+/** Babylon.js `IStaticSoundCloneOptions`. */
+export interface IStaticSoundCloneOptions {
+    /** Clone the underlying buffer (Lite reuses the same buffer). Defaults to `false`. */
+    cloneBuffer?: boolean;
+    /** Output bus for the clone. */
+    outBus?: PrimaryAudioBus | null;
+}
+
+/** Babylon.js `IStreamingSoundOptions`. */
+export interface IStreamingSoundOptions extends IAbstractSoundOptions {
+    /** Number of instances to preload. Defaults to `1`. */
+    preloadCount?: number;
+}
+
+/** Babylon.js `IStreamingSoundPlayOptions`. */
+export interface IStreamingSoundPlayOptions {
+    /** Loop playback. */
+    loop?: boolean;
+    /** Start offset in seconds. */
+    startOffset?: number;
+    /** Per-instance volume. */
+    volume?: number;
+}
+
+/** Babylon.js `IAudioBusOptions` (subset). */
+export interface IAudioBusOptions extends Partial<IVolumeAudioOptions> {
+    /** Output bus. Defaults to the engine's default main bus. */
+    outBus?: PrimaryAudioBus;
+}
+
+/** Babylon.js `IMainAudioBusOptions`. */
+export interface IMainAudioBusOptions extends Partial<IVolumeAudioOptions> {}
+
+/** Babylon.js `ISoundSourceOptions` (subset). */
+export interface ISoundSourceOptions extends Partial<IVolumeAudioOptions> {
+    /** Name. */
+    name?: string;
+    /** Output bus. */
+    outBus?: PrimaryAudioBus | null;
+    /** Auto-assign the default main bus when `outBus` is null. */
+    outBusAutoDefault?: boolean;
+}
+
+// ───────────────────────────── Node base classes ─────────────────────────────
+
+/** Babylon.js `AbstractAudioNode` — the root of the AudioV2 node hierarchy. */
+export abstract class AbstractAudioNode {
+    /** The engine that owns this node. */
+    public readonly engine: AudioEngineV2;
+    /** Fires when this node is disposed. */
+    public readonly onDisposeObservable = new Observable<AbstractAudioNode>();
+
+    protected constructor(engine: AudioEngineV2) {
+        this.engine = engine;
+    }
+
+    /** Disposes the node. */
+    public dispose(): void {
+        this.onDisposeObservable.notifyObservers(this);
+        this.onDisposeObservable.clear();
+    }
+
+    /** The class name (mirrors Babylon.js `getClassName()`). */
+    public abstract getClassName(): string;
+}
+
+/** Payload for `AbstractNamedAudioNode.onNameChangedObservable`. */
+export interface IAudioNodeNameChange {
+    /** The new name. */
+    newName: string;
+    /** The previous name. */
+    oldName: string;
+    /** The node whose name changed. */
+    node: AbstractNamedAudioNode;
+}
+
+/** Babylon.js `AbstractNamedAudioNode` — an `AbstractAudioNode` with a mutable name. */
+export abstract class AbstractNamedAudioNode extends AbstractAudioNode {
+    /** Fires when {@link name} changes. */
+    public readonly onNameChangedObservable = new Observable<IAudioNodeNameChange>();
+    private _name: string;
+
+    protected constructor(name: string, engine: AudioEngineV2) {
+        super(engine);
+        this._name = name;
+        engine._addNode(this);
+    }
+
+    /** The node name. */
+    public get name(): string {
+        return this._name;
+    }
+    public set name(value: string) {
+        const oldName = this._name;
+        if (oldName === value) {
+            return;
+        }
+        this._name = value;
+        this.onNameChangedObservable.notifyObservers({ newName: value, oldName, node: this });
+    }
+
+    public override dispose(): void {
+        this.engine._removeNode(this);
+        this.onNameChangedObservable.clear();
+        super.dispose();
+    }
+}
+
+/**
+ * Babylon.js `AbstractAudioOutNode` — a named node with a volume and a lazily
+ * created analyzer.
+ */
+export abstract class AbstractAudioOutNode extends AbstractNamedAudioNode {
+    protected _volume = 1;
+    private _analyzer: AbstractAudioAnalyzer | null = null;
+
+    /** The node output volume. */
+    public get volume(): number {
+        return this._volume;
+    }
+    public set volume(value: number) {
+        this.setVolume(value);
+    }
+
+    /** Lazily-built audio analyzer for this node's output. */
+    public get analyzer(): AbstractAudioAnalyzer {
+        return (this._analyzer ??= new AbstractAudioAnalyzer(this._spatialHost()));
+    }
+
+    /** Sets the volume, optionally ramping. */
+    public setVolume(value: number, options?: Partial<IAudioParameterRampOptions> | null): void {
+        this._volume = value;
+        this._applyVolume(value, options);
+    }
+
+    public override dispose(): void {
+        this._analyzer?.dispose();
+        this._analyzer = null;
+        super.dispose();
+    }
+
+    /** @internal Apply the volume to the backing Lite handle. */
+    protected abstract _applyVolume(value: number, options?: Partial<IAudioParameterRampOptions> | null): void;
+    /** @internal The Lite host used to back spatial/stereo/analyzer sub-nodes. */
+    protected abstract _spatialHost(): LiteHost;
+}
+
+// ───────────────────────────── Sub-properties ────────────────────────────────
+
+/** Babylon.js `AbstractStereoAudio` — the `sound.stereo` / `bus.stereo` sub-property. */
+export class AbstractStereoAudio {
+    private readonly _host: LiteHost;
+    private _pan = 0;
+    private _enabled = false;
+
+    /** @internal */
+    public constructor(host: LiteHost) {
+        this._host = host;
+    }
+
+    /** Stereo pan, `-1` (left) to `1` (right). */
+    public get pan(): number {
+        return this._pan;
+    }
+    public set pan(value: number) {
+        this._pan = value;
+        if (!this._enabled) {
+            enableStereo(this._host, { pan: value });
+            this._enabled = true;
+        } else {
+            setStereoPan(this._host, value);
+        }
+    }
+}
+
+/** Babylon.js `AbstractAudioAnalyzer` — the `sound.analyzer` / `bus.analyzer` sub-property. */
+export class AbstractAudioAnalyzer {
+    private readonly _host: LiteHost;
+    private _fftSize: AudioAnalyzerFFTSizeType = 2048;
+    private _minDecibels = -100;
+    private _maxDecibels = -30;
+    private _smoothing = 0.8;
+    private _enabled = false;
+
+    /** @internal */
+    public constructor(host: LiteHost) {
+        this._host = host;
+    }
+
+    /** FFT window size. */
+    public get fftSize(): AudioAnalyzerFFTSizeType {
+        return this._fftSize;
+    }
+    public set fftSize(value: AudioAnalyzerFFTSizeType) {
+        this._fftSize = value;
+        this._reapply();
+    }
+
+    /** Number of frequency bins (`fftSize / 2`). */
+    public get frequencyBinCount(): number {
+        return this._fftSize / 2;
+    }
+
+    /** Whether the analyzer is enabled. */
+    public get isEnabled(): boolean {
+        return this._enabled;
+    }
+
+    /** Minimum dB. */
+    public get minDecibels(): number {
+        return this._minDecibels;
+    }
+    public set minDecibels(value: number) {
+        this._minDecibels = value;
+        this._reapply();
+    }
+
+    /** Maximum dB. */
+    public get maxDecibels(): number {
+        return this._maxDecibels;
+    }
+    public set maxDecibels(value: number) {
+        this._maxDecibels = value;
+        this._reapply();
+    }
+
+    /** Time-averaging constant `[0, 1]`. */
+    public get smoothing(): number {
+        return this._smoothing;
+    }
+    public set smoothing(value: number) {
+        this._smoothing = value;
+        this._reapply();
+    }
+
+    /** Builds (enables) the analyzer tap. */
+    public async enableAsync(): Promise<void> {
+        this._apply();
+    }
+
+    /** Returns the byte frequency-domain data. Empty when disabled. */
+    public getByteFrequencyData(): Uint8Array {
+        if (!this._enabled) {
+            return new Uint8Array(0);
+        }
+        const out = new Uint8Array(this.frequencyBinCount);
+        getByteFrequencyData(this._host, out);
+        return out;
+    }
+
+    /** Returns the float frequency-domain data. Empty when disabled. */
+    public getFloatFrequencyData(): Float32Array {
+        if (!this._enabled) {
+            return new Float32Array(0);
+        }
+        const out = new Float32Array(this.frequencyBinCount);
+        getFloatFrequencyData(this._host, out);
+        return out;
+    }
+
+    /** Returns the byte time-domain data. Empty when disabled. */
+    public getByteTimeDomainData(): Uint8Array {
+        if (!this._enabled) {
+            return new Uint8Array(0);
+        }
+        const out = new Uint8Array(this._fftSize);
+        getByteTimeDomainData(this._host, out);
+        return out;
+    }
+
+    /** Returns the float time-domain data. Empty when disabled. */
+    public getFloatTimeDomainData(): Float32Array {
+        if (!this._enabled) {
+            return new Float32Array(0);
+        }
+        const out = new Float32Array(this._fftSize);
+        getFloatTimeDomainData(this._host, out);
+        return out;
+    }
+
+    /** Disposes the analyzer (Lite tears it down with the host). */
+    public dispose(): void {
+        this._enabled = false;
+    }
+
+    private _apply(): void {
+        enableAnalyzer(this._host, {
+            fftSize: this._fftSize,
+            minDecibels: this._minDecibels,
+            maxDecibels: this._maxDecibels,
+            smoothing: this._smoothing,
+        });
+        this._enabled = true;
+    }
+
+    private _reapply(): void {
+        if (this._enabled) {
+            this._apply();
+        }
+    }
+}
+
+/** Babylon.js `AbstractSpatialAudio` — the `sound.spatial` / `bus.spatial` sub-property. */
+export class AbstractSpatialAudio {
+    private readonly _host: LiteHost;
+    private _enabled = false;
+
+    private _position = new Vector3(0, 0, 0);
+    private _orientation = new Vector3(1, 0, 0);
+    private _rotationQuaternion = new Quaternion(0, 0, 0, 1);
+
+    /** Cone inner angle, radians. */
+    public coneInnerAngle = 2 * Math.PI;
+    /** Cone outer angle, radians. */
+    public coneOuterAngle = 2 * Math.PI;
+    /** Volume outside the cone. */
+    public coneOuterVolume = 0;
+    /** Distance attenuation model. */
+    public distanceModel: DistanceModelType = "linear";
+    /** Max distance. */
+    public maxDistance = 10000;
+    /** Reference / min distance. */
+    public minDistance = 1;
+    /** Minimum time between auto-updates, seconds. */
+    public minUpdateTime = 0;
+    /** Enable left/right panning. */
+    public panningEnabled = true;
+    /** Panning algorithm. */
+    public panningModel: PanningModelType = "equalpower";
+    /** Roll-off factor. */
+    public rolloffFactor = 1;
+    /** Whether following a scene node. */
+    public useBoundingBox = false;
+    /** Which transform components are followed. */
+    public attachmentType: SpatialAudioAttachmentType = SpatialAudioAttachmentType.PositionAndRotation;
+
+    private _attachedNode: SpatialNodeLike | null = null;
+
+    /** @internal */
+    public constructor(host: LiteHost) {
+        this._host = host;
+    }
+
+    /** Source world position. */
+    public get position(): Vector3 {
+        return this._position;
+    }
+    public set position(value: Vector3) {
+        this._position = value;
+        this._ensure();
+        setSpatialPosition(this._host, value);
+    }
+
+    /** Source facing direction. */
+    public get orientation(): Vector3 {
+        return this._orientation;
+    }
+    public set orientation(value: Vector3) {
+        this._orientation = value;
+        this._ensure();
+        setSpatialOrientation(this._host, value);
+    }
+
+    /** Source rotation quaternion. */
+    public get rotationQuaternion(): Quaternion {
+        return this._rotationQuaternion;
+    }
+    public set rotationQuaternion(value: Quaternion) {
+        this._rotationQuaternion = value;
+        this._reapply();
+    }
+
+    /** Whether attached to a scene node. */
+    public get isAttached(): boolean {
+        return this._attachedNode !== null;
+    }
+
+    /** The scene node this source follows, if any. */
+    public get attachedNode(): SpatialNodeLike | null {
+        return this._attachedNode;
+    }
+
+    /** Follows a scene node's world transform. */
+    public attach(sceneNode: SpatialNodeLike | null, useBoundingBox = false, attachmentType: SpatialAudioAttachmentType = SpatialAudioAttachmentType.PositionAndRotation): void {
+        this._attachedNode = sceneNode;
+        this.useBoundingBox = useBoundingBox;
+        this.attachmentType = attachmentType;
+        this._ensure();
+        this.update();
+    }
+
+    /** Stops following a scene node. */
+    public detach(): void {
+        this._attachedNode = null;
+    }
+
+    /** Pulls the attached node's current world position/rotation into the source. */
+    public update(): void {
+        const pos = readNodePosition(this._attachedNode);
+        if (pos) {
+            this._position = new Vector3(pos.x, pos.y, pos.z);
+            this._ensure();
+            setSpatialPosition(this._host, pos);
+        }
+    }
+
+    /** Disposes the spatial sub-node (Lite tears it down with the host). */
+    public dispose(): void {
+        this._attachedNode = null;
+        this._enabled = false;
+    }
+
+    private _ensure(): void {
+        if (!this._enabled) {
+            enableSpatial(this._host, this._options());
+            this._enabled = true;
+        }
+    }
+
+    private _reapply(): void {
+        if (this._enabled) {
+            enableSpatial(this._host, this._options());
+        }
+    }
+
+    private _options(): LiteSpatialSoundOptions {
+        return {
+            position: this._position,
+            orientation: this._orientation,
+            rotationQuaternion: this._rotationQuaternion,
+            panningEnabled: this.panningEnabled,
+            panningModel: this.panningModel,
+            distanceModel: this.distanceModel,
+            minDistance: this.minDistance,
+            maxDistance: this.maxDistance,
+            rolloffFactor: this.rolloffFactor,
+            coneInnerAngle: this.coneInnerAngle,
+            coneOuterAngle: this.coneOuterAngle,
+            coneOuterVolume: this.coneOuterVolume,
+        };
+    }
+}
+
+/** Babylon.js `AbstractSpatialAudioListener` — the engine's `listener` (the "ears"). */
+export class AbstractSpatialAudioListener {
+    private readonly _engine: LiteAudioEngine;
+    private _position = new Vector3(0, 0, 0);
+    private _rotation = new Vector3(0, 0, 0);
+    private _rotationQuaternion = new Quaternion(0, 0, 0, 1);
+    private _attachedNode: SpatialNodeLike | null = null;
+
+    /** Minimum time between auto-updates, seconds. */
+    public minUpdateTime = 0;
+
+    /** @internal */
+    public constructor(engine: LiteAudioEngine) {
+        this._engine = engine;
+    }
+
+    /** Whether attached to a scene node. */
+    public get isAttached(): boolean {
+        return this._attachedNode !== null;
+    }
+
+    /** The scene node the listener follows, if any. */
+    public get attachedNode(): SpatialNodeLike | null {
+        return this._attachedNode;
+    }
+
+    /** Listener world position. */
+    public get position(): Vector3 {
+        return this._position;
+    }
+    public set position(value: Vector3) {
+        this._position = value;
+        setSpatialListenerPosition(this._engine, value);
+    }
+
+    /** Listener Euler rotation. */
+    public get rotation(): Vector3 {
+        return this._rotation;
+    }
+    public set rotation(value: Vector3) {
+        this._rotation = value;
+    }
+
+    /** Listener rotation quaternion. */
+    public get rotationQuaternion(): Quaternion {
+        return this._rotationQuaternion;
+    }
+    public set rotationQuaternion(value: Quaternion) {
+        this._rotationQuaternion = value;
+        setSpatialListener(this._engine, { rotationQuaternion: value });
+    }
+
+    /** Follows a scene node's world transform. */
+    public attach(sceneNode: SpatialNodeLike | null): void {
+        this._attachedNode = sceneNode;
+        this.update();
+    }
+
+    /** Stops following a scene node. */
+    public detach(): void {
+        this._attachedNode = null;
+    }
+
+    /** Pulls the attached node's current world position into the listener. */
+    public update(): void {
+        const pos = readNodePosition(this._attachedNode);
+        if (pos) {
+            this._position = new Vector3(pos.x, pos.y, pos.z);
+            setSpatialListenerPosition(this._engine, pos);
+        }
+        updateSpatialAudio(this._engine);
+    }
+}
+
+// ───────────────────────────── Buses ─────────────────────────────────────────
+
+/** Babylon.js `AbstractAudioBus` — base class for both bus kinds. */
+export abstract class AbstractAudioBus extends AbstractAudioOutNode {}
+
+/** Babylon.js `AudioBus` — a generic mixer bus. */
+export class AudioBus extends AbstractAudioBus {
+    /** @internal The backing Lite bus. */
+    public readonly _lite: LiteAudioBus;
+    private _spatial: AbstractSpatialAudio | null = null;
+    private _stereo: AbstractStereoAudio | null = null;
+    private _outBus: PrimaryAudioBus | null;
+
+    /** @internal */
+    public constructor(engine: AudioEngineV2, lite: LiteAudioBus, outBus: PrimaryAudioBus | null) {
+        super(lite.name, engine);
+        this._lite = lite;
+        this._outBus = outBus;
+    }
+
+    /** The output bus this bus routes to. */
+    public get outBus(): PrimaryAudioBus | null {
+        return this._outBus;
+    }
+    public set outBus(value: PrimaryAudioBus | null) {
+        this._outBus = value;
+    }
+
+    /** Lazily-built spatial sub-property. */
+    public get spatial(): AbstractSpatialAudio {
+        return (this._spatial ??= new AbstractSpatialAudio(this._lite));
+    }
+
+    /** Lazily-built stereo sub-property. */
+    public get stereo(): AbstractStereoAudio {
+        return (this._stereo ??= new AbstractStereoAudio(this._lite));
+    }
+
+    public getClassName(): string {
+        return "AudioBus";
+    }
+
+    public override dispose(): void {
+        disposeAudioBus(this._lite);
+        super.dispose();
+    }
+
+    protected _applyVolume(value: number, options?: Partial<IAudioParameterRampOptions> | null): void {
+        setBusVolume(this._lite, value, toLiteRamp(options));
+    }
+
+    protected _spatialHost(): LiteHost {
+        return this._lite;
+    }
+}
+
+/** Babylon.js `MainAudioBus` — a bus that connects directly to the engine output. */
+export class MainAudioBus extends AbstractAudioBus {
+    /** @internal The backing Lite main bus. */
+    public readonly _lite: LiteMainBus;
+
+    /** @internal */
+    public constructor(engine: AudioEngineV2, lite: LiteMainBus) {
+        super(lite.name, engine);
+        this._lite = lite;
+    }
+
+    public getClassName(): string {
+        return "MainAudioBus";
+    }
+
+    protected _applyVolume(value: number, options?: Partial<IAudioParameterRampOptions> | null): void {
+        setBusVolume(this._lite as LitePrimaryAudioBus, value, toLiteRamp(options));
+    }
+
+    protected _spatialHost(): LiteHost {
+        // The Lite main bus is not an `AudioGraphHost`; spatial/stereo/analyzer
+        // are not available on a main bus (matching the BJS `MainAudioBus`, which
+        // exposes neither). Accessing `.analyzer` on a main bus is unsupported.
+        return unsupported("MainAudioBus.analyzer", "Main buses have no analyzer; attach one to a sound or generic AudioBus instead.");
+    }
+}
+
+// ───────────────────────────── Sound source / sounds ─────────────────────────
+
+/** Babylon.js `AbstractSoundSource` — an out-node with an output bus + spatial/stereo. */
+export abstract class AbstractSoundSource extends AbstractAudioOutNode {
+    private _spatial: AbstractSpatialAudio | null = null;
+    private _stereo: AbstractStereoAudio | null = null;
+    protected _outBus: PrimaryAudioBus | null;
+
+    protected constructor(name: string, engine: AudioEngineV2, outBus: PrimaryAudioBus | null) {
+        super(name, engine);
+        this._outBus = outBus;
+    }
+
+    /** The output bus this source routes to. */
+    public get outBus(): PrimaryAudioBus | null {
+        return this._outBus;
+    }
+    public set outBus(value: PrimaryAudioBus | null) {
+        this._outBus = value;
+    }
+
+    /** Lazily-built spatial sub-property. */
+    public get spatial(): AbstractSpatialAudio {
+        return (this._spatial ??= new AbstractSpatialAudio(this._spatialHost()));
+    }
+
+    /** Lazily-built stereo sub-property. */
+    public get stereo(): AbstractStereoAudio {
+        return (this._stereo ??= new AbstractStereoAudio(this._spatialHost()));
+    }
+}
+
+/** A live input source (e.g. microphone) wrapping a Lite `AudioInputSource`. */
+export class SoundSource extends AbstractSoundSource {
+    /** @internal The backing Lite input source. */
+    public readonly _lite: LiteAudioInputSource;
+
+    /** @internal */
+    public constructor(engine: AudioEngineV2, lite: LiteAudioInputSource, outBus: PrimaryAudioBus | null) {
+        super(lite.name, engine, outBus);
+        this._lite = lite;
+    }
+
+    public getClassName(): string {
+        return "SoundSource";
+    }
+
+    public override dispose(): void {
+        disposeSoundSource(this._lite);
+        super.dispose();
+    }
+
+    protected _applyVolume(value: number, options?: Partial<IAudioParameterRampOptions> | null): void {
+        setSoundSourceVolume(this._lite, value, toLiteRamp(options));
+    }
+
+    protected _spatialHost(): LiteHost {
+        return this._lite;
+    }
+}
+
+/** Babylon.js `AbstractSound` — a playable sound (static or streaming). */
+export abstract class AbstractSound extends AbstractSoundSource {
+    /** Fires when the sound finishes (all instances ended). */
+    public readonly onEndedObservable = new Observable<AbstractSound>();
+
+    protected constructor(name: string, engine: AudioEngineV2, outBus: PrimaryAudioBus | null) {
+        super(name, engine, outBus);
+        engine._addSound(this);
+    }
+
+    /** Number of live playing instances. */
+    public abstract get activeInstancesCount(): number;
+    /** Whether the sound auto-plays on creation. */
+    public abstract get autoplay(): boolean;
+    /** Current playback state. */
+    public abstract get state(): SoundState;
+
+    /** Whether the sound loops. */
+    public abstract get loop(): boolean;
+    public abstract set loop(value: boolean);
+
+    /** Start offset, seconds. */
+    public abstract get startOffset(): number;
+    public abstract set startOffset(value: number);
+
+    /** Maximum simultaneous instances. */
+    public abstract get maxInstances(): number;
+    public abstract set maxInstances(value: number);
+
+    /** Current playback time of the newest instance, seconds. */
+    public abstract get currentTime(): number;
+    public abstract set currentTime(value: number);
+
+    /** Plays the sound. */
+    public abstract play(options?: Partial<IStaticSoundPlayOptions & IStreamingSoundPlayOptions>): void;
+    /** Pauses the sound. */
+    public abstract pause(): void;
+    /** Resumes the sound. */
+    public abstract resume(options?: Partial<IStaticSoundPlayOptions & IStreamingSoundPlayOptions>): void;
+    /** Stops the sound. */
+    public abstract stop(options?: Partial<IStaticSoundStopOptions>): void;
+
+    public override dispose(): void {
+        this.engine._removeSound(this);
+        this.onEndedObservable.clear();
+        super.dispose();
+    }
+}
+
+/** Babylon.js `StaticSoundBuffer` — a decoded buffer wrapping a Lite `SoundBuffer`. */
+export class StaticSoundBuffer {
+    /** The engine that owns this buffer. */
+    public readonly engine: AudioEngineV2;
+    /** The buffer name. */
+    public name: string;
+    /** @internal The backing Lite sound buffer. */
+    public readonly _lite: LiteSoundBuffer;
+
+    /** @internal */
+    public constructor(engine: AudioEngineV2, lite: LiteSoundBuffer, name = "StaticSoundBuffer") {
+        this.engine = engine;
+        this._lite = lite;
+        this.name = name;
+    }
+
+    /** Sample rate, Hz. */
+    public get sampleRate(): number {
+        return this._lite.sampleRate;
+    }
+    /** Length in sample frames. */
+    public get length(): number {
+        return this._lite.length;
+    }
+    /** Duration, seconds. */
+    public get duration(): number {
+        return this._lite.duration;
+    }
+    /** Number of channels. */
+    public get channelCount(): number {
+        return this._lite.channelCount;
+    }
+
+    /** Clones the buffer. Lite buffers are immutable, so the clone shares the data. */
+    public clone(options?: Partial<{ name: string }>): StaticSoundBuffer {
+        return new StaticSoundBuffer(this.engine, this._lite, options?.name ?? this.name);
+    }
+}
+
+/** Babylon.js `StaticSound` — a buffer-backed sound wrapping a Lite `StaticSound`. */
+export class StaticSound extends AbstractSound {
+    /** @internal The backing Lite static sound. */
+    public readonly _lite: LiteStaticSound;
+    private readonly _autoplay: boolean;
+    private _buffer: StaticSoundBuffer;
+
+    /** @internal */
+    public constructor(engine: AudioEngineV2, lite: LiteStaticSound, buffer: StaticSoundBuffer, outBus: PrimaryAudioBus | null, autoplay: boolean) {
+        super(lite.name ?? "Sound", engine, outBus);
+        this._lite = lite;
+        this._buffer = buffer;
+        this._autoplay = autoplay;
+        lite.onEnded.add(() => this.onEndedObservable.notifyObservers(this));
+    }
+
+    /** The decoded buffer this sound plays. */
+    public get buffer(): StaticSoundBuffer {
+        return this._buffer;
+    }
+
+    public get activeInstancesCount(): number {
+        return this._lite.instanceCount;
+    }
+    public get autoplay(): boolean {
+        return this._autoplay;
+    }
+    public get state(): SoundState {
+        return this._lite.state as SoundState;
+    }
+
+    public get loop(): boolean {
+        return this._lite._options.loop;
+    }
+    public set loop(value: boolean) {
+        this._lite._options.loop = value;
+    }
+
+    public get startOffset(): number {
+        return this._lite._options.startOffset;
+    }
+    public set startOffset(value: number) {
+        this._lite._options.startOffset = value;
+    }
+
+    public get maxInstances(): number {
+        return this._lite._options.maxInstances;
+    }
+    public set maxInstances(value: number) {
+        this._lite._options.maxInstances = value;
+    }
+
+    public get duration(): number {
+        return this._lite._options.duration;
+    }
+    public set duration(value: number) {
+        this._lite._options.duration = value;
+    }
+
+    public get loopStart(): number {
+        return this._lite._options.loopStart;
+    }
+    public set loopStart(value: number) {
+        this._lite._options.loopStart = value;
+    }
+
+    public get loopEnd(): number {
+        return this._lite._options.loopEnd;
+    }
+    public set loopEnd(value: number) {
+        this._lite._options.loopEnd = value;
+    }
+
+    public get pitch(): number {
+        return this._lite._options.pitch;
+    }
+    public set pitch(value: number) {
+        this._lite._options.pitch = value;
+        for (const instance of this._lite._instances) {
+            if (instance._sourceNode) {
+                instance._sourceNode.detune.value = value;
+            }
+        }
+    }
+
+    public get playbackRate(): number {
+        return this._lite._options.playbackRate;
+    }
+    public set playbackRate(value: number) {
+        this._lite._options.playbackRate = value;
+        for (const instance of this._lite._instances) {
+            if (instance._sourceNode) {
+                instance._sourceNode.playbackRate.value = value;
+            }
+        }
+    }
+
+    public get currentTime(): number {
+        return this.startOffset;
+    }
+    public set currentTime(value: number) {
+        this.startOffset = value;
+    }
+
+    public play(options?: Partial<IStaticSoundPlayOptions>): void {
+        playSound(this._lite, options);
+    }
+
+    public pause(): void {
+        pauseSound(this._lite);
+    }
+
+    public resume(options?: Partial<IStaticSoundPlayOptions>): void {
+        resumeSound(this._lite, options);
+    }
+
+    public stop(options?: Partial<IStaticSoundStopOptions>): void {
+        stopSound(this._lite, options);
+    }
+
+    /** Clones the sound (shares the decoded buffer). */
+    public async cloneAsync(options?: Partial<IStaticSoundCloneOptions>): Promise<StaticSound> {
+        const outBus = (options?.outBus as PrimaryAudioBus | undefined) ?? this._outBus ?? undefined;
+        return this.engine.createSoundAsync(this.name, this._buffer, { outBus });
+    }
+
+    public getClassName(): string {
+        return "StaticSound";
+    }
+
+    public override dispose(): void {
+        disposeSound(this._lite);
+        super.dispose();
+    }
+
+    protected _applyVolume(value: number, options?: Partial<IAudioParameterRampOptions> | null): void {
+        setSoundVolume(this._lite, value, toLiteRamp(options));
+    }
+
+    protected _spatialHost(): LiteHost {
+        return this._lite;
+    }
+}
+
+/** Babylon.js `StreamingSound` — a media-element-backed sound. */
+export class StreamingSound extends AbstractSound {
+    /** @internal The backing Lite streaming sound. */
+    public readonly _lite: LiteStreamingSound;
+    private readonly _autoplay: boolean;
+    private _loop: boolean;
+    private _startOffset: number;
+    private _maxInstances: number;
+
+    /** @internal */
+    public constructor(engine: AudioEngineV2, lite: LiteStreamingSound, outBus: PrimaryAudioBus | null, options: Partial<IStreamingSoundOptions>) {
+        super(lite.name ?? "Sound", engine, outBus);
+        this._lite = lite;
+        this._autoplay = options.autoplay ?? false;
+        this._loop = options.loop ?? false;
+        this._startOffset = options.startOffset ?? 0;
+        this._maxInstances = options.maxInstances ?? Infinity;
+        lite.onEnded.add(() => this.onEndedObservable.notifyObservers(this));
+    }
+
+    /** Number of instances configured to preload. */
+    public get preloadCount(): number {
+        return this._lite._options.preloadCount;
+    }
+
+    /** Number of instances that have finished preloading. */
+    public get preloadCompletedCount(): number {
+        return this._lite.preloadCompletedCount;
+    }
+
+    public get activeInstancesCount(): number {
+        return this._lite.instanceCount;
+    }
+    public get autoplay(): boolean {
+        return this._autoplay;
+    }
+    public get state(): SoundState {
+        return this._lite.state as SoundState;
+    }
+
+    public get loop(): boolean {
+        return this._loop;
+    }
+    public set loop(value: boolean) {
+        this._loop = value;
+        this._lite._options.loop = value;
+    }
+
+    public get startOffset(): number {
+        return this._startOffset;
+    }
+    public set startOffset(value: number) {
+        this._startOffset = value;
+        this._lite._options.startOffset = value;
+    }
+
+    public get maxInstances(): number {
+        return this._maxInstances;
+    }
+    public set maxInstances(value: number) {
+        this._maxInstances = value;
+        this._lite._options.maxInstances = value;
+    }
+
+    public get currentTime(): number {
+        return this._startOffset;
+    }
+    public set currentTime(value: number) {
+        this.startOffset = value;
+    }
+
+    public play(options?: Partial<IStreamingSoundPlayOptions>): void {
+        playStreamingSound(this._lite, options);
+    }
+
+    public pause(): void {
+        pauseStreamingSound(this._lite);
+    }
+
+    public resume(options?: Partial<IStreamingSoundPlayOptions>): void {
+        resumeStreamingSound(this._lite, options);
+    }
+
+    public stop(): void {
+        stopStreamingSound(this._lite);
+    }
+
+    /** Preloads a single instance. */
+    public preloadInstanceAsync(): Promise<void> {
+        return preloadStreamingInstanceAsync(this._lite);
+    }
+
+    /** Preloads `count` instances. */
+    public preloadInstancesAsync(count: number): Promise<void> {
+        return preloadStreamingInstancesAsync(this._lite, count);
+    }
+
+    public getClassName(): string {
+        return "StreamingSound";
+    }
+
+    public override dispose(): void {
+        disposeStreamingSound(this._lite);
+        super.dispose();
+    }
+
+    protected _applyVolume(value: number, options?: Partial<IAudioParameterRampOptions> | null): void {
+        setStreamingSoundVolume(this._lite, value, toLiteRamp(options));
+    }
+
+    protected _spatialHost(): LiteHost {
+        return this._lite;
+    }
+}
+
+// ───────────────────────────── Engine ────────────────────────────────────────
+
+const FormatMimeTypes: { [key: string]: string } = {
+    aac: "audio/aac",
+    ac3: "audio/ac3",
+    flac: "audio/flac",
+    m4a: "audio/mp4",
+    mp3: 'audio/mpeg; codecs="mp3"',
+    mp4: "audio/mp4",
+    ogg: 'audio/ogg; codecs="vorbis"',
+    wav: "audio/wav",
+    webm: 'audio/webm; codecs="vorbis"',
+};
+
+/** Source accepted by `createSoundAsync` / `createSoundBufferAsync`. */
+export type StaticSoundSource = ArrayBuffer | AudioBuffer | StaticSoundBuffer | string | string[];
+
+function unwrapBus(bus: PrimaryAudioBus | null | undefined): LitePrimaryAudioBus | undefined {
+    if (!bus) {
+        return undefined;
+    }
+    return (bus as AudioBus | MainAudioBus)._lite as LitePrimaryAudioBus;
+}
+
+function unwrapBufferSource(source: StaticSoundSource): ArrayBuffer | AudioBuffer | LiteSoundBuffer | string | string[] {
+    if (source instanceof StaticSoundBuffer) {
+        return source._lite;
+    }
+    return source;
+}
+
+/**
+ * Babylon.js `AudioEngineV2` — the AudioV2 engine. Backed by a Lite audio engine.
+ * Created via {@link CreateAudioEngineAsync}.
+ */
+export class AudioEngineV2 {
+    private static _Instances: AudioEngineV2[] = [];
+    /** All live audio engines. */
+    public static get Instances(): readonly AudioEngineV2[] {
+        return AudioEngineV2._Instances;
+    }
+
+    /** Fires when a named node is added to the engine. */
+    public readonly onNodeAddedObservable = new Observable<AbstractNamedAudioNode>();
+    /** Fires when a named node is removed from the engine. */
+    public readonly onNodeRemovedObservable = new Observable<AbstractNamedAudioNode>();
+    /** Fires when the engine is disposed. */
+    public readonly onDisposeObservable = new Observable<AudioEngineV2>();
+
+    /** @internal The backing Lite audio engine. */
+    public readonly _lite: LiteAudioEngine;
+
+    private readonly _sounds = new Set<AbstractSound>();
+    private readonly _nodes = new Set<AbstractNamedAudioNode>();
+    private _defaultMainBus: MainAudioBus | null = null;
+    private _listener: AbstractSpatialAudioListener | null = null;
+    private _mainOut: AbstractAudioNode | null = null;
+
+    /** @internal */
+    public constructor(lite: LiteAudioEngine) {
+        this._lite = lite;
+        AudioEngineV2._Instances.push(this);
+    }
+
+    /** The audio context's current time, seconds. */
+    public get currentTime(): number {
+        return this._lite.currentTime;
+    }
+
+    /** The context state. */
+    public get state(): AudioEngineV2State {
+        return this._lite.state;
+    }
+
+    /** Master output volume. */
+    public get volume(): number {
+        return getMasterVolume(this._lite);
+    }
+    public set volume(value: number) {
+        setMasterVolume(this._lite, value);
+    }
+
+    /** Default parameter ramp duration, seconds. */
+    public get parameterRampDuration(): number {
+        return this._lite._rampDuration;
+    }
+    public set parameterRampDuration(value: number) {
+        this._lite._rampDuration = value;
+    }
+
+    /** The default main bus all sounds route to. */
+    public get defaultMainBus(): MainAudioBus | null {
+        return (this._defaultMainBus ??= new MainAudioBus(this, this._lite._mainBus));
+    }
+
+    /** The spatial-audio listener (the "ears"). */
+    public get listener(): AbstractSpatialAudioListener {
+        return (this._listener ??= new AbstractSpatialAudioListener(this._lite));
+    }
+
+    /** The engine output node. */
+    public get mainOut(): AbstractAudioNode {
+        return (this._mainOut ??= new MainOutNode(this));
+    }
+
+    /** All live sounds. */
+    public get sounds(): readonly AbstractSound[] {
+        return Array.from(this._sounds);
+    }
+
+    /** All live named nodes. */
+    public get nodes(): ReadonlySet<AbstractNamedAudioNode> {
+        return this._nodes;
+    }
+
+    /** Sets the master volume, optionally ramping. */
+    public setVolume(value: number, options?: Partial<IAudioParameterRampOptions>): void {
+        setMasterVolume(this._lite, value, toLiteRamp(options));
+    }
+
+    /** Whether the given audio format/extension can be decoded. */
+    public isFormatValid(format: string): boolean {
+        const mimeType = FormatMimeTypes[format.toLowerCase()];
+        if (mimeType === undefined) {
+            return false;
+        }
+        if (typeof Audio === "undefined") {
+            return true;
+        }
+        return new Audio().canPlayType(mimeType) !== "";
+    }
+
+    /** Suspends the engine context. */
+    public async pauseAsync(): Promise<void> {
+        const ctx = this._lite._ctx as AudioContext;
+        if (typeof ctx.suspend === "function" && ctx.state === "running") {
+            await ctx.suspend();
+        }
+    }
+
+    /** Resumes the engine context. */
+    public async resumeAsync(): Promise<void> {
+        await unlockAudioEngineAsync(this._lite);
+    }
+
+    /** Resumes the engine context (alias of {@link resumeAsync}). */
+    public async unlockAsync(): Promise<void> {
+        await unlockAudioEngineAsync(this._lite);
+    }
+
+    /** Creates a buffer-backed sound. */
+    public async createSoundAsync(name: string, source: StaticSoundSource, options?: Partial<IStaticSoundOptions>): Promise<StaticSound> {
+        const liteOptions = toLiteStaticSoundOptions(name, options);
+        const lite = await createSoundAsync(this._lite, unwrapBufferSource(source), liteOptions);
+        const buffer = new StaticSoundBuffer(this, lite.buffer, name);
+        return new StaticSound(this, lite, buffer, (options?.outBus as PrimaryAudioBus | undefined) ?? this.defaultMainBus, options?.autoplay ?? false);
+    }
+
+    /** Creates a decoded sound buffer. */
+    public async createSoundBufferAsync(source: StaticSoundSource, options?: Partial<IStaticSoundBufferOptions>): Promise<StaticSoundBuffer> {
+        const lite = await createSoundBufferAsync(this._lite, unwrapBufferSource(source), { skipCodecCheck: options?.skipCodecCheck });
+        return new StaticSoundBuffer(this, lite);
+    }
+
+    /** Creates a streaming, media-element-backed sound. */
+    public async createStreamingSoundAsync(_name: string, source: HTMLMediaElement | string | string[], options?: Partial<IStreamingSoundOptions>): Promise<StreamingSound> {
+        const liteOptions: LiteStreamingSoundOptions = {
+            autoplay: options?.autoplay,
+            loop: options?.loop,
+            maxInstances: options?.maxInstances,
+            outBus: unwrapBus(options?.outBus) as LitePrimaryAudioBus | undefined,
+            preloadCount: options?.preloadCount,
+            startOffset: options?.startOffset,
+            volume: options?.volume,
+        };
+        const lite = await createStreamingSoundAsync(this._lite, source, liteOptions);
+        return new StreamingSound(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? this.defaultMainBus, options ?? {});
+    }
+
+    /** Creates a generic mixer bus. */
+    public async createBusAsync(name: string, options?: Partial<IAudioBusOptions>): Promise<AudioBus> {
+        const lite = await createAudioBusAsync(this._lite, name, {
+            volume: options?.volume,
+            outBus: unwrapBus(options?.outBus) as LitePrimaryAudioBus | undefined,
+        });
+        return new AudioBus(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? this.defaultMainBus);
+    }
+
+    /**
+     * Creates a main bus. Babylon Lite builds a single default main bus per engine
+     * and does not expose creating additional ones, so this resolves the default
+     * main bus.
+     */
+    public async createMainBusAsync(_name: string, _options?: Partial<IMainAudioBusOptions>): Promise<MainAudioBus> {
+        return this.defaultMainBus as MainAudioBus;
+    }
+
+    /** Wraps an arbitrary Web Audio node as a sound source. */
+    public async createSoundSourceAsync(name: string, source: AudioNode, options?: Partial<ISoundSourceOptions>): Promise<SoundSource> {
+        const lite = await createSoundSourceAsync(this._lite, source, {
+            name,
+            outBus: unwrapBus(options?.outBus) as LitePrimaryAudioBus | undefined,
+            outBusAutoDefault: options?.outBusAutoDefault,
+            volume: options?.volume,
+        });
+        return new SoundSource(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? null);
+    }
+
+    /** Creates a microphone-backed sound source. */
+    public async createMicrophoneSoundSourceAsync(name: string, options?: Partial<ISoundSourceOptions>): Promise<SoundSource> {
+        const lite = await createMicrophoneSoundSourceAsync(this._lite, {
+            name,
+            outBus: unwrapBus(options?.outBus) as LitePrimaryAudioBus | undefined,
+            outBusAutoDefault: options?.outBusAutoDefault,
+            volume: options?.volume,
+        });
+        return new SoundSource(this, lite, (options?.outBus as PrimaryAudioBus | undefined) ?? null);
+    }
+
+    /** Disposes the engine and all its sounds/buses. */
+    public dispose(): void {
+        disposeAudioEngine(this._lite);
+        this.onDisposeObservable.notifyObservers(this);
+        this.onDisposeObservable.clear();
+        this.onNodeAddedObservable.clear();
+        this.onNodeRemovedObservable.clear();
+        this._sounds.clear();
+        this._nodes.clear();
+        const i = AudioEngineV2._Instances.indexOf(this);
+        if (i !== -1) {
+            AudioEngineV2._Instances.splice(i, 1);
+        }
+        if (LastCreatedEngine === this) {
+            LastCreatedEngine = null;
+        }
+    }
+
+    /** @internal */
+    public _addSound(sound: AbstractSound): void {
+        this._sounds.add(sound);
+    }
+    /** @internal */
+    public _removeSound(sound: AbstractSound): void {
+        this._sounds.delete(sound);
+    }
+    /** @internal */
+    public _addNode(node: AbstractNamedAudioNode): void {
+        this._nodes.add(node);
+        this.onNodeAddedObservable.notifyObservers(node);
+    }
+    /** @internal */
+    public _removeNode(node: AbstractNamedAudioNode): void {
+        if (this._nodes.delete(node)) {
+            this.onNodeRemovedObservable.notifyObservers(node);
+        }
+    }
+}
+
+/** The engine output node returned by `engine.mainOut`. */
+class MainOutNode extends AbstractAudioNode {
+    public constructor(engine: AudioEngineV2) {
+        super(engine);
+    }
+    public getClassName(): string {
+        return "_MainAudioOut";
+    }
+}
+
+// ───────────────────────────── Option mapping ────────────────────────────────
+
+function toLiteStaticSoundOptions(_name: string, options?: Partial<IStaticSoundOptions>): LiteStaticSoundOptions {
+    return {
+        autoplay: options?.autoplay,
+        duration: options?.duration,
+        loop: options?.loop,
+        loopEnd: options?.loopEnd,
+        loopStart: options?.loopStart,
+        maxInstances: options?.maxInstances,
+        outBus: unwrapBus(options?.outBus) as LitePrimaryAudioBus | undefined,
+        pitch: options?.pitch,
+        playbackRate: options?.playbackRate,
+        startOffset: options?.startOffset,
+        volume: options?.volume,
+        skipCodecCheck: options?.skipCodecCheck,
+    };
+}
+
+function toLiteEngineOptions(options?: Partial<IWebAudioEngineOptions>): LiteAudioEngineOptions {
+    return {
+        audioContext: options?.audioContext,
+        volume: options?.volume,
+        parameterRampDuration: options?.parameterRampDuration,
+        resumeOnInteraction: options?.resumeOnInteraction,
+        resumeOnPause: options?.resumeOnPause,
+        resumeOnPauseRetryInterval: options?.resumeOnPauseRetryInterval,
+    };
+}
+
+// ───────────────────────────── Factory functions ─────────────────────────────
+
+/**
+ * Module-level "last created engine", mirroring Babylon.js. Assigning a primitive
+ * default is bundler-safe (no allocation at import time) and the compat package is
+ * excluded from Lite bundle ceilings.
+ */
+let LastCreatedEngine: AudioEngineV2 | null = null;
+
+/** Babylon.js `OnAudioEngineV2CreatedObservable` — fires when an engine is created. */
+export const OnAudioEngineV2CreatedObservable = new Observable<AudioEngineV2>();
+
+/** Babylon.js `LastCreatedAudioEngine()` — the most recently created engine, if any. */
+export function LastCreatedAudioEngine(): AudioEngineV2 | null {
+    return LastCreatedEngine;
+}
+
+function resolveEngine(engine?: AudioEngineV2 | null): AudioEngineV2 {
+    const resolved = engine ?? LastCreatedEngine;
+    if (!resolved) {
+        return unsupported("AudioV2 factory", "No audio engine available. Call CreateAudioEngineAsync(...) first or pass an engine.");
+    }
+    return resolved;
+}
+
+/** Babylon.js `CreateAudioEngineAsync` — creates and initialises an AudioV2 engine. */
+export async function CreateAudioEngineAsync(options?: Partial<IWebAudioEngineOptions>): Promise<AudioEngineV2> {
+    const lite = await createAudioEngineAsync(toLiteEngineOptions(options));
+    const engine = new AudioEngineV2(lite);
+    LastCreatedEngine = engine;
+    OnAudioEngineV2CreatedObservable.notifyObservers(engine);
+    return engine;
+}
+
+/** Babylon.js `CreateSoundAsync`. */
+export function CreateSoundAsync(name: string, source: StaticSoundSource, options?: Partial<IStaticSoundOptions>, engine?: AudioEngineV2 | null): Promise<StaticSound> {
+    return resolveEngine(engine).createSoundAsync(name, source, options);
+}
+
+/** Babylon.js `CreateSoundBufferAsync`. */
+export function CreateSoundBufferAsync(source: StaticSoundSource, options?: Partial<IStaticSoundBufferOptions>, engine?: AudioEngineV2 | null): Promise<StaticSoundBuffer> {
+    return resolveEngine(engine).createSoundBufferAsync(source, options);
+}
+
+/** Babylon.js `CreateStreamingSoundAsync`. */
+export function CreateStreamingSoundAsync(
+    name: string,
+    source: HTMLMediaElement | string | string[],
+    options?: Partial<IStreamingSoundOptions>,
+    engine?: AudioEngineV2 | null
+): Promise<StreamingSound> {
+    return resolveEngine(engine).createStreamingSoundAsync(name, source, options);
+}
+
+/** Babylon.js `CreateAudioBusAsync`. */
+export function CreateAudioBusAsync(name: string, options?: Partial<IAudioBusOptions>, engine?: AudioEngineV2 | null): Promise<AudioBus> {
+    return resolveEngine(engine).createBusAsync(name, options);
+}
+
+/** Babylon.js `CreateMainAudioBusAsync`. */
+export function CreateMainAudioBusAsync(name: string, options?: Partial<IMainAudioBusOptions>, engine?: AudioEngineV2 | null): Promise<MainAudioBus> {
+    return resolveEngine(engine).createMainBusAsync(name, options);
+}
+
+/** Babylon.js `CreateSoundSourceAsync`. */
+export function CreateSoundSourceAsync(name: string, source: AudioNode, options?: Partial<ISoundSourceOptions>, engine?: AudioEngineV2 | null): Promise<SoundSource> {
+    return resolveEngine(engine).createSoundSourceAsync(name, source, options);
+}
+
+/** Babylon.js `CreateMicrophoneSoundSourceAsync`. */
+export function CreateMicrophoneSoundSourceAsync(name: string, options?: Partial<ISoundSourceOptions>, engine?: AudioEngineV2 | null): Promise<SoundSource> {
+    return resolveEngine(engine).createMicrophoneSoundSourceAsync(name, options);
+}

--- a/packages/babylon-lite-compat/src/index.ts
+++ b/packages/babylon-lite-compat/src/index.ts
@@ -195,6 +195,7 @@ export {
 export type {
     PrimaryAudioBus,
     StaticSoundSource,
+    SpatialNodeLike,
     IAudioNodeNameChange,
     IAudioEngineV2Options,
     IWebAudioEngineOptions,

--- a/packages/babylon-lite-compat/src/index.ts
+++ b/packages/babylon-lite-compat/src/index.ts
@@ -160,6 +160,61 @@ export {
     ActionManagerTriggers,
 } from "./actions/actions.js";
 
+// ─── Audio (AudioV2) ─────────────────────────────────────────────────
+export { SoundState, AudioParameterRampShape, SpatialAudioAttachmentType } from "./audio/audio-enums.js";
+export type { AudioAnalyzerFFTSizeType, AudioEngineV2State, IAudioParameterRampOptions } from "./audio/audio-enums.js";
+export {
+    AbstractAudioNode,
+    AbstractNamedAudioNode,
+    AbstractAudioOutNode,
+    AbstractAudioBus,
+    AudioBus,
+    MainAudioBus,
+    AbstractSoundSource,
+    SoundSource,
+    AbstractSound,
+    StaticSound,
+    StreamingSound,
+    StaticSoundBuffer,
+    AudioEngineV2,
+    AbstractSpatialAudio,
+    AbstractSpatialAudioListener,
+    AbstractStereoAudio,
+    AbstractAudioAnalyzer,
+    CreateAudioEngineAsync,
+    CreateSoundAsync,
+    CreateSoundBufferAsync,
+    CreateStreamingSoundAsync,
+    CreateAudioBusAsync,
+    CreateMainAudioBusAsync,
+    CreateSoundSourceAsync,
+    CreateMicrophoneSoundSourceAsync,
+    LastCreatedAudioEngine,
+    OnAudioEngineV2CreatedObservable,
+} from "./audio/audio.js";
+export type {
+    PrimaryAudioBus,
+    StaticSoundSource,
+    IAudioNodeNameChange,
+    IAudioEngineV2Options,
+    IWebAudioEngineOptions,
+    IVolumeAudioOptions,
+    IAudioAnalyzerOptions,
+    IStereoAudioOptions,
+    ISpatialAudioOptions,
+    IStaticSoundBufferOptions,
+    IAbstractSoundOptions,
+    IStaticSoundOptions,
+    IStaticSoundPlayOptions,
+    IStaticSoundStopOptions,
+    IStaticSoundCloneOptions,
+    IStreamingSoundOptions,
+    IStreamingSoundPlayOptions,
+    IAudioBusOptions,
+    IMainAudioBusOptions,
+    ISoundSourceOptions,
+} from "./audio/audio.js";
+
 // ─── Known but unsupported (throw LiteCompatError on use) ─────────────
 export {
     MultiMaterial,

--- a/packages/babylon-lite-compat/tests/audio.test.ts
+++ b/packages/babylon-lite-compat/tests/audio.test.ts
@@ -305,6 +305,82 @@ describe("SoundSource", () => {
     });
 });
 
+describe("review-feedback fixes", () => {
+    it("StaticSound uses the caller-provided name over the Lite handle and the creation volume", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const lite = makeFakeLiteStaticSound(); // lite.name === "shoot"
+        const buffer = new StaticSoundBuffer(engine, lite.buffer, "explosion");
+        const sound = new StaticSound(engine, lite, buffer, engine.defaultMainBus, false, "explosion", 0.3);
+        expect(sound.name).toBe("explosion");
+        expect(sound.volume).toBe(0.3);
+        engine.dispose();
+    });
+
+    it("StreamingSound initializes volume from creation options and uses the caller name", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const lite: any = { name: "fallback", state: SoundState.Stopped, instanceCount: 0, preloadCompletedCount: 0, onEnded: makeSignal(), _options: {} };
+        const sound = new StreamingSound(engine, lite, engine.defaultMainBus, { volume: 0.7 }, "track");
+        expect(sound.name).toBe("track");
+        expect(sound.volume).toBe(0.7);
+        engine.dispose();
+    });
+
+    it("AudioBus and SoundSource initialize volume from the creation volume", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const bus = new AudioBus(engine, { name: "music" } as any, engine.defaultMainBus, 0.25);
+        const source = new SoundSource(engine, { name: "mic", _instances: new Set() } as any, null, 0.6);
+        expect(bus.volume).toBe(0.25);
+        expect(source.volume).toBe(0.6);
+        engine.dispose();
+    });
+
+    it("AudioBus.outBus reassignment reroutes the Lite output graph", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const connected: any[] = [];
+        const disconnected: any[] = [];
+        const tail = { connect: (n: any) => connected.push(n), disconnect: (n: any) => disconnected.push(n) };
+        const oldIn = { id: "old-in" };
+        const newIn = { id: "new-in" };
+        const oldLiteBus: any = { name: "old", _graph: { _in: oldIn } };
+        const newLiteBus: any = { name: "new", _graph: { _in: newIn } };
+        const oldCompat = new AudioBus(engine, oldLiteBus, null);
+        const newCompat = new AudioBus(engine, newLiteBus, null);
+        const liteBus: any = { name: "src", _graph: { _in: {}, _out: tail }, _outBus: oldLiteBus };
+        const bus = new AudioBus(engine, liteBus, oldCompat);
+
+        bus.outBus = newCompat;
+
+        expect(disconnected).toContain(oldIn);
+        expect(connected).toContain(newIn);
+        expect(bus.outBus).toBe(newCompat);
+        expect(liteBus._outBus).toBe(newLiteBus);
+
+        // Reassigning to the same bus is a no-op (no extra connect calls).
+        const connectsBefore = connected.length;
+        bus.outBus = newCompat;
+        expect(connected.length).toBe(connectsBefore);
+        engine.dispose();
+    });
+
+    it("SoundSource.outBus reassignment reroutes the Lite output graph", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const connected: any[] = [];
+        const tail = { connect: (n: any) => connected.push(n), disconnect() {} };
+        const newIn = { id: "new-in" };
+        const newLiteBus: any = { name: "new", _graph: { _in: newIn } };
+        const newCompat = new AudioBus(engine, newLiteBus, null);
+        const liteSource: any = { name: "mic", _instances: new Set(), _graph: { _in: {}, _out: tail }, _outBus: null };
+        const source = new SoundSource(engine, liteSource, null);
+
+        source.outBus = newCompat;
+
+        expect(connected).toContain(newIn);
+        expect(source.outBus).toBe(newCompat);
+        expect(liteSource._outBus).toBe(newLiteBus);
+        engine.dispose();
+    });
+});
+
 describe("sub-properties (defaults)", () => {
     it("AbstractSpatialAudio exposes Babylon.js defaults before enabling", () => {
         const spatial = new AbstractSpatialAudio({} as any);

--- a/packages/babylon-lite-compat/tests/audio.test.ts
+++ b/packages/babylon-lite-compat/tests/audio.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    SoundState,
+    AudioParameterRampShape,
+    SpatialAudioAttachmentType,
+    AbstractAudioNode,
+    AbstractNamedAudioNode,
+    AbstractAudioOutNode,
+    AbstractAudioBus,
+    AbstractSoundSource,
+    AbstractSound,
+    AudioBus,
+    MainAudioBus,
+    SoundSource,
+    StaticSound,
+    StreamingSound,
+    StaticSoundBuffer,
+    AudioEngineV2,
+    AbstractSpatialAudio,
+    AbstractStereoAudio,
+    AbstractAudioAnalyzer,
+    AbstractSpatialAudioListener,
+    CreateSoundAsync,
+    CreateAudioBusAsync,
+    LastCreatedAudioEngine,
+    LiteCompatError,
+} from "../src/index";
+import { toLiteRamp } from "../src/audio/audio-enums";
+
+/**
+ * GPU-free coverage for the AudioV2 compat wrappers. Node has no Web Audio
+ * device, so the real Lite audio functions (which build `AudioContext` graph
+ * nodes) cannot run here. These tests exercise the pure-logic surface: enum
+ * values, ramp-option mapping, property get/set proxying against a minimal fake
+ * Lite handle, the class hierarchy / `instanceof` chain, observable wiring, and
+ * the throwing paths. The full graph behaviour is covered by the Lite audio
+ * suite, which renders an `OfflineAudioContext` to PCM.
+ */
+
+function makeSignal<T>(): { add(cb: (v: T) => void): () => void; _fire(v: T): void } {
+    const cbs: Array<(v: T) => void> = [];
+    return {
+        add(cb) {
+            cbs.push(cb);
+            return () => cbs.splice(cbs.indexOf(cb), 1);
+        },
+        _fire(v) {
+            for (const cb of cbs.slice()) {
+                cb(v);
+            }
+        },
+    };
+}
+
+/** A minimal fake Lite audio engine that `AudioEngineV2` + `disposeAudioEngine` tolerate. */
+function makeFakeLiteEngine(): any {
+    return {
+        currentTime: 1.5,
+        state: "running",
+        _rampDuration: 0.01,
+        _volume: 1,
+        _ctx: { state: "closed" },
+        _isOffline: true,
+        _mainBus: { name: "default", _volume: { disconnect() {} } },
+        _mainOut: { _gain: { disconnect() {} } },
+        _sounds: new Set(),
+        _buses: new Set(),
+        _spatialUpdaters: new Set(),
+        _spatialAutoStop: null,
+        _listener: null,
+        _disposers: [],
+        _onStateChanged: { _clear() {} },
+        _onUserGesture: { _clear() {} },
+    };
+}
+
+/** A minimal fake Lite StaticSound carrying the stored-options bag the wrapper proxies. */
+function makeFakeLiteStaticSound(): any {
+    return {
+        name: "shoot",
+        state: SoundState.Stopped,
+        instanceCount: 0,
+        buffer: { duration: 2, sampleRate: 48000, channelCount: 2, length: 96000 },
+        onEnded: makeSignal(),
+        _instances: new Set(),
+        _options: {
+            autoplay: false,
+            duration: 0,
+            loop: false,
+            loopEnd: 0,
+            loopStart: 0,
+            maxInstances: Infinity,
+            pitch: 0,
+            playbackRate: 1,
+            startOffset: 0,
+        },
+    };
+}
+
+describe("AudioV2 enums", () => {
+    it("SoundState matches Babylon.js values", () => {
+        expect(SoundState.Stopping).toBe(0);
+        expect(SoundState.Stopped).toBe(1);
+        expect(SoundState.Starting).toBe(2);
+        expect(SoundState.Started).toBe(3);
+        expect(SoundState.FailedToStart).toBe(4);
+        expect(SoundState.Paused).toBe(5);
+    });
+
+    it("AudioParameterRampShape matches Babylon.js values", () => {
+        expect(AudioParameterRampShape.Linear).toBe("linear");
+        expect(AudioParameterRampShape.Exponential).toBe("exponential");
+        expect(AudioParameterRampShape.Logarithmic).toBe("logarithmic");
+        expect(AudioParameterRampShape.None).toBe("none");
+    });
+
+    it("SpatialAudioAttachmentType matches Babylon.js values", () => {
+        expect(SpatialAudioAttachmentType.Position).toBe(1);
+        expect(SpatialAudioAttachmentType.Rotation).toBe(2);
+        expect(SpatialAudioAttachmentType.PositionAndRotation).toBe(3);
+    });
+
+    it("maps ramp options to the Lite shape", () => {
+        expect(toLiteRamp(undefined)).toBeUndefined();
+        expect(toLiteRamp({ duration: 0.5, shape: AudioParameterRampShape.Exponential })).toEqual({ duration: 0.5, shape: "exponential" });
+    });
+});
+
+describe("AudioEngineV2", () => {
+    it("reads state/currentTime/volume from the Lite engine", () => {
+        const lite = makeFakeLiteEngine();
+        const engine = new AudioEngineV2(lite);
+        expect(engine.state).toBe("running");
+        expect(engine.currentTime).toBe(1.5);
+        lite._volume = 0.42;
+        expect(engine.volume).toBe(0.42);
+        engine.dispose();
+    });
+
+    it("proxies parameterRampDuration to the Lite engine", () => {
+        const lite = makeFakeLiteEngine();
+        const engine = new AudioEngineV2(lite);
+        expect(engine.parameterRampDuration).toBe(0.01);
+        engine.parameterRampDuration = 0.25;
+        expect(lite._rampDuration).toBe(0.25);
+        engine.dispose();
+    });
+
+    it("exposes the default main bus, listener and main out", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        expect(engine.defaultMainBus).toBeInstanceOf(MainAudioBus);
+        expect(engine.defaultMainBus).toBe(engine.defaultMainBus); // cached
+        expect(engine.listener).toBeInstanceOf(AbstractSpatialAudioListener);
+        expect(engine.mainOut.getClassName()).toBe("_MainAudioOut");
+        engine.dispose();
+    });
+
+    it("validates audio formats via mime types", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        expect(engine.isFormatValid("mp3")).toBe(true);
+        expect(engine.isFormatValid("xyz")).toBe(false);
+        engine.dispose();
+    });
+
+    it("tracks live engines in the static Instances array and untracks on dispose", () => {
+        const before = AudioEngineV2.Instances.length;
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        expect(AudioEngineV2.Instances.length).toBe(before + 1);
+        engine.dispose();
+        expect(AudioEngineV2.Instances.length).toBe(before);
+    });
+
+    it("tracks created sounds in the sounds list", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const buffer = new StaticSoundBuffer(engine, makeFakeLiteStaticSound().buffer);
+        const sound = new StaticSound(engine, makeFakeLiteStaticSound(), buffer, engine.defaultMainBus, false);
+        expect(engine.sounds).toContain(sound);
+        engine.dispose();
+    });
+});
+
+describe("StaticSound", () => {
+    function build(): { engine: AudioEngineV2; lite: any; sound: StaticSound } {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const lite = makeFakeLiteStaticSound();
+        const buffer = new StaticSoundBuffer(engine, lite.buffer, "shoot");
+        const sound = new StaticSound(engine, lite, buffer, engine.defaultMainBus, false);
+        return { engine, lite, sound };
+    }
+
+    it("mirrors the Babylon.js class hierarchy", () => {
+        const { sound } = build();
+        expect(sound).toBeInstanceOf(AbstractSound);
+        expect(sound).toBeInstanceOf(AbstractSoundSource);
+        expect(sound).toBeInstanceOf(AbstractAudioOutNode);
+        expect(sound).toBeInstanceOf(AbstractNamedAudioNode);
+        expect(sound).toBeInstanceOf(AbstractAudioNode);
+        expect(sound.getClassName()).toBe("StaticSound");
+    });
+
+    it("reads state, name and buffer metadata from the Lite handle", () => {
+        const { sound, lite } = build();
+        expect(sound.name).toBe("shoot");
+        expect(sound.state).toBe(SoundState.Stopped);
+        lite.state = SoundState.Started;
+        expect(sound.state).toBe(SoundState.Started);
+        expect(sound.activeInstancesCount).toBe(0);
+        expect(sound.buffer.duration).toBe(2);
+        expect(sound.buffer.sampleRate).toBe(48000);
+        expect(sound.buffer.channelCount).toBe(2);
+    });
+
+    it("proxies stored playback options to the Lite options bag", () => {
+        const { sound, lite } = build();
+        sound.loop = true;
+        sound.startOffset = 0.5;
+        sound.maxInstances = 3;
+        sound.duration = 1.2;
+        sound.loopStart = 0.1;
+        sound.loopEnd = 1.9;
+        expect(lite._options).toMatchObject({ loop: true, startOffset: 0.5, maxInstances: 3, duration: 1.2, loopStart: 0.1, loopEnd: 1.9 });
+        // getters reflect the same bag
+        expect(sound.loop).toBe(true);
+        expect(sound.startOffset).toBe(0.5);
+        expect(sound.currentTime).toBe(0.5); // currentTime aliases startOffset
+    });
+
+    it("propagates pitch and playbackRate to active instances", () => {
+        const { sound, lite } = build();
+        const instance = { _sourceNode: { detune: { value: 0 }, playbackRate: { value: 1 } } };
+        lite._instances.add(instance);
+        sound.pitch = 600;
+        sound.playbackRate = 1.5;
+        expect(lite._options.pitch).toBe(600);
+        expect(lite._options.playbackRate).toBe(1.5);
+        expect(instance._sourceNode.detune.value).toBe(600);
+        expect(instance._sourceNode.playbackRate.value).toBe(1.5);
+    });
+
+    it("fires onEndedObservable when the Lite sound ends", () => {
+        const { sound, lite } = build();
+        let fired: AbstractSound | null = null;
+        sound.onEndedObservable.add((s) => (fired = s));
+        lite.onEnded._fire(lite);
+        expect(fired).toBe(sound);
+    });
+});
+
+describe("StreamingSound", () => {
+    it("mirrors the hierarchy and proxies preload counts", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const lite: any = {
+            name: "music",
+            state: SoundState.Stopped,
+            instanceCount: 0,
+            preloadCompletedCount: 2,
+            onEnded: makeSignal(),
+            _options: { autoplay: false, loop: false, maxInstances: Infinity, preloadCount: 3, startOffset: 0 },
+        };
+        const sound = new StreamingSound(engine, lite, engine.defaultMainBus, { preloadCount: 3 });
+        expect(sound).toBeInstanceOf(AbstractSound);
+        expect(sound.getClassName()).toBe("StreamingSound");
+        expect(sound.preloadCount).toBe(3);
+        expect(sound.preloadCompletedCount).toBe(2);
+        sound.loop = true;
+        expect(lite._options.loop).toBe(true);
+        engine.dispose();
+    });
+});
+
+describe("AudioBus / MainAudioBus", () => {
+    it("AudioBus mirrors the bus hierarchy and exposes spatial/stereo", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const liteBus: any = { name: "music" };
+        const bus = new AudioBus(engine, liteBus, engine.defaultMainBus);
+        expect(bus).toBeInstanceOf(AbstractAudioBus);
+        expect(bus).toBeInstanceOf(AbstractAudioOutNode);
+        expect(bus.getClassName()).toBe("AudioBus");
+        expect(bus.name).toBe("music");
+        expect(bus.spatial).toBeInstanceOf(AbstractSpatialAudio);
+        expect(bus.stereo).toBeInstanceOf(AbstractStereoAudio);
+        expect(bus.outBus).toBe(engine.defaultMainBus);
+        engine.dispose();
+    });
+
+    it("MainAudioBus has no analyzer (unsupported on a main bus)", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const bus = engine.defaultMainBus!;
+        expect(bus).toBeInstanceOf(MainAudioBus);
+        expect(() => bus.analyzer).toThrow(LiteCompatError);
+        engine.dispose();
+    });
+});
+
+describe("SoundSource", () => {
+    it("mirrors the source hierarchy", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const lite: any = { name: "mic", _instances: new Set() };
+        const source = new SoundSource(engine, lite, null);
+        expect(source).toBeInstanceOf(AbstractSoundSource);
+        expect(source).toBeInstanceOf(AbstractAudioOutNode);
+        expect(source.getClassName()).toBe("SoundSource");
+        engine.dispose();
+    });
+});
+
+describe("sub-properties (defaults)", () => {
+    it("AbstractSpatialAudio exposes Babylon.js defaults before enabling", () => {
+        const spatial = new AbstractSpatialAudio({} as any);
+        expect(spatial.position.x).toBe(0);
+        expect(spatial.coneInnerAngle).toBeCloseTo(2 * Math.PI);
+        expect(spatial.maxDistance).toBe(10000);
+        expect(spatial.minDistance).toBe(1);
+        expect(spatial.panningModel).toBe("equalpower");
+        expect(spatial.distanceModel).toBe("linear");
+        expect(spatial.isAttached).toBe(false);
+        expect(spatial.attachedNode).toBeNull();
+    });
+
+    it("AbstractStereoAudio defaults to centre pan", () => {
+        const stereo = new AbstractStereoAudio({} as any);
+        expect(stereo.pan).toBe(0);
+    });
+
+    it("AbstractAudioAnalyzer exposes defaults and empty data while disabled", () => {
+        const analyzer = new AbstractAudioAnalyzer({} as any);
+        expect(analyzer.fftSize).toBe(2048);
+        expect(analyzer.frequencyBinCount).toBe(1024);
+        expect(analyzer.isEnabled).toBe(false);
+        expect(analyzer.getByteFrequencyData()).toHaveLength(0);
+        expect(analyzer.getFloatFrequencyData()).toHaveLength(0);
+        expect(analyzer.getByteTimeDomainData()).toHaveLength(0);
+        expect(analyzer.getFloatTimeDomainData()).toHaveLength(0);
+    });
+});
+
+describe("named-node observables", () => {
+    it("fires onNameChangedObservable when a node is renamed", () => {
+        const engine = new AudioEngineV2(makeFakeLiteEngine());
+        const bus = new AudioBus(engine, { name: "a" } as any, null);
+        let change: { newName: string; oldName: string } | null = null;
+        bus.onNameChangedObservable.add((c) => (change = c));
+        bus.name = "b";
+        expect(change).toMatchObject({ newName: "b", oldName: "a" });
+        engine.dispose();
+    });
+
+    it("fires engine node-added/removed observables", () => {
+        const liteEngine = makeFakeLiteEngine();
+        const engine = new AudioEngineV2(liteEngine);
+        let added: unknown = null;
+        let removed: unknown = null;
+        engine.onNodeAddedObservable.add((n) => (added = n));
+        engine.onNodeRemovedObservable.add((n) => (removed = n));
+        const liteBus: any = {
+            name: "a",
+            _engine: liteEngine,
+            _graph: { _spatial: null, _stereo: null, _analyzer: null, _root: { disconnect() {} }, _volume: { disconnect() {} } },
+        };
+        const bus = new AudioBus(engine, liteBus, null);
+        expect(added).toBe(bus);
+        expect(engine.nodes.has(bus)).toBe(true);
+        bus.dispose();
+        expect(removed).toBe(bus);
+        expect(engine.nodes.has(bus)).toBe(false);
+        engine.dispose();
+    });
+});
+
+describe("factory functions without an engine", () => {
+    it("throw a discoverable error when no engine exists", () => {
+        // No engine has been created in this test, so LastCreatedAudioEngine is null.
+        expect(LastCreatedAudioEngine()).toBeNull();
+        expect(() => CreateSoundAsync("s", "x.mp3")).toThrow(LiteCompatError);
+        expect(() => CreateAudioBusAsync("b")).toThrow(LiteCompatError);
+    });
+});


### PR DESCRIPTION
Automated sync of `@babylonjs/lite-compat` against the latest Babylon.js and Babylon Lite changes,
produced by the [`update-compat-layer`](.github/copilot/skills/update-compat-layer.md) skill.

Addresses #296.

**Synced against BJS commit:** `c729b94f2e36f2d915415620857452f7ad0ff731`

### Validation (run independently by the pipeline)
- ✅ compat unit tests
- ✅ compat typecheck

### Changed files
- `ackages/babylon-lite-compat/COMPAT-STATUS.md`
- `packages/babylon-lite-compat/README.md`
- `packages/babylon-lite-compat/src/index.ts`
- `packages/babylon-lite-compat/src/audio/`
- `packages/babylon-lite-compat/tests/audio.test.ts`

> Validation passed. Please review the wrapper changes and the updated `COMPAT-STATUS.md` before merging.

> Opened as a **draft** by the compat-sync pipeline. Review and mark ready when satisfied.