### PR TITLE
fix(shadow): align CSM cascade snap anchor to light right/up axes

### DIFF
--- a/lab/public/bundle/manifest/scene214.json
+++ b/lab/public/bundle/manifest/scene214.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 68.2,
-  "gzipKB": 27,
+  "rawKB": 68.3,
+  "gzipKB": 27.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene214-material-view-Dua1bl7W.js",

--- a/lab/public/bundle/manifest/scene215.json
+++ b/lab/public/bundle/manifest/scene215.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 79.4,
-  "gzipKB": 31.9,
+  "rawKB": 79.5,
+  "gzipKB": 32,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene215-material-view-Dua1bl7W.js",

--- a/packages/babylon-lite/src/shadow/csm-shadow-task-hooks.ts
+++ b/packages/babylon-lite/src/shadow/csm-shadow-task-hooks.ts
@@ -541,9 +541,23 @@ function _computeCsmCascades(engine: EngineContext, camera: Camera, light: Direc
         let aClipY = transform[13]!;
         if (cfg._stabilizeCascades && stableRadius > 0) {
             const texelWorld = (2 * stableRadius) / cfg._mapSize;
-            const ax = Math.round(cx / texelWorld) * texelWorld;
-            const ay = Math.round(cy / texelWorld) * texelWorld;
-            const az = Math.round(cz / texelWorld) * texelWorld;
+            // Align the world anchor grid to the LIGHT's right/up axes (R,U), not world x/y/z. A translating camera then
+            // switches cells by exactly ONE texel along R/U -> an integer texel shift in clip space (no crawl). The old
+            // world-axis grid jumped texelWorld along a world axis, which projects to a NON-integer texel count (R,U are
+            // not the world axes) -> the sub-texel wiggle that crawled during translation. R,U = view rows 0,1.
+            const rX = view[0]!,
+                rY = view[4]!,
+                rZ = view[8]!;
+            const uX = view[1]!,
+                uY = view[5]!,
+                uZ = view[9]!;
+            // Project the centre onto R,U, round to the texel grid, rebuild the world anchor in the R-U plane (the
+            // light-dir component only affects clip Z, so dropping it leaves clip X/Y, which depend on R,U, exact).
+            const sr = Math.round((rX * cx + rY * cy + rZ * cz) / texelWorld) * texelWorld;
+            const tr = Math.round((uX * cx + uY * cy + uZ * cz) / texelWorld) * texelWorld;
+            const ax = sr * rX + tr * uX;
+            const ay = sr * rY + tr * uY;
+            const az = sr * rZ + tr * uZ;
             aClipX = transform[0]! * ax + transform[4]! * ay + transform[8]! * az + transform[12]!;
             aClipY = transform[1]! * ax + transform[5]! * ay + transform[9]! * az + transform[13]!;
         }


### PR DESCRIPTION
## Summary
Stabilizes CSM cascades against camera translation. The texel-snap world anchor was rounded on world x/y/z, which projects to a non-integer texel count along the light's right/up axes -> sub-texel wiggle that crawled while the camera translated. Now the anchor is snapped on the light's R/U axes (view rows 0,1), so a translating camera switches cells by exactly one texel in clip space (no crawl).

## Impact
- Only CSM scenes (214/215) use this path; parity unchanged: scene214 MAD 0.278, scene215 MAD 0.157.
- Bundle: scene214 +0.1 KB; all 205 bundle-size ceilings pass.
- Per-scene manifests regenerated for affected shadow scenes.

## Tests
- pnpm build:bundle-scenes
- pnpm test:parity (CSM 214/215 green; full suite in progress)