### PR TITLE
fix(release): prevent lite-gl release tag collisions on rerun

### DIFF
--- a/azure-pipelines-npm-publish-gl.yml
+++ b/azure-pipelines-npm-publish-gl.yml
@@ -109,6 +109,7 @@ stages:
                       RELEASE_SOURCE_PACKAGE_JSON: packages/babylon-lite-gl/package.json
                       RELEASE_CONFIG_PATH: config/release-gl.json
                       RELEASE_TAG_PATTERN: "npm-lite-gl-v*"
+                      RELEASE_TAG_AWARE_RESOLUTION: "true"
 
                 - script: pnpm build:gl
                   displayName: "Build package"
@@ -138,6 +139,16 @@ stages:
                       TAG="npm-lite-gl-v$(PACKAGE_VERSION)"
                       git config user.email "bjsplat@gmail.com"
                       git config user.name "Babylon.js CI"
-                      git tag "$TAG" -m "Publish @babylonjs/lite-gl $(PACKAGE_VERSION)"
-                      git push origin "refs/tags/$TAG"
+
+                      if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+                        echo "Tag $TAG already exists locally; skipping creation."
+                      else
+                        git tag "$TAG" -m "Publish @babylonjs/lite-gl $(PACKAGE_VERSION)"
+                      fi
+
+                      if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+                        echo "Tag $TAG already exists on origin; skipping push."
+                      else
+                        git push origin "refs/tags/$TAG"
+                      fi
                   displayName: "Tag published npm version"

--- a/scripts/prepare-npm-release.ts
+++ b/scripts/prepare-npm-release.ts
@@ -32,6 +32,11 @@ const SOURCE_PACKAGE_JSON = resolve(process.cwd(), process.env.RELEASE_SOURCE_PA
 const RELEASE_CONFIG_PATH = resolve(process.cwd(), process.env.RELEASE_CONFIG_PATH ?? "config/release.json");
 const RELEASE_TAG_PATTERN = process.env.RELEASE_TAG_PATTERN ?? "npm-lite-v*";
 const RELEASE_TAG_PREFIX = RELEASE_TAG_PATTERN.replace(/\*$/, "");
+// Opt-in: also consider existing release git tags when resolving the next
+// version (see getHighestReleasedTagVersion). Off by default so the established
+// @babylonjs/lite pipeline keeps its exact prior behaviour; only pipelines that
+// set this env (currently @babylonjs/lite-gl) get tag-aware resolution.
+const RELEASE_TAG_AWARE_RESOLUTION = (process.env.RELEASE_TAG_AWARE_RESOLUTION ?? "false").toLowerCase() === "true";
 
 function run(command: string, args: string[], options: { allowFailure?: boolean } = {}): string {
     try {
@@ -98,6 +103,25 @@ function parseVersion(version: string): [number, number, number] {
     return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
+function compareVersions(a: [number, number, number], b: [number, number, number]): number {
+    for (let i = 0; i < 3; i++) {
+        if (a[i] !== b[i]) {
+            return a[i] - b[i];
+        }
+    }
+    return 0;
+}
+
+function maxVersion(a: string, b: string): string {
+    if (!a) {
+        return b;
+    }
+    if (!b) {
+        return a;
+    }
+    return compareVersions(parseVersion(a), parseVersion(b)) >= 0 ? a : b;
+}
+
 function bumpVersion(version: string, releaseType: ResolvedReleaseType): string {
     const [major, minor, patch] = parseVersion(version);
     if (releaseType === "major") {
@@ -112,6 +136,36 @@ function bumpVersion(version: string, releaseType: ResolvedReleaseType): string 
 function getLatestPublishedVersion(fallbackVersion: string): string {
     const publishedVersion = run("npm", ["view", PACKAGE_NAME, "version", "--registry", "https://registry.npmjs.org/"], { allowFailure: true });
     return publishedVersion || fallbackVersion;
+}
+
+// Git tags are the authoritative, push-once record of what has already been
+// released. When tag-aware resolution is enabled (RELEASE_TAG_AWARE_RESOLUTION),
+// version resolution considers them in addition to npm: if npm's reported
+// version and the tags drift out of sync — e.g. `npm view` returns empty
+// (transient registry/auth failure) so we fall back to the source manifest, or
+// an npm version was unpublished — bumping from npm alone can land on a version
+// whose tag already exists. The tag-push step then fails fatally (`git tag`
+// refuses to overwrite), wedging every subsequent run. Basing the bump on the
+// highest existing tag as well guarantees the next version is strictly greater
+// than every released tag, so the tag can never collide.
+function getHighestReleasedTagVersion(): string {
+    const tagList = run("git", ["tag", "--list", RELEASE_TAG_PATTERN], { allowFailure: true });
+    if (!tagList) {
+        return "";
+    }
+    let highest = "";
+    for (const line of tagList.split(/\r?\n/)) {
+        const tag = line.trim();
+        if (!tag.startsWith(RELEASE_TAG_PREFIX)) {
+            continue;
+        }
+        const versionPart = tag.slice(RELEASE_TAG_PREFIX.length);
+        if (!/^\d+\.\d+\.\d+$/.test(versionPart)) {
+            continue;
+        }
+        highest = maxVersion(highest, versionPart);
+    }
+    return highest;
 }
 
 function getPublishedBuildId(version: string): string {
@@ -150,6 +204,13 @@ if (!pkg.version) {
 }
 
 const latestPublishedVersion = getLatestPublishedVersion(pkg.version);
+// Tag-aware resolution is opt-in (lite-gl only). When disabled, the base is the
+// npm-reported latest exactly as before, so @babylonjs/lite is byte-for-byte
+// unaffected. When enabled, bump from whichever is greater: npm's reported
+// latest or the highest existing release tag, keeping the next version strictly
+// ahead of every released tag so the tag-push step can never collide.
+const highestReleasedTagVersion = RELEASE_TAG_AWARE_RESOLUTION ? getHighestReleasedTagVersion() : "";
+const resolutionBaseVersion = RELEASE_TAG_AWARE_RESOLUTION ? maxVersion(latestPublishedVersion, highestReleasedTagVersion) : latestPublishedVersion;
 const currentBuildId = process.env.BUILD_BUILDID;
 const latestPublishedBuildId = getPublishedBuildId(latestPublishedVersion);
 
@@ -157,7 +218,7 @@ if (currentBuildId && latestPublishedBuildId === currentBuildId) {
     throw new Error(`Azure build ${currentBuildId} already published ${PACKAGE_NAME}@${latestPublishedVersion}. Refusing to publish another version from the same build rerun.`);
 }
 
-const previousReleaseTag = getPreviousReleaseTag(latestPublishedVersion);
+const previousReleaseTag = getPreviousReleaseTag(resolutionBaseVersion);
 const breakingChangesDetected = hasBreakingChanges(previousReleaseTag);
 
 if (breakingChangesDetected && requestedReleaseType !== "auto" && requestedReleaseType !== "major") {
@@ -171,7 +232,7 @@ if (breakingChangesDetected && requestedReleaseType !== "auto" && requestedRelea
 }
 
 const resolvedReleaseType: ResolvedReleaseType = requestedReleaseType === "auto" ? (breakingChangesDetected ? "major" : "minor") : requestedReleaseType;
-const nextVersion = bumpVersion(latestPublishedVersion, resolvedReleaseType);
+const nextVersion = bumpVersion(resolutionBaseVersion, resolvedReleaseType);
 
 if (isVersionPublished(nextVersion)) {
     throw new Error(`${PACKAGE_NAME}@${nextVersion} is already published. Refusing to overwrite an existing npm version.`);
@@ -183,6 +244,10 @@ if (isVersionPublished(nextVersion)) {
 // provenance from `BUILD_BUILDID` / `BUILD_SOURCEVERSION`. Nothing is written here.
 console.log(`Package: ${PACKAGE_NAME}`);
 console.log(`Latest published version: ${latestPublishedVersion}`);
+if (RELEASE_TAG_AWARE_RESOLUTION) {
+    console.log(`Highest released tag version: ${highestReleasedTagVersion || "<none>"}`);
+    console.log(`Resolution base version: ${resolutionBaseVersion}`);
+}
 console.log(`Previous release tag: ${previousReleaseTag || "<none>"}`);
 console.log(`Requested release type: ${requestedReleaseType}`);
 console.log(`Release type source: ${requested.source}`);


### PR DESCRIPTION
## Problem

The **`@babylonjs/lite-gl`** npm publish pipeline wedges on its second run with a fatal `fatal: tag 'npm-lite-gl-v0.2.0' already exists` error at the **"Tag published npm version"** step.

### What actually happened (evidence)

The pre-#311 GL pipeline built the package **before** resolving the version and never baked the resolved version back into the dist. So in a single run:

- **npm publish** uploaded the unbumped source version `0.1.0` (no build provenance).
- **tag step** computed `npm-lite-gl-v$(PACKAGE_VERSION)` from the *bumped* `0.2.0` and pushed it.

The registry confirms the drift to the second:

| Artifact | Version | Timestamp | Provenance |
|---|---|---|---|
| npm publish | `0.1.0` | 2026-06-25 14:20:17Z | none |
| git tag `npm-lite-gl-v0.2.0` | `0.2.0` | 2026-06-25 14:20:18Z | — |

One run left **npm at `0.1.0` but the `v0.2.0` tag already pushed**. On the next run, version resolution (still seeing npm's `0.1.0`) bumped to `0.2.0` again, and the bare `git tag npm-lite-gl-v0.2.0` aborted because the tag was already there.

#311 ("Fix Lite-gl Package") fixed the root **ordering** bug (resolve → build with `PACKAGE_VERSION` baked in). This PR adds the **defensive backstop** so any future npm/tag drift can never wedge the pipeline again.

## Fix

1. **Tag-aware version resolution** in `scripts/prepare-npm-release.ts`, gated behind a new opt-in env flag `RELEASE_TAG_AWARE_RESOLUTION` (set only by the lite-gl pipeline). When enabled, the next version is bumped from `max(npm latest, highest existing npm-lite-gl-v* tag)`, keeping it strictly ahead of every released tag — so a stale/empty `npm view` can no longer steer resolution onto an existing tag.
2. **Idempotent tag step** in `azure-pipelines-npm-publish-gl.yml`: skip `git tag` if the tag already exists locally, and skip the push if it already exists on `origin`, instead of aborting fatally.

## Scope / safety

- **`@babylonjs/lite` is byte-for-byte unchanged.** `azure-pipelines-npm-publish.yml` has zero diff. The shared script never sets the flag for lite, so it takes the exact original code path (npm-only resolution, same logging, same bump). Lite never had #311's ordering bug, so its npm/tag pair stays in sync regardless.
- The new resolution logic is fully opt-in; default behaviour is identical to before.

## Verification

Simulated against the current real registry/tag state (npm `0.2.0`, tag `npm-lite-gl-v0.2.0`):

| Scenario | Resolved base | minor → next | Collision? |
|---|---|---|---|
| normal (npm `0.2.0`) | `0.2.0` | `0.3.0` | no |
| **`npm view` fails → fallback source `0.1.0`** | `0.2.0` | `0.3.0` | **no** |

The second row is the exact condition that previously wedged the pipeline — it now resolves above the highest tag. (Local `tsc`/`lint` not run because `node_modules` isn't installed in this checkout; logic validated with a standalone Node probe against the live tags and registry.)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>