### PR TITLE
[compat-sync] Babylon.js compat-layer sync

### DIFF
--- a/packages/babylon-lite-compat/COMPAT-STATUS.md
+++ b/packages/babylon-lite-compat/COMPAT-STATUS.md
@@ -7,8 +7,8 @@ updated by the `update-compat-layer` skill.
 <!-- The two markers below are machine-read by the update-compat-layer skill.
      Do not rename them. Update the SHA after re-syncing against BJS master. -->
 
-- **Last synced BJS commit:** `c729b94f2e36f2d915415620857452f7ad0ff731`
-- **Last sync date:** 2026-06-25
+- **Last synced BJS commit:** `4a4481e911bee11cb4b9e92689f65c69edb474b8`
+- **Last sync date:** 2026-06-27
 - **Lite compat package version:** 0.0.1
 
 > The "Last synced BJS commit" is the `BabylonJS/Babylon.js` `master` HEAD that the
@@ -68,7 +68,7 @@ date` markers above record the `BabylonJS/Babylon.js` `master` HEAD the surface
 | -------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Vector2` / `Vector3` / `Vector4`                  | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
 | `Color3` / `Color4`                                | ✅ Full    | [math/color.ts](src/math/color.ts)                                                                                                                              |
-| `Quaternion`                                       | ✅ Full    | [math/quaternion.ts](src/math/quaternion.ts) (incl. `FromRotationMatrix` / `FromRotationMatrixToRef` / `fromRotationMatrix` over Lite `quatFromRotationMatrix`) |
+| `Quaternion`                                       | ✅ Full    | [math/quaternion.ts](src/math/quaternion.ts) (incl. `FromRotationMatrix` / `FromRotationMatrixToRef` / `fromRotationMatrix` over Lite `quatFromRotationMatrix`, plus `RotationQuaternionFromAxis` / `RotationQuaternionFromAxisToRef` / `toRotationMatrix`) |
 | `Matrix`                                           | ✅ Full    | [math/matrix.ts](src/math/matrix.ts) (incl. `decompose` — BJS-accurate scale/negative-determinant handling, rotation via Lite `quatFromRotationMatrix`)         |
 | `Vector3.TransformCoordinates` / `TransformNormal` | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
 | `Vector3.Center` / `CenterToRef`                   | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
