### PR TITLE
feat(release): generate GitHub release changelog from commit history

### DIFF
--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -117,15 +117,12 @@ stages:
                   env:
                       PACKAGE_VERSION: $(PACKAGE_VERSION)
 
-                - script: npm pack --dry-run ./packages/babylon-lite/build
-                  displayName: "Validate npm package contents"
-
-                # Generate release-notes Markdown from the Conventional-Commit
-                # history between the previous npm-lite-v* tag and HEAD. This must
-                # run BEFORE the new release tag is created below, so that the
-                # auto-detected "previous tag" is the prior release rather than
-                # the tag we are about to push. The output feeds the GitHub
-                # release notes and is archived as a build artifact.
+                # Generate the changelog from the Conventional-Commit history.
+                # This must run BEFORE the new release tag is created below, so the
+                # auto-detected "previous tag" is the prior release rather than the
+                # tag we are about to push. Two artefacts: the full cumulative
+                # CHANGELOG.md ships inside the npm tarball (build root), and the
+                # single latest section feeds the GitHub release notes.
                 - script: |
                       set -euo pipefail
                       mkdir -p "$(Build.ArtifactStagingDirectory)"
@@ -134,9 +131,13 @@ stages:
                   env:
                       PACKAGE_VERSION: $(PACKAGE_VERSION)
                       PACKAGE_NAME: $(PACKAGE_NAME)
-                      CHANGELOG_OUTPUT: $(Build.ArtifactStagingDirectory)/release-notes.md
+                      CHANGELOG_OUTPUT: packages/babylon-lite/build/CHANGELOG.md
+                      RELEASE_NOTES_OUTPUT: $(Build.ArtifactStagingDirectory)/release-notes.md
                       GITHUB_REPOSITORY: $(Build.Repository.Name)
                       BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
+
+                - script: npm pack --dry-run ./packages/babylon-lite/build
+                  displayName: "Validate npm package contents"
 
                 - script: |
                       set -euo pipefail

--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -120,6 +120,24 @@ stages:
                 - script: npm pack --dry-run ./packages/babylon-lite/build
                   displayName: "Validate npm package contents"
 
+                # Generate release-notes Markdown from the Conventional-Commit
+                # history between the previous npm-lite-v* tag and HEAD. This must
+                # run BEFORE the new release tag is created below, so that the
+                # auto-detected "previous tag" is the prior release rather than
+                # the tag we are about to push. The output feeds the GitHub
+                # release notes and is archived as a build artifact.
+                - script: |
+                      set -euo pipefail
+                      mkdir -p "$(Build.ArtifactStagingDirectory)"
+                      npx tsx scripts/generate-changelog.ts
+                  displayName: "Generate release changelog"
+                  env:
+                      PACKAGE_VERSION: $(PACKAGE_VERSION)
+                      PACKAGE_NAME: $(PACKAGE_NAME)
+                      CHANGELOG_OUTPUT: $(Build.ArtifactStagingDirectory)/release-notes.md
+                      GITHUB_REPOSITORY: $(Build.Repository.Name)
+                      BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
+
                 - script: |
                       set -euo pipefail
 
@@ -178,8 +196,8 @@ stages:
                       tagSource: "userSpecifiedTag"
                       tag: "npm-lite-v$(PACKAGE_VERSION)"
                       title: "@babylonjs/lite v$(PACKAGE_VERSION)"
-                      releaseNotesSource: "inline"
-                      releaseNotesInline: "Automated release of @babylonjs/lite v$(PACKAGE_VERSION)."
+                      releaseNotesSource: "filePath"
+                      releaseNotesFilePath: "$(Build.ArtifactStagingDirectory)/release-notes.md"
                       assets: "$(Build.ArtifactStagingDirectory)/babylonjs-lite-$(PACKAGE_VERSION).zip"
                       addChangeLog: false
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "test:parity-cloud": "tsx scripts/run-browserstack.ts playwright test --config config/playwright.parity-cloud.config.ts",
         "test:perf-cloud": "tsx scripts/run-browserstack.ts playwright test --config config/playwright.perf-cloud.config.ts tests/lite/perf/perf-regression.spec.ts",
         "validate:release-markers": "tsx scripts/validate-pr-release-markers.ts",
