### PR TITLE
feat(effect): support array/cube view dimensions in effect texture bindings

### DIFF
--- a/packages/babylon-lite/src/effect/effect-renderer.ts
+++ b/packages/babylon-lite/src/effect/effect-renderer.ts
@@ -23,6 +23,9 @@ export interface EffectBindingLayout {
     visibility?: GPUShaderStageFlags;
     uniformByteLength?: number;
     textureSampleType?: GPUTextureSampleType;
+    /** Texture view dimension for a `texture` binding (default `"2d"`). Set `"2d-array"`/`"cube"`/… so a
+     *  fullscreen effect can sample an array/cube texture (e.g. the CSM cascade depth array). */
+    viewDimension?: GPUTextureViewDimension;
     samplerType?: GPUSamplerBindingType;
     textureBinding?: string | number;
 }
@@ -498,7 +501,7 @@ function bindingLayoutEntry(layout: EffectBindingLayout): GPUBindGroupLayoutEntr
         return { binding: layout.binding, visibility, buffer: { type: "uniform" } };
     }
     if (layout.kind === "texture") {
-        return { binding: layout.binding, visibility, texture: { sampleType: layout.textureSampleType ?? "float" } };
+        return { binding: layout.binding, visibility, texture: { sampleType: layout.textureSampleType ?? "float", viewDimension: layout.viewDimension ?? "2d" } };
     }
     return { binding: layout.binding, visibility, sampler: { type: layout.samplerType ?? "filtering" } };
 }

--- a/scene-config.json
+++ b/scene-config.json
@@ -804,7 +804,7 @@
         "slug": "scene75-effect-rtt-sphere",
         "name": "Scene 75 — Effect RTT Sphere",
         "maxMad": 0.05,
-        "maxRawKB": 50.3,
+        "maxRawKB": 50.6,
         "description": "EffectRenderer-style WGSL pass renders a 512×512 green offscreen texture, then an unlit sphere displays that render target as its base-color texture.",
         "tags": ["procedural", "effect", "rtt"],
         "skipPerf": true


### PR DESCRIPTION
## What

Adds an optional `viewDimension?: GPUTextureViewDimension` to `EffectBindingLayout`. The texture bind-group-layout entry built by `bindingLayoutEntry` now forwards it as `viewDimension ?? "2d"`.

This lets a fullscreen effect sample an **array** or **cube** texture (for example, a CSM cascade depth array) instead of being limited to plain `2d` textures.

## Why

`EffectRenderer` previously hard-coded `2d` texture bindings, so any effect that needs to read an array/cube texture had no way to declare it. The new field is opt-in and defaults to `"2d"`, which is the WebGPU default, so every existing effect produces a byte-for-byte identical bind group layout.

## Behavior impact

- **Behavior-preserving.** `viewDimension ?? "2d"` is functionally identical to omitting the member (WebGPU defaults `viewDimension` to `"2d"`). No rendering output changes.
- **Bundle:** `EffectRenderer` is only bundled by **Scene 75 — Effect RTT Sphere** (the sole `EffectRenderer` consumer). Its runtime grows ~11 bytes, so its ceiling is raised `50.3 → 50.6 KB` (author-approved). The other 204 scenes are byte-identical (`effect-renderer.ts` is tree-shaken out of them).

## Testing

- `pnpm lint` — pass (eslint + tsc across all projects).
- `pnpm build:bundle-scenes` — pass; per-scene manifests regenerate byte-identical (no manifest churn to commit).
- `pnpm test:bundle-size` — 205 scenes pass (Scene 75 at 50.3 KB raw under the new 50.6 ceiling).
- `pnpm test:parity` — running; this change cannot move MAD (identical bind group layout).
