### PR TITLE
[compat-sync] Babylon.js compat-layer sync

### DIFF
--- a/packages/babylon-lite-compat/COMPAT-STATUS.md
+++ b/packages/babylon-lite-compat/COMPAT-STATUS.md
@@ -7,8 +7,8 @@ updated by the `update-compat-layer` skill.
 <!-- The two markers below are machine-read by the update-compat-layer skill.
      Do not rename them. Update the SHA after re-syncing against BJS master. -->
 
-- **Last synced BJS commit:** `c729b94f2e36f2d915415620857452f7ad0ff731`
-- **Last sync date:** 2026-06-25
+- **Last synced BJS commit:** `4a4481e911bee11cb4b9e92689f65c69edb474b8`
+- **Last sync date:** 2026-06-28
 - **Lite compat package version:** 0.0.1
 
 > The "Last synced BJS commit" is the `BabylonJS/Babylon.js` `master` HEAD that the
@@ -68,17 +68,18 @@ date` markers above record the `BabylonJS/Babylon.js` `master` HEAD the surface
 | -------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Vector2` / `Vector3` / `Vector4`                  | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
 | `Color3` / `Color4`                                | ✅ Full    | [math/color.ts](src/math/color.ts)                                                                                                                              |
-| `Quaternion`                                       | ✅ Full    | [math/quaternion.ts](src/math/quaternion.ts) (incl. `FromRotationMatrix` / `FromRotationMatrixToRef` / `fromRotationMatrix` over Lite `quatFromRotationMatrix`) |
+| `Quaternion`                                       | ✅ Full    | [math/quaternion.ts](src/math/quaternion.ts) (incl. `FromRotationMatrix` / `FromRotationMatrixToRef` / `fromRotationMatrix` over Lite `quatFromRotationMatrix`, `toRotationMatrix`, `RotationQuaternionFromAxis` / `RotationQuaternionFromAxisToRef`, `Slerp`) |
 | `Matrix`                                           | ✅ Full    | [math/matrix.ts](src/math/matrix.ts) (incl. `decompose` — BJS-accurate scale/negative-determinant handling, rotation via Lite `quatFromRotationMatrix`)         |
 | `Vector3.TransformCoordinates` / `TransformNormal` | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
 | `Vector3.Center` / `CenterToRef`                   | ✅ Full    | [math/vector.ts](src/math/vector.ts)                                                                                                                            |
+| `Vector3.Hermite` / `Vector3.CatmullRom`           | ✅ Full    | [math/vector.ts](src/math/vector.ts) (spline sample helpers used by `Curve3` / `Path3D`)                                                                        |
 | `Matrix.copyToArray`                               | ✅ Full    | [math/matrix.ts](src/math/matrix.ts)                                                                                                                            |
 | `Scalar`                                           | ✅ Full    | [math/scalar.ts](src/math/scalar.ts)                                                                                                                            |
 | `Axis` / `Space` / `Epsilon`                       | ✅ Full    | [math/constants.ts](src/math/constants.ts)                                                                                                                      |
 | `Plane` / `Ray` / `Frustum`                        | ✅ Full    | [math/plane.ts](src/math/plane.ts), [ray.ts](src/math/ray.ts), [frustum.ts](src/math/frustum.ts)                                                                |
 | `Size` / `Viewport`                                | ✅ Full    | [math/size.ts](src/math/size.ts)                                                                                                                                |
-| `Angle` / `Curve3` / `Path3D`                      | ⚡ Partial | [math/curve.ts](src/math/curve.ts)                                                                                                                              |
-| `Curve3` / `Path3D` / easing curves on math        | ⚡ Partial | curve + easing                                                                                                                                                  |
+| `Angle` / `Curve3` / `Path3D`                      | ✅ Full    | [math/curve.ts](src/math/curve.ts)                                                                                                                              |
+| `Curve3` spline builders + `Path3D` frames         | ✅ Full    | curve — `Create{Quadratic,Cubic}Bezier` / `CreateHermiteSpline` / `CreateCatmullRomSpline` (open+closed) / `ArcThru3Points` / `continue`; `Path3D` tangents/normals/binormals, `getPointAt` / `getTangentAt`(interp) / `getNormalAt` / `getBinormalAt` / `getDistanceAt` / `getSubPositionAt` / `getClosestPositionTo` / `slice` / `update`; `Angle.BetweenTwoPoints` / `BetweenTwoVectors` |
 
 ## Core
 
@@ -466,3 +467,18 @@ large-world-rendering scenes are now resolved.
 > (`PhysicsAggregate` not yet wrapped), not a Lite-core unblock; and audio scenes
 > have no pixel oracle. So no scene moved into the working list this run — Task 2 is
 > dormant, as expected when no Lite change unblocks a scene.