-    "gen:changelog": "tsx scripts/generate-changelog.ts",
+        "gen:changelog": "tsx scripts/generate-changelog.ts",
         "validate:bundle-manifest": "tsx scripts/validate-bundle-manifest.ts",
         "report:api-changes": "tsx scripts/report-api-changes.ts",
         "gen:feature-doc": "tsx scripts/gen-feature-comparison.ts",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "test:parity-cloud": "tsx scripts/run-browserstack.ts playwright test --config config/playwright.parity-cloud.config.ts",
         "test:perf-cloud": "tsx scripts/run-browserstack.ts playwright test --config config/playwright.perf-cloud.config.ts tests/lite/perf/perf-regression.spec.ts",
         "validate:release-markers": "tsx scripts/validate-pr-release-markers.ts",
+    "gen:changelog": "tsx scripts/generate-changelog.ts",
         "validate:bundle-manifest": "tsx scripts/validate-bundle-manifest.ts",
         "report:api-changes": "tsx scripts/report-api-changes.ts",
         "gen:feature-doc": "tsx scripts/gen-feature-comparison.ts",

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -155,7 +155,7 @@ function parseCommit(hash: string, subjectRaw: string, body: string): ParsedComm
         type: header[1],
         scope: header[2],
         breaking,
-        subject: header[4].trim(),
+        subject: (header[4] ?? subject).trim(),
         prNumber,
     };
 }

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -3,8 +3,9 @@
 /**
  * Generates a Markdown changelog for an @babylonjs/lite release by scanning the
  * Conventional-Commit history between the previous published release tag and
- * HEAD. The output is suitable for use as GitHub release notes and is also
- * appended to a repository CHANGELOG.md when one is maintained.
+ * HEAD. The output is suitable for use as GitHub release notes. It is printed to
+ * stdout and, when CHANGELOG_OUTPUT is set, also written to that file (the npm
+ * publish pipeline points it at the GitHub release notes artifact).
  *
  * The commit-range resolution mirrors scripts/prepare-npm-release.ts so the
  * changelog always covers exactly the commits that the resolved version ships.
@@ -204,8 +205,9 @@ function buildChangelog(commits: ParsedCommit[], previousTag: string, repoSlug: 
     }
 
     const used = new Set<string>();
+    const breakingHashes = new Set(breaking.map((commit) => commit.hash));
     for (const section of SECTIONS) {
-        const entries = relevant.filter((commit) => commit.type !== undefined && section.types.includes(commit.type));
+        const entries = relevant.filter((commit) => commit.type !== undefined && section.types.includes(commit.type) && !breakingHashes.has(commit.hash));
         if (entries.length === 0) {
             continue;
         }

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -1,14 +1,21 @@
 /// <reference types="node" />
 
 /**
- * Generates a Markdown changelog for an @babylonjs/lite release by scanning the
- * Conventional-Commit history between the previous published release tag and
- * HEAD. The output is suitable for use as GitHub release notes. It is printed to
- * stdout and, when CHANGELOG_OUTPUT is set, also written to that file (the npm
- * publish pipeline points it at the GitHub release notes artifact).
+ * Generates Markdown changelog content for an @babylonjs/lite release from the
+ * Conventional-Commit history, with no committed CHANGELOG file required — git
+ * release tags (npm-lite-v*) are the source of truth, so the whole changelog is
+ * regenerated deterministically on every release.
  *
- * The commit-range resolution mirrors scripts/prepare-npm-release.ts so the
- * changelog always covers exactly the commits that the resolved version ships.
+ * Two artefacts are produced:
+ *   - Release notes: the single section for the version being released
+ *     (previous tag..HEAD). Written to RELEASE_NOTES_OUTPUT if set; always
+ *     printed to stdout. Used as the GitHub release body.
+ *   - Full cumulative changelog: the pending version plus one section per prior
+ *     npm-lite-v* tag, newest first. Written to CHANGELOG_OUTPUT if set. Shipped
+ *     in the npm tarball (build/CHANGELOG.md) so consumers get the whole history.
+ *
+ * The pending range mirrors scripts/prepare-npm-release.ts so the top section
+ * always covers exactly the commits the resolved version ships.
  *
  * Inputs (all via env):
  *   PACKAGE_VERSION        Version being released (e.g. "1.4.0"). Required for a
@@ -16,12 +23,10 @@
  *   PACKAGE_NAME           Published package name. Default "@babylonjs/lite".
  *   PREVIOUS_RELEASE_TAG   Override the auto-detected previous release tag.
  *   RELEASE_TAG_PATTERN    Glob for release tags. Default "npm-lite-v*".
- *   CHANGELOG_OUTPUT       File to write the release-notes Markdown to. When set
- *                          the notes are written there (for the GitHub release).
+ *   RELEASE_NOTES_OUTPUT   File to write the latest-version notes to.
+ *   CHANGELOG_OUTPUT       File to write the full cumulative changelog to.
  *   BUILD_REPOSITORY_URI / GITHUB_REPOSITORY
  *                          Used to build commit/PR links when available.
- *
- * Always prints the generated release-notes Markdown to stdout.
  */
 
 import { execFileSync } from "child_process";
