### PR TITLE
[compat-sync] Babylon.js compat-layer sync

### DIFF
--- a/packages/babylon-lite-compat/COMPAT-STATUS.md
+++ b/packages/babylon-lite-compat/COMPAT-STATUS.md
@@ -8,7 +8,7 @@ updated by the `update-compat-layer` skill.
      Do not rename them. Update the SHA after re-syncing against BJS master. -->
 
 - **Last synced BJS commit:** `c729b94f2e36f2d915415620857452f7ad0ff731`
-- **Last sync date:** 2026-06-25
+- **Last sync date:** 2026-06-26
 - **Lite compat package version:** 0.0.1
 
 > The "Last synced BJS commit" is the `BabylonJS/Babylon.js` `master` HEAD that the
@@ -176,7 +176,7 @@ date` markers above record the `BabylonJS/Babylon.js` `master` HEAD the surface
 | `mesh.thinInstanceSetBuffer`                                                                                    | ⚡ Partial         | meshes (`matrix` + `color` → Lite thin instances)                                                                                                                                                                                          |
 | `mesh.clone` / `createInstance`                                                                                 | ⚡ Partial         | throwing stub                                                                                                                                                                                                                              |
 | `TransformNode`                                                                                                 | ✅ Full            | meshes                                                                                                                                                                                                                                     |
-| `mesh.getBoundingInfo`                                                                                          | 🔧 Needs Lite core | bounds accessor                                                                                                                                                                                                                            |
+| `mesh.getBoundingInfo`                                                                                          | ✅ Full            | meshes (local-space `BoundingInfo` from Lite mesh `boundMin`/`boundMax`, with a `computeAabb` fold of the retained CPU positions as fallback — matches `LoadedMesh.getBoundingInfo`)                                                        |
 | LOD / `EdgesRenderer` / `OutlineRenderer`                                                                       | ❌ Not supported   | throwing stub; not in Lite                                                                                                                                                                                                                 |
 | `CSG` / `CSG2` (+ `InitializeCSG2Async`)                                                                        | ✅ Full            | [meshes/csg.ts](src/meshes/csg.ts) over Lite `createCsgFromMesh`/`createMeshFromCsg` and `createCsg2FromMesh`/`createMeshesFromCsg2` (CSG2 preserves per-source materials)                                                                 |
 
@@ -466,3 +466,9 @@ large-world-rendering scenes are now resolved.
 > (`PhysicsAggregate` not yet wrapped), not a Lite-core unblock; and audio scenes
 > have no pixel oracle. So no scene moved into the working list this run — Task 2 is
 > dormant, as expected when no Lite change unblocks a scene.
+>
+> **Task 2 re-check (2026-06-26):** the only commit to land since the last sync
+> (#313, "Move Lite gl ping pong out of the package") touches `packages/babylon-lite-gl/`
+> and the `lab/gl` WebGL track only — **nothing under `packages/babylon-lite/src/**`**,
+> so no new Lite capability came online. No previously-skipped scene is newly
+> unblocked; Task 2 stays dormant this run.

--- a/packages/babylon-lite-compat/src/meshes/meshes.ts
+++ b/packages/babylon-lite-compat/src/meshes/meshes.ts
@@ -281,11 +281,11 @@ export class AbstractMesh extends TransformNode {
      *
      * Babylon Lite stores a mesh's local bounds on `boundMin` / `boundMax` (set by
      * the mesh factories and the glTF loader); when present they are returned
-     * directly. For a mesh whose bounds were never precomputed (e.g. one rebuilt
-     * via `setVerticesData`), the AABB is folded on demand from the retained CPU
-     * position buffer with Lite's `computeAabb`. Bounds are reported in local
-     * geometry space, matching `LoadedMesh.getBoundingInfo` and how Lite's
-     * `createDefaultCamera` frames models.
+     * directly. When the bounds were never set but a CPU position buffer is still
+     * retained, the AABB is folded on demand from those positions with Lite's
+     * `computeAabb`. Bounds are reported in local geometry space, matching
+     * `LoadedMesh.getBoundingInfo` and how Lite's `createDefaultCamera` frames
+     * models.
      */
     public getBoundingInfo(): BoundingInfo {
         const lo = this._lite.boundMin;
@@ -294,9 +294,9 @@ export class AbstractMesh extends TransformNode {
             return new BoundingInfo(new Vector3(lo[0], lo[1], lo[2]), new Vector3(hi[0], hi[1], hi[2]));
         }
         const positions = this._lite._cpuPositions;
-        if (positions && positions.length >= 3) {
+        if (positions && positions.length >= 3 && positions.length % 3 === 0) {
             const [min, max] = computeAabb(positions);
-            if (isFinite(min[0])) {
+            if (isFinite(min[0]) && isFinite(min[1]) && isFinite(min[2])) {
                 return new BoundingInfo(new Vector3(min[0], min[1], min[2]), new Vector3(max[0], max[1], max[2]));
             }
         }

--- a/packages/babylon-lite-compat/src/meshes/meshes.ts
+++ b/packages/babylon-lite-compat/src/meshes/meshes.ts
@@ -34,11 +34,13 @@ import {
     resizeMeshGeometry,
     updateMeshUvs,
     createGroundFromHeightMap,
+    computeAabb,
 } from "babylon-lite";
 import type { Mesh as LiteMesh, SceneNode, EngineContext } from "babylon-lite";
 
-import type { Vector3 } from "../math/vector.js";
+import { Vector3 } from "../math/vector.js";
 import { liteBackedVector3 } from "../math/vector.js";
+import { BoundingInfo } from "../culling/bounding.js";
 import { Quaternion } from "../math/quaternion.js";
 import { Matrix } from "../math/matrix.js";
 import { unsupported } from "../error.js";
@@ -274,9 +276,31 @@ export class AbstractMesh extends TransformNode {
         this.isVisible = enabled;
     }
 
-    /** Bounding info accessor — needs a public Lite bounds accessor that does not yet exist. */
-    public getBoundingInfo(): never {
-        return unsupported("AbstractMesh.getBoundingInfo", "Babylon Lite does not expose a public mesh bounding-info accessor yet.");
+    /**
+     * Babylon.js `mesh.getBoundingInfo()` — local-space AABB of this mesh.
+     *
+     * Babylon Lite stores a mesh's local bounds on `boundMin` / `boundMax` (set by
+     * the mesh factories and the glTF loader); when present they are returned
+     * directly. For a mesh whose bounds were never precomputed (e.g. one rebuilt
+     * via `setVerticesData`), the AABB is folded on demand from the retained CPU
+     * position buffer with Lite's `computeAabb`. Bounds are reported in local
+     * geometry space, matching `LoadedMesh.getBoundingInfo` and how Lite's
+     * `createDefaultCamera` frames models.
+     */
+    public getBoundingInfo(): BoundingInfo {
+        const lo = this._lite.boundMin;
+        const hi = this._lite.boundMax;
+        if (lo && hi) {
+            return new BoundingInfo(new Vector3(lo[0], lo[1], lo[2]), new Vector3(hi[0], hi[1], hi[2]));
+        }
+        const positions = this._lite._cpuPositions;
+        if (positions && positions.length >= 3) {
+            const [min, max] = computeAabb(positions);
+            if (isFinite(min[0])) {
+                return new BoundingInfo(new Vector3(min[0], min[1], min[2]), new Vector3(max[0], max[1], max[2]));
+            }
+        }
+        return new BoundingInfo(new Vector3(0, 0, 0), new Vector3(0, 0, 0));
     }
 
     /**

--- a/packages/babylon-lite-compat/tests/bounding-info.test.ts
+++ b/packages/babylon-lite-compat/tests/bounding-info.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { AbstractMesh } from "../src/meshes/meshes";
+import { BoundingInfo } from "../src/culling/bounding";
+
+/**
+ * `AbstractMesh.getBoundingInfo()` reads a mesh's local-space AABB from the Lite
+ * mesh's `boundMin`/`boundMax`, falling back to folding the retained CPU position
+ * buffer with Lite's `computeAabb`. None of that needs a GPU device, so we drive
+ * it against a minimal fake `_lite` adopted onto the prototype.
+ */
+describe("AbstractMesh.getBoundingInfo", () => {
+    function meshWithLite(lite: object): AbstractMesh {
+        const mesh = Object.create(AbstractMesh.prototype) as AbstractMesh;
+        Object.defineProperty(mesh, "_lite", { value: lite, configurable: true });
+        return mesh;
+    }
+
+    it("returns the precomputed boundMin/boundMax when present", () => {
+        const mesh = meshWithLite({ boundMin: [-1, -2, -3], boundMax: [4, 5, 6] });
+        const info = mesh.getBoundingInfo();
+        expect(info).toBeInstanceOf(BoundingInfo);
+        expect(info.minimum.asArray()).toEqual([-1, -2, -3]);
+        expect(info.maximum.asArray()).toEqual([4, 5, 6]);
+        // Center/extents derive from the AABB.
+        expect(info.boundingBox.center.asArray()).toEqual([1.5, 1.5, 1.5]);
+    });
+
+    it("folds the CPU position buffer when bounds were never precomputed", () => {
+        // A 1×1×1 corner spread: min (0,0,0), max (1,1,1).
+        const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1]);
+        const mesh = meshWithLite({ _cpuPositions: positions });
+        const info = mesh.getBoundingInfo();
+        expect(info.minimum.asArray()).toEqual([0, 0, 0]);
+        expect(info.maximum.asArray()).toEqual([1, 1, 1]);
+    });
+
+    it("returns a zero-extent box when no bounds or positions exist", () => {
+        const mesh = meshWithLite({});
+        const info = mesh.getBoundingInfo();
+        expect(info.minimum.asArray()).toEqual([0, 0, 0]);
+        expect(info.maximum.asArray()).toEqual([0, 0, 0]);
+    });
+});

--- a/packages/babylon-lite-compat/tests/bounding-info.test.ts
+++ b/packages/babylon-lite-compat/tests/bounding-info.test.ts
@@ -35,6 +35,16 @@ describe("AbstractMesh.getBoundingInfo", () => {
         expect(info.maximum.asArray()).toEqual([1, 1, 1]);
     });
 
+    it("returns a zero-extent box when the CPU position buffer is not a multiple of 3", () => {
+        // A truncated buffer (length 4) would make computeAabb read past the end,
+        // leaving Y/Z as Infinity; getBoundingInfo must reject it.
+        const positions = new Float32Array([0, 0, 0, 1]);
+        const mesh = meshWithLite({ _cpuPositions: positions });
+        const info = mesh.getBoundingInfo();
+        expect(info.minimum.asArray()).toEqual([0, 0, 0]);
+        expect(info.maximum.asArray()).toEqual([0, 0, 0]);
+    });
+
     it("returns a zero-extent box when no bounds or positions exist", () => {
         const mesh = meshWithLite({});
         const info = mesh.getBoundingInfo();


### PR DESCRIPTION
Automated sync of `@babylonjs/lite-compat` against the latest Babylon.js and Babylon Lite changes,
produced by the [`update-compat-layer`](.github/copilot/skills/update-compat-layer.md) skill.

**Synced against BJS commit:** `c729b94f2e36f2d915415620857452f7ad0ff731`

### Validation (run independently by the pipeline)
- ✅ compat unit tests
- ✅ compat typecheck

### Changed files
- `ackages/babylon-lite-compat/COMPAT-STATUS.md`
- `packages/babylon-lite-compat/src/meshes/meshes.ts`
- `packages/babylon-lite-compat/tests/bounding-info.test.ts`

> Validation passed. Please review the wrapper changes and the updated `COMPAT-STATUS.md` before merging.

> Opened as a **draft** by the compat-sync pipeline. Review and mark ready when satisfied.