### PR TITLE
feat(frame-graph): Hi-Z depth pyramid, addTaskAfter, and runtime addMesh

### DIFF
--- a/docs/lite/architecture/28-frame-graph.md
+++ b/docs/lite/architecture/28-frame-graph.md
@@ -26,7 +26,7 @@ This gives Babylon Lite enough structure for offscreen RTT passes, per-pass came
 export type { FrameGraph } from "./frame-graph/frame-graph.js";
 export type { Task } from "./frame-graph/task.js";
 export { getFrameGraph } from "./scene/scene.js";
-export { addRenderPass, addTask, addTaskAtStart, addTaskBefore } from "./frame-graph/frame-graph-actions.js";
+export { addRenderPass, addTask, addTaskAtStart, addTaskBefore, addTaskAfter } from "./frame-graph/frame-graph-actions.js";
 
 export type { Pass } from "./frame-graph/pass.js";
 export { addPassDependencies } from "./frame-graph/pass.js";
@@ -169,6 +169,7 @@ Tasks execute in array order. There is no automatic dependency analysis; caller 
 addTask(sceneOrGraph, task); // append at end
 addTaskAtStart(sceneOrGraph, task); // insert at start of user work, after built-in system tasks such as ShadowTask
 addTaskBefore(sceneOrGraph, task, beforeTask);
+addTaskAfter(sceneOrGraph, task, afterTask); // insert immediately after afterTask
 ```
 
 Rules:
@@ -176,6 +177,7 @@ Rules:
 - Offscreen producer tasks must run before consumers that sample their output.
 - Overlay tasks should use `clr: false` and run after the task they overlay.
 - `addTaskBefore()` appends if the `beforeTask` is not found.
+- `addTaskAfter()` inserts immediately after `afterTask`, and appends if it is not found.
 - If tasks are added or inserted outside the startup/resize path, caller code must rebuild the graph before the next frame.
 - If a task uses `addMesh()` before `registerScene()`, defer the explicit `build()` call until after `registerScene()` so deferred material builders have run.
 
@@ -349,7 +351,9 @@ task.addMesh(mesh);
 task.addMesh(mesh, { material: overrideMaterialOrView });
 ```
 
-`addMesh()` accepts a source material or `MaterialView` and resolves at `record()` time through the source material family's `_buildGroup._rebuildSingle` hook. The mesh's material family must already be registered with the scene so the builder has run. Passing a material view lets a pass reuse source material state with pass-specific render feature bits, for example Standard/PBR/Node no-color shadow variants used by PCF shadow render tasks.
+`addMesh()` accepts a source material or `MaterialView` and resolves through the source material family's `_buildGroup._rebuildSingle` hook. The mesh's material family must already be registered with the scene so the builder has run. Passing a material view lets a pass reuse source material state with pass-specific render feature bits, for example Standard/PBR/Node no-color shadow variants used by PCF shadow render tasks.
+
+Adds made **before** the task's first `record()` are queued and drained at `record()` time. A **runtime** add (after `record()`, once the task is live) resolves the mesh and re-buckets it into that task immediately, so it renders on the next frame without a `frameGraph.build()` — a full rebuild would reallocate the shared scene UBO and every task's render target mid-frame. The task tracks this via its internal `_recorded` flag.
 
 If a task has explicit renderables, it does **not** auto-mirror the scene.
 

--- a/lab/public/bundle/manifest/scene1.json
+++ b/lab/public/bundle/manifest/scene1.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 89,
-  "gzipKB": 37.1,
+  "rawKB": 89.1,
+  "gzipKB": 37.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene1-background-dds-skybox-CCuisDEl.js",

--- a/lab/public/bundle/manifest/scene10.json
+++ b/lab/public/bundle/manifest/scene10.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 52.3,
+  "rawKB": 52.4,
   "gzipKB": 21.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene100.json
+++ b/lab/public/bundle/manifest/scene100.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 50.3,
-  "gzipKB": 20.2,
+  "rawKB": 50.4,
+  "gzipKB": 20.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene100-standard-renderable-Buv_s4dX.js",

--- a/lab/public/bundle/manifest/scene101.json
+++ b/lab/public/bundle/manifest/scene101.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 53.7,
+  "rawKB": 53.8,
   "gzipKB": 21.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene102.json
+++ b/lab/public/bundle/manifest/scene102.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.4,
+  "rawKB": 59.5,
   "gzipKB": 23.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene103.json
+++ b/lab/public/bundle/manifest/scene103.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 62,
-  "gzipKB": 24.7,
+  "rawKB": 62.1,
+  "gzipKB": 24.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene103-standard-renderable-DKLp8FJA.js",

--- a/lab/public/bundle/manifest/scene104.json
+++ b/lab/public/bundle/manifest/scene104.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 101.7,
-  "gzipKB": 39.3,
+  "rawKB": 101.8,
+  "gzipKB": 39.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene104-generate-mipmaps-BGv6wRC-.js",

--- a/lab/public/bundle/manifest/scene106.json
+++ b/lab/public/bundle/manifest/scene106.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 51.4,
+  "rawKB": 51.5,
   "gzipKB": 20.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene110.json
+++ b/lab/public/bundle/manifest/scene110.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 50.8,
-  "gzipKB": 19.9,
+  "rawKB": 50.9,
+  "gzipKB": 20,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene110-standard-renderable-D6cO9rrY.js",

--- a/lab/public/bundle/manifest/scene112.json
+++ b/lab/public/bundle/manifest/scene112.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 120,
+  "rawKB": 120.1,
   "gzipKB": 48.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene113.json
+++ b/lab/public/bundle/manifest/scene113.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62.9,
+  "rawKB": 63,
   "gzipKB": 24.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene114.json
+++ b/lab/public/bundle/manifest/scene114.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 80,
+  "rawKB": 80.1,
   "gzipKB": 31.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene12.json
+++ b/lab/public/bundle/manifest/scene12.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.2,
+  "rawKB": 103.3,
   "gzipKB": 42.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene120.json
+++ b/lab/public/bundle/manifest/scene120.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 35.4,
-  "gzipKB": 14,
+  "rawKB": 35.5,
+  "gzipKB": 14.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene120.js"

--- a/lab/public/bundle/manifest/scene122.json
+++ b/lab/public/bundle/manifest/scene122.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 48,
-  "gzipKB": 19.2,
+  "rawKB": 48.1,
+  "gzipKB": 19.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene122-gaussian-splatting-pipeline-sh-DIpbh4iH.js",

--- a/lab/public/bundle/manifest/scene123.json
+++ b/lab/public/bundle/manifest/scene123.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 44.7,
+  "rawKB": 44.8,
   "gzipKB": 18.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene124.json
+++ b/lab/public/bundle/manifest/scene124.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.7,
+  "rawKB": 50.8,
   "gzipKB": 20.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene126.json
+++ b/lab/public/bundle/manifest/scene126.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 35.6,
-  "gzipKB": 14.1,
+  "rawKB": 35.7,
+  "gzipKB": 14.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene126.js"

--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 57.9,
+  "rawKB": 58,
   "gzipKB": 22,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene127-shader-renderable-D60PBm4V.js",
+    "scene127-shader-renderable-DPHbffHV.js",
     "scene127.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 57.9,
+  "rawKB": 58,
   "gzipKB": 22,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene128-shader-renderable-8WDn10yb.js",
+    "scene128-shader-renderable-bpk4e7g8.js",
     "scene128.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene129.json
+++ b/lab/public/bundle/manifest/scene129.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 82.8,
-  "gzipKB": 31.5,
+  "rawKB": 82.9,
+  "gzipKB": 31.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene129-gs-picking-pipeline-wk9cVMav.js",

--- a/lab/public/bundle/manifest/scene13.json
+++ b/lab/public/bundle/manifest/scene13.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 84.5,
-  "gzipKB": 34.8,
+  "rawKB": 84.6,
+  "gzipKB": 34.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene13-background-ground-InM-psQA.js",