@@ -77,8 +77,10 @@ date` markers above record the `BabylonJS/Babylon.js` `master` HEAD the surface
 | `Axis` / `Space` / `Epsilon`                       | ✅ Full    | [math/constants.ts](src/math/constants.ts)                                                                                                                      |
 | `Plane` / `Ray` / `Frustum`                        | ✅ Full    | [math/plane.ts](src/math/plane.ts), [ray.ts](src/math/ray.ts), [frustum.ts](src/math/frustum.ts)                                                                |
 | `Size` / `Viewport`                                | ✅ Full    | [math/size.ts](src/math/size.ts)                                                                                                                                |
-| `Angle` / `Curve3` / `Path3D`                      | ⚡ Partial | [math/curve.ts](src/math/curve.ts)                                                                                                                              |
-| `Curve3` / `Path3D` / easing curves on math        | ⚡ Partial | curve + easing                                                                                                                                                  |
+| `Vector3.Hermite` / `Vector3.CatmullRom`           | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
+| `Angle`                                            | ✅ Full    | [math/curve.ts](src/math/curve.ts)                                                                                                                             |
+| `Curve3` (`CreateQuadraticBezier` / `CreateCubicBezier` / `CreateHermiteSpline` / `CreateCatmullRomSpline`, `length` / `continue`) | ✅ Full    | [math/curve.ts](src/math/curve.ts)                                                                                                                             |
+| `Path3D` (Frenet frames: `getTangents`/`getNormals`/`getBinormals`/`getDistances`; `getPointAt`/`getTangentAt`/`getNormalAt`/`getBinormalAt`/`getDistanceAt`/`getPreviousPointIndexAt`/`getSubPositionAt`/`getClosestPositionTo`/`slice`/`update`) | ✅ Full    | [math/curve.ts](src/math/curve.ts) (BJS-exact port; interpolated TNB via `Quaternion.RotationQuaternionFromAxis` + `Slerp`)                                     |
 
 ## Core
 

--- a/packages/babylon-lite-compat/README.md
+++ b/packages/babylon-lite-compat/README.md
@@ -116,7 +116,7 @@ overloads within a supported area may still be absent.
 
 | Feature area                                                                                            | Status | Notes                                                                                                    |
 | ------------------------------------------------------------------------------------------------------- | :----: | -------------------------------------------------------------------------------------------------------- |
-| Math (`Vector*`, `Color*`, `Quaternion`, `Matrix`, `Plane`, `Ray`, `Frustum`, `Scalar`, `Axis`/`Space`) |   ✅   | `Angle` / `Curve3` / `Path3D` partial                                                                    |
+| Math (`Vector*`, `Color*`, `Quaternion`, `Matrix`, `Plane`, `Ray`, `Frustum`, `Scalar`, `Axis`/`Space`) |   ✅   | incl. `Angle` / `Curve3` (Bézier + Hermite/Catmull-Rom splines) / `Path3D` (Frenet frames)               |
 | Engine (`WebGPUEngine`, `Engine`, `ThinEngine`, `NullEngine`)                                           |   ⚡   | async startup + render loop; `beginFrame`/`endFrame` and manual `scene.render()` unsupported             |
 | Scene (clear color, cameras/lights, fog, environment, observables, ready state)                         |   ⚡   | sync `scene.pick` unsupported (use async `GPUPicker`); some scene enumeration needs Lite core            |
 | Cameras (`ArcRotateCamera`, `FreeCamera`/`Universal`/`Target`, `FollowCamera`, `GeospatialCamera`)      |   ✅   | XR / device-orientation / stereoscopic rigs unsupported                                                  |

--- a/packages/babylon-lite-compat/src/math/curve.ts
+++ b/packages/babylon-lite-compat/src/math/curve.ts
@@ -1,6 +1,9 @@
 /** Babylon.js-compatible curve/path helpers: `Angle`, `Curve3`, `Path3D` (pure JS). */
 
 import { Vector3 } from "./vector.js";
+import { Matrix } from "./matrix.js";
+import { Quaternion } from "./quaternion.js";
+import { Epsilon, Scalar } from "./scalar.js";
 
 export class Angle {
     public constructor(private readonly _radians: number) {}
@@ -79,21 +82,105 @@ export class Curve3 {
         }
         return new Curve3(points);
     }
+
+    /**
+     * Babylon.js `Curve3.CreateHermiteSpline` — Hermite spline from `p1` → `p2` with
+     * tangents `t1`/`t2`, sampled in `nSeg` segments.
+     */
+    public static CreateHermiteSpline(p1: Vector3, t1: Vector3, p2: Vector3, t2: Vector3, nSeg: number): Curve3 {
+        const hermite: Vector3[] = [];
+        const step = 1.0 / nSeg;
+        for (let i = 0; i <= nSeg; i++) {
+            hermite.push(Vector3.Hermite(p1, t1, p2, t2, i * step));
+        }
+        return new Curve3(hermite);
+    }
+
+    /**
+     * Babylon.js `Curve3.CreateCatmullRomSpline` — Catmull-Rom spline through `points`,
+     * with `nbPoints` interpolated points between each control point. When `closed`, the
+     * spline forms a loop.
+     */
+    public static CreateCatmullRomSpline(points: Vector3[], nbPoints: number, closed?: boolean): Curve3 {
+        const catmullRom: Vector3[] = [];
+        const step = 1.0 / nbPoints;
+        let amount = 0.0;
+        if (closed) {
+            const pointsCount = points.length;
+            for (let i = 0; i < pointsCount; i++) {
+                amount = 0;
+                for (let c = 0; c < nbPoints; c++) {
+                    catmullRom.push(
+                        Vector3.CatmullRom(points[i % pointsCount]!, points[(i + 1) % pointsCount]!, points[(i + 2) % pointsCount]!, points[(i + 3) % pointsCount]!, amount)
+                    );
+                    amount += step;
+                }
+            }
+            catmullRom.push(catmullRom[0]!);
+        } else {
+            const totalPoints: Vector3[] = [];
+            totalPoints.push(points[0]!.clone());
+            totalPoints.push(...points);
+            totalPoints.push(points[points.length - 1]!.clone());
+            let i = 0;
+            for (; i < totalPoints.length - 3; i++) {
+                amount = 0;
+                for (let c = 0; c < nbPoints; c++) {
+                    catmullRom.push(Vector3.CatmullRom(totalPoints[i]!, totalPoints[i + 1]!, totalPoints[i + 2]!, totalPoints[i + 3]!, amount));
+                    amount += step;
+                }
+            }
+            i--;
+            catmullRom.push(Vector3.CatmullRom(totalPoints[i]!, totalPoints[i + 1]!, totalPoints[i + 2]!, totalPoints[i + 3]!, amount));
+        }
+        return new Curve3(catmullRom);
+    }
 }
 
-/** A 3D path with cumulative-distance queries over its points. */
-export class Path3D {
-    private readonly _curve: Vector3[];
-    private readonly _distances: number[] = [];
-    private _length = 0;
+interface PointAtData {
+    id: number;
+    point: Vector3;
+    previousPointArrayIndex: number;
+    position: number;
+    subPosition: number;
+    interpolateReady: boolean;
+    interpolationMatrix: Matrix;
+}
 
-    public constructor(points: Vector3[]) {
-        this._curve = points.map((p) => p.clone());
-        this._distances[0] = 0;
-        for (let i = 1; i < this._curve.length; i++) {
-            this._length += Vector3.Distance(this._curve[i]!, this._curve[i - 1]!);
-            this._distances[i] = this._length;
+/**
+ * Babylon.js `Path3D` — a logical 3D path that computes a Frenet-like frame
+ * (tangents, normals, binormals) and cumulative distances over its curve points,
+ * with interpolated-point queries (`getPointAt` / `getTangentAt` / …).
+ */
+export class Path3D {
+    private readonly _curve: Vector3[] = [];
+    private readonly _distances: number[] = [];
+    private readonly _tangents: Vector3[] = [];
+    private readonly _normals: Vector3[] = [];
+    private readonly _binormals: Vector3[] = [];
+    private readonly _raw: boolean;
+    private readonly _alignTangentsWithPath: boolean;
+
+    private readonly _pointAtData: PointAtData = {
+        id: 0,
+        point: Vector3.Zero(),
+        previousPointArrayIndex: 0,
+        position: 0,
+        subPosition: 0,
+        interpolateReady: false,
+        interpolationMatrix: Matrix.Identity(),
+    };
+
+    public path: Vector3[];
+
+    public constructor(path: Vector3[], firstNormal: Vector3 | null = null, raw?: boolean, alignTangentsWithPath = false) {
+        this.path = path;
+        for (let p = 0; p < path.length; p++) {
+            this._curve[p] = path[p]!.clone();
         }
+        this._raw = raw || false;
+        this._alignTangentsWithPath = alignTangentsWithPath;
+        this._compute(firstNormal, alignTangentsWithPath);
     }
 
     public getCurve(): Vector3[] {
@@ -105,11 +192,305 @@ export class Path3D {
     }
 
     public length(): number {
-        return this._length;
+        return this._distances[this._distances.length - 1]!;
     }
 
-    /** Distances of each point from the path start, normalized to [0, 1] when `length > 0`. */
+    public getTangents(): Vector3[] {
+        return this._tangents;
+    }
+
+    public getNormals(): Vector3[] {
+        return this._normals;
+    }
+
+    public getBinormals(): Vector3[] {
+        return this._binormals;
+    }
+
     public getDistances(): number[] {
         return this._distances;
+    }
+
+    /** Returns an interpolated point along this path, `position` in [0, 1]. */
+    public getPointAt(position: number): Vector3 {
+        return this._updatePointAtData(position).point;
+    }
+
+    public getTangentAt(position: number, interpolated = false): Vector3 {
+        this._updatePointAtData(position, interpolated);
+        return interpolated ? Vector3.TransformCoordinates(Vector3.Forward(), this._pointAtData.interpolationMatrix) : this._tangents[this._pointAtData.previousPointArrayIndex]!;
+    }
+
+    public getNormalAt(position: number, interpolated = false): Vector3 {
+        this._updatePointAtData(position, interpolated);
+        return interpolated ? Vector3.TransformCoordinates(Vector3.Right(), this._pointAtData.interpolationMatrix) : this._normals[this._pointAtData.previousPointArrayIndex]!;
+    }
+
+    public getBinormalAt(position: number, interpolated = false): Vector3 {
+        this._updatePointAtData(position, interpolated);
+        return interpolated ? Vector3.TransformCoordinates(Vector3.Up(), this._pointAtData.interpolationMatrix) : this._binormals[this._pointAtData.previousPointArrayIndex]!;
+    }
+
+    public getDistanceAt(position: number): number {
+        return this.length() * position;
+    }
+
+    public getPreviousPointIndexAt(position: number): number {
+        this._updatePointAtData(position);
+        return this._pointAtData.previousPointArrayIndex;
+    }
+
+    public getSubPositionAt(position: number): number {
+        this._updatePointAtData(position);
+        return this._pointAtData.subPosition;
+    }
+
+    /** Returns the position (in [0, 1]) of the closest virtual point on this path to `target`. */
+    public getClosestPositionTo(target: Vector3): number {
+        let smallestDistance = Number.MAX_VALUE;
+        let closestPosition = 0.0;
+        for (let i = 0; i < this._curve.length - 1; i++) {
+            const point = this._curve[i + 0]!;
+            const tangent = this._curve[i + 1]!.subtract(point).normalize();
+            const subLength = this._distances[i + 1]! - this._distances[i + 0]!;
+            const subPosition = Math.min((Math.max(Vector3.Dot(tangent, target.subtract(point).normalize()), 0.0) * Vector3.Distance(point, target)) / subLength, 1.0);
+            const distance = Vector3.Distance(point.add(tangent.scale(subPosition * subLength)), target);
+
+            if (distance < smallestDistance) {
+                smallestDistance = distance;
+                closestPosition = (this._distances[i + 0]! + subLength * subPosition) / this.length();
+            }
+        }
+        return closestPosition;
+    }
+
+    /** Returns a sub-path (slice) of this path between `start` and `end` (each in [0, 1]). */
+    public slice(start = 0.0, end = 1.0): Path3D {
+        if (start < 0.0) {
+            start = 1 - ((start * -1.0) % 1.0);
+        }
+        if (end < 0.0) {
+            end = 1 - ((end * -1.0) % 1.0);
+        }
+        if (start > end) {
+            const _start = start;
+            start = end;
+            end = _start;
+        }
+        const curvePoints = this.getCurve();
+
+        const startPoint = this.getPointAt(start);
+        let startIndex = this.getPreviousPointIndexAt(start);
+
+        const endPoint = this.getPointAt(end);
+        const endIndex = this.getPreviousPointIndexAt(end) + 1;
+
+        const slicePoints: Vector3[] = [];
+        if (start !== 0.0) {
+            startIndex++;
+            slicePoints.push(startPoint);
+        }
+
+        slicePoints.push(...curvePoints.slice(startIndex, endIndex));
+        if (end !== 1.0 || start === 1.0) {
+            slicePoints.push(endPoint);
+        }
+        return new Path3D(slicePoints, this.getNormalAt(start), this._raw, this._alignTangentsWithPath);
+    }
+
+    /** Recomputes the path's tangents, normals, binormals and distances from `path`. */
+    public update(path: Vector3[], firstNormal: Vector3 | null = null, alignTangentsWithPath = false): Path3D {
+        for (let p = 0; p < path.length; p++) {
+            this._curve[p]!.x = path[p]!.x;
+            this._curve[p]!.y = path[p]!.y;
+            this._curve[p]!.z = path[p]!.z;
+        }
+        this._compute(firstNormal, alignTangentsWithPath);
+        return this;
+    }
+
+    private _compute(firstNormal: Vector3 | null, alignTangentsWithPath = false): void {
+        const l = this._curve.length;
+
+        if (l < 2) {
+            return;
+        }
+
+        this._tangents[0] = this._getFirstNonNullVector(0);
+        if (!this._raw) {
+            this._tangents[0].normalize();
+        }
+        this._tangents[l - 1] = this._curve[l - 1]!.subtract(this._curve[l - 2]!);
+        if (!this._raw) {
+            this._tangents[l - 1]!.normalize();
+        }
+
+        const tg0 = this._tangents[0];
+        const pp0 = this._normalVector(tg0, firstNormal);
+        this._normals[0] = pp0;
+        if (!this._raw) {
+            this._normals[0].normalize();
+        }
+        this._binormals[0] = Vector3.Cross(tg0, this._normals[0]);
+        if (!this._raw) {
+            this._binormals[0].normalize();
+        }
+        this._distances[0] = 0.0;
+
+        let prev: Vector3;
+        let cur: Vector3;
+        let curTang: Vector3;
+        let prevNor: Vector3;
+        let prevBinor: Vector3;
+
+        for (let i = 1; i < l; i++) {
+            prev = this._getLastNonNullVector(i);
+            if (i < l - 1) {
+                cur = this._getFirstNonNullVector(i);
+                this._tangents[i] = alignTangentsWithPath ? cur : prev.add(cur);
+                this._tangents[i]!.normalize();
+            }
+            this._distances[i] = this._distances[i - 1]! + this._curve[i]!.subtract(this._curve[i - 1]!).length();
+
+            curTang = this._tangents[i]!;
+            prevBinor = this._binormals[i - 1]!;
+            this._normals[i] = Vector3.Cross(prevBinor, curTang);
+            if (!this._raw) {
+                if (this._normals[i]!.length() === 0) {
+                    prevNor = this._normals[i - 1]!;
+                    this._normals[i] = prevNor.clone();
+                } else {
+                    this._normals[i]!.normalize();
+                }
+            }
+            this._binormals[i] = Vector3.Cross(curTang, this._normals[i]!);
+            if (!this._raw) {
+                this._binormals[i]!.normalize();
+            }
+        }
+        this._pointAtData.id = NaN;
+    }
+
+    private _getFirstNonNullVector(index: number): Vector3 {
+        let i = 1;
+        let nNVector: Vector3 = this._curve[index + i]!.subtract(this._curve[index]!);
+        while (nNVector.length() === 0 && index + i + 1 < this._curve.length) {
+            i++;
+            nNVector = this._curve[index + i]!.subtract(this._curve[index]!);
+        }
+        return nNVector;
+    }
+
+    private _getLastNonNullVector(index: number): Vector3 {
+        let i = 1;
+        let nLVector: Vector3 = this._curve[index]!.subtract(this._curve[index - i]!);
+        while (nLVector.length() === 0 && index > i + 1) {
+            i++;
+            nLVector = this._curve[index]!.subtract(this._curve[index - i]!);
+        }
+        return nLVector;
+    }
+
+    private _normalVector(vt: Vector3, va: Vector3 | null): Vector3 {
+        let normal0: Vector3;
+        let tgl = vt.length();
+        if (tgl === 0.0) {
+            tgl = 1.0;
+        }
+
+        if (va === undefined || va === null) {
+            let point: Vector3;
+            if (!Scalar.WithinEpsilon(Math.abs(vt.y) / tgl, 1.0, Epsilon)) {
+                point = new Vector3(0.0, -1.0, 0.0);
+            } else if (!Scalar.WithinEpsilon(Math.abs(vt.x) / tgl, 1.0, Epsilon)) {
+                point = new Vector3(1.0, 0.0, 0.0);
+            } else if (!Scalar.WithinEpsilon(Math.abs(vt.z) / tgl, 1.0, Epsilon)) {
+                point = new Vector3(0.0, 0.0, 1.0);
+            } else {
+                point = Vector3.Zero();
+            }
+            normal0 = Vector3.Cross(vt, point);
+        } else {
+            normal0 = Vector3.Cross(vt, va);
+            Vector3.CrossToRef(normal0, vt, normal0);
+        }
+        normal0.normalize();
+        return normal0;
+    }
+
+    private _updatePointAtData(position: number, interpolateTNB = false): PointAtData {
+        if (this._pointAtData.id === position) {
+            if (!this._pointAtData.interpolateReady) {
+                this._updateInterpolationMatrix();
+            }
+            return this._pointAtData;
+        } else {
+            this._pointAtData.id = position;
+        }
+        const curvePoints = this.getPoints();
+
+        if (position <= 0.0) {
+            return this._setPointAtData(0.0, 0.0, curvePoints[0]!, 0, interpolateTNB);
+        } else if (position >= 1.0) {
+            return this._setPointAtData(1.0, 1.0, curvePoints[curvePoints.length - 1]!, curvePoints.length - 1, interpolateTNB);
+        }
+
+        let previousPoint: Vector3 = curvePoints[0]!;
+        let currentPoint: Vector3;
+        let currentLength = 0.0;
+        const targetLength = position * this.length();
+
+        for (let i = 1; i < curvePoints.length; i++) {
+            currentPoint = curvePoints[i]!;
+            const distance = Vector3.Distance(previousPoint, currentPoint);
+            currentLength += distance;
+            if (currentLength === targetLength) {
+                return this._setPointAtData(position, 1.0, currentPoint, i, interpolateTNB);
+            } else if (currentLength > targetLength) {
+                const toLength = currentLength - targetLength;
+                const diff = toLength / distance;
+                const dir = previousPoint.subtract(currentPoint);
+                const point = currentPoint.add(dir.scaleInPlace(diff));
+                return this._setPointAtData(position, 1 - diff, point, i - 1, interpolateTNB);
+            }
+            previousPoint = currentPoint;
+        }
+        return this._pointAtData;
+    }
+
+    private _setPointAtData(position: number, subPosition: number, point: Vector3, parentIndex: number, interpolateTNB: boolean): PointAtData {
+        this._pointAtData.point = point;
+        this._pointAtData.position = position;
+        this._pointAtData.subPosition = subPosition;
+        this._pointAtData.previousPointArrayIndex = parentIndex;
+        this._pointAtData.interpolateReady = interpolateTNB;
+
+        if (interpolateTNB) {
+            this._updateInterpolationMatrix();
+        }
+        return this._pointAtData;
+    }
+
+    private _updateInterpolationMatrix(): void {
+        this._pointAtData.interpolationMatrix = Matrix.Identity();
+        const parentIndex = this._pointAtData.previousPointArrayIndex;
+
+        if (parentIndex !== this._tangents.length - 1) {
+            const index = parentIndex + 1;
+
+            const tangentFrom = this._tangents[parentIndex]!.clone();
+            const normalFrom = this._normals[parentIndex]!.clone();
+            const binormalFrom = this._binormals[parentIndex]!.clone();
+
+            const tangentTo = this._tangents[index]!.clone();
+            const normalTo = this._normals[index]!.clone();
+            const binormalTo = this._binormals[index]!.clone();
+
+            const quatFrom = Quaternion.RotationQuaternionFromAxis(normalFrom, binormalFrom, tangentFrom);
+            const quatTo = Quaternion.RotationQuaternionFromAxis(normalTo, binormalTo, tangentTo);
+            const quatAt = Quaternion.Slerp(quatFrom, quatTo, this._pointAtData.subPosition);
+
+            quatAt.toRotationMatrix(this._pointAtData.interpolationMatrix);
+        }
     }
 }

--- a/packages/babylon-lite-compat/src/math/matrix.ts
+++ b/packages/babylon-lite-compat/src/math/matrix.ts
@@ -191,6 +191,31 @@ export class Matrix {
         return Matrix.FromValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
     }
 
+    /**
+     * Babylon.js `Matrix.FromXYZAxesToRef` — build a rotation matrix from three axes
+     * (each axis becomes a row, matching the row-major / row-vector convention).
+     */
+    public static FromXYZAxesToRef(xaxis: Vector3, yaxis: Vector3, zaxis: Vector3, result: Matrix): Matrix {
+        const m = result.m;
+        m[0] = xaxis.x;
+        m[1] = xaxis.y;
+        m[2] = xaxis.z;
+        m[3] = 0;
+        m[4] = yaxis.x;
+        m[5] = yaxis.y;
+        m[6] = yaxis.z;
+        m[7] = 0;
+        m[8] = zaxis.x;
+        m[9] = zaxis.y;
+        m[10] = zaxis.z;
+        m[11] = 0;
+        m[12] = 0;
+        m[13] = 0;
+        m[14] = 0;
+        m[15] = 1;
+        return result;
+    }
+
     public static Zero(): Matrix {
         return new Matrix();
     }

--- a/packages/babylon-lite-compat/src/math/quaternion.ts
+++ b/packages/babylon-lite-compat/src/math/quaternion.ts
@@ -9,7 +9,7 @@ import { quatFromRotationMatrix } from "babylon-lite";
 import type { Mat4 } from "babylon-lite";
 
 import { Vector3 } from "./vector.js";
-import type { Matrix } from "./matrix.js";
+import { Matrix } from "./matrix.js";
 
 export class Quaternion {
     public constructor(
@@ -81,6 +81,40 @@ export class Quaternion {
         return new Quaternion(this.x, this.y, this.z, this.w);
     }
 
+    /**
+     * Babylon.js `Quaternion.toRotationMatrix` — write this quaternion's rotation
+     * into `result` (row-major, matching the compat `Matrix` storage convention).
+     */
+    public toRotationMatrix(result: Matrix): Matrix {
+        const xx = this.x * this.x;
+        const yy = this.y * this.y;
+        const zz = this.z * this.z;
+        const xy = this.x * this.y;
+        const zw = this.z * this.w;
+        const zx = this.z * this.x;
+        const yw = this.y * this.w;
+        const yz = this.y * this.z;
+        const xw = this.x * this.w;
+        const m = result.m;
+        m[0] = 1 - 2 * (yy + zz);
+        m[1] = 2 * (xy + zw);
+        m[2] = 2 * (zx - yw);
+        m[3] = 0;
+        m[4] = 2 * (xy - zw);
+        m[5] = 1 - 2 * (zz + xx);
+        m[6] = 2 * (yz + xw);
+        m[7] = 0;
+        m[8] = 2 * (zx + yw);
+        m[9] = 2 * (yz - xw);
+        m[10] = 1 - 2 * (yy + xx);
+        m[11] = 0;
+        m[12] = 0;
+        m[13] = 0;
+        m[14] = 0;
+        m[15] = 1;
+        return result;
+    }
+
     public equals(other: Quaternion): boolean {
         return this.x === other.x && this.y === other.y && this.z === other.z && this.w === other.w;
     }
@@ -146,6 +180,24 @@ export class Quaternion {
         result.z = q.z;
         result.w = q.w;
         return result;
+    }
+
+    /**
+     * Babylon.js `Quaternion.RotationQuaternionFromAxis` — create a rotation quaternion
+     * from three orthonormal axes (normalized in place, matching Babylon.js).
+     */
+    public static RotationQuaternionFromAxis(axis1: Vector3, axis2: Vector3, axis3: Vector3, ref?: Quaternion): Quaternion {
+        const result = ref ?? new Quaternion(0, 0, 0, 0);
+        return Quaternion.RotationQuaternionFromAxisToRef(axis1, axis2, axis3, result);
+    }
+
+    /**
+     * Babylon.js `Quaternion.RotationQuaternionFromAxisToRef` — write a rotation
+     * quaternion built from three orthonormal axes into `ref`.
+     */
+    public static RotationQuaternionFromAxisToRef(axis1: Vector3, axis2: Vector3, axis3: Vector3, ref: Quaternion): Quaternion {
+        const rotMat = Matrix.FromXYZAxesToRef(axis1.normalize(), axis2.normalize(), axis3.normalize(), Matrix.Identity());
+        return Quaternion.FromRotationMatrixToRef(rotMat, ref);
     }
 
     public static FromEulerAngles(x: number, y: number, z: number): Quaternion {

--- a/packages/babylon-lite-compat/src/math/vector.ts
+++ b/packages/babylon-lite-compat/src/math/vector.ts
@@ -334,6 +334,44 @@ export class Vector3 {
         return result;
     }
 
+    /** Babylon.js `Vector3.Hermite` — cubic Hermite interpolation between `value1` and `value2` with the given tangents. */
+    public static Hermite(value1: Vector3, tangent1: Vector3, value2: Vector3, tangent2: Vector3, amount: number): Vector3 {
+        const squared = amount * amount;
+        const cubed = amount * squared;
+        const part1 = 2 * cubed - 3 * squared + 1;
+        const part2 = -2 * cubed + 3 * squared;
+        const part3 = cubed - 2 * squared + amount;
+        const part4 = cubed - squared;
+        return new Vector3(
+            value1.x * part1 + value2.x * part2 + tangent1.x * part3 + tangent2.x * part4,
+            value1.y * part1 + value2.y * part2 + tangent1.y * part3 + tangent2.y * part4,
+            value1.z * part1 + value2.z * part2 + tangent1.z * part3 + tangent2.z * part4
+        );
+    }
+
+    /** Babylon.js `Vector3.CatmullRom` — Catmull-Rom interpolation through the four control points. */
+    public static CatmullRom(value1: Vector3, value2: Vector3, value3: Vector3, value4: Vector3, amount: number): Vector3 {
+        const squared = amount * amount;
+        const cubed = squared * amount;
+        return new Vector3(
+            0.5 *
+                (2 * value2.x +
+                    (-value1.x + value3.x) * amount +
+                    (2 * value1.x - 5 * value2.x + 4 * value3.x - value4.x) * squared +
+                    (-value1.x + 3 * value2.x - 3 * value3.x + value4.x) * cubed),
+            0.5 *
+                (2 * value2.y +
+                    (-value1.y + value3.y) * amount +
+                    (2 * value1.y - 5 * value2.y + 4 * value3.y - value4.y) * squared +
+                    (-value1.y + 3 * value2.y - 3 * value3.y + value4.y) * cubed),
+            0.5 *
+                (2 * value2.z +
+                    (-value1.z + value3.z) * amount +
+                    (2 * value1.z - 5 * value2.z + 4 * value3.z - value4.z) * squared +
+                    (-value1.z + 3 * value2.z - 3 * value3.z + value4.z) * cubed)
+        );
+    }
+
     /** Midpoint between two vectors. */
     public static Center(a: Vector3, b: Vector3): Vector3 {
         return Vector3.CenterToRef(a, b, new Vector3());

--- a/packages/babylon-lite-compat/tests/curve.test.ts
+++ b/packages/babylon-lite-compat/tests/curve.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import { Vector3 } from "../src/math/vector";
+import { Quaternion } from "../src/math/quaternion";
+import { Matrix } from "../src/math/matrix";
+import { Curve3, Path3D } from "../src/math/curve";
+
+describe("Vector3.Hermite / CatmullRom", () => {
+    it("Hermite returns the endpoints at t=0 and t=1", () => {
+        const p1 = new Vector3(0, 0, 0);
+        const p2 = new Vector3(1, 2, 3);
+        const t1 = new Vector3(1, 0, 0);
+        const t2 = new Vector3(0, 1, 0);
+        const a = Vector3.Hermite(p1, t1, p2, t2, 0);
+        const b = Vector3.Hermite(p1, t1, p2, t2, 1);
+        expect([a.x, a.y, a.z]).toEqual([0, 0, 0]);
+        expect([b.x, b.y, b.z]).toEqual([1, 2, 3]);
+    });
+
+    it("CatmullRom passes through the inner control points at t=0 and t=1", () => {
+        const v1 = new Vector3(0, 0, 0);
+        const v2 = new Vector3(1, 0, 0);
+        const v3 = new Vector3(2, 1, 0);
+        const v4 = new Vector3(3, 0, 0);
+        const at0 = Vector3.CatmullRom(v1, v2, v3, v4, 0);
+        const at1 = Vector3.CatmullRom(v1, v2, v3, v4, 1);
+        expect(at0.x).toBeCloseTo(1, 6);
+        expect(at0.y).toBeCloseTo(0, 6);
+        expect(at1.x).toBeCloseTo(2, 6);
+        expect(at1.y).toBeCloseTo(1, 6);
+    });
+});
+
+describe("Curve3 spline factories", () => {
+    it("CreateHermiteSpline produces nSeg+1 points hitting both endpoints", () => {
+        const curve = Curve3.CreateHermiteSpline(new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 1, 0), new Vector3(0, 1, 0), 10);
+        const pts = curve.getPoints();
+        expect(pts.length).toBe(11);
+        expect([pts[0]!.x, pts[0]!.y]).toEqual([0, 0]);
+        expect([pts[10]!.x, pts[10]!.y]).toEqual([1, 1]);
+    });
+
+    it("CreateCatmullRomSpline (open) spans the control points", () => {
+        const points = [new Vector3(0, 0, 0), new Vector3(1, 1, 0), new Vector3(2, 0, 0), new Vector3(3, 1, 0)];
+        const curve = Curve3.CreateCatmullRomSpline(points, 5);
+        const pts = curve.getPoints();
+        // 4 control points → 6 padded points → 3 segments * nbPoints + 1 closing point.
+        expect(pts.length).toBe(3 * 5 + 1);
+        expect([pts[0]!.x, pts[0]!.y]).toEqual([0, 0]);
+        const last = pts[pts.length - 1]!;
+        expect(last.x).toBeCloseTo(3, 6);
+        expect(last.y).toBeCloseTo(1, 6);
+    });
+
+    it("CreateCatmullRomSpline (closed) loops back to the start", () => {
+        const points = [new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 1, 0), new Vector3(0, 1, 0)];
+        const curve = Curve3.CreateCatmullRomSpline(points, 4, true);
+        const pts = curve.getPoints();
+        expect(pts.length).toBe(points.length * 4 + 1);
+        const first = pts[0]!;
+        const last = pts[pts.length - 1]!;
+        expect(last.x).toBeCloseTo(first.x, 6);
+        expect(last.y).toBeCloseTo(first.y, 6);
+        expect(last.z).toBeCloseTo(first.z, 6);
+    });
+});
+
+describe("Path3D", () => {
+    const straight = () => new Path3D([new Vector3(0, 0, 0), new Vector3(0, 0, 1), new Vector3(0, 0, 2), new Vector3(0, 0, 3)]);
+
+    it("computes cumulative distances and total length", () => {
+        const path = straight();
+        expect(path.getDistances()).toEqual([0, 1, 2, 3]);
+        expect(path.length()).toBe(3);
+        expect(path.getDistanceAt(0.5)).toBeCloseTo(1.5, 6);
+    });
+
+    it("produces normalized orthonormal Frenet frames", () => {
+        const path = straight();
+        const tangents = path.getTangents();
+        const normals = path.getNormals();
+        const binormals = path.getBinormals();
+        expect(tangents.length).toBe(4);
+        for (let i = 0; i < 4; i++) {
+            expect(tangents[i]!.length()).toBeCloseTo(1, 6);
+            expect(normals[i]!.length()).toBeCloseTo(1, 6);
+            expect(binormals[i]!.length()).toBeCloseTo(1, 6);
+            expect(Vector3.Dot(tangents[i]!, normals[i]!)).toBeCloseTo(0, 6);
+            expect(Vector3.Dot(tangents[i]!, binormals[i]!)).toBeCloseTo(0, 6);
+        }
+        // Tangent of a +Z line is +Z.
+        expect(tangents[0]!.z).toBeCloseTo(1, 6);
+    });
+
+    it("interpolates points along the path", () => {
+        const path = straight();
+        const mid = path.getPointAt(0.5);
+        expect(mid.z).toBeCloseTo(1.5, 6);
+        expect(path.getPreviousPointIndexAt(0.5)).toBe(1);
+        const start = path.getPointAt(0);
+        const end = path.getPointAt(1);
+        expect(start.z).toBeCloseTo(0, 6);
+        expect(end.z).toBeCloseTo(3, 6);
+    });
+
+    it("returns a tangent at an interpolated position (interpolated frame)", () => {
+        const path = straight();
+        const tangent = path.getTangentAt(0.5, true);
+        expect(tangent.length()).toBeCloseTo(1, 6);
+        expect(tangent.z).toBeCloseTo(1, 6);
+    });
+
+    it("finds the closest position to an arbitrary point", () => {
+        const path = straight();
+        const pos = path.getClosestPositionTo(new Vector3(0.5, 0, 1.5));
+        expect(pos).toBeCloseTo(0.5, 4);
+    });
+
+    it("slices a sub-path", () => {
+        const path = straight();
+        const sub = path.slice(0.25, 0.75);
+        const pts = sub.getCurve();
+        expect(pts[0]!.z).toBeCloseTo(0.75, 6);
+        expect(pts[pts.length - 1]!.z).toBeCloseTo(2.25, 6);
+    });
+
+    it("update recomputes the frame from new points", () => {
+        const path = straight();
+        path.update([new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(2, 0, 0), new Vector3(3, 0, 0)]);
+        expect(path.length()).toBeCloseTo(3, 6);
+        expect(path.getTangents()[0]!.x).toBeCloseTo(1, 6);
+    });
+});
+
+describe("Quaternion axis/matrix helpers", () => {
+    it("RotationQuaternionFromAxis builds an identity quaternion from the standard basis", () => {
+        const q = Quaternion.RotationQuaternionFromAxis(new Vector3(1, 0, 0), new Vector3(0, 1, 0), new Vector3(0, 0, 1));
+        expect(q.x).toBeCloseTo(0, 6);
+        expect(q.y).toBeCloseTo(0, 6);
+        expect(q.z).toBeCloseTo(0, 6);
+        expect(Math.abs(q.w)).toBeCloseTo(1, 6);
+    });
+
+    it("toRotationMatrix round-trips the identity quaternion", () => {
+        const m = Quaternion.Identity().toRotationMatrix(Matrix.Identity());
+        const id = Matrix.Identity();
+        for (let i = 0; i < 16; i++) {
+            expect(m.m[i]!).toBeCloseTo(id.m[i]!, 6);
+        }
+    });
+});


### PR DESCRIPTION
Automated sync of `@babylonjs/lite-compat` against the latest Babylon.js and Babylon Lite changes,
produced by the [`update-compat-layer`](.github/copilot/skills/update-compat-layer.md) skill.

**Synced against BJS commit:** `4a4481e911bee11cb4b9e92689f65c69edb474b8`

### Validation (run independently by the pipeline)
- ✅ compat unit tests
- ✅ compat typecheck

### Changed files
- `ackages/babylon-lite-compat/COMPAT-STATUS.md`
- `packages/babylon-lite-compat/README.md`
- `packages/babylon-lite-compat/src/math/curve.ts`
- `packages/babylon-lite-compat/src/math/matrix.ts`
- `packages/babylon-lite-compat/src/math/quaternion.ts`
- `packages/babylon-lite-compat/src/math/vector.ts`
- `packages/babylon-lite-compat/tests/curve.test.ts`

> Validation passed. Please review the wrapper changes and the updated `COMPAT-STATUS.md` before merging.

> Opened as a **draft** by the compat-sync pipeline. Review and mark ready when satisfied.