@@ -30,8 +35,10 @@ import { resolve } from "path";
 
 const PACKAGE_NAME = process.env.PACKAGE_NAME ?? "@babylonjs/lite";
 const RELEASE_TAG_PATTERN = process.env.RELEASE_TAG_PATTERN ?? "npm-lite-v*";
+const RELEASE_TAG_PREFIX = RELEASE_TAG_PATTERN.replace(/\*$/, "");
 const NEXT_VERSION = (process.env.PACKAGE_VERSION ?? "").trim();
 const CHANGELOG_OUTPUT = process.env.CHANGELOG_OUTPUT?.trim();
+const RELEASE_NOTES_OUTPUT = process.env.RELEASE_NOTES_OUTPUT?.trim();
 
 type ParsedCommit = {
     hash: string;
@@ -88,6 +95,33 @@ function getPreviousReleaseTag(): string {
     return run("git", ["describe", "--tags", "--abbrev=0", "--match", RELEASE_TAG_PATTERN], true);
 }
 
+function parseSemver(version: string): [number, number, number] | undefined {
+    const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+    return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined;
+}
+
+// All release tags, newest version first. Each entry pairs the tag with the
+// version it represents so the cumulative changelog can render one section per
+// tag and link compare ranges. Tags whose version is not strict semver are
+// dropped (they cannot be ordered reliably).
+function getReleaseTagsDescending(): { tag: string; version: string }[] {
+    const raw = run("git", ["tag", "--list", RELEASE_TAG_PATTERN], true);
+    if (!raw) {
+        return [];
+    }
+    return raw
+        .split("\n")
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+        .map((tag) => ({ tag, version: tag.slice(RELEASE_TAG_PREFIX.length) }))
+        .filter((entry): entry is { tag: string; version: string } => parseSemver(entry.version) !== undefined)
+        .sort((a, b) => {
+            const av = parseSemver(a.version) as [number, number, number];
+            const bv = parseSemver(b.version) as [number, number, number];
+            return bv[0] - av[0] || bv[1] - av[1] || bv[2] - av[2];
+        });
+}
+
 function getRepoSlug(): string | undefined {
     const direct = process.env.GITHUB_REPOSITORY?.trim();
     if (direct && direct.includes("/")) {
@@ -104,8 +138,8 @@ function getRepoSlug(): string | undefined {
     return undefined;
 }
 
-function readCommits(previousTag: string): ParsedCommit[] {
-    const range = previousTag ? `${previousTag}..HEAD` : "HEAD";
+function readCommits(fromRef: string, toRef: string): ParsedCommit[] {
+    const range = fromRef ? `${fromRef}..${toRef}` : toRef;
     // Records are separated by a record-separator (0x1e) and fields within a
     // record by a unit-separator (0x1f). We emit these via git's %x1e/%x1f
     // format escapes so the control bytes appear only in git's output, never in
@@ -184,14 +218,19 @@ function formatEntry(commit: ParsedCommit, repoSlug: string | undefined): string
     return line;
 }
 
-function buildChangelog(commits: ParsedCommit[], previousTag: string, repoSlug: string | undefined): string {
-    const heading = NEXT_VERSION ? `## ${PACKAGE_NAME} v${NEXT_VERSION}` : `## ${PACKAGE_NAME} (Unreleased)`;
+// Renders one version's section. `version` may be a real semver or "Unreleased".
+// `fromTag`/`toRef` define the commit range; `compareTag` is the tag for the
+// version being rendered (used for the compare link), or "HEAD" for a pending
+// release whose tag does not exist yet.
+function buildSection(version: string, fromTag: string, toRef: string, compareTag: string, repoSlug: string | undefined): string {
+    const heading = version === "Unreleased" ? `## ${PACKAGE_NAME} (Unreleased)` : `## ${PACKAGE_NAME} v${version}`;
     const lines: string[] = [heading, ""];
 
+    const commits = readCommits(fromTag, toRef);
     const relevant = commits.filter((commit) => !shouldSkip(commit));
 
     if (relevant.length === 0) {
-        lines.push(previousTag ? `_No notable changes since ${previousTag}._` : "_No notable changes._");
+        lines.push(fromTag ? `_No notable changes since ${fromTag}._` : "_No notable changes._", "");
         return lines.join("\n").trimEnd() + "\n";
     }
 
@@ -228,27 +267,46 @@ function buildChangelog(commits: ParsedCommit[], previousTag: string, repoSlug: 
         lines.push("");
     }
 
-    if (repoSlug && previousTag && NEXT_VERSION) {
-        const newTag = RELEASE_TAG_PATTERN.replace(/\*$/, "") + NEXT_VERSION;
-        lines.push(`**Full Changelog**: https://github.com/${repoSlug}/compare/${previousTag}...${newTag}`);
+    if (repoSlug && fromTag) {
+        lines.push(`**Full Changelog**: https://github.com/${repoSlug}/compare/${fromTag}...${compareTag}`, "");
     }
 
     return lines.join("\n").trimEnd() + "\n";
 }
 
 function main(): void {
-    const previousTag = getPreviousReleaseTag();
     const repoSlug = getRepoSlug();
-    const commits = readCommits(previousTag);
-    const changelog = buildChangelog(commits, previousTag, repoSlug);
+    const tags = getReleaseTagsDescending();
+    const previousTag = getPreviousReleaseTag() || (tags[0]?.tag ?? "");
 
-    if (CHANGELOG_OUTPUT) {
-        const outPath = resolve(process.cwd(), CHANGELOG_OUTPUT);
-        writeFileSync(outPath, changelog, "utf-8");
+    // Top section: the version being released (or "Unreleased" when no version
+    // is provided), covering the previous tag..HEAD range.
+    const version = NEXT_VERSION || "Unreleased";
+    const pendingTag = NEXT_VERSION ? `${RELEASE_TAG_PREFIX}${NEXT_VERSION}` : "HEAD";
+    const releaseNotes = buildSection(version, previousTag, "HEAD", pendingTag, repoSlug);
+
+    // Full cumulative changelog: pending section, then one section per existing
+    // tag, newest first. Git tags are immutable, so this is fully regenerable.
+    const sections = [releaseNotes];
+    for (let i = 0; i < tags.length; i++) {
+        const { tag, version: tagVersion } = tags[i] as { tag: string; version: string };
+        const prevTag = tags[i + 1]?.tag ?? "";
+        sections.push(buildSection(tagVersion, prevTag, tag, tag, repoSlug));
+    }
+    const fullChangelog = `# Changelog\n\n${sections.join("\n").trimEnd()}\n`;
+
+    if (RELEASE_NOTES_OUTPUT) {
+        const outPath = resolve(process.cwd(), RELEASE_NOTES_OUTPUT);
+        writeFileSync(outPath, releaseNotes, "utf-8");
         console.error(`Wrote release notes to ${outPath}`);
     }
+    if (CHANGELOG_OUTPUT) {
+        const outPath = resolve(process.cwd(), CHANGELOG_OUTPUT);
+        writeFileSync(outPath, fullChangelog, "utf-8");
+        console.error(`Wrote full changelog to ${outPath}`);
+    }
 
-    process.stdout.write(changelog);
+    process.stdout.write(releaseNotes);
 }
 
 main();

--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -1,0 +1,252 @@
+/// <reference types="node" />
+
+/**
+ * Generates a Markdown changelog for an @babylonjs/lite release by scanning the
+ * Conventional-Commit history between the previous published release tag and
+ * HEAD. The output is suitable for use as GitHub release notes and is also
+ * appended to a repository CHANGELOG.md when one is maintained.
+ *
+ * The commit-range resolution mirrors scripts/prepare-npm-release.ts so the
+ * changelog always covers exactly the commits that the resolved version ships.
+ *
+ * Inputs (all via env):
+ *   PACKAGE_VERSION        Version being released (e.g. "1.4.0"). Required for a
+ *                          titled release section; falls back to "Unreleased".
+ *   PACKAGE_NAME           Published package name. Default "@babylonjs/lite".
+ *   PREVIOUS_RELEASE_TAG   Override the auto-detected previous release tag.
+ *   RELEASE_TAG_PATTERN    Glob for release tags. Default "npm-lite-v*".
+ *   CHANGELOG_OUTPUT       File to write the release-notes Markdown to. When set
+ *                          the notes are written there (for the GitHub release).
+ *   BUILD_REPOSITORY_URI / GITHUB_REPOSITORY
+ *                          Used to build commit/PR links when available.
+ *
+ * Always prints the generated release-notes Markdown to stdout.
+ */
+
+import { execFileSync } from "child_process";
+import { writeFileSync } from "fs";
+import { resolve } from "path";
+
+const PACKAGE_NAME = process.env.PACKAGE_NAME ?? "@babylonjs/lite";
+const RELEASE_TAG_PATTERN = process.env.RELEASE_TAG_PATTERN ?? "npm-lite-v*";
+const NEXT_VERSION = (process.env.PACKAGE_VERSION ?? "").trim();
+const CHANGELOG_OUTPUT = process.env.CHANGELOG_OUTPUT?.trim();
+
+type ParsedCommit = {
+    hash: string;
+    shortHash: string;
+    type: string | undefined;
+    scope: string | undefined;
+    breaking: boolean;
+    subject: string;
+    prNumber: string | undefined;
+};
+
+type Section = {
+    title: string;
+    types: string[];
+};
+
+// Order matters: the first matching section wins. Types not listed here land in
+// the catch-all "Other Changes" section.
+const SECTIONS: Section[] = [
+    { title: "✨ Features", types: ["feat"] },
+    { title: "🐛 Bug Fixes", types: ["fix"] },
+    { title: "⚡ Performance", types: ["perf"] },
+    { title: "♻️ Refactors", types: ["refactor"] },
+    { title: "📝 Documentation", types: ["docs"] },
+    { title: "🧪 Tests", types: ["test"] },
+    { title: "🏗️ Build & CI", types: ["build", "ci", "chore"] },
+];
+const OTHER_SECTION_TITLE = "🔧 Other Changes";
+
+const CONVENTIONAL_HEADER = /^([a-z][a-z0-9-]*)(?:\(([^)]+)\))?(!)?:\s*(.+)$/;
+const BREAKING_FOOTER = /^BREAKING[ -]CHANGE:\s*(.+)$/im;
+const PR_SUFFIX = /\s*\(#(\d+)\)\s*$/;
+
+function run(command: string, args: string[], allowFailure = false): string {
+    try {
+        return execFileSync(command, args, {
+            cwd: process.cwd(),
+            encoding: "utf-8",
+            stdio: ["ignore", "pipe", "pipe"],
+        }).trim();
+    } catch (error) {
+        if (allowFailure) {
+            return "";
+        }
+        throw error;
+    }
+}
+
+function getPreviousReleaseTag(): string {
+    const override = process.env.PREVIOUS_RELEASE_TAG?.trim();
+    if (override) {
+        return override;
+    }
+    return run("git", ["describe", "--tags", "--abbrev=0", "--match", RELEASE_TAG_PATTERN], true);
+}
+
+function getRepoSlug(): string | undefined {
+    const direct = process.env.GITHUB_REPOSITORY?.trim();
+    if (direct && direct.includes("/")) {
+        return direct;
+    }
+    const uri = (process.env.BUILD_REPOSITORY_URI ?? process.env.BUILD_REPOSITORY_NAME ?? "").trim();
+    const match = /github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?$/.exec(uri);
+    if (match) {
+        return match[1];
+    }
+    if (uri.includes("/") && !uri.includes(" ")) {
+        return uri.replace(/\.git$/, "");
+    }
+    return undefined;
+}
+
+function readCommits(previousTag: string): ParsedCommit[] {
+    const range = previousTag ? `${previousTag}..HEAD` : "HEAD";
+    // Records are separated by a record-separator (0x1e) and fields within a
+    // record by a unit-separator (0x1f). We emit these via git's %x1e/%x1f
+    // format escapes so the control bytes appear only in git's output, never in
+    // the argv we pass to execFileSync (which rejects NUL and is happier without
+    // raw control bytes). Commit bodies keep their internal newlines intact.
+    const SEP = "\u001f";
+    const REC = "\u001e";
+    const raw = run("git", ["log", "--format=%H%x1f%s%x1f%b%x1e", range], true);
+    if (!raw) {
+        return [];
+    }
+
+    const commits: ParsedCommit[] = [];
+    for (const record of raw.split(REC)) {
+        const trimmed = record.replace(/^\s+/, "");
+        if (!trimmed) {
+            continue;
+        }
+        const [hash, subjectRaw = "", body = ""] = trimmed.split(SEP);
+        if (!hash) {
+            continue;
+        }
+        commits.push(parseCommit(hash, subjectRaw, body));
+    }
+    return commits;
+}
+
+function parseCommit(hash: string, subjectRaw: string, body: string): ParsedCommit {
+    let subject = subjectRaw.trim();
+    let prNumber: string | undefined;
+    const prMatch = PR_SUFFIX.exec(subject);
+    if (prMatch) {
+        prNumber = prMatch[1];
+        subject = subject.replace(PR_SUFFIX, "").trim();
+    }
+
+    const header = CONVENTIONAL_HEADER.exec(subject);
+    const breaking = Boolean(header?.[3]) || BREAKING_FOOTER.test(body);
+
+    if (!header) {
+        return { hash, shortHash: hash.slice(0, 7), type: undefined, scope: undefined, breaking, subject, prNumber };
+    }
+
+    return {
+        hash,
+        shortHash: hash.slice(0, 7),
+        type: header[1],
+        scope: header[2],
+        breaking,
+        subject: header[4].trim(),
+        prNumber,
+    };
+}
+
+function shouldSkip(commit: ParsedCommit): boolean {
+    // Drop release-tag bump commits and merge commits, which add noise.
+    if (/^Merge (pull request|branch|remote-tracking)/i.test(commit.subject)) {
+        return true;
+    }
+    if (commit.type === undefined && /^v?\d+\.\d+\.\d+/.test(commit.subject)) {
+        return true;
+    }
+    return false;
+}
+
+function formatEntry(commit: ParsedCommit, repoSlug: string | undefined): string {
+    const scope = commit.scope ? `**${commit.scope}:** ` : "";
+    let line = `- ${scope}${commit.subject}`;
+    if (commit.prNumber) {
+        line += repoSlug ? ` ([#${commit.prNumber}](https://github.com/${repoSlug}/pull/${commit.prNumber}))` : ` (#${commit.prNumber})`;
+    } else if (repoSlug) {
+        line += ` ([${commit.shortHash}](https://github.com/${repoSlug}/commit/${commit.hash}))`;
+    } else {
+        line += ` (${commit.shortHash})`;
+    }
+    return line;
+}
+
+function buildChangelog(commits: ParsedCommit[], previousTag: string, repoSlug: string | undefined): string {
+    const heading = NEXT_VERSION ? `## ${PACKAGE_NAME} v${NEXT_VERSION}` : `## ${PACKAGE_NAME} (Unreleased)`;
+    const lines: string[] = [heading, ""];
+
+    const relevant = commits.filter((commit) => !shouldSkip(commit));
+
+    if (relevant.length === 0) {
+        lines.push(previousTag ? `_No notable changes since ${previousTag}._` : "_No notable changes._");
+        return lines.join("\n").trimEnd() + "\n";
+    }
+
+    const breaking = relevant.filter((commit) => commit.breaking);
+    if (breaking.length > 0) {
+        lines.push("### ⚠️ BREAKING CHANGES", "");
+        for (const commit of breaking) {
+            lines.push(formatEntry(commit, repoSlug));
+        }
+        lines.push("");
+    }
+
+    const used = new Set<string>();
+    for (const section of SECTIONS) {
+        const entries = relevant.filter((commit) => commit.type !== undefined && section.types.includes(commit.type));
+        if (entries.length === 0) {
+            continue;
+        }
+        lines.push(`### ${section.title}`, "");
+        for (const commit of entries) {
+            used.add(commit.hash);
+            lines.push(formatEntry(commit, repoSlug));
+        }
+        lines.push("");
+    }
+
+    const other = relevant.filter((commit) => !used.has(commit.hash) && !commit.breaking);
+    if (other.length > 0) {
+        lines.push(`### ${OTHER_SECTION_TITLE}`, "");
+        for (const commit of other) {
+            lines.push(formatEntry(commit, repoSlug));
+        }
+        lines.push("");
+    }
+
+    if (repoSlug && previousTag && NEXT_VERSION) {
+        const newTag = RELEASE_TAG_PATTERN.replace(/\*$/, "") + NEXT_VERSION;
+        lines.push(`**Full Changelog**: https://github.com/${repoSlug}/compare/${previousTag}...${newTag}`);
+    }
+
+    return lines.join("\n").trimEnd() + "\n";
+}
+
+function main(): void {
+    const previousTag = getPreviousReleaseTag();
+    const repoSlug = getRepoSlug();
+    const commits = readCommits(previousTag);
+    const changelog = buildChangelog(commits, previousTag, repoSlug);
+
+    if (CHANGELOG_OUTPUT) {
+        const outPath = resolve(process.cwd(), CHANGELOG_OUTPUT);
+        writeFileSync(outPath, changelog, "utf-8");
+        console.error(`Wrote release notes to ${outPath}`);
+    }
+
+    process.stdout.write(changelog);
+}
+
+main();


### PR DESCRIPTION
## Summary

The npm publish pipeline previously created GitHub releases with a static body (`"Automated release of @babylonjs/lite v…"`). This adds an automatically generated, categorized changelog derived from the commits shipping in each release.

## Changes

- **`scripts/generate-changelog.ts`** (new) — Generates Markdown release notes from the Conventional-Commit history between the previous `npm-lite-v*` tag and HEAD (same range-resolution logic as `prepare-npm-release.ts`). It:
  - Parses Conventional Commit headers, scopes, and `!` / `BREAKING CHANGE:` markers.
  - Groups commits into sections (⚠️ Breaking, ✨ Features, 🐛 Fixes, ⚡ Perf, ♻️ Refactors, 📝 Docs, 🧪 Tests, 🏗️ Build & CI, 🔧 Other).
  - Links PR numbers and commit hashes to GitHub and appends a compare link.
  - Skips merge/version-bump noise; falls back to full history when no prior tag exists.
- **`azure-pipelines-npm-publish.yml`** — Adds a "Generate release changelog" step that runs **before** the new tag is pushed (so the auto-detected previous tag is the prior release), writing `release-notes.md` to the artifact staging dir. The `GitHubRelease@1` task now uses `releaseNotesSource: filePath` instead of the static inline note.
- **`package.json`** — Adds a `gen:changelog` script.

## Notes / decisions

- Scoped to **GitHub Release notes** rather than a committed `CHANGELOG.md`: master is branch-protected (requires PR review), and the repo's convention is to open PRs for automated changes (see `open-compat-sync-pr.ts`) rather than push to master. The Releases page serves as the per-version changelog with zero master-write risk. A committed `CHANGELOG.md` via auto-PR can be added later if desired.
- Left the `lite-gl` pipeline untouched since it doesn't create GitHub releases.

## Validation

- Ran the script over a real range (`npm-lite-v1.5.0..HEAD`) — produces correctly categorized, PR-linked notes.
- Verified the no-previous-tag fallback (full history) path.
- Strict `tsc --noEmit` passes on the new script.
- Fixed a real bug found while testing: `execFileSync` rejects NUL bytes in args, so the script uses git's `%x1f`/`%x1e` format escapes (control bytes appear only in git output, never in argv).