--- a/lab/public/bundle/manifest/scene140.json
+++ b/lab/public/bundle/manifest/scene140.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 89.4,
-  "gzipKB": 41.4,
+  "rawKB": 89.5,
+  "gzipKB": 41.5,
   "ignoredRawKB": 6.6,
   "runtimeChunks": [
     "scene140-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene141.json
+++ b/lab/public/bundle/manifest/scene141.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 123.4,
+  "rawKB": 123.5,
   "gzipKB": 50.9,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene142.json
+++ b/lab/public/bundle/manifest/scene142.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 61.1,
-  "gzipKB": 22.8,
+  "rawKB": 61.2,
+  "gzipKB": 22.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene142-standard-renderable-COIztMWN.js",

--- a/lab/public/bundle/manifest/scene143.json
+++ b/lab/public/bundle/manifest/scene143.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 70.2,
-  "gzipKB": 27.3,
+  "rawKB": 70.3,
+  "gzipKB": 27.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene143-generate-mipmaps-CiyhUZPA.js",

--- a/lab/public/bundle/manifest/scene144.json
+++ b/lab/public/bundle/manifest/scene144.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 110.4,
+  "rawKB": 110.5,
   "gzipKB": 44.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene145.json
+++ b/lab/public/bundle/manifest/scene145.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 88.9,
-  "gzipKB": 36.2,
+  "rawKB": 89,
+  "gzipKB": 36.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene145-bake-local-matrix-67U-IT8C.js",

--- a/lab/public/bundle/manifest/scene146.json
+++ b/lab/public/bundle/manifest/scene146.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 111.6,
-  "gzipKB": 45.5,
+  "rawKB": 111.7,
+  "gzipKB": 45.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene146-alpha-test-fragment-DKqMogCi.js",

--- a/lab/public/bundle/manifest/scene147.json
+++ b/lab/public/bundle/manifest/scene147.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 103.7,
-  "gzipKB": 41.4,
+  "rawKB": 103.8,
+  "gzipKB": 41.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene147-directional-light-CwjabfgT.js",

--- a/lab/public/bundle/manifest/scene148.json
+++ b/lab/public/bundle/manifest/scene148.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 109.6,
+  "rawKB": 109.7,
   "gzipKB": 43,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene149.json
+++ b/lab/public/bundle/manifest/scene149.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 109,
-  "gzipKB": 44.5,
+  "rawKB": 109.1,
+  "gzipKB": 44.6,
   "ignoredRawKB": 6.8,
   "runtimeChunks": [
     "scene149-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene15.json
+++ b/lab/public/bundle/manifest/scene15.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 47.3,
+  "rawKB": 47.4,
   "gzipKB": 19,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene150.json
+++ b/lab/public/bundle/manifest/scene150.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 55.2,
-  "gzipKB": 21.6,
+  "rawKB": 55.3,
+  "gzipKB": 21.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene150-standard-renderable-Dwlmn5s3.js",

--- a/lab/public/bundle/manifest/scene151.json
+++ b/lab/public/bundle/manifest/scene151.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 55.5,
+  "rawKB": 55.6,
   "gzipKB": 21.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene155.json
+++ b/lab/public/bundle/manifest/scene155.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 58.1,
+  "rawKB": 58.2,
   "gzipKB": 22.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene156.json
+++ b/lab/public/bundle/manifest/scene156.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 58.8,
-  "gzipKB": 22.8,
+  "rawKB": 58.9,
+  "gzipKB": 22.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene156-standard-renderable-DJlsSdaM.js",

--- a/lab/public/bundle/manifest/scene158.json
+++ b/lab/public/bundle/manifest/scene158.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 95.8,
+  "rawKB": 95.9,
   "gzipKB": 39,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 37.7,
+  "rawKB": 37.8,
   "gzipKB": 14.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene159-shader-renderable-C8g4Yu4F.js",
+    "scene159-shader-renderable-8p-CCRDr.js",
     "scene159.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene16.json
+++ b/lab/public/bundle/manifest/scene16.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 48.8,
+  "rawKB": 48.9,
   "gzipKB": 19.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 39.8,
+  "rawKB": 39.9,
   "gzipKB": 15.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene160-shader-renderable-DHMpTlUs.js",
+    "scene160-shader-renderable-CpXv1snw.js",
     "scene160.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -3,7 +3,7 @@
   "gzipKB": 14.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene161-shader-renderable-CDPWjQTK.js",
+    "scene161-shader-renderable-BS-nG3s4.js",
     "scene161.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 37.8,
-  "gzipKB": 14.8,
+  "rawKB": 37.9,
+  "gzipKB": 14.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene162-shader-renderable-ClGNyQWj.js",
+    "scene162-shader-renderable-DFciSp7P.js",
     "scene162.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -3,7 +3,7 @@
   "gzipKB": 14.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene163-shader-renderable-_LYs9u8m.js",
+    "scene163-shader-renderable-DtrEIcU-.js",
     "scene163.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene164.json
+++ b/lab/public/bundle/manifest/scene164.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 98.4,
-  "gzipKB": 40.7,
+  "rawKB": 98.5,
+  "gzipKB": 40.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene164-create-morph-targets-DRqKS4bi.js",

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -1,9 +1,9 @@
 {
   "rawKB": 42.6,
-  "gzipKB": 16.8,
+  "gzipKB": 16.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene165-shader-renderable-DutLMQZf.js",
+    "scene165-shader-renderable-B0VQUzUX.js",
     "scene165-shader-thin-instance-4I-7OUWJ.js",
     "scene165-thin-instance-gpu-BhWPyvxZ.js",
     "scene165.js"

--- a/lab/public/bundle/manifest/scene17.json
+++ b/lab/public/bundle/manifest/scene17.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 85.8,
+  "rawKB": 85.9,
   "gzipKB": 35.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene170.json
+++ b/lab/public/bundle/manifest/scene170.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 51.5,
+  "rawKB": 51.6,
   "gzipKB": 20.4,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene171.json
+++ b/lab/public/bundle/manifest/scene171.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 96.4,
-  "gzipKB": 39.2,
+  "rawKB": 96.5,
+  "gzipKB": 39.3,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [
     "scene171-generate-mipmaps-DXPozdXM.js",

--- a/lab/public/bundle/manifest/scene172.json
+++ b/lab/public/bundle/manifest/scene172.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.9,
+  "rawKB": 60,
   "gzipKB": 23.5,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene173.json
+++ b/lab/public/bundle/manifest/scene173.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62,
+  "rawKB": 62.1,
   "gzipKB": 24.2,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene174.json
+++ b/lab/public/bundle/manifest/scene174.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 97,
+  "rawKB": 97.1,
   "gzipKB": 39.6,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene175.json
+++ b/lab/public/bundle/manifest/scene175.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 95.4,
-  "gzipKB": 38.9,
+  "gzipKB": 39,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [
     "scene175-generate-mipmaps-B-d91NI_.js",

--- a/lab/public/bundle/manifest/scene176.json
+++ b/lab/public/bundle/manifest/scene176.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.4,
+  "rawKB": 103.5,
   "gzipKB": 41.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene177.json
+++ b/lab/public/bundle/manifest/scene177.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 69.6,
+  "rawKB": 69.7,
   "gzipKB": 28.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene178.json
+++ b/lab/public/bundle/manifest/scene178.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 87.8,
+  "rawKB": 87.9,
   "gzipKB": 35.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene179.json
+++ b/lab/public/bundle/manifest/scene179.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 72.9,
+  "rawKB": 73,
   "gzipKB": 29.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene18.json
+++ b/lab/public/bundle/manifest/scene18.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 60.7,
-  "gzipKB": 24.3,
+  "rawKB": 60.8,
+  "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene18-generate-mipmaps-CORvzSVx.js",

--- a/lab/public/bundle/manifest/scene19.json
+++ b/lab/public/bundle/manifest/scene19.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 70.2,
-  "gzipKB": 28.6,
+  "gzipKB": 28.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene19-clearcoat-fragment-Cbq-w7I6.js",

--- a/lab/public/bundle/manifest/scene2.json
+++ b/lab/public/bundle/manifest/scene2.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 47,
-  "gzipKB": 18.8,
+  "rawKB": 47.1,
+  "gzipKB": 18.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene2-standard-renderable-BiFo_CfT.js",

--- a/lab/public/bundle/manifest/scene20.json
+++ b/lab/public/bundle/manifest/scene20.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 78.7,
+  "rawKB": 78.8,
   "gzipKB": 33,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene201.json
+++ b/lab/public/bundle/manifest/scene201.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 48.6,
-  "gzipKB": 19.7,
+  "rawKB": 48.7,
+  "gzipKB": 19.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene201-_mat4-storage-f64-BubF55_X.js",

--- a/lab/public/bundle/manifest/scene202.json
+++ b/lab/public/bundle/manifest/scene202.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 49.3,
-  "gzipKB": 20,
+  "rawKB": 49.4,
+  "gzipKB": 20.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene202-_mat4-storage-f64-Cxw5KwUZ.js",

--- a/lab/public/bundle/manifest/scene203.json
+++ b/lab/public/bundle/manifest/scene203.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 49.6,
-  "gzipKB": 20.1,
+  "rawKB": 49.7,
+  "gzipKB": 20.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene203-_mat4-storage-f64-C0lTlSaC.js",

--- a/lab/public/bundle/manifest/scene204.json
+++ b/lab/public/bundle/manifest/scene204.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 51.1,
-  "gzipKB": 20.8,
+  "gzipKB": 20.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene204-_mat4-storage-f64-7Hs0bt2y.js",

--- a/lab/public/bundle/manifest/scene205.json
+++ b/lab/public/bundle/manifest/scene205.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 61.9,
-  "gzipKB": 25.4,
+  "rawKB": 62,
+  "gzipKB": 25.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene205-_mat4-storage-f64-BubVEbOW.js",

--- a/lab/public/bundle/manifest/scene206.json
+++ b/lab/public/bundle/manifest/scene206.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 62.3,
-  "gzipKB": 25.5,
+  "gzipKB": 25.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene206-_mat4-storage-f64-FI8ZUjRd.js",

--- a/lab/public/bundle/manifest/scene207.json
+++ b/lab/public/bundle/manifest/scene207.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.6,
+  "rawKB": 59.7,
   "gzipKB": 24,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene209.json
+++ b/lab/public/bundle/manifest/scene209.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 54.3,
-  "gzipKB": 22.2,
+  "rawKB": 54.4,
+  "gzipKB": 22.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene209-_mat4-storage-f64-3NavC9Rv.js",

--- a/lab/public/bundle/manifest/scene210.json
+++ b/lab/public/bundle/manifest/scene210.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 76.8,
-  "gzipKB": 31.8,
+  "gzipKB": 31.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene210-generate-mipmaps-BeLXoJVY.js",

--- a/lab/public/bundle/manifest/scene212.json
+++ b/lab/public/bundle/manifest/scene212.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.7,
+  "rawKB": 103.8,
   "gzipKB": 41.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 45.7,
-  "gzipKB": 17.3,
+  "rawKB": 45.8,
+  "gzipKB": 17.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene213-shader-renderable-OSW7gK8P.js",
+    "scene213-shader-renderable-HUy37cis.js",
     "scene213.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene214.json
+++ b/lab/public/bundle/manifest/scene214.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 68.2,
+  "rawKB": 68.3,
   "gzipKB": 27.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene215.json
+++ b/lab/public/bundle/manifest/scene215.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 79.4,
-  "gzipKB": 31.9,
+  "rawKB": 79.5,
+  "gzipKB": 32,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene215-material-view-Dua1bl7W.js",

--- a/lab/public/bundle/manifest/scene216.json
+++ b/lab/public/bundle/manifest/scene216.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 53.7,
-  "gzipKB": 22,
+  "gzipKB": 22.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene216-pbr-fog-wgsl-BuLKZvgv.js",

--- a/lab/public/bundle/manifest/scene217.json
+++ b/lab/public/bundle/manifest/scene217.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 78.1,
+  "rawKB": 78.2,
   "gzipKB": 31.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene218.json
+++ b/lab/public/bundle/manifest/scene218.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92.3,
+  "rawKB": 92.4,
   "gzipKB": 38.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene219.json
+++ b/lab/public/bundle/manifest/scene219.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 94.9,
-  "gzipKB": 39.6,
+  "rawKB": 95,
+  "gzipKB": 39.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene219-create-skeleton-DNC_UZif.js",

--- a/lab/public/bundle/manifest/scene22.json
+++ b/lab/public/bundle/manifest/scene22.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 97.6,
+  "rawKB": 97.7,
   "gzipKB": 39.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 100.3,
-  "gzipKB": 37.9,
+  "rawKB": 100.4,
+  "gzipKB": 38,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene221-shader-renderable-tHF1mFau.js",
+    "scene221-shader-renderable-DsTWdQIY.js",
     "scene221-standard-renderable-qDSfNdr4.js",
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221-ubo-layout-CnrP4RZD.js",

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 111.4,
+  "rawKB": 111.5,
   "gzipKB": 41,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene222-gpu-pool-CHlSfwGp.js",
-    "scene222-shader-renderable-D9pd8HjW.js",
+    "scene222-shader-renderable-DalN8ei-.js",
     "scene222-standard-renderable-BdLy8HER.js",
     "scene222-swapchain-overlay-ilhN4El_.js",
     "scene222-ubo-layout-Cs5YvLYZ.js",

--- a/lab/public/bundle/manifest/scene223.json
+++ b/lab/public/bundle/manifest/scene223.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 63.9,
-  "gzipKB": 24.3,
+  "rawKB": 64,
+  "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene223-standard-renderable-DnE_HU3_.js",

--- a/lab/public/bundle/manifest/scene224.json
+++ b/lab/public/bundle/manifest/scene224.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 81.8,
-  "gzipKB": 30.4,
+  "gzipKB": 30.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene224-standard-renderable-DWNKdo2N.js",

--- a/lab/public/bundle/manifest/scene225.json
+++ b/lab/public/bundle/manifest/scene225.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 58.2,
+  "rawKB": 58.3,
   "gzipKB": 23.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene228.json
+++ b/lab/public/bundle/manifest/scene228.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 50.2,
-  "gzipKB": 19.9,
+  "rawKB": 50.3,
+  "gzipKB": 20,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene228-standard-renderable-DlLkRdiv.js",

--- a/lab/public/bundle/manifest/scene23.json
+++ b/lab/public/bundle/manifest/scene23.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 78.6,
-  "gzipKB": 32.4,
+  "rawKB": 78.7,
+  "gzipKB": 32.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene23-anisotropy-fragment-CbNkTpSR.js",

--- a/lab/public/bundle/manifest/scene24.json
+++ b/lab/public/bundle/manifest/scene24.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 59,
-  "gzipKB": 24.5,
+  "gzipKB": 24.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene24-bake-local-matrix-67U-IT8C.js",

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.7,
+  "rawKB": 90.8,
   "gzipKB": 37.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene241.json
+++ b/lab/public/bundle/manifest/scene241.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 161,
+  "rawKB": 161.1,
   "gzipKB": 65.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 96.9,
-  "gzipKB": 40,
+  "gzipKB": 40.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene242-animation-pointer-basecolor-C0cq9A_I.js",

--- a/lab/public/bundle/manifest/scene243.json
+++ b/lab/public/bundle/manifest/scene243.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 97.1,
+  "rawKB": 97.2,
   "gzipKB": 40.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 132.9,
+  "rawKB": 133,
   "gzipKB": 53.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene245.json
+++ b/lab/public/bundle/manifest/scene245.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 100.2,
+  "rawKB": 100.3,
   "gzipKB": 42.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 99.1,
-  "gzipKB": 42,
+  "rawKB": 99.2,
+  "gzipKB": 42.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene246-create-skeleton-COkERfCM.js",

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 83.9,
-  "gzipKB": 34.8,
+  "rawKB": 84,
+  "gzipKB": 34.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene247-generate-mipmaps-Crazqgzv.js",

--- a/lab/public/bundle/manifest/scene249.json
+++ b/lab/public/bundle/manifest/scene249.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 78.4,
+  "rawKB": 78.5,
   "gzipKB": 32.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene25.json
+++ b/lab/public/bundle/manifest/scene25.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 52,
+  "rawKB": 52.1,
   "gzipKB": 20.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene251.json
+++ b/lab/public/bundle/manifest/scene251.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.5,
+  "rawKB": 89.6,
   "gzipKB": 37,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene252.json
+++ b/lab/public/bundle/manifest/scene252.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49,
+  "rawKB": 49.1,
   "gzipKB": 19.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 152.1,
+  "rawKB": 152.2,
   "gzipKB": 64.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene254.json
+++ b/lab/public/bundle/manifest/scene254.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92.1,
+  "rawKB": 92.2,
   "gzipKB": 38.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 93.8,
-  "gzipKB": 39.2,
+  "gzipKB": 39.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene255-create-skeleton-T6FJrUnE.js",

--- a/lab/public/bundle/manifest/scene258.json
+++ b/lab/public/bundle/manifest/scene258.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 82.8,
+  "rawKB": 82.9,
   "gzipKB": 34.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene259.json
+++ b/lab/public/bundle/manifest/scene259.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 77.1,
+  "rawKB": 77.2,
   "gzipKB": 31.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene26.json
+++ b/lab/public/bundle/manifest/scene26.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 90.2,
-  "gzipKB": 36.6,
+  "gzipKB": 36.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene26-emissive-fragment-NHEUTzE3.js",

--- a/lab/public/bundle/manifest/scene261.json
+++ b/lab/public/bundle/manifest/scene261.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 54.4,
-  "gzipKB": 21.2,
+  "rawKB": 54.5,
+  "gzipKB": 21.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene261-standard-renderable-BVWOm7Y2.js",

--- a/lab/public/bundle/manifest/scene27.json
+++ b/lab/public/bundle/manifest/scene27.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 82.7,
-  "gzipKB": 33.7,
+  "gzipKB": 33.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene27-generate-mipmaps-CaLzDGPp.js",

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 86.4,
+  "rawKB": 86.5,
   "gzipKB": 35.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene29.json
+++ b/lab/public/bundle/manifest/scene29.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 90,
-  "gzipKB": 37.1,
+  "rawKB": 90.1,
+  "gzipKB": 37.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene29-generate-mipmaps-DJCYSY1_.js",

--- a/lab/public/bundle/manifest/scene3.json
+++ b/lab/public/bundle/manifest/scene3.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 53.9,
+  "rawKB": 54,
   "gzipKB": 21.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 103.3,
-  "gzipKB": 42.5,
+  "gzipKB": 42.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene30-alpha-test-fragment-Dp7v2RIU.js",

--- a/lab/public/bundle/manifest/scene31.json
+++ b/lab/public/bundle/manifest/scene31.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 80,
-  "gzipKB": 32.8,
+  "rawKB": 80.1,
+  "gzipKB": 32.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene31-emissive-fragment-C1TNSo0w.js",

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 79.9,
-  "gzipKB": 32.8,
+  "rawKB": 80,
+  "gzipKB": 32.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene32-generate-mipmaps-DdnhjgK3.js",

--- a/lab/public/bundle/manifest/scene33.json
+++ b/lab/public/bundle/manifest/scene33.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.3,
+  "rawKB": 103.4,
   "gzipKB": 42.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 96.7,
-  "gzipKB": 39.8,
+  "rawKB": 96.8,
+  "gzipKB": 39.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene34-generate-mipmaps-C244DQVV.js",

--- a/lab/public/bundle/manifest/scene36.json
+++ b/lab/public/bundle/manifest/scene36.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 51.6,
-  "gzipKB": 20.3,
+  "rawKB": 51.7,
+  "gzipKB": 20.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene36-standard-renderable-DZtkeKp5.js",

--- a/lab/public/bundle/manifest/scene37.json
+++ b/lab/public/bundle/manifest/scene37.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 97,
+  "rawKB": 97.1,
   "gzipKB": 39.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene38.json
+++ b/lab/public/bundle/manifest/scene38.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 61.2,
+  "rawKB": 61.3,
   "gzipKB": 24.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene4.json
+++ b/lab/public/bundle/manifest/scene4.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 72.6,
+  "rawKB": 72.7,
   "gzipKB": 28.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene40.json
+++ b/lab/public/bundle/manifest/scene40.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49.6,
+  "rawKB": 49.7,
   "gzipKB": 20,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene41.json
+++ b/lab/public/bundle/manifest/scene41.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 92.9,
-  "gzipKB": 36.9,
+  "rawKB": 93,
+  "gzipKB": 37,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene41-generate-mipmaps-BWxJCIcc.js",

--- a/lab/public/bundle/manifest/scene42.json
+++ b/lab/public/bundle/manifest/scene42.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 51.2,
-  "gzipKB": 20.3,
+  "rawKB": 51.3,
+  "gzipKB": 20.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene42-standard-renderable-B-mqcMeS.js",

--- a/lab/public/bundle/manifest/scene43.json
+++ b/lab/public/bundle/manifest/scene43.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 58.1,
-  "gzipKB": 23.2,
+  "gzipKB": 23.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene43-standard-renderable-BeC4p3CE.js",

--- a/lab/public/bundle/manifest/scene44.json
+++ b/lab/public/bundle/manifest/scene44.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.1,
+  "rawKB": 50.2,
   "gzipKB": 20.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene46.json
+++ b/lab/public/bundle/manifest/scene46.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 54.4,
-  "gzipKB": 21.3,
+  "rawKB": 54.5,
+  "gzipKB": 21.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene46-standard-renderable-hx5y8uJN.js",

--- a/lab/public/bundle/manifest/scene47.json
+++ b/lab/public/bundle/manifest/scene47.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 92.2,
-  "gzipKB": 36.8,
+  "rawKB": 92.3,
+  "gzipKB": 36.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene47-generate-mipmaps-CmIGpFd5.js",

--- a/lab/public/bundle/manifest/scene48.json
+++ b/lab/public/bundle/manifest/scene48.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 54.3,
+  "rawKB": 54.4,
   "gzipKB": 21.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92.7,
+  "rawKB": 92.8,
   "gzipKB": 35,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene5.json
+++ b/lab/public/bundle/manifest/scene5.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 91.5,
+  "rawKB": 91.6,
   "gzipKB": 38.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 57.4,
-  "gzipKB": 23,
+  "rawKB": 57.5,
+  "gzipKB": 23.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene52-standard-renderable-DXnTjsje.js",

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 57.5,
+  "rawKB": 57.6,
   "gzipKB": 23,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene54.json
+++ b/lab/public/bundle/manifest/scene54.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 59.9,
-  "gzipKB": 24.3,
+  "rawKB": 60,
+  "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene54-billboard-renderable-BeTxDz7N.js",

--- a/lab/public/bundle/manifest/scene55.json
+++ b/lab/public/bundle/manifest/scene55.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 31.3,
+  "rawKB": 31.4,
   "gzipKB": 13,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene56.json
+++ b/lab/public/bundle/manifest/scene56.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 60.2,
-  "gzipKB": 24.4,
+  "rawKB": 60.3,
+  "gzipKB": 24.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene56-billboard-renderable-rwL30tEO.js",

--- a/lab/public/bundle/manifest/scene57.json
+++ b/lab/public/bundle/manifest/scene57.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60,
+  "rawKB": 60.1,
   "gzipKB": 24.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene59.json
+++ b/lab/public/bundle/manifest/scene59.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 63.1,
-  "gzipKB": 25.3,
+  "rawKB": 63.2,
+  "gzipKB": 25.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene59-billboard-renderable-KN9gLXsu.js",

--- a/lab/public/bundle/manifest/scene60.json
+++ b/lab/public/bundle/manifest/scene60.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 55.4,
+  "rawKB": 55.5,
   "gzipKB": 22.7,
   "ignoredRawKB": 4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene61.json
+++ b/lab/public/bundle/manifest/scene61.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 54.3,
-  "gzipKB": 23.2,
+  "rawKB": 54.4,
+  "gzipKB": 23.3,
   "ignoredRawKB": 7.3,
   "runtimeChunks": [
     "scene61-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene63.json
+++ b/lab/public/bundle/manifest/scene63.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 58.6,
+  "rawKB": 58.7,
   "gzipKB": 24.6,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene64.json
+++ b/lab/public/bundle/manifest/scene64.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 56.6,
+  "rawKB": 56.7,
   "gzipKB": 23.5,
   "ignoredRawKB": 4.3,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene65.json
+++ b/lab/public/bundle/manifest/scene65.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 74.4,
+  "rawKB": 74.5,
   "gzipKB": 30.6,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene66.json
+++ b/lab/public/bundle/manifest/scene66.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 88.9,
-  "gzipKB": 40.9,
+  "rawKB": 89,
+  "gzipKB": 41,
   "ignoredRawKB": 5.5,
   "runtimeChunks": [
     "scene66-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene68.json
+++ b/lab/public/bundle/manifest/scene68.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 91,
+  "rawKB": 91.1,
   "gzipKB": 35.8,
   "ignoredRawKB": 11.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene69.json
+++ b/lab/public/bundle/manifest/scene69.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.4,
+  "rawKB": 90.5,
   "gzipKB": 36.1,
   "ignoredRawKB": 13.3,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene70.json
+++ b/lab/public/bundle/manifest/scene70.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 90.7,
-  "gzipKB": 36.6,
+  "rawKB": 90.8,
+  "gzipKB": 36.7,
   "ignoredRawKB": 14.9,
   "runtimeChunks": [
     "scene70-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene71.json
+++ b/lab/public/bundle/manifest/scene71.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 90.6,
-  "gzipKB": 36,
+  "rawKB": 90.7,
+  "gzipKB": 36.1,
   "ignoredRawKB": 12.9,
   "runtimeChunks": [
     "scene71-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene72.json
+++ b/lab/public/bundle/manifest/scene72.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 108.3,
+  "rawKB": 108.4,
   "gzipKB": 43.8,
   "ignoredRawKB": 3.3,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene73.json
+++ b/lab/public/bundle/manifest/scene73.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 143.7,
+  "rawKB": 143.8,
   "gzipKB": 58,
   "ignoredRawKB": 3.3,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene75.json
+++ b/lab/public/bundle/manifest/scene75.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 50.3,
-  "gzipKB": 20.1,
+  "rawKB": 50.4,
+  "gzipKB": 20.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene75-standard-renderable-CYo4Y48I.js",

--- a/lab/public/bundle/manifest/scene78.json
+++ b/lab/public/bundle/manifest/scene78.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 57.5,
-  "gzipKB": 27.3,
+  "rawKB": 57.6,
+  "gzipKB": 27.4,
   "ignoredRawKB": 9.7,
   "runtimeChunks": [
     "scene78-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene79.json
+++ b/lab/public/bundle/manifest/scene79.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 61.1,
+  "rawKB": 61.2,
   "gzipKB": 27.6,
   "ignoredRawKB": 8.1,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene8.json
+++ b/lab/public/bundle/manifest/scene8.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 74.5,
+  "rawKB": 74.6,
   "gzipKB": 29.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene80.json
+++ b/lab/public/bundle/manifest/scene80.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.5,
+  "rawKB": 60.6,
   "gzipKB": 26.6,
   "ignoredRawKB": 6,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene81.json
+++ b/lab/public/bundle/manifest/scene81.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 66.5,
-  "gzipKB": 29.7,
+  "rawKB": 66.6,
+  "gzipKB": 29.8,
   "ignoredRawKB": 7,
   "runtimeChunks": [
     "scene81-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene83.json
+++ b/lab/public/bundle/manifest/scene83.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 70.3,
+  "rawKB": 70.4,
   "gzipKB": 33.2,
   "ignoredRawKB": 11.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene86.json
+++ b/lab/public/bundle/manifest/scene86.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.7,
+  "rawKB": 59.8,
   "gzipKB": 27.1,
   "ignoredRawKB": 8,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene87.json
+++ b/lab/public/bundle/manifest/scene87.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 93.7,
+  "rawKB": 93.8,
   "gzipKB": 37.5,
   "ignoredRawKB": 12,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene88.json
+++ b/lab/public/bundle/manifest/scene88.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.4,
+  "rawKB": 60.5,
   "gzipKB": 26.8,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene89.json
+++ b/lab/public/bundle/manifest/scene89.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.8,
+  "rawKB": 59.9,
   "gzipKB": 27,
   "ignoredRawKB": 7.6,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene9.json
+++ b/lab/public/bundle/manifest/scene9.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.5,
+  "rawKB": 59.6,
   "gzipKB": 24.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene90.json
+++ b/lab/public/bundle/manifest/scene90.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 59.3,
-  "gzipKB": 23.4,
+  "gzipKB": 23.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene90-generate-mipmaps-SRXClq-S.js",

--- a/lab/public/bundle/manifest/scene91.json
+++ b/lab/public/bundle/manifest/scene91.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 58.4,
+  "rawKB": 58.5,
   "gzipKB": 23.3,
   "ignoredRawKB": 1227.9,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene94.json
+++ b/lab/public/bundle/manifest/scene94.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 63.8,
-  "gzipKB": 25.2,
+  "rawKB": 63.9,
+  "gzipKB": 25.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene94-billboard-renderable-BgBdc7uu.js",

--- a/lab/public/bundle/manifest/scene95.json
+++ b/lab/public/bundle/manifest/scene95.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 64.9,
-  "gzipKB": 25.5,
+  "rawKB": 65,
+  "gzipKB": 25.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene95-billboard-renderable-D1Ojksz4.js",

--- a/lab/public/bundle/manifest/scene98.json
+++ b/lab/public/bundle/manifest/scene98.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.2,
+  "rawKB": 60.3,
   "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene99.json
+++ b/lab/public/bundle/manifest/scene99.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 91.9,
-  "gzipKB": 38.1,
+  "gzipKB": 38.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene99-animation-group-BMEfNKqK.js",

--- a/packages/babylon-lite/src/engine/device-lost-recovery.ts
+++ b/packages/babylon-lite/src/engine/device-lost-recovery.ts
@@ -237,6 +237,7 @@ async function rebuildSceneGpu(engine: EngineContext, scene: SceneContext): Prom
     scene._renderables.length = 0;
     scene._uniformUpdaters.length = 0;
     scene._meshDisposables.clear();
+    scene._meshAuxDisposables.clear();
     if (scene._lightGpuState) {
         scene._lightGpuState = undefined;
     }

--- a/packages/babylon-lite/src/frame-graph/depth-pyramid.ts
+++ b/packages/babylon-lite/src/frame-graph/depth-pyramid.ts
@@ -1,0 +1,262 @@
+/**
+ * Depth pyramid — a hierarchical ("Hi-Z") mip chain of a depth buffer where each coarser level combines its
+ * four child texels with `min()` or `max()`. The classic uses are GPU occlusion culling (test a screen-space
+ * bounding box against the coarse level that covers it) and hierarchical screen-space ray marching (skip empty
+ * space at coarse mips, refine to a precise hit at level 0), plus horizon-search AO and contact shadows.
+ *
+ * WebGPU has no built-in min/max mip reduction, so — like `generate-mipmaps` — we render a fullscreen triangle
+ * per level. Two pipelines:
+ *   • COPY:   sample the source `texture_depth_2d` → write its NDC depth into mip 0 of an `r32float` texture.
+ *   • REDUCE: each coarser level = `min`/`max` of its four child texels of the previous level.
+ *
+ * The `reduce` mode is the caller's choice of depth convention + use: a reverse-Z Hi-Z (near = 1) wants `max`
+ * (keeps the NEAREST surface per tile — what a skip-empty ray march needs); a farthest-occluder pyramid for
+ * occlusion culling wants `min` in reverse-Z (the deepest occluder is the conservative bound). Nearest sampler,
+ * so the consumer reads it with `textureLoad(tex, coord, mip)`.
+ *
+ * The output `Texture2D` ref-counts through the shared texture pool: the pyramid holds one base ref so a
+ * consumer material's bind/rebind churn can never drive it to zero. `resize()` mints a FRESH wrapper (new
+ * identity) so the consumer's `setShaderTexture` sees the change and rebuilds its bind group against the new
+ * view; the old texture stays alive until the consumer releases its own ref (no destroy-while-referenced).
+ */
+
+import { TU, SS } from "../engine/gpu-flags.js";
+import { acquireTexture, releaseTexture, getOrCreateSampler } from "../resource/gpu-pool.js";
+import type { EngineContext } from "../engine/engine.js";
+import type { SceneContext } from "../scene/scene-core.js";
+import type { Texture2D } from "../texture/texture-2d.js";
+import type { Task } from "./task.js";
+
+/** Full mip chain length for a width/height (log2 of the larger side + 1). */
+function mipLevelCount(width: number, height: number): number {
+    return Math.floor(Math.log2(Math.max(width, height))) + 1;
+}
+
+const COPY_SHADER = `@group(0)@binding(0)var src:texture_depth_2d;
+struct V{@builtin(position)p:vec4f};
+@vertex fn vs(@builtin(vertex_index)i:u32)->V{let p=array<vec2f,3>(vec2f(-1,-1),vec2f(3,-1),vec2f(-1,3))[i];return V(vec4f(p,0,1));}
+@fragment fn fs(@builtin(position)fc:vec4f)->@location(0)f32{return textureLoad(src,vec2<i32>(fc.xy),0);}`;
+
+/** REDUCE fragment: `op` is `min` or `max` of the four child texels of the previous level. */
+function reduceShader(op: "min" | "max"): string {
+    return `@group(0)@binding(0)var src:texture_2d<f32>;
+struct V{@builtin(position)p:vec4f};
+@vertex fn vs(@builtin(vertex_index)i:u32)->V{let p=array<vec2f,3>(vec2f(-1,-1),vec2f(3,-1),vec2f(-1,3))[i];return V(vec4f(p,0,1));}
+@fragment fn fs(@builtin(position)fc:vec4f)->@location(0)f32{
+  let c=vec2<i32>(fc.xy)*2;
+  let d=vec2<i32>(textureDimensions(src))-vec2<i32>(1,1);
+  let x1=min(c.x+1,d.x); let y1=min(c.y+1,d.y);
+  let a=textureLoad(src,vec2<i32>(c.x,c.y),0).r;
+  let b=textureLoad(src,vec2<i32>(x1,c.y),0).r;
+  let e=textureLoad(src,vec2<i32>(c.x,y1),0).r;
+  let f=textureLoad(src,vec2<i32>(x1,y1),0).r;
+  return ${op}(${op}(a,b),${op}(e,f));
+}`;
+}
+
+/** How each coarser pyramid level combines its four child texels. */
+export type DepthPyramidReduce = "min" | "max";
+
+export interface DepthPyramidOptions {
+    /** Mip-0 width — match the source depth texture. */
+    width: number;
+    /** Mip-0 height — match the source depth texture. */
+    height: number;
+    /** Child-texel combine: `max` (default; reverse-Z nearest-surface Hi-Z) or `min` (forward-Z, or
+     *  reverse-Z farthest-occluder for occlusion culling). */
+    reduce?: DepthPyramidReduce;
+}
+
+/** A rebuildable hierarchical depth pyramid. Create with `createDepthPyramid`; drive its per-frame build with
+ *  `createDepthPyramidTask` (in-frame) or by calling `build()` yourself. */
+export interface DepthPyramid {
+    /** `r32float`, full mip chain, nearest sampler. Bind to a material; read `textureLoad(tex, coord, mip)`.
+     *  A `resize()` replaces this wrapper (new identity) — re-read it and re-bind after a resize. */
+    readonly texture: Texture2D;
+    /** Number of mip levels in the current pyramid. */
+    readonly mipCount: number;
+    /** Re-derive the pyramid from `depthTexture` (a `texture_depth_2d` of matching mip-0 size). Pass the frame
+     *  `encoder` to record the COPY/REDUCE passes in-frame (e.g. after a depth prepass, before the consumer that
+     *  samples the pyramid); omit it to run on a private encoder + submit immediately. */
+    build(depthTexture: Texture2D, encoder?: GPUCommandEncoder): void;
+    /** Reallocate the pyramid texture at a new mip-0 size (call when the source depth target resizes). No-op if
+     *  unchanged. Mint a new `texture` wrapper on a real change; safe to call any time (does not destroy the old
+     *  texture while a consumer still references it). */
+    resize(width: number, height: number): void;
+    /** Release the pyramid's base texture ref (frees the GPU texture once no consumer holds it). */
+    dispose(): void;
+}
+
+interface EngineDevice {
+    _device: GPUDevice;
+}
+
+/** Create a hierarchical depth pyramid sized `width`×`height`. Build it each frame from the live depth texture
+ *  (via `createDepthPyramidTask`, or `build()` directly). Owns its COPY/REDUCE pipelines + the mipped texture. */
+export function createDepthPyramid(engine: EngineContext, opts: DepthPyramidOptions): DepthPyramid {
+    const device = (engine as unknown as EngineDevice)._device;
+    const reduce = opts.reduce ?? "max";
+    const sampler = getOrCreateSampler(engine, { minFilter: "nearest", magFilter: "nearest", addressModeU: "clamp-to-edge", addressModeV: "clamp-to-edge" });
+
+    const copyBGL = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: SS.FRAGMENT, texture: { sampleType: "depth", viewDimension: "2d" } }],
+    });
+    const reduceBGL = device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: SS.FRAGMENT, texture: { sampleType: "unfilterable-float", viewDimension: "2d" } }],
+    });
+    const mk = (code: string, layout: GPUBindGroupLayout): GPURenderPipeline =>
+        device.createRenderPipeline({
+            layout: device.createPipelineLayout({ bindGroupLayouts: [layout] }),
+            vertex: { module: device.createShaderModule({ code }), entryPoint: "vs" },
+            fragment: { module: device.createShaderModule({ code }), entryPoint: "fs", targets: [{ format: "r32float" }] },
+            primitive: { topology: "triangle-list" },
+        });
+    const copyPipeline = mk(COPY_SHADER, copyBGL);
+    const reducePipeline = mk(reduceShader(reduce), reduceBGL);
+
+    let w = Math.max(1, opts.width | 0);
+    let h = Math.max(1, opts.height | 0);
+    let mips = mipLevelCount(w, h);
+
+    function makeTexture(): GPUTexture {
+        return device.createTexture({
+            label: "depth-pyramid",
+            size: { width: w, height: h },
+            format: "r32float",
+            usage: TU.RENDER_ATTACHMENT | TU.TEXTURE_BINDING,
+            mipLevelCount: mips,
+        });
+    }
+    function makeWrapper(tex: GPUTexture): Texture2D {
+        // One base ref so a consuming material's per-version release/acquire churn never drives the pool count to
+        // 0 and destroys the texture out from under us. `_sampleType: "float"` — r32float sampled as unfilterable float.
+        const wr = { texture: tex, view: tex.createView(), sampler, width: w, height: h, _sampleType: "float" } as Texture2D;
+        acquireTexture(wr);
+        return wr;
+    }
+
+    let gpuTex = makeTexture();
+    let wrapper = makeWrapper(gpuTex);
+
+    // Per-frame GPU objects cached across build() calls and rebuilt only on resize(): the mip-0 COPY target view and,
+    // for each coarser level, a { dst view, REDUCE bind group } pair (the reduce bind group reads the previous level
+    // of our own texture, so it only changes when the texture is reallocated). The COPY bind group reads the EXTERNAL
+    // source depth, so it is rebuilt lazily only when that source Texture2D changes identity (e.g. a canvas-resize
+    // reallocation). This keeps build() free of per-frame view/bind-group churn.
+    let copyDstView: GPUTextureView;
+    let reduceLevels: { dst: GPUTextureView; bindGroup: GPUBindGroup }[] = [];
+    let copyBindGroup: GPUBindGroup | null = null;
+    let copyBindGroupSource: Texture2D | null = null;
+
+    function rebuildViews(): void {
+        copyDstView = gpuTex.createView({ baseMipLevel: 0, mipLevelCount: 1 });
+        reduceLevels = [];
+        for (let mip = 1; mip < mips; mip++) {
+            const src = gpuTex.createView({ baseMipLevel: mip - 1, mipLevelCount: 1 });
+            const dst = gpuTex.createView({ baseMipLevel: mip, mipLevelCount: 1 });
+            reduceLevels.push({ dst, bindGroup: device.createBindGroup({ layout: reduceBGL, entries: [{ binding: 0, resource: src }] }) });
+        }
+        // The texture identity changed, so the source-keyed COPY bind group is stale — force a rebuild next build().
+        copyBindGroup = null;
+        copyBindGroupSource = null;
+    }
+    rebuildViews();
+
+    return {
+        get texture(): Texture2D {
+            return wrapper;
+        },
+        get mipCount(): number {
+            return mips;
+        },
+        build(depthTexture: Texture2D, encoder?: GPUCommandEncoder): void {
+            const enc = encoder ?? device.createCommandEncoder();
+            // COPY bind group reads the external source depth; rebuild only when that source changes identity.
+            if (copyBindGroup === null || copyBindGroupSource !== depthTexture) {
+                copyBindGroup = device.createBindGroup({ layout: copyBGL, entries: [{ binding: 0, resource: depthTexture.view }] });
+                copyBindGroupSource = depthTexture;
+            }
+            // mip 0 ← source depth.
+            const copyPass = enc.beginRenderPass({
+                label: "depth-pyramid-copy",
+                colorAttachments: [{ view: copyDstView, loadOp: "clear", storeOp: "store", clearValue: { r: 0, g: 0, b: 0, a: 0 } }],
+            });
+            copyPass.setPipeline(copyPipeline);
+            copyPass.setBindGroup(0, copyBindGroup);
+            copyPass.draw(3);
+            copyPass.end();
+            // mips 1..N ← min/max reduction of the previous level.
+            for (const level of reduceLevels) {
+                const pass = enc.beginRenderPass({
+                    label: "depth-pyramid-reduce",
+                    colorAttachments: [{ view: level.dst, loadOp: "clear", storeOp: "store", clearValue: { r: 0, g: 0, b: 0, a: 0 } }],
+                });
+                pass.setPipeline(reducePipeline);
+                pass.setBindGroup(0, level.bindGroup);
+                pass.draw(3);
+                pass.end();
+            }
+            // Submit only when we own the encoder. With an external (frame) encoder the frame graph submits it,
+            // and WebGPU auto-inserts the depth→sampled barrier between the source-producing pass and our COPY.
+            if (!encoder) {
+                device.queue.submit([enc.finish()]);
+            }
+        },
+        resize(nw: number, nh: number): void {
+            const cw = Math.max(1, nw | 0);
+            const ch = Math.max(1, nh | 0);
+            if (cw === w && ch === h) {
+                return;
+            }
+            w = cw;
+            h = ch;
+            mips = mipLevelCount(w, h);
+            const old = wrapper;
+            gpuTex = makeTexture();
+            wrapper = makeWrapper(gpuTex); // fresh identity → consumer's setShaderTexture rebuilds against the new view
+            rebuildViews(); // cached views/bind groups point at the old texture — rebuild them against the new one
+            releaseTexture(old); // drop OUR base ref; the old texture frees once the consumer releases its ref too
+        },
+        dispose(): void {
+            releaseTexture(wrapper);
+        },
+    };
+}
+
+/** Options for `createDepthPyramidTask`. */
+export interface DepthPyramidTaskOptions {
+    /** The pyramid to build each frame. The task ADOPTS it — the frame graph disposes it on graph dispose, so do
+     *  not also dispose it yourself. */
+    pyramid: DepthPyramid;
+    /** The live source depth texture for this frame (e.g. a depth-prepass target). Return `null` to skip the
+     *  build this frame (e.g. before the source exists, or when nothing consumes the pyramid). */
+    source: () => Texture2D | null;
+}
+
+/** Create a frame-graph task that rebuilds `pyramid` from `source()` into the FRAME command encoder each frame.
+ *  Order it right after the pass that produces the depth (e.g. `addTaskAfter(scene, task, depthPrepassTask)`) so
+ *  the pyramid reflects THIS frame's depth. Resize the pyramid to the source's size before the frame is recorded
+ *  (the source depth target only changes size on a canvas resize). */
+export function createDepthPyramidTask(engine: EngineContext, scene: SceneContext, opts: DepthPyramidTaskOptions): Task {
+    const { pyramid, source } = opts;
+    return {
+        name: "depth-pyramid",
+        engine,
+        scene,
+        _passes: [],
+        record(): void {
+            /* No recorded Pass objects — the COPY/REDUCE passes are recorded straight into the frame encoder in execute(). */
+        },
+        execute(): number {
+            const src = source();
+            if (!src) {
+                return 0;
+            }
+            pyramid.build(src, engine._currentEncoder);
+            return pyramid.mipCount;
+        },
+        dispose(): void {
+            pyramid.dispose();
+        },
+    };
+}

--- a/packages/babylon-lite/src/frame-graph/frame-graph-actions.ts
+++ b/packages/babylon-lite/src/frame-graph/frame-graph-actions.ts
@@ -44,6 +44,18 @@ export function addTaskBefore(target: FrameGraph | SceneContext, task: Task, bef
     }
 }
 
+/** Insert a task immediately AFTER another task in execute order. Accepts a FrameGraph or a SceneContext.
+ *  If `after` is not found, the task is appended at the end (matching `addTaskBefore`'s fallback). */
+export function addTaskAfter(target: FrameGraph | SceneContext, task: Task, after: Task): void {
+    const fg = resolveFg(target);
+    const i = fg._tasks.indexOf(after);
+    if (i < 0) {
+        fg._tasks.push(task);
+    } else {
+        fg._tasks.splice(i + 1, 0, task);
+    }
+}
+
 /** Create a `RenderPass`, wire it to the task currently recording, and return
  *  it. Must be called from inside `Task.record()` so the FG can associate the
  *  new pass with the right task (mirrors BJS `frameGraph.addRenderPass`).

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -120,6 +120,9 @@ export interface RenderTask extends Task {
     _lastVersion: number;
     /** @internal */
     _lastVis: number;
+    /** @internal True once `record()` has run — the task is "live" (GPU target allocated, material batch builders
+     *  present). A runtime `addMesh` after this resolves + re-buckets THIS task immediately (no frame-graph rebuild). */
+    _recorded: boolean;
 
     /** @internal */
     _renderPassDescriptor: GPURenderPassDescriptor;
@@ -152,10 +155,11 @@ export interface RenderTask extends Task {
     /** @internal */
     _targetSignature: RenderTargetSignature;
 
-    /** Add a mesh to this task's explicit render list with an optional per-pass material override.
-     *  Resolved at `record()` time via `material._buildGroup._rebuildSingle`,
-     *  so the mesh's material family must already have been registered with
-     *  the scene (so its batch builder has run). */
+    /** Add a mesh to this task's explicit render list with an optional per-pass material override. Resolved via
+     *  `material._buildGroup._rebuildSingle`, so the mesh's material family must already have been registered with the
+     *  scene (its batch builder has run). BEFORE the first `record()` the add is QUEUED and drained at record() time;
+     *  AFTER (a live/runtime add) it is resolved + re-bucketed into THIS task immediately, so the mesh renders on the
+     *  next frame without a `frameGraph.build()` (which would re-allocate shared GPU resources across all tasks). */
     addMesh(mesh: Mesh, opts?: { material?: Material }): void;
     /** @internal */
     _pendingMeshes: { mesh: Mesh; material: Material }[];
@@ -212,6 +216,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
         _opaqueBundles: [],
         _lastVersion: -1,
         _lastVis: 0,
+        _recorded: false,
         _renderPassDescriptor: { colorAttachments: [colorAttachment] },
         _colorAttachment: colorAttachment,
         _depthSrc: config.depth,
@@ -229,6 +234,17 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
                 return;
             }
             task._pendingMeshes.push({ mesh, material });
+            if (task._recorded) {
+                // Live (post-record) add: resolve + re-bucket THIS task now — buildBindings clears its bundle cache
+                // so it re-records on the next execute. Deliberately NOT a frame-graph rebuild (that re-allocates the
+                // shared scene UBO + every task's render target mid-frame and crashes the in-flight submit).
+                resolvePendingMeshes(task, sc);
+                // A live add makes the render list explicit (mirrors record(), where a pending mesh forces
+                // _autoFromScene = false). Without this, an auto-mirroring task's next scene-version resync in
+                // prepareRenderTaskPass would clear _renderables and drop the just-added mesh.
+                task._autoFromScene = false;
+                buildBindings(task, engine, targetSignature);
+            }
         },
         record(): void {
             if (task._autoFromScene) {
@@ -258,6 +274,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
             refreshTaskSceneBindGroup(task, engine);
             buildBindings(task, engine, targetSignature);
             buildRenderPassDescriptor(task, rt);
+            task._recorded = true; // task is now live — a subsequent addMesh resolves + re-buckets immediately
         },
         execute(): number {
             return executePass(task, engine, targetSignature, updateContext);

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -47,7 +47,7 @@ export { setSubtreeVisible } from "./scene/visibility.js";
 // RenderTask, and user tasks can render offscreen RTTs, overlays, etc.
 export { getFrameGraph } from "./scene/scene.js";
 export type { FrameGraph } from "./frame-graph/frame-graph.js";
-export { addRenderPass, addTask, addTaskAtStart, addTaskBefore } from "./frame-graph/frame-graph-actions.js";
+export { addRenderPass, addTask, addTaskAtStart, addTaskBefore, addTaskAfter } from "./frame-graph/frame-graph-actions.js";
 export { createFrameGraphContext, registerFrameGraphContext, unregisterFrameGraphContext, disposeFrameGraphContext } from "./frame-graph/frame-graph-context.js";
 export type { FrameGraphContext, FrameGraphContextOptions } from "./frame-graph/frame-graph-context.js";
 export type { Task } from "./frame-graph/task.js";
@@ -56,6 +56,8 @@ export { addPassDependencies } from "./frame-graph/pass.js";
 export type { RenderPass } from "./frame-graph/render-pass.js";
 export type { RenderTask, RenderTaskConfig } from "./frame-graph/render-task.js";
 export { createRenderTask, removeMeshFromTask } from "./frame-graph/render-task.js";
+export type { DepthPyramid, DepthPyramidOptions, DepthPyramidReduce, DepthPyramidTaskOptions } from "./frame-graph/depth-pyramid.js";
+export { createDepthPyramid, createDepthPyramidTask } from "./frame-graph/depth-pyramid.js";
 export { createImageProcessingTask } from "./frame-graph/image-processing-task.js";
 export type { ImageProcessingSource, ImageProcessingTaskConfig } from "./frame-graph/image-processing-task.js";
 export type { PostProcessTask, PostProcessTaskSettings, PostProcessAlphaMode, PostProcessSamplingMode } from "./frame-graph/post-process-task.js";

--- a/packages/babylon-lite/src/material/shader/shader-renderable.ts
+++ b/packages/babylon-lite/src/material/shader/shader-renderable.ts
@@ -112,7 +112,10 @@ function buildMaterialRenderables(scene: SceneContext, material: ShaderMaterial,
     const engine = scene.surface.engine;
     const bindings = getOrCreateShaderPipelineBindings(engine, material);
     ensureCustomUbo(engine, material, bindings.customSpec);
-    const packets = meshes.map((mesh) => createPacket(scene, material, bindings.systemSpec, mesh));
+    // `isOverride` marks an AUX view packet (a material-override registered into an explicit task, e.g. a
+    // depth/SSAO no-colour view) — route its disposer to `_meshAuxDisposables` so a MAIN-material swap of this
+    // same mesh does not tear it down out from under that task.
+    const packets = meshes.map((mesh) => createPacket(scene, material, bindings.systemSpec, mesh, isOverride));
     const isTransparent = material.needAlphaBlending;
     if (isTransparent) {
         return packets.map((packet) => createTransparentRenderable(scene, material, packet, isOverride));
@@ -120,7 +123,7 @@ function buildMaterialRenderables(scene: SceneContext, material: ShaderMaterial,
     return [createOpaqueRenderable(scene, material, packets, isOverride)];
 }
 
-function createPacket(scene: SceneContext, material: ShaderMaterial, systemSpec: UboSpec, mesh: Mesh): ShaderPacket {
+function createPacket(scene: SceneContext, material: ShaderMaterial, systemSpec: UboSpec, mesh: Mesh, aux = false): ShaderPacket {
     const engine = scene.surface.engine;
     const systemUBO = createEmptyUniformBuffer(engine, systemSpec._totalBytes, "shader-system-ubo");
     const systemData = new F32(systemSpec._totalBytes / 4);
@@ -138,7 +141,7 @@ function createPacket(scene: SceneContext, material: ShaderMaterial, systemSpec:
     for (const tex of packet._boundTextures) {
         acquireTexture(tex);
     }
-    registerMeshTextureDisposer(scene, mesh, packet);
+    registerMeshTextureDisposer(scene, mesh, packet, aux);
     return packet;
 }
 
@@ -363,8 +366,11 @@ function collectShaderStorageBuffers(material: ShaderMaterial): GPUBuffer[] {
     return buffers;
 }
 
-function registerMeshTextureDisposer(scene: SceneContext, mesh: Mesh, packet: ShaderPacket): void {
-    const list = scene._meshDisposables.get(mesh) ?? [];
+function registerMeshTextureDisposer(scene: SceneContext, mesh: Mesh, packet: ShaderPacket, aux = false): void {
+    // Aux (override) view packets go in `_meshAuxDisposables` so a main-material swap leaves them alone; main
+    // packets stay in `_meshDisposables` (torn down + rebuilt by the swap drain). Both are drained on real removal.
+    const map = aux ? scene._meshAuxDisposables : scene._meshDisposables;
+    const list = map.get(mesh) ?? [];
     list.push(() => {
         packet._disposed = true;
         if (packet._owner) {
@@ -381,7 +387,7 @@ function registerMeshTextureDisposer(scene: SceneContext, mesh: Mesh, packet: Sh
         packet._boundTextures = [];
         packet._boundStorageBuffers = [];
     });
-    scene._meshDisposables.set(mesh, list);
+    map.set(mesh, list);
 }
 
 function writeSystemUniforms(data: Float32Array, spec: UboSpec, material: ShaderMaterial, mesh: Mesh, camera: Camera | null, targetWidth: number, targetHeight: number): void {

--- a/packages/babylon-lite/src/scene/scene-core.ts
+++ b/packages/babylon-lite/src/scene/scene-core.ts
@@ -102,6 +102,13 @@ export interface SceneContext extends RenderingContext {
     _disposables: (() => void)[];
     /** @internal Per-mesh cleanup callbacks (mesh UBOs, bind groups). For material swap + dispose. */
     _meshDisposables: Map<Mesh, (() => void)[]>;
+    /** @internal Per-mesh cleanup callbacks for AUX (material-OVERRIDE) view packets that an explicit render
+     *  task registered on a mesh it does not own — e.g. a depth-prepass / SSAO no-colour view of a wall. Kept
+     *  SEPARATE from `_meshDisposables` because a MAIN-material swap (`processMaterialSwaps`, which rebuilds
+     *  only the main renderable) must NOT tear these down: they belong to another task, whose cached bundle
+     *  would then replay a destroyed system UBO ("used in submit while destroyed"). Drained only on a real mesh
+     *  removal (`removeFromScene`) and scene dispose, exactly like `_meshDisposables` minus the swap path. */
+    _meshAuxDisposables: Map<Mesh, (() => void)[]>;
     /** @internal Meshes whose material was changed via setter — drained before each render frame. */
     _materialSwapQueue: Mesh[];
     /** @internal Monotonic counter bumped when the renderable list changes (add/remove/rebuild). */
@@ -178,6 +185,7 @@ export function createSceneContext(surface: SurfaceContext, options?: SceneConte
         _groups: new Map(),
         _disposables: [],
         _meshDisposables: new Map(),
+        _meshAuxDisposables: new Map(),
         _materialSwapQueue: [],
         _renderableVersion: 0,
         _materialEpoch: 0,
@@ -375,6 +383,12 @@ export function disposeScene(scene: SceneContext): void {
         }
     }
     ctx._meshDisposables.clear();
+    for (const fns of ctx._meshAuxDisposables.values()) {
+        for (const fn of fns) {
+            fn();
+        }
+    }
+    ctx._meshAuxDisposables.clear();
     for (const mesh of ctx.meshes) {
         // Free the mesh's shared GPU buffers only when this was its LAST owning scene.
         if (unregisterMeshScene(ctx, mesh)) {

--- a/packages/babylon-lite/src/scene/scene-remove.ts
+++ b/packages/babylon-lite/src/scene/scene-remove.ts
@@ -20,6 +20,16 @@ export function removeFromScene(scene: SceneContext, mesh: Mesh): void {
         }
         scene._meshDisposables.delete(mesh);
     }
+    // AUX (override) view packets — depth/SSAO no-colour views another task registered on this mesh. A material
+    // swap deliberately leaves these alone (see `_meshAuxDisposables`); a real removal must still free them.
+    const auxFns = scene._meshAuxDisposables.get(mesh);
+    if (auxFns) {
+        didMutate = true;
+        for (const fn of auxFns) {
+            fn();
+        }
+        scene._meshAuxDisposables.delete(mesh);
+    }
     const mi2 = scene.meshes.indexOf(mesh);
     if (mi2 >= 0) {
         scene.meshes.splice(mi2, 1);

--- a/scene-config.json
+++ b/scene-config.json
@@ -27,7 +27,7 @@
         "slug": "scene3-fog",
         "name": "Scene 3 — Fog + Skybox",
         "maxMad": 0.01,
-        "maxRawKB": 54,
+        "maxRawKB": 54.3,
         "description": "Exponential² fog, multiple colored boxes, skybox, ground plane.",
         "tags": ["fog", "procedural", "std"],
         "skipPerf": true
@@ -37,7 +37,7 @@
         "slug": "scene4-shadows",
         "name": "Scene 4 — Shadows",
         "maxMad": 0.08,
-        "maxRawKB": 72.8,
+        "maxRawKB": 73,
         "description": "DirectionalLight, ESM shadow map with blur, heightmap ground, torus caster.",
         "tags": ["shadow", "procedural", "std"],
         "compatParity": true
@@ -165,7 +165,7 @@
         "slug": "scene16-thin-instances",
         "name": "Scene 16 — Thin Instances",
         "maxMad": 0.01,
-        "maxRawKB": 49,
+        "maxRawKB": 49.2,
         "description": "64,000 colored cubes via thin instances. Per-instance color, disableLighting, emissive-only rendering.",
         "tags": ["std", "procedural"],
         "compatParity": true
@@ -340,7 +340,7 @@
         "slug": "scene33-lights-punctual",
         "name": "Scene 33 — KHR_lights_punctual",
         "maxMad": 0.07,
-        "maxRawKB": 103.5,
+        "maxRawKB": 103.7,
         "description": "LightsPunctualLamp.glb (KHR_lights_punctual point lights + KHR_materials_transmission) with default IBL environment. Matches PG #YG3BBF#54.",
         "tags": ["pbr", "gltf", "env", "lights-punctual", "transmission"],
         "skipPerf": true,
@@ -383,7 +383,7 @@
         "slug": "scene37-sheen-sofa",
         "name": "Scene 37 — Sheen Wood Leather Sofa",
         "maxMad": 0.02,
-        "maxRawKB": 97.2,
+        "maxRawKB": 97.3,
         "description": "SheenWoodLeatherSofa.glb (KHR_materials_sheen + KHR_materials_specular + KHR_texture_transform + EXT_texture_webp) with default IBL environment (no skybox, no ground). Matches PG #YG3BBF#58.",
         "tags": ["pbr", "gltf", "env", "sheen", "specular", "texture-transform", "webp"],
         "compatParity": true
@@ -1210,7 +1210,7 @@
         "slug": "scene120-gaussian-splatting",
         "name": "Scene 120 — Gaussian Splatting",
         "maxMad": 1,
-        "maxRawKB": 35.5,
+        "maxRawKB": 35.8,
         "description": "Loads Halo_Believe.ply via loadSplat(); renders the splat cloud with a back-to-front sort produced by an inline worker thread.",
         "tags": ["gaussian-splatting", "ply"],
         "compatParity": true
@@ -1275,7 +1275,7 @@
         "slug": "scene126-gs-material-plugin",
         "name": "Scene 126 — Gaussian Splatting Material Plugin",
         "maxMad": 0.5,
-        "maxRawKB": 35.7,
+        "maxRawKB": 36,
         "description": "Loads Halo_Believe.splat and applies a GsShaderFragment that overrides finalColor at GS_FRAGMENT_MAIN_END (parity with BJS MaterialPluginBase CUSTOM_FRAGMENT_MAIN_END).",
         "tags": ["gaussian-splatting", "material-plugin"]
     },
@@ -1542,7 +1542,7 @@
         "slug": "scene162-shader-material-defines",
         "name": "Scene 162 - ShaderMaterial Defines",
         "maxMad": 0.02,
-        "maxRawKB": 38,
+        "maxRawKB": 38.2,
         "description": "WGSL ShaderMaterial emits defines as const pipeline variants.",
         "tags": ["shader", "procedural"],
         "skipPerf": true
@@ -2052,7 +2052,7 @@
         "slug": "scene244-pot-of-coals-animation-pointer",
         "name": "Scene 244 — PotOfCoalsAnimationPointer",
         "maxMad": 0.2,
-        "maxRawKB": 133,
+        "maxRawKB": 133.3,
         "description": "PotOfCoalsAnimationPointer.gltf — cx20 gltf-test. KHR_animation_pointer texture-transform rotation.",
         "tags": ["gltf"],
         "skipPerf": true
@@ -2102,7 +2102,7 @@
         "slug": "scene249-vertex-color-alpha-clip-test",
         "name": "Scene 249 — VertexColorAlphaClipTest",
         "maxMad": 0.2,
-        "maxRawKB": 78.5,
+        "maxRawKB": 78.8,
         "description": "VertexColorAlphaClipTest.gltf — cx20 gltf-test. Vertex-color alpha with alpha-clip.",
         "tags": ["gltf"],
         "skipPerf": true


### PR DESCRIPTION
## Summary

Frame-graph enhancements plus a scene-lifecycle disposal fix, all centered on
runtime task/mesh composition and a new Hi-Z depth utility.

- **`addTaskAfter(target, task, after)`**: insert a task immediately after another
  in execute order, mirroring `addTaskBefore` (appends if `after` is not found).
- **Runtime `RenderTask.addMesh`**: a new `_recorded` flag makes a post-`record()`
  `addMesh` resolve and re-bucket into that task immediately, so the mesh renders on
  the next frame without a full `frameGraph.build()` (which would reallocate the
  shared scene UBO and every task's render target mid-frame). Adds before the first
  `record()` keep the existing queued-then-drained behavior, so all current callers
  are unaffected. A live add also flips `_autoFromScene` to `false` so an
  auto-mirroring task's next scene-version resync cannot drop the just-added mesh.
- **Hi-Z depth pyramid** (new `depth-pyramid.ts`): `createDepthPyramid` +
  `createDepthPyramidTask` build a hierarchical `min`/`max` mip chain of a depth
  buffer via fullscreen COPY + REDUCE passes. Useful for GPU occlusion culling,
  hierarchical SSR, horizon-AO, and contact shadows. The public surface returns
  `Texture2D` (no raw GPU handles) and ref-counts through the shared texture pool;
  `resize()` mints a fresh wrapper identity. Per-mip views and bind groups are
  cached and rebuilt only on `resize()` (the COPY bind group only when the source
  depth texture changes identity), so `build()` has no per-frame object churn.
- **Fix: separate disposal for aux (material-override) view packets**: shader-material
  override packets that an explicit task registers on a mesh it does not own now live
  in a dedicated `_meshAuxDisposables` map. A main-material swap must not tear these
  down, or the other task's cached bundle replays a destroyed system UBO ("used in
  submit while destroyed"). They are drained on real mesh removal and on scene
  dispose, and cleared on device-lost rebuild.

Docs: `28-frame-graph.md` updated for `addTaskAfter` and the runtime `addMesh`
behavior.

## Breaking changes

None. All public API changes are additive (`addTaskAfter`, `createDepthPyramid`,
`createDepthPyramidTask`, and the `DepthPyramid*` types). The new `_recorded` and
`_meshAuxDisposables` fields are `@internal` and trimmed from the public `.d.ts`.

## Bundle size

`depth-pyramid.ts` is not imported by any scene, so it is fully tree-shaken (0 bytes
everywhere). The `_meshAuxDisposables` field + dispose-drain and the runtime-addMesh
path live in the shared scene/frame-graph chunk and add ~0.1 KB raw to scenes that
render through it (a legitimate core-fix cost, maintainer-approved).

Rebased onto `master` (#254 landed first and also consumed shared-chunk headroom).
Ten scenes that sat at their `maxRawKB` ceiling with <=0.1 KB headroom are raised by
the measured amount (to ~0.3 KB headroom): `scene3`, `scene4`, `scene16`, `scene33`,
`scene37`, `scene120`, `scene126`, `scene162`, `scene244`, `scene249`. No other
ceilings changed; per-scene bundle manifests are regenerated and committed.

## Review

Addressed both Copilot review comments (live `addMesh` auto-mirror handling; depth
pyramid per-frame view/bind-group caching); threads resolved.

## Validation

- Lint / type-check, unit tests, bundle-size ceilings, API report, compat layer,
  release markers, parity, and performance: all green in CI.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
