### PR TITLE
feat(playground): make the playground mobile friendly

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -12,8 +12,8 @@
             <header class="toolbar">
                 <div class="brand"><img class="brand-logo" src="/favicon.svg" alt="" width="28" height="28" /><span class="brand-text">Babylon <span>Lite</span> Playground</span><span class="beta-badge" title="This playground is in beta — expect rough edges">Beta</span></div>
                 <div class="mode-toggle" id="modeToggle" role="tablist" aria-label="View mode">
-                    <button id="modeCodeBtn" class="mode-btn" type="button" role="tab" aria-selected="false">Code</button>
-                    <button id="modeSceneBtn" class="mode-btn" type="button" role="tab" aria-selected="true">Scene</button>
+                    <button id="modeCodeBtn" class="mode-btn" type="button" role="tab" aria-selected="false" tabindex="-1">Code</button>
+                    <button id="modeSceneBtn" class="mode-btn" type="button" role="tab" aria-selected="true" tabindex="0">Scene</button>
                 </div>
                 <div class="actions" id="actionsMenu">
                     <button id="newBtn" class="btn btn-icon" title="New project" aria-label="New project">

--- a/playground/index.html
+++ b/playground/index.html
@@ -11,15 +11,21 @@
         <div id="app">
             <header class="toolbar">
                 <div class="brand"><img class="brand-logo" src="/favicon.svg" alt="" width="28" height="28" /><span class="brand-text">Babylon <span>Lite</span> Playground</span><span class="beta-badge" title="This playground is in beta — expect rough edges">Beta</span></div>
-                <div class="actions">
+                <div class="mode-toggle" id="modeToggle" role="tablist" aria-label="View mode">
+                    <button id="modeCodeBtn" class="mode-btn" type="button" role="tab" aria-selected="false">Code</button>
+                    <button id="modeSceneBtn" class="mode-btn" type="button" role="tab" aria-selected="true">Scene</button>
+                </div>
+                <div class="actions" id="actionsMenu">
                     <button id="newBtn" class="btn btn-icon" title="New project" aria-label="New project">
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="12" y1="12" x2="12" y2="18"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
+                        <span class="action-label">New</span>
                     </button>
                     <select id="examples" class="select" title="Load an example" aria-label="Examples"></select>
                     <select id="versionSelect" class="select" title="Engine version" aria-label="Engine version"></select>
                     <div class="save-group">
                         <button id="saveBtn" class="btn btn-icon" title="Save &amp; copy link" aria-label="Save and copy link">
                             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+                            <span class="action-label">Save &amp; copy link</span>
                         </button>
                         <button id="saveDetailsBtn" class="btn btn-icon btn-caret" title="Save with details…" aria-label="Save with details">
                             <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
@@ -27,14 +33,20 @@
                     </div>
                     <button id="downloadBtn" class="btn btn-icon" title="Download as a runnable zip" aria-label="Download as zip">
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                        <span class="action-label">Download</span>
                     </button>
                     <button id="runBtn" class="btn btn-icon btn-primary" title="Run (Ctrl/Cmd+Enter)" aria-label="Run">
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" stroke="none" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"/></svg>
+                        <span class="action-label">Run</span>
                     </button>
                     <a id="openFullBtn" class="btn btn-icon" href="#" title="Open this code in the full Lite Playground" aria-label="Open in Lite Playground">
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                        <span class="action-label">Open in Playground</span>
                     </a>
                 </div>
+                <button id="menuBtn" class="btn btn-icon menu-btn" type="button" title="Menu" aria-label="Menu" aria-expanded="false" aria-controls="actionsMenu">
+                    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+                </button>
             </header>
             <main class="split" id="split">
                 <section class="pane pane-editor">

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -364,11 +364,19 @@ document.addEventListener("click", (event) => {
     }
 });
 
