### PR TITLE
docs: mention @babylonjs/lite-compat in the Lite porting guide

### DIFF
--- a/docs/lite/03-porting-guide.md
+++ b/docs/lite/03-porting-guide.md
@@ -2,6 +2,25 @@
 
 This guide shows how to translate a Babylon.js (BJS) scene to Babylon Lite, side by side. Babylon Lite uses **factory functions** instead of constructors, **plain data** instead of class instances, and explicit `addToScene()` instead of auto-registration.
 
+> **Not ready for a full rewrite? Start with `@babylonjs/lite-compat`.** The
+> [`@babylonjs/lite-compat`](https://www.npmjs.com/package/@babylonjs/lite-compat)
+> package is an opt-in, **Babylon.js-shaped** compatibility layer built on top of
+> the native Lite API described below. It keeps the familiar class-based surface
+> (`new WebGPUEngine`, `new Scene`, `new ArcRotateCamera`, `MeshBuilder`,
+> `StandardMaterial`, …), so an existing BJS scene runs on Lite's WebGPU renderer
+> with little or no code change — and its bundler plugins (Vite / Rollup /
+> Webpack / esbuild) can even **rewrite your existing `@babylonjs/core`,
+> `@babylonjs/loaders`, `@babylonjs/addons`, and `@babylonjs/materials` imports
+> at build time**, so you don't touch a single import. Unsupported APIs throw
+> `LiteCompatError` rather than mis-rendering. The intended path is:
+>
+> ```
+> @babylonjs/core  →  @babylonjs/lite-compat  →  babylon-lite (native)
+> ```
+>
+> Use lite-compat to get running fast, then port to the native factory-function
+> API in this guide (smaller bundles, full tree-shaking) at your own pace.
+
 ---
 
 ## Quick Reference

--- a/docs/lite/03-porting-guide.md
+++ b/docs/lite/03-porting-guide.md
@@ -15,7 +15,7 @@ This guide shows how to translate a Babylon.js (BJS) scene to Babylon Lite, side
 > `LiteCompatError` rather than mis-rendering. The intended path is:
 >
 > ```
-> @babylonjs/core  →  @babylonjs/lite-compat  →  babylon-lite (native)
+> @babylonjs/core  →  @babylonjs/lite-compat  →  @babylonjs/lite (native)
 > ```
 >
 > Use lite-compat to get running fast, then port to the native factory-function


### PR DESCRIPTION
## What

Adds a callout to the **Babylon.js → Babylon Lite** porting guide (`docs/lite/03-porting-guide.md`) introducing the opt-in [`@babylonjs/lite-compat`](https://www.npmjs.com/package/@babylonjs/lite-compat) compatibility layer as a lower-friction first step before a full native port.

## Why

Developers migrating an existing Babylon.js app may not be ready for a full rewrite to Lite's factory-function API. The compat layer lets them run on Lite's WebGPU renderer with little/no code change (its bundler plugins can even rewrite `@babylonjs/*` imports at build time), then port to the native API at their own pace. The guide is the natural place to surface that path.

## Notes

- Links to the **published npm package**, not an internal repo `.md`, so the reference resolves correctly once these docs are published to the website.
- Documentation-only change — no build/test impact.