+
+> **Task 2 re-check (2026-06-28):** the Lite changes landed since the 2026-06-25 sync —
+> the MSAA depth/colour resolve frame-graph task (`createDepthResolveTask` /
+> `DepthResolveTaskConfig`, #326), the `_shadowCasterMaterial` caster override + a
+> mid-`buildScene` group-renderable fix (#320), and the sprite refactor that makes
+> `coverageGamma` and per-sprite `uvOffset` opt-in/import-triggered
+> (`setSprite2DCoverageGamma` / `setSprite2DUvOffset`, #314) — were cross-referenced
+> against the blocker table above. **None clears a previously-skipped scene's
+> blocker:** the new depth-resolve task is a frame-graph internal (the
+> `PostProcess` / RTT scenes 116/142–146 are deferred _by design_, not for lack of a
+> depth-resolve primitive); the shadow caster override and group-renderable fix do
+> not touch any blocked scene's chain; and the sprite changes only make already-working
+> sprite features (scenes 50–58, 92–97) opt-in, with their compat ports unchanged. So
+> no scene moved into the working list this run — Task 2 is dormant, as expected when
+> no Lite change unblocks a scene.

--- a/packages/babylon-lite-compat/README.md
+++ b/packages/babylon-lite-compat/README.md
@@ -116,7 +116,7 @@ overloads within a supported area may still be absent.
 
 | Feature area                                                                                            | Status | Notes                                                                                                    |
 | ------------------------------------------------------------------------------------------------------- | :----: | -------------------------------------------------------------------------------------------------------- |
-| Math (`Vector*`, `Color*`, `Quaternion`, `Matrix`, `Plane`, `Ray`, `Frustum`, `Scalar`, `Axis`/`Space`) |   ✅   | `Angle` / `Curve3` / `Path3D` partial                                                                    |
+| Math (`Vector*`, `Color*`, `Quaternion`, `Matrix`, `Plane`, `Ray`, `Frustum`, `Scalar`, `Axis`/`Space`) |   ✅   | incl. `Angle` / `Curve3` / `Path3D` (spline builders + tangent/normal/binormal frames)                   |
 | Engine (`WebGPUEngine`, `Engine`, `ThinEngine`, `NullEngine`)                                           |   ⚡   | async startup + render loop; `beginFrame`/`endFrame` and manual `scene.render()` unsupported             |
 | Scene (clear color, cameras/lights, fog, environment, observables, ready state)                         |   ⚡   | sync `scene.pick` unsupported (use async `GPUPicker`); some scene enumeration needs Lite core            |
 | Cameras (`ArcRotateCamera`, `FreeCamera`/`Universal`/`Target`, `FollowCamera`, `GeospatialCamera`)      |   ✅   | XR / device-orientation / stereoscopic rigs unsupported                                                  |

--- a/packages/babylon-lite-compat/src/math/curve.ts
+++ b/packages/babylon-lite-compat/src/math/curve.ts
@@ -1,9 +1,18 @@
 /** Babylon.js-compatible curve/path helpers: `Angle`, `Curve3`, `Path3D` (pure JS). */
 
+import { Epsilon, Scalar } from "./scalar.js";
+import { Matrix } from "./matrix.js";
+import { Quaternion } from "./quaternion.js";
+import type { Vector2 } from "./vector.js";
 import { Vector3 } from "./vector.js";
 
+/** Babylon.js `Angle` — an angle stored in radians, normalized to `[0, 2π)`. */
 export class Angle {
-    public constructor(private readonly _radians: number) {}
+    private readonly _radians: number;
+
+    public constructor(radians: number) {
+        this._radians = radians < 0.0 ? radians + 2.0 * Math.PI : radians;
+    }
 
     public radians(): number {
         return this._radians;
@@ -11,6 +20,28 @@ export class Angle {
 
     public degrees(): number {
         return (this._radians * 180) / Math.PI;
+    }
+
+    /** Angle (radians) between the line through `a`→`b` and the x-axis. */
+    public static BetweenTwoPoints(a: Vector2, b: Vector2): Angle {
+        const delta = b.subtract(a);
+        return new Angle(Math.atan2(delta.y, delta.x));
+    }
+
+    /** Angle between two vectors, in `[0, π]`. */
+    public static BetweenTwoVectors(a: VectorLike, b: VectorLike): Angle {
+        let product = a.lengthSquared() * b.lengthSquared();
+        if (product === 0) {
+            return new Angle(Math.PI / 2);
+        }
+        product = Math.sqrt(product);
+        const az = a.z ?? 0;
+        const bz = b.z ?? 0;
+        const aw = a.w ?? 0;
+        const bw = b.w ?? 0;
+        const dot = a.x * b.x + a.y * b.y + az * bz + aw * bw;
+        const cosVal = Scalar.Clamp(dot / product, -1, 1);
+        return new Angle(Math.acos(cosVal));
     }
 
     public static FromRadians(radians: number): Angle {
@@ -22,9 +53,26 @@ export class Angle {
     }
 }
 
-/** A 3D curve built from an ordered list of points. */
+interface VectorLike {
+    x: number;
+    y: number;
+    z?: number;
+    w?: number;
+    lengthSquared(): number;
+}
+
+/**
+ * Babylon.js `Curve3` — a 3D curve built from an ordered list of points, with the
+ * full set of static spline builders (Bézier / Hermite / Catmull-Rom / arc).
+ */
 export class Curve3 {
-    public constructor(private readonly _points: Vector3[]) {}
+    private readonly _points: Vector3[];
+    private readonly _length: number;
+
+    public constructor(points: Vector3[]) {
+        this._points = points;
+        this._length = Curve3._ComputeLength(points);
+    }
 
     public getPoints(): Vector3[] {
         return this._points;
@@ -32,68 +80,198 @@ export class Curve3 {
 
     /** Total polyline length along the curve points. */
     public length(): number {
-        let total = 0;
-        for (let i = 1; i < this._points.length; i++) {
-            total += Vector3.Distance(this._points[i]!, this._points[i - 1]!);
-        }
-        return total;
+        return this._length;
     }
 
-    /** Concatenate another curve (dropping the duplicated join point). */
+    /**
+     * Babylon.js `continue` — translate `curve` so its first point coincides with
+     * this curve's last point, then append it (dropping the duplicated join point).
+     */
     public continue(curve: Curve3): Curve3 {
-        const points = this._points.slice();
-        const other = curve.getPoints();
-        for (let i = 1; i < other.length; i++) {
-            points.push(other[i]!.clone());
+        const lastPoint = this._points[this._points.length - 1]!;
+        const continuedPoints = this._points.slice();
+        const curvePoints = curve.getPoints();
+        for (let i = 1; i < curvePoints.length; i++) {
+            continuedPoints.push(curvePoints[i]!.subtract(curvePoints[0]!).add(lastPoint));
         }
-        return new Curve3(points);
+        return new Curve3(continuedPoints);
     }
 
     /** Quadratic Bézier from `v0` → `v2` with control `v1`, sampled `nbPoints` times. */
     public static CreateQuadraticBezier(v0: Vector3, v1: Vector3, v2: Vector3, nbPoints: number): Curve3 {
-        const count = Math.max(nbPoints, 2);
-        const points: Vector3[] = [];
-        for (let i = 0; i <= count; i++) {
-            const t = i / count;
-            const u = 1 - t;
-            const x = u * u * v0.x + 2 * u * t * v1.x + t * t * v2.x;
-            const y = u * u * v0.y + 2 * u * t * v1.y + t * t * v2.y;
-            const z = u * u * v0.z + 2 * u * t * v1.z + t * t * v2.z;
-            points.push(new Vector3(x, y, z));
+        nbPoints = nbPoints > 2 ? nbPoints : 3;
+        const bez: Vector3[] = [];
+        const equation = (t: number, val0: number, val1: number, val2: number): number => (1.0 - t) * (1.0 - t) * val0 + 2.0 * t * (1.0 - t) * val1 + t * t * val2;
+        for (let i = 0; i <= nbPoints; i++) {
+            const t = i / nbPoints;
+            bez.push(new Vector3(equation(t, v0.x, v1.x, v2.x), equation(t, v0.y, v1.y, v2.y), equation(t, v0.z, v1.z, v2.z)));
         }
-        return new Curve3(points);
+        return new Curve3(bez);
     }
 
     /** Cubic Bézier from `v0` → `v3` with controls `v1`, `v2`, sampled `nbPoints` times. */
     public static CreateCubicBezier(v0: Vector3, v1: Vector3, v2: Vector3, v3: Vector3, nbPoints: number): Curve3 {
-        const count = Math.max(nbPoints, 2);
-        const points: Vector3[] = [];
-        for (let i = 0; i <= count; i++) {
-            const t = i / count;
-            const u = 1 - t;
-            const w0 = u * u * u;
-            const w1 = 3 * u * u * t;
-            const w2 = 3 * u * t * t;
-            const w3 = t * t * t;
-            points.push(new Vector3(w0 * v0.x + w1 * v1.x + w2 * v2.x + w3 * v3.x, w0 * v0.y + w1 * v1.y + w2 * v2.y + w3 * v3.y, w0 * v0.z + w1 * v1.z + w2 * v2.z + w3 * v3.z));
+        nbPoints = nbPoints > 3 ? nbPoints : 4;
+        const bez: Vector3[] = [];
+        const equation = (t: number, val0: number, val1: number, val2: number, val3: number): number =>
+            (1.0 - t) * (1.0 - t) * (1.0 - t) * val0 + 3.0 * t * (1.0 - t) * (1.0 - t) * val1 + 3.0 * t * t * (1.0 - t) * val2 + t * t * t * val3;
+        for (let i = 0; i <= nbPoints; i++) {
+            const t = i / nbPoints;
+            bez.push(new Vector3(equation(t, v0.x, v1.x, v2.x, v3.x), equation(t, v0.y, v1.y, v2.y, v3.y), equation(t, v0.z, v1.z, v2.z, v3.z)));
         }
-        return new Curve3(points);
+        return new Curve3(bez);
+    }
+
+    /** Hermite spline from `p1`/`p2` with tangents `t1`/`t2`, `nSeg` segments. */
+    public static CreateHermiteSpline(p1: Vector3, t1: Vector3, p2: Vector3, t2: Vector3, nSeg: number): Curve3 {
+        const hermite: Vector3[] = [];
+        const step = 1.0 / nSeg;
+        for (let i = 0; i <= nSeg; i++) {
+            hermite.push(Vector3.Hermite(p1, t1, p2, t2, i * step));
+        }
+        return new Curve3(hermite);
+    }
+
+    /** Catmull-Rom spline through `points` (≥4), `nbPoints` between each control point. */
+    public static CreateCatmullRomSpline(points: Vector3[], nbPoints: number, closed?: boolean): Curve3 {
+        const catmullRom: Vector3[] = [];
+        const step = 1.0 / nbPoints;
+        let amount = 0.0;
+        if (closed) {
+            const pointsCount = points.length;
+            for (let i = 0; i < pointsCount; i++) {
+                amount = 0;
+                for (let c = 0; c < nbPoints; c++) {
+                    catmullRom.push(
+                        Vector3.CatmullRom(points[i % pointsCount]!, points[(i + 1) % pointsCount]!, points[(i + 2) % pointsCount]!, points[(i + 3) % pointsCount]!, amount)
+                    );
+                    amount += step;
+                }
+            }
+            catmullRom.push(catmullRom[0]!);
+        } else {
+            const totalPoints: Vector3[] = [];
+            totalPoints.push(points[0]!.clone());
+            totalPoints.push(...points);
+            totalPoints.push(points[points.length - 1]!.clone());
+            let i = 0;
+            for (; i < totalPoints.length - 3; i++) {
+                amount = 0;
+                for (let c = 0; c < nbPoints; c++) {
+                    catmullRom.push(Vector3.CatmullRom(totalPoints[i]!, totalPoints[i + 1]!, totalPoints[i + 2]!, totalPoints[i + 3]!, amount));
+                    amount += step;
+                }
+            }
+            i--;
+            catmullRom.push(Vector3.CatmullRom(totalPoints[i]!, totalPoints[i + 1]!, totalPoints[i + 2]!, totalPoints[i + 3]!, amount));
+        }
+        return new Curve3(catmullRom);
+    }
+
+    /** Arc passing through three (non-colinear) points; empty curve if colinear. */
+    public static ArcThru3Points(first: Vector3, second: Vector3, third: Vector3, steps = 32, closed = false, fullCircle = false): Curve3 {
+        const arc: Vector3[] = [];
+        const vec1 = second.subtract(first);
+        const vec2 = third.subtract(second);
+        const vec3 = first.subtract(third);
+        const zAxis = Vector3.Cross(vec1, vec2);
+        const len4 = zAxis.length();
+        if (len4 < Math.pow(10, -8)) {
+            return new Curve3(arc);
+        }
+        const len1Sq = vec1.lengthSquared();
+        const len2Sq = vec2.lengthSquared();
+        const len3Sq = vec3.lengthSquared();
+        const len4Sq = zAxis.lengthSquared();
+        const len1 = vec1.length();
+        const len2 = vec2.length();
+        const len3 = vec3.length();
+        const radius = (0.5 * len1 * len2 * len3) / len4;
+        const dot1 = Vector3.Dot(vec1, vec3);
+        const dot2 = Vector3.Dot(vec1, vec2);
+        const dot3 = Vector3.Dot(vec2, vec3);
+        const a = (-0.5 * len2Sq * dot1) / len4Sq;
+        const b = (-0.5 * len3Sq * dot2) / len4Sq;
+        const c = (-0.5 * len1Sq * dot3) / len4Sq;
+        const center = first.scale(a).add(second.scale(b)).add(third.scale(c));
+        const radiusVec = first.subtract(center);
+        const xAxis = radiusVec.normalize();
+        const yAxis = Vector3.Cross(zAxis, xAxis).normalize();
+        if (fullCircle) {
+            const dStep = (2 * Math.PI) / steps;
+            for (let theta = 0; theta <= 2 * Math.PI; theta += dStep) {
+                arc.push(center.add(xAxis.scale(radius * Math.cos(theta)).add(yAxis.scale(radius * Math.sin(theta)))));
+            }
+            arc.push(first);
+        } else {
+            const dStep = 1 / steps;
+            let theta = 0;
+            let point: Vector3;
+            do {
+                point = center.add(xAxis.scale(radius * Math.cos(theta)).add(yAxis.scale(radius * Math.sin(theta))));
+                arc.push(point);
+                theta += dStep;
+            } while (!point.equalsWithEpsilon(third, radius * dStep * 1.1));
+            arc.push(third);
+            if (closed) {
+                arc.push(first);
+            }
+        }
+        return new Curve3(arc);
+    }
+
+    private static _ComputeLength(path: Vector3[]): number {
+        let l = 0;
+        for (let i = 1; i < path.length; i++) {
+            l += path[i]!.subtract(path[i - 1]!).length();
+        }
+        return l;
     }
 }
 
-/** A 3D path with cumulative-distance queries over its points. */
-export class Path3D {
-    private readonly _curve: Vector3[];
-    private readonly _distances: number[] = [];
-    private _length = 0;
+interface PointAtData {
+    id: number;
+    point: Vector3;
+    previousPointArrayIndex: number;
+    position: number;
+    subPosition: number;
+    interpolateReady: boolean;
+    interpolationMatrix: Matrix;
+}
 
-    public constructor(points: Vector3[]) {
-        this._curve = points.map((p) => p.clone());
-        this._distances[0] = 0;
-        for (let i = 1; i < this._curve.length; i++) {
-            this._length += Vector3.Distance(this._curve[i]!, this._curve[i - 1]!);
-            this._distances[i] = this._length;
+/**
+ * Babylon.js `Path3D` — a 3D path with cumulative-distance, tangent / normal /
+ * binormal frames and interpolated point/frame queries over its curve points.
+ */
+export class Path3D {
+    public path: Vector3[];
+
+    private readonly _curve: Vector3[] = [];
+    private readonly _distances: number[] = [];
+    private readonly _tangents: Vector3[] = [];
+    private readonly _normals: Vector3[] = [];
+    private readonly _binormals: Vector3[] = [];
+    private readonly _raw: boolean;
+    private readonly _alignTangentsWithPath: boolean;
+
+    private readonly _pointAtData: PointAtData = {
+        id: 0,
+        point: Vector3.Zero(),
+        previousPointArrayIndex: 0,
+        position: 0,
+        subPosition: 0,
+        interpolateReady: false,
+        interpolationMatrix: Matrix.Identity(),
+    };
+
+    public constructor(path: Vector3[], firstNormal: Vector3 | null = null, raw?: boolean, alignTangentsWithPath = false) {
+        this.path = path;
+        for (let p = 0; p < path.length; p++) {
+            this._curve[p] = path[p]!.clone();
         }
+        this._raw = raw || false;
+        this._alignTangentsWithPath = alignTangentsWithPath;
+        this._compute(firstNormal, alignTangentsWithPath);
     }
 
     public getCurve(): Vector3[] {
@@ -105,11 +283,298 @@ export class Path3D {
     }
 
     public length(): number {
-        return this._length;
+        return this._distances[this._distances.length - 1]!;
     }
 
-    /** Distances of each point from the path start, normalized to [0, 1] when `length > 0`. */
+    public getTangents(): Vector3[] {
+        return this._tangents;
+    }
+
+    public getNormals(): Vector3[] {
+        return this._normals;
+    }
+
+    public getBinormals(): Vector3[] {
+        return this._binormals;
+    }
+
     public getDistances(): number[] {
         return this._distances;
+    }
+
+    public getPointAt(position: number): Vector3 {
+        return this._updatePointAtData(position).point;
+    }
+
+    public getTangentAt(position: number, interpolated = false): Vector3 {
+        this._updatePointAtData(position, interpolated);
+        return interpolated ? Vector3.TransformCoordinates(Vector3.Forward(), this._pointAtData.interpolationMatrix) : this._tangents[this._pointAtData.previousPointArrayIndex]!;
+    }
+
+    public getNormalAt(position: number, interpolated = false): Vector3 {
+        this._updatePointAtData(position, interpolated);
+        return interpolated ? Vector3.TransformCoordinates(Vector3.Right(), this._pointAtData.interpolationMatrix) : this._normals[this._pointAtData.previousPointArrayIndex]!;
+    }
+
+    public getBinormalAt(position: number, interpolated = false): Vector3 {
+        this._updatePointAtData(position, interpolated);
+        return interpolated ? Vector3.TransformCoordinates(Vector3.Up(), this._pointAtData.interpolationMatrix) : this._binormals[this._pointAtData.previousPointArrayIndex]!;
+    }
+
+    public getDistanceAt(position: number): number {
+        return this.length() * position;
+    }
+
+    public getPreviousPointIndexAt(position: number): number {
+        this._updatePointAtData(position);
+        return this._pointAtData.previousPointArrayIndex;
+    }
+
+    public getSubPositionAt(position: number): number {
+        this._updatePointAtData(position);
+        return this._pointAtData.subPosition;
+    }
+
+    public getClosestPositionTo(target: Vector3): number {
+        let smallestDistance = Number.MAX_VALUE;
+        let closestPosition = 0.0;
+        for (let i = 0; i < this._curve.length - 1; i++) {
+            const point = this._curve[i + 0]!;
+            const tangent = this._curve[i + 1]!.subtract(point).normalize();
+            const subLength = this._distances[i + 1]! - this._distances[i + 0]!;
+            const subPosition = Math.min((Math.max(Vector3.Dot(tangent, target.subtract(point).normalize()), 0.0) * Vector3.Distance(point, target)) / subLength, 1.0);
+            const distance = Vector3.Distance(point.add(tangent.scale(subPosition * subLength)), target);
+            if (distance < smallestDistance) {
+                smallestDistance = distance;
+                closestPosition = (this._distances[i + 0]! + subLength * subPosition) / this.length();
+            }
+        }
+        return closestPosition;
+    }
+
+    public slice(start = 0.0, end = 1.0): Path3D {
+        if (start < 0.0) {
+            start = 1 - ((start * -1.0) % 1.0);
+        }
+        if (end < 0.0) {
+            end = 1 - ((end * -1.0) % 1.0);
+        }
+        if (start > end) {
+            const _start = start;
+            start = end;
+            end = _start;
+        }
+        const curvePoints = this.getCurve();
+
+        const startPoint = this.getPointAt(start);
+        let startIndex = this.getPreviousPointIndexAt(start);
+
+        const endPoint = this.getPointAt(end);
+        const endIndex = this.getPreviousPointIndexAt(end) + 1;
+
+        const slicePoints: Vector3[] = [];
+        if (start !== 0.0) {
+            startIndex++;
+            slicePoints.push(startPoint);
+        }
+
+        slicePoints.push(...curvePoints.slice(startIndex, endIndex));
+        if (end !== 1.0 || start === 1.0) {
+            slicePoints.push(endPoint);
+        }
+        return new Path3D(slicePoints, this.getNormalAt(start), this._raw, this._alignTangentsWithPath);
+    }
+
+    public update(path: Vector3[], firstNormal: Vector3 | null = null, alignTangentsWithPath = false): Path3D {
+        for (let p = 0; p < path.length; p++) {
+            this._curve[p]!.x = path[p]!.x;
+            this._curve[p]!.y = path[p]!.y;
+            this._curve[p]!.z = path[p]!.z;
+        }
+        this._compute(firstNormal, alignTangentsWithPath);
+        return this;
+    }
+
+    private _compute(firstNormal: Vector3 | null, alignTangentsWithPath = false): void {
+        const l = this._curve.length;
+        if (l < 2) {
+            return;
+        }
+
+        this._tangents[0] = this._getFirstNonNullVector(0);
+        if (!this._raw) {
+            this._tangents[0].normalize();
+        }
+        this._tangents[l - 1] = this._curve[l - 1]!.subtract(this._curve[l - 2]!);
+        if (!this._raw) {
+            this._tangents[l - 1]!.normalize();
+        }
+
+        const tg0 = this._tangents[0]!;
+        const pp0 = this._normalVector(tg0, firstNormal);
+        this._normals[0] = pp0;
+        if (!this._raw) {
+            this._normals[0]!.normalize();
+        }
+        this._binormals[0] = Vector3.Cross(tg0, this._normals[0]!);
+        if (!this._raw) {
+            this._binormals[0]!.normalize();
+        }
+        this._distances[0] = 0.0;
+
+        let prev: Vector3;
+        let cur: Vector3;
+        let curTang: Vector3;
+        let prevNor: Vector3;
+        let prevBinor: Vector3;
+
+        for (let i = 1; i < l; i++) {
+            prev = this._getLastNonNullVector(i);
+            if (i < l - 1) {
+                cur = this._getFirstNonNullVector(i);
+                this._tangents[i] = alignTangentsWithPath ? cur : prev.add(cur);
+                this._tangents[i]!.normalize();
+            }
+            this._distances[i] = this._distances[i - 1]! + this._curve[i]!.subtract(this._curve[i - 1]!).length();
+
+            curTang = this._tangents[i]!;
+            prevBinor = this._binormals[i - 1]!;
+            this._normals[i] = Vector3.Cross(prevBinor, curTang);
+            if (!this._raw) {
+                if (this._normals[i]!.length() === 0) {
+                    prevNor = this._normals[i - 1]!;
+                    this._normals[i] = prevNor.clone();
+                } else {
+                    this._normals[i]!.normalize();
+                }
+            }
+            this._binormals[i] = Vector3.Cross(curTang, this._normals[i]!);
+            if (!this._raw) {
+                this._binormals[i]!.normalize();
+            }
+        }
+        this._pointAtData.id = NaN;
+    }
+
+    private _getFirstNonNullVector(index: number): Vector3 {
+        let i = 1;
+        let nNVector: Vector3 = this._curve[index + i]!.subtract(this._curve[index]!);
+        while (nNVector.length() === 0 && index + i + 1 < this._curve.length) {
+            i++;
+            nNVector = this._curve[index + i]!.subtract(this._curve[index]!);
+        }
+        return nNVector;
+    }
+
+    private _getLastNonNullVector(index: number): Vector3 {
+        let i = 1;
+        let nLVector: Vector3 = this._curve[index]!.subtract(this._curve[index - i]!);
+        while (nLVector.length() === 0 && index > i + 1) {
+            i++;
+            nLVector = this._curve[index]!.subtract(this._curve[index - i]!);
+        }
+        return nLVector;
+    }
+
+    private _normalVector(vt: Vector3, va: Vector3 | null): Vector3 {
+        let normal0: Vector3;
+        let tgl = vt.length();
+        if (tgl === 0.0) {
+            tgl = 1.0;
+        }
+
+        if (va === undefined || va === null) {
+            let point: Vector3;
+            if (!Scalar.WithinEpsilon(Math.abs(vt.y) / tgl, 1.0, Epsilon)) {
+                point = new Vector3(0.0, -1.0, 0.0);
+            } else if (!Scalar.WithinEpsilon(Math.abs(vt.x) / tgl, 1.0, Epsilon)) {
+                point = new Vector3(1.0, 0.0, 0.0);
+            } else if (!Scalar.WithinEpsilon(Math.abs(vt.z) / tgl, 1.0, Epsilon)) {
+                point = new Vector3(0.0, 0.0, 1.0);
+            } else {
+                point = Vector3.Zero();
+            }
+            normal0 = Vector3.Cross(vt, point);
+        } else {
+            normal0 = Vector3.Cross(vt, va);
+            Vector3.CrossToRef(normal0, vt, normal0);
+        }
+        normal0.normalize();
+        return normal0;
+    }
+
+    private _updatePointAtData(position: number, interpolateTNB = false): PointAtData {
+        if (this._pointAtData.id === position) {
+            if (!this._pointAtData.interpolateReady) {
+                this._updateInterpolationMatrix();
+            }
+            return this._pointAtData;
+        } else {
+            this._pointAtData.id = position;
+        }
+        const curvePoints = this.getPoints();
+
+        if (position <= 0.0) {
+            return this._setPointAtData(0.0, 0.0, curvePoints[0]!, 0, interpolateTNB);
+        } else if (position >= 1.0) {
+            return this._setPointAtData(1.0, 1.0, curvePoints[curvePoints.length - 1]!, curvePoints.length - 1, interpolateTNB);
+        }
+
+        let previousPoint: Vector3 = curvePoints[0]!;
+        let currentPoint: Vector3;
+        let currentLength = 0.0;
+        const targetLength = position * this.length();
+
+        for (let i = 1; i < curvePoints.length; i++) {
+            currentPoint = curvePoints[i]!;
+            const distance = Vector3.Distance(previousPoint, currentPoint);
+            currentLength += distance;
+            if (currentLength === targetLength) {
+                return this._setPointAtData(position, 1.0, currentPoint, i, interpolateTNB);
+            } else if (currentLength > targetLength) {
+                const toLength = currentLength - targetLength;
+                const diff = toLength / distance;
+                const dir = previousPoint.subtract(currentPoint);
+                const point = currentPoint.add(dir.scaleInPlace(diff));
+                return this._setPointAtData(position, 1 - diff, point, i - 1, interpolateTNB);
+            }
+            previousPoint = currentPoint;
+        }
+        return this._pointAtData;
+    }
+
+    private _setPointAtData(position: number, subPosition: number, point: Vector3, parentIndex: number, interpolateTNB: boolean): PointAtData {
+        this._pointAtData.point = point;
+        this._pointAtData.position = position;
+        this._pointAtData.subPosition = subPosition;
+        this._pointAtData.previousPointArrayIndex = parentIndex;
+        this._pointAtData.interpolateReady = interpolateTNB;
+        if (interpolateTNB) {
+            this._updateInterpolationMatrix();
+        }
+        return this._pointAtData;
+    }
+
+    private _updateInterpolationMatrix(): void {
+        this._pointAtData.interpolationMatrix = Matrix.Identity();
+        const parentIndex = this._pointAtData.previousPointArrayIndex;
+
+        if (parentIndex !== this._tangents.length - 1) {
+            const index = parentIndex + 1;
+
+            const tangentFrom = this._tangents[parentIndex]!.clone();
+            const normalFrom = this._normals[parentIndex]!.clone();
+            const binormalFrom = this._binormals[parentIndex]!.clone();
+
+            const tangentTo = this._tangents[index]!.clone();
+            const normalTo = this._normals[index]!.clone();
+            const binormalTo = this._binormals[index]!.clone();
+
+            const quatFrom = Quaternion.RotationQuaternionFromAxis(normalFrom, binormalFrom, tangentFrom);
+            const quatTo = Quaternion.RotationQuaternionFromAxis(normalTo, binormalTo, tangentTo);
+            const quatAt = Quaternion.Slerp(quatFrom, quatTo, this._pointAtData.subPosition);
+
+            quatAt.toRotationMatrix(this._pointAtData.interpolationMatrix);
+        }
     }
 }

--- a/packages/babylon-lite-compat/src/math/quaternion.ts
+++ b/packages/babylon-lite-compat/src/math/quaternion.ts
@@ -89,6 +89,45 @@ export class Quaternion {
         return [this.x, this.y, this.z, this.w];
     }
 
+    /**
+     * Babylon.js `Quaternion.toRotationMatrix(result)` — write this quaternion's
+     * rotation into `result` (a 4×4 row-major matrix, translation cleared).
+     */
+    public toRotationMatrix(result: Matrix): Matrix {
+        const x = this.x,
+            y = this.y,
+            z = this.z,
+            w = this.w;
+        const xx = x * x,
+            yy = y * y,
+            zz = z * z,
+            xy = x * y,
+            zw = z * w,
+            zx = z * x,
+            yw = y * w,
+            yz = y * z,
+            xw = x * w;
+        const m = result.m;
+        m[0] = 1.0 - 2.0 * (yy + zz);
+        m[1] = 2.0 * (xy + zw);
+        m[2] = 2.0 * (zx - yw);
+        m[3] = 0;
+        m[4] = 2.0 * (xy - zw);
+        m[5] = 1.0 - 2.0 * (zz + xx);
+        m[6] = 2.0 * (yz + xw);
+        m[7] = 0;
+        m[8] = 2.0 * (zx + yw);
+        m[9] = 2.0 * (yz - xw);
+        m[10] = 1.0 - 2.0 * (yy + xx);
+        m[11] = 0;
+        m[12] = 0;
+        m[13] = 0;
+        m[14] = 0;
+        m[15] = 1.0;
+        result.markAsUpdated();
+        return result;
+    }
+
     public toEulerAngles(): Vector3 {
         const result = new Vector3();
         const qz = this.z;
@@ -176,6 +215,34 @@ export class Quaternion {
         const sin = Math.sin(angle / 2);
         const len = axis.length() || 1;
         return new Quaternion((axis.x / len) * sin, (axis.y / len) * sin, (axis.z / len) * sin, Math.cos(angle / 2));
+    }
+
+    /**
+     * Babylon.js `Quaternion.RotationQuaternionFromAxis(axis1, axis2, axis3)` — build a
+     * rotation quaternion from three orthonormal-ish axes (X, Y, Z). The axes are
+     * normalized, assembled into a rotation matrix, then converted to a quaternion.
+     */
+    public static RotationQuaternionFromAxis(axis1: Vector3, axis2: Vector3, axis3: Vector3): Quaternion {
+        const result = new Quaternion();
+        Quaternion.RotationQuaternionFromAxisToRef(axis1, axis2, axis3, result);
+        return result;
+    }
+
+    /**
+     * Babylon.js `Quaternion.RotationQuaternionFromAxisToRef` — like
+     * {@link Quaternion.RotationQuaternionFromAxis} but writes into `ref`.
+     */
+    public static RotationQuaternionFromAxisToRef(axis1: Vector3, axis2: Vector3, axis3: Vector3, ref: Quaternion): Quaternion {
+        const a1 = Vector3.Normalize(axis1);
+        const a2 = Vector3.Normalize(axis2);
+        const a3 = Vector3.Normalize(axis3);
+        const rotMat = new Float32Array([a1.x, a1.y, a1.z, 0, a2.x, a2.y, a2.z, 0, a3.x, a3.y, a3.z, 0, 0, 0, 0, 1]);
+        const q = quatFromRotationMatrix(rotMat as unknown as Mat4);
+        ref.x = q.x;
+        ref.y = q.y;
+        ref.z = q.z;
+        ref.w = q.w;
+        return ref;
     }
 
     public static Slerp(left: Quaternion, right: Quaternion, amount: number): Quaternion {

--- a/packages/babylon-lite-compat/src/math/vector.ts
+++ b/packages/babylon-lite-compat/src/math/vector.ts
@@ -399,6 +399,46 @@ export class Vector3 {
         result.set(x * m[0]! + y * m[4]! + z * m[8]!, x * m[1]! + y * m[5]! + z * m[9]!, x * m[2]! + y * m[6]! + z * m[10]!);
         return result;
     }
+
+    /** Babylon.js `Vector3.Hermite` — point on the Hermite spline at `amount`. */
+    public static Hermite(value1: Vector3, tangent1: Vector3, value2: Vector3, tangent2: Vector3, amount: number): Vector3 {
+        const squared = amount * amount;
+        const cubed = amount * squared;
+        const part1 = 2.0 * cubed - 3.0 * squared + 1.0;
+        const part2 = -2.0 * cubed + 3.0 * squared;
+        const part3 = cubed - 2.0 * squared + amount;
+        const part4 = cubed - squared;
+        return new Vector3(
+            value1.x * part1 + value2.x * part2 + tangent1.x * part3 + tangent2.x * part4,
+            value1.y * part1 + value2.y * part2 + tangent1.y * part3 + tangent2.y * part4,
+            value1.z * part1 + value2.z * part2 + tangent1.z * part3 + tangent2.z * part4
+        );
+    }
+
+    /** Babylon.js `Vector3.CatmullRom` — point on the Catmull-Rom spline at `amount`. */
+    public static CatmullRom(value1: Vector3, value2: Vector3, value3: Vector3, value4: Vector3, amount: number): Vector3 {
+        const squared = amount * amount;
+        const cubed = amount * squared;
+        const x =
+            0.5 *
+            (2.0 * value2.x +
+                (-value1.x + value3.x) * amount +
+                (2.0 * value1.x - 5.0 * value2.x + 4.0 * value3.x - value4.x) * squared +
+                (-value1.x + 3.0 * value2.x - 3.0 * value3.x + value4.x) * cubed);
+        const y =
+            0.5 *
+            (2.0 * value2.y +
+                (-value1.y + value3.y) * amount +
+                (2.0 * value1.y - 5.0 * value2.y + 4.0 * value3.y - value4.y) * squared +
+                (-value1.y + 3.0 * value2.y - 3.0 * value3.y + value4.y) * cubed);
+        const z =
+            0.5 *
+            (2.0 * value2.z +
+                (-value1.z + value3.z) * amount +
+                (2.0 * value1.z - 5.0 * value2.z + 4.0 * value3.z - value4.z) * squared +
+                (-value1.z + 3.0 * value2.z - 3.0 * value3.z + value4.z) * cubed);
+        return new Vector3(x, y, z);
+    }
 }
 
 /** Minimal live 3-component backing (Babylon Lite's `ObservableVec3`). */

--- a/packages/babylon-lite-compat/tests/curve-path.test.ts
+++ b/packages/babylon-lite-compat/tests/curve-path.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import { Vector2, Vector3 } from "../src/math/vector";
+import { Quaternion } from "../src/math/quaternion";
+import { Matrix } from "../src/math/matrix";
+import { Angle, Curve3, Path3D } from "../src/math/curve";
+
+describe("Vector3 spline helpers", () => {
+    it("Hermite passes through its endpoints", () => {
+        const p1 = new Vector3(0, 0, 0);
+        const p2 = new Vector3(1, 0, 0);
+        const t1 = new Vector3(0, 1, 0);
+        const t2 = new Vector3(0, 1, 0);
+        expect(Vector3.Hermite(p1, t1, p2, t2, 0).asArray()).toEqual([0, 0, 0]);
+        const end = Vector3.Hermite(p1, t1, p2, t2, 1);
+        expect(end.x).toBeCloseTo(1, 6);
+        expect(end.y).toBeCloseTo(0, 6);
+    });
+
+    it("CatmullRom passes through the inner control points", () => {
+        const a = new Vector3(0, 0, 0);
+        const b = new Vector3(1, 1, 0);
+        const c = new Vector3(2, 0, 0);
+        const d = new Vector3(3, 1, 0);
+        expect(Vector3.CatmullRom(a, b, c, d, 0).asArray()).toEqual([1, 1, 0]);
+        expect(Vector3.CatmullRom(a, b, c, d, 1).asArray()).toEqual([2, 0, 0]);
+    });
+});
+
+describe("Quaternion axis/matrix helpers", () => {
+    it("RotationQuaternionFromAxis on identity axes yields identity", () => {
+        const q = Quaternion.RotationQuaternionFromAxis(new Vector3(1, 0, 0), new Vector3(0, 1, 0), new Vector3(0, 0, 1));
+        expect(q.x).toBeCloseTo(0, 6);
+        expect(q.y).toBeCloseTo(0, 6);
+        expect(q.z).toBeCloseTo(0, 6);
+        expect(Math.abs(q.w)).toBeCloseTo(1, 6);
+    });
+
+    it("toRotationMatrix round-trips through FromRotationMatrix", () => {
+        const q = Quaternion.RotationYawPitchRoll(0.4, -0.3, 0.6).normalize();
+        const m = Matrix.Identity();
+        q.toRotationMatrix(m);
+        const back = Quaternion.FromRotationMatrix(m);
+        // Quaternions q and -q represent the same rotation; compare with sign alignment.
+        const sign = q.w * back.w < 0 ? -1 : 1;
+        expect(back.x * sign).toBeCloseTo(q.x, 5);
+        expect(back.y * sign).toBeCloseTo(q.y, 5);
+        expect(back.z * sign).toBeCloseTo(q.z, 5);
+        expect(back.w * sign).toBeCloseTo(q.w, 5);
+    });
+
+    it("toRotationMatrix of identity is the identity matrix", () => {
+        const m = Matrix.Identity();
+        Quaternion.Identity().toRotationMatrix(m);
+        expect(Array.from(m.m)).toEqual([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+    });
+});
+
+describe("Curve3 builders", () => {
+    it("Hermite spline starts and ends at its control points", () => {
+        const curve = Curve3.CreateHermiteSpline(new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(4, 0, 0), new Vector3(1, 0, 0), 20);
+        const pts = curve.getPoints();
+        expect(pts.length).toBe(21);
+        expect(pts[0]!.asArray()).toEqual([0, 0, 0]);
+        expect(pts[pts.length - 1]!.x).toBeCloseTo(4, 6);
+    });
+
+    it("open Catmull-Rom spline interpolates the given points", () => {
+        const points = [new Vector3(0, 0, 0), new Vector3(1, 2, 0), new Vector3(3, 2, 0), new Vector3(4, 0, 0)];
+        const curve = Curve3.CreateCatmullRomSpline(points, 8, false);
+        const pts = curve.getPoints();
+        expect(pts[0]!.asArray()).toEqual([0, 0, 0]);
+        expect(pts[pts.length - 1]!.x).toBeCloseTo(4, 6);
+    });
+
+    it("closed Catmull-Rom spline loops back to its first sample", () => {
+        const points = [new Vector3(0, 0, 0), new Vector3(2, 0, 0), new Vector3(2, 2, 0), new Vector3(0, 2, 0)];
+        const curve = Curve3.CreateCatmullRomSpline(points, 6, true);
+        const pts = curve.getPoints();
+        expect(pts[0]!.equalsWithEpsilon(pts[pts.length - 1]!, 1e-6)).toBe(true);
+    });
+
+    it("ArcThru3Points returns an empty curve for colinear points", () => {
+        const arc = Curve3.ArcThru3Points(new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(2, 0, 0));
+        expect(arc.getPoints().length).toBe(0);
+    });
+
+    it("ArcThru3Points passes through the three points", () => {
+        const first = new Vector3(1, 0, 0);
+        const second = new Vector3(0, 1, 0);
+        const third = new Vector3(-1, 0, 0);
+        const arc = Curve3.ArcThru3Points(first, second, third, 36);
+        const pts = arc.getPoints();
+        expect(pts.length).toBeGreaterThan(2);
+        expect(pts[0]!.equalsWithEpsilon(first, 1e-6)).toBe(true);
+        expect(pts[pts.length - 1]!.equalsWithEpsilon(third, 1e-6)).toBe(true);
+        // every arc point is on the unit circle (radius 1)
+        for (const p of pts) {
+            expect(p.length()).toBeCloseTo(1, 4);
+        }
+    });
+
+    it("continue translates the second curve onto the first's end", () => {
+        const a = new Curve3([new Vector3(0, 0, 0), new Vector3(1, 0, 0)]);
+        const b = new Curve3([new Vector3(5, 5, 5), new Vector3(6, 5, 5)]);
+        const joined = a.continue(b);
+        const pts = joined.getPoints();
+        expect(pts.length).toBe(3);
+        // b's first point (5,5,5) is dropped; its second point is translated so the join is seamless
+        expect(pts[2]!.asArray()).toEqual([2, 0, 0]);
+    });
+});
+
+describe("Path3D frames and interpolation", () => {
+    const square = [new Vector3(0, 0, 0), new Vector3(1, 0, 0), new Vector3(1, 1, 0), new Vector3(0, 1, 0)];
+
+    it("computes an orthonormal tangent/normal/binormal frame per point", () => {
+        const path = new Path3D(square);
+        const tangents = path.getTangents();
+        const normals = path.getNormals();
+        const binormals = path.getBinormals();
+        expect(tangents.length).toBe(square.length);
+        for (let i = 0; i < square.length; i++) {
+            expect(tangents[i]!.length()).toBeCloseTo(1, 5);
+            expect(normals[i]!.length()).toBeCloseTo(1, 5);
+            expect(binormals[i]!.length()).toBeCloseTo(1, 5);
+            expect(Vector3.Dot(tangents[i]!, normals[i]!)).toBeCloseTo(0, 5);
+            expect(Vector3.Dot(tangents[i]!, binormals[i]!)).toBeCloseTo(0, 5);
+        }
+    });
+
+    it("getPointAt walks the arc-length parameterisation", () => {
+        const path = new Path3D([new Vector3(0, 0, 0), new Vector3(0, 0, 4)]);
+        expect(path.getPointAt(0).asArray()).toEqual([0, 0, 0]);
+        expect(path.getPointAt(0.5).z).toBeCloseTo(2, 6);
+        expect(path.getPointAt(1).z).toBeCloseTo(4, 6);
+        expect(path.getDistanceAt(0.25)).toBeCloseTo(1, 6);
+    });
+
+    it("getSubPositionAt and getPreviousPointIndexAt locate the segment", () => {
+        const path = new Path3D([new Vector3(0, 0, 0), new Vector3(0, 0, 2), new Vector3(0, 0, 4)]);
+        expect(path.getPreviousPointIndexAt(0.25)).toBe(0);
+        expect(path.getSubPositionAt(0.25)).toBeCloseTo(0.5, 6);
+        expect(path.getPreviousPointIndexAt(0.75)).toBe(1);
+    });
+
+    it("getTangentAt interpolated returns a unit tangent", () => {
+        const path = new Path3D(square);
+        const t = path.getTangentAt(0.4, true);
+        expect(t.length()).toBeCloseTo(1, 5);
+    });
+
+    it("getClosestPositionTo finds the nearest position on the path", () => {
+        const path = new Path3D([new Vector3(0, 0, 0), new Vector3(4, 0, 0)]);
+        const pos = path.getClosestPositionTo(new Vector3(1, 1, 0));
+        expect(pos).toBeCloseTo(0.25, 5);
+    });
+
+    it("slice extracts a sub-path", () => {
+        const path = new Path3D([new Vector3(0, 0, 0), new Vector3(0, 0, 2), new Vector3(0, 0, 4)]);
+        const sub = path.slice(0.25, 0.75);
+        expect(sub.getPointAt(0).z).toBeCloseTo(1, 5);
+        expect(sub.getPointAt(1).z).toBeCloseTo(3, 5);
+    });
+
+    it("update recomputes distances in place", () => {
+        const path = new Path3D([new Vector3(0, 0, 0), new Vector3(0, 0, 1)]);
+        expect(path.length()).toBeCloseTo(1, 6);
+        path.update([new Vector3(0, 0, 0), new Vector3(0, 0, 5)]);
+        expect(path.length()).toBeCloseTo(5, 6);
+    });
+});
+
+describe("Angle", () => {
+    it("normalises negative angles into [0, 2π)", () => {
+        expect(new Angle(-Math.PI / 2).radians()).toBeCloseTo((3 * Math.PI) / 2, 6);
+    });
+
+    it("BetweenTwoPoints measures against the x-axis", () => {
+        expect(Angle.BetweenTwoPoints(new Vector2(0, 0), new Vector2(1, 1)).radians()).toBeCloseTo(Math.PI / 4, 6);
+    });
+
+    it("BetweenTwoVectors returns the unsigned angle", () => {
+        expect(Angle.BetweenTwoVectors(new Vector3(1, 0, 0), new Vector3(0, 1, 0)).radians()).toBeCloseTo(Math.PI / 2, 6);
+        expect(Angle.BetweenTwoVectors(new Vector2(1, 0), new Vector2(1, 0)).radians()).toBeCloseTo(0, 6);
+    });
+});


### PR DESCRIPTION
Automated sync of `@babylonjs/lite-compat` against the latest Babylon.js and Babylon Lite changes,
produced by the [`update-compat-layer`](.github/copilot/skills/update-compat-layer.md) skill.

**Synced against BJS commit:** `4a4481e911bee11cb4b9e92689f65c69edb474b8`

### Validation (run independently by the pipeline)
- ✅ compat unit tests
- ✅ compat typecheck

### Changed files
- `ackages/babylon-lite-compat/COMPAT-STATUS.md`
- `packages/babylon-lite-compat/README.md`
- `packages/babylon-lite-compat/src/math/curve.ts`
- `packages/babylon-lite-compat/src/math/quaternion.ts`
- `packages/babylon-lite-compat/src/math/vector.ts`
- `packages/babylon-lite-compat/tests/curve-path.test.ts`

> Validation passed. Please review the wrapper changes and the updated `COMPAT-STATUS.md` before merging.

> Opened as a **draft** by the compat-sync pipeline. Review and mark ready when satisfied.