+// The two mode tabs, in DOM order, for roving-tabindex keyboard navigation.
+const modeTabs = [modeCodeBtn, modeSceneBtn];
+
 function setMode(mode: "code" | "scene"): void {
     document.body.classList.toggle("mode-code", mode === "code");
     document.body.classList.toggle("mode-scene", mode === "scene");
-    modeCodeBtn.setAttribute("aria-selected", String(mode === "code"));
-    modeSceneBtn.setAttribute("aria-selected", String(mode === "scene"));
+    // ARIA tab semantics: the selected tab is the single roving tab stop; the
+    // other is removed from the tab order and reached via arrow keys.
+    for (const tab of modeTabs) {
+        const isActive = (tab === modeCodeBtn) === (mode === "code");
+        tab.setAttribute("aria-selected", String(isActive));
+        tab.tabIndex = isActive ? 0 : -1;
+    }
     try {
         localStorage.setItem(MODE_KEY, mode);
     } catch {
@@ -379,7 +387,45 @@ function setMode(mode: "code" | "scene"): void {
 modeCodeBtn.addEventListener("click", () => setMode("code"));
 modeSceneBtn.addEventListener("click", () => setMode("scene"));
 
-setMode(localStorage.getItem(MODE_KEY) === "code" ? "code" : "scene");
+// Arrow/Home/End move selection between the tabs (WAI-ARIA tabs pattern).
+function onModeKeydown(event: KeyboardEvent): void {
+    const index = modeTabs.indexOf(event.currentTarget as HTMLButtonElement);
+    let next: number;
+    switch (event.key) {
+        case "ArrowRight":
+        case "ArrowDown":
+            next = (index + 1) % modeTabs.length;
+            break;
+        case "ArrowLeft":
+        case "ArrowUp":
+            next = (index - 1 + modeTabs.length) % modeTabs.length;
+            break;
+        case "Home":
+            next = 0;
+            break;
+        case "End":
+            next = modeTabs.length - 1;
+            break;
+        default:
+            return;
+    }
+    event.preventDefault();
+    setMode(next === 0 ? "code" : "scene");
+    modeTabs[next]?.focus();
+}
+
+for (const tab of modeTabs) {
+    tab.addEventListener("keydown", onModeKeydown);
+}
+
+// Restore the persisted mode (storage may be unavailable / throw — fall back to scene).
+let storedMode: string | null = null;
+try {
+    storedMode = localStorage.getItem(MODE_KEY);
+} catch {
+    // Storage blocked (private mode / third-party iframe); use the default.
+}
+setMode(storedMode === "code" ? "code" : "scene");
 
 // New: discard the current project (with a guard if there are unsaved edits) and
 // load a clean starter scene.

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -45,6 +45,10 @@ const snippetDescriptionInput = document.getElementById("snippetDescription") as
 const snippetTagsInput = document.getElementById("snippetTags") as HTMLInputElement;
 const toastEl = document.getElementById("toast") as HTMLElement;
 const openFullBtn = document.getElementById("openFullBtn") as HTMLAnchorElement;
+const menuBtn = document.getElementById("menuBtn") as HTMLButtonElement;
+const actionsMenu = document.getElementById("actionsMenu") as HTMLElement;
+const modeCodeBtn = document.getElementById("modeCodeBtn") as HTMLButtonElement;
+const modeSceneBtn = document.getElementById("modeSceneBtn") as HTMLButtonElement;
 
 // Embed mode (`?embed=runner|split`) hosts the playground inside another page and
 // exposes a postMessage API. `null` when running as the standalone app.
@@ -323,6 +327,59 @@ examplesEl.addEventListener("change", () => {
 });
 
 runBtn.addEventListener("click", () => void run());
+
+// --- Mobile chrome: hamburger menu + Code/Scene view toggle ------------------
+// On narrow screens the toolbar actions collapse into a dropdown, and the
+// side-by-side split becomes a single pane that switches between editing the
+// code and viewing the scene. Both are driven by classes on <body>; the CSS
+// media query decides whether they have any visual effect.
+
+const MODE_KEY = "bl-pg-mode";
+
+function closeMenu(): void {
+    document.body.classList.remove("menu-open");
+    menuBtn.setAttribute("aria-expanded", "false");
+}
+
+function toggleMenu(): void {
+    const open = document.body.classList.toggle("menu-open");
+    menuBtn.setAttribute("aria-expanded", String(open));
+}
+
+menuBtn.addEventListener("click", (event) => {
+    event.stopPropagation();
+    toggleMenu();
+});
+
+// Close the menu after picking an action, or when tapping outside it.
+actionsMenu.addEventListener("click", (event) => {
+    if ((event.target as HTMLElement).closest(".btn, a")) {
+        closeMenu();
+    }
+});
+actionsMenu.addEventListener("change", closeMenu);
+document.addEventListener("click", (event) => {
+    if (document.body.classList.contains("menu-open") && !(event.target as HTMLElement).closest(".toolbar")) {
+        closeMenu();
+    }
+});
+
+function setMode(mode: "code" | "scene"): void {
+    document.body.classList.toggle("mode-code", mode === "code");
+    document.body.classList.toggle("mode-scene", mode === "scene");
+    modeCodeBtn.setAttribute("aria-selected", String(mode === "code"));
+    modeSceneBtn.setAttribute("aria-selected", String(mode === "scene"));
+    try {
+        localStorage.setItem(MODE_KEY, mode);
+    } catch {
+        // Best-effort persistence; ignore storage failures.
+    }
+}
+
+modeCodeBtn.addEventListener("click", () => setMode("code"));
+modeSceneBtn.addEventListener("click", () => setMode("scene"));
+
+setMode(localStorage.getItem(MODE_KEY) === "code" ? "code" : "scene");
 
 // New: discard the current project (with a guard if there are unsaved edits) and
 // load a clean starter scene.

--- a/playground/src/styles.css
+++ b/playground/src/styles.css
@@ -88,6 +88,45 @@ body {
     gap: 0.5rem;
 }
 
+/* Text labels inside the (otherwise icon-only) action buttons. Hidden on desktop,
+   revealed when the actions collapse into the mobile dropdown menu. */
+.action-label {
+    display: none;
+}
+
+/* Mobile-only chrome: the Code/Scene segmented toggle and the hamburger button.
+   Hidden on desktop; the mobile media query reveals them. The hamburger uses a
+   `.btn.menu-btn` selector so it outranks the `.btn-icon { display: inline-flex }`
+   rule defined further down. */
+.mode-toggle,
+.btn.menu-btn {
+    display: none;
+}
+
+.mode-toggle {
+    flex: 0 0 auto;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--bg);
+}
+
+.mode-btn {
+    font: inherit;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    background: transparent;
+    border: none;
+    padding: 0.4rem 0.8rem;
+    cursor: pointer;
+}
+
+.mode-btn[aria-selected="true"] {
+    background: var(--accent-strong);
+    color: #fff;
+    font-weight: 600;
+}
+
 .select {
     font: inherit;
     font-size: 0.85rem;
@@ -633,4 +672,124 @@ body.embed-runner .splitter {
 
 body.embed-runner .split {
     grid-template-columns: 1fr;
+}
+
+/* Runner embed has no editor, so the Code/Scene toggle would have nothing to
+   switch to — hide it even on mobile. */
+body.embed-runner .mode-toggle {
+    display: none;
+}
+
+/* ---------------------------------------------------------------------------
+   Mobile layout (<= 768px)
+
+   The desktop side-by-side split doesn't work on a narrow screen, so we:
+   - collapse the toolbar actions into a hamburger dropdown menu,
+   - swap the row of icon buttons for a centered Code/Scene segmented toggle,
+   - stack both panes in a single full-screen cell and show one at a time.
+
+   The editor and preview overlap in the same grid cell and are toggled with
+   `visibility` (not `display`), so the preview iframe keeps its full size and
+   the WebGPU canvas never has to re-layout when switching back to Scene.
+--------------------------------------------------------------------------- */
+@media (max-width: 768px) {
+    .toolbar {
+        position: relative;
+        padding: 0.5rem 0.75rem;
+        gap: 0.5rem;
+    }
+
+    /* Pare the brand back to just the logo to free up horizontal space. */
+    .brand-text,
+    .brand .beta-badge {
+        display: none;
+    }
+
+    .mode-toggle {
+        display: inline-flex;
+    }
+
+    .btn.menu-btn {
+        display: inline-flex;
+    }
+
+    /* Actions become a dropdown panel anchored under the hamburger button. */
+    .actions {
+        position: absolute;
+        top: calc(100% + 0.4rem);
+        right: 0.5rem;
+        z-index: 20;
+        flex-direction: column;
+        align-items: stretch;
+        min-width: 13rem;
+        padding: 0.5rem;
+        background: var(--bg-elevated);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        box-shadow: 0 12px 28px rgba(1, 4, 9, 0.55);
+    }
+
+    body:not(.menu-open) .actions {
+        display: none;
+    }
+
+    /* In the menu, icon buttons become full-width rows with a visible label. */
+    .actions .action-label {
+        display: inline;
+    }
+
+    .actions .btn-icon {
+        width: 100%;
+        height: auto;
+        justify-content: flex-start;
+        gap: 0.6rem;
+        padding: 0.55rem 0.65rem;
+    }
+
+    .actions .select {
+        width: 100%;
+    }
+
+    .actions .save-group {
+        width: 100%;
+    }
+
+    .actions .save-group .btn:first-child {
+        flex: 1 1 auto;
+    }
+
+    .actions .btn-caret {
+        flex: 0 0 auto;
+        width: auto;
+        justify-content: center;
+    }
+
+    /* Single full-screen pane; both panes share one grid cell and overlap. */
+    .split {
+        grid-template-columns: 1fr !important;
+        grid-template-rows: 1fr;
+    }
+
+    .splitter {
+        display: none;
+    }
+
+    .pane-editor,
+    .pane-preview {
+        grid-column: 1;
+        grid-row: 1;
+    }
+
+    .pane-editor {
+        border-right: none;
+    }
+
+    /* Show exactly one pane based on the active mode. */
+    body.mode-scene .pane-editor {
+        visibility: hidden;
+    }
+
+    body.mode-code .pane-preview {
+        visibility: hidden;
+    }
 }


### PR DESCRIPTION
## Summary

On narrow screens the playground didn't fit: the editor/preview vertical split looked wrong and the toolbar stretched off the right edge. This makes the playground mobile friendly at `<= 768px` while leaving the desktop layout untouched.

## What changed

- **Hamburger menu** — On mobile the toolbar action buttons collapse into a labeled dropdown menu opened by a hamburger button (New, Examples, Version, Save & copy link, Download, Run, Open in Playground). On desktop the toolbar is unchanged.
- **Code / Scene toggle** — Instead of a side-by-side split, mobile shows a centered segmented toggle that switches between editing the **Code** and viewing the **Scene**. The two panes share a single full-screen grid cell and toggle via `visibility` (not `display`), so the WebGPU canvas keeps its size and never has to re-layout when switching back to Scene. The active mode is persisted to `localStorage`.
- **Tighter header** — The brand collapses to just the logo on mobile to free up horizontal space.

## Files

- `playground/index.html` — added the mode toggle + hamburger button and text labels for the (otherwise icon-only) action buttons.
- `playground/src/styles.css` — `@media (max-width: 768px)` block for the dropdown menu, segmented toggle, and single-pane switch.
- `playground/src/main.ts` — wiring for the menu (open/close, close on outside tap / after an action) and the Code/Scene toggle.

## Testing

Verified with Playwright at a 390px mobile viewport and a 1280px desktop viewport:

- Mobile: logo left, centered Code/Scene toggle, hamburger right; clean labeled dropdown; toggling switches between full-screen editor and full-screen scene.
- Desktop: unchanged — full inline toolbar, side-by-side split, no hamburger/toggle.
- `eslint`, `tsc -p playground/tsconfig.json`, and `prettier --check` all clean.

Playground-only UI change — no engine code touched, so no parity/bundle-size impact.