### PR TITLE
fix(camera): invalidate projection cache on fov/near/far change

### DIFF
--- a/lab/public/bundle/manifest/scene1.json
+++ b/lab/public/bundle/manifest/scene1.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.1,
+  "rawKB": 89.3,
   "gzipKB": 37.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene10.json
+++ b/lab/public/bundle/manifest/scene10.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 52.4,
+  "rawKB": 52.6,
   "gzipKB": 21.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene100.json
+++ b/lab/public/bundle/manifest/scene100.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.4,
+  "rawKB": 50.6,
   "gzipKB": 20.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene101.json
+++ b/lab/public/bundle/manifest/scene101.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 53.8,
-  "gzipKB": 21.5,
+  "rawKB": 54,
+  "gzipKB": 21.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene101-standard-renderable-BAYncetB.js",

--- a/lab/public/bundle/manifest/scene102.json
+++ b/lab/public/bundle/manifest/scene102.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 59.5,
-  "gzipKB": 23.7,
+  "rawKB": 59.7,
+  "gzipKB": 23.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene102-standard-renderable-VJFYqVqL.js",

--- a/lab/public/bundle/manifest/scene103.json
+++ b/lab/public/bundle/manifest/scene103.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62.1,
+  "rawKB": 62.3,
   "gzipKB": 24.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene104.json
+++ b/lab/public/bundle/manifest/scene104.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 101.8,
+  "rawKB": 101.9,
   "gzipKB": 39.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene105.json
+++ b/lab/public/bundle/manifest/scene105.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 102.4,
-  "gzipKB": 39.6,
+  "rawKB": 102.6,
+  "gzipKB": 39.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene105-generate-mipmaps-Bw7xZIhD.js",

--- a/lab/public/bundle/manifest/scene106.json
+++ b/lab/public/bundle/manifest/scene106.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 51.5,
+  "rawKB": 51.6,
   "gzipKB": 20.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene11.json
+++ b/lab/public/bundle/manifest/scene11.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 88.9,
-  "gzipKB": 37.3,
+  "rawKB": 89.1,
+  "gzipKB": 37.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene11-create-skeleton-D7GjlnE9.js",

--- a/lab/public/bundle/manifest/scene110.json
+++ b/lab/public/bundle/manifest/scene110.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.9,
+  "rawKB": 51,
   "gzipKB": 20,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene111.json
+++ b/lab/public/bundle/manifest/scene111.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 134.6,
-  "gzipKB": 54.3,
+  "rawKB": 134.8,
+  "gzipKB": 54.4,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
     "scene111-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene112.json
+++ b/lab/public/bundle/manifest/scene112.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 120.6,
-  "gzipKB": 48.9,
+  "rawKB": 120.8,
+  "gzipKB": 49,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene112-background-dds-skybox-CBVfRJkx.js",

--- a/lab/public/bundle/manifest/scene113.json
+++ b/lab/public/bundle/manifest/scene113.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 63.1,
+  "rawKB": 63.3,
   "gzipKB": 24.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene114.json
+++ b/lab/public/bundle/manifest/scene114.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 80.2,
-  "gzipKB": 31.3,
+  "rawKB": 80.4,
+  "gzipKB": 31.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene114-morph-fragment-BBLksRug.js",

--- a/lab/public/bundle/manifest/scene115.json
+++ b/lab/public/bundle/manifest/scene115.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 126.2,
+  "rawKB": 126.4,
   "gzipKB": 51.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene116.json
+++ b/lab/public/bundle/manifest/scene116.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 76.5,
+  "rawKB": 76.7,
   "gzipKB": 31.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene12.json
+++ b/lab/public/bundle/manifest/scene12.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 103.3,
-  "gzipKB": 42.1,
+  "rawKB": 103.5,
+  "gzipKB": 42.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene12-create-skeleton-Cjf80v3R.js",

--- a/lab/public/bundle/manifest/scene120.json
+++ b/lab/public/bundle/manifest/scene120.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 35.5,
+  "rawKB": 35.6,
   "gzipKB": 14.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene121.json
+++ b/lab/public/bundle/manifest/scene121.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 35.6,
-  "gzipKB": 14.1,
+  "rawKB": 35.8,
+  "gzipKB": 14.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene121.js"

--- a/lab/public/bundle/manifest/scene122.json
+++ b/lab/public/bundle/manifest/scene122.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 48.1,
+  "rawKB": 48.2,
   "gzipKB": 19.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene123.json
+++ b/lab/public/bundle/manifest/scene123.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 44.8,
-  "gzipKB": 18.2,
+  "rawKB": 44.9,
+  "gzipKB": 18.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene123-gaussian-splatting-pipeline-sh-B7FPpJ0P.js",

--- a/lab/public/bundle/manifest/scene124.json
+++ b/lab/public/bundle/manifest/scene124.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.8,
+  "rawKB": 50.9,
   "gzipKB": 20.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene125.json
+++ b/lab/public/bundle/manifest/scene125.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 37.3,
+  "rawKB": 37.5,
   "gzipKB": 14.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene126.json
+++ b/lab/public/bundle/manifest/scene126.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 35.7,
+  "rawKB": 35.8,
   "gzipKB": 14.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 58.3,
-  "gzipKB": 22.1,
+  "rawKB": 58.5,
+  "gzipKB": 22.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene127-shader-renderable-D-mlf3g2.js",

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 58.3,
-  "gzipKB": 22.1,
+  "rawKB": 58.5,
+  "gzipKB": 22.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene128-shader-renderable-CLHEZYZ3.js",

--- a/lab/public/bundle/manifest/scene129.json
+++ b/lab/public/bundle/manifest/scene129.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 83.1,
-  "gzipKB": 31.6,
+  "rawKB": 83.2,
+  "gzipKB": 31.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene129-gs-picking-pipeline-wk9cVMav.js",

--- a/lab/public/bundle/manifest/scene13.json
+++ b/lab/public/bundle/manifest/scene13.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 84.6,
+  "rawKB": 84.8,
   "gzipKB": 34.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene14.json
+++ b/lab/public/bundle/manifest/scene14.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.3,
+  "rawKB": 89.5,
   "gzipKB": 37.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene140.json
+++ b/lab/public/bundle/manifest/scene140.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.5,
+  "rawKB": 89.6,
   "gzipKB": 41.5,
   "ignoredRawKB": 6.6,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene141.json
+++ b/lab/public/bundle/manifest/scene141.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 123.5,
-  "gzipKB": 50.9,
+  "rawKB": 123.7,
+  "gzipKB": 51,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
     "scene141-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene142.json
+++ b/lab/public/bundle/manifest/scene142.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 61.2,
+  "rawKB": 61.4,
   "gzipKB": 22.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene143.json
+++ b/lab/public/bundle/manifest/scene143.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 70.3,
+  "rawKB": 70.5,
   "gzipKB": 27.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene144.json
+++ b/lab/public/bundle/manifest/scene144.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 110.5,
-  "gzipKB": 44.6,
+  "rawKB": 110.6,
+  "gzipKB": 44.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene144-create-skeleton-pj3iqxnA.js",

--- a/lab/public/bundle/manifest/scene145.json
+++ b/lab/public/bundle/manifest/scene145.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 89,
-  "gzipKB": 36.3,
+  "rawKB": 89.1,
+  "gzipKB": 36.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene145-bake-local-matrix-67U-IT8C.js",

--- a/lab/public/bundle/manifest/scene146.json
+++ b/lab/public/bundle/manifest/scene146.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 111.7,
+  "rawKB": 111.8,
   "gzipKB": 45.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene147.json
+++ b/lab/public/bundle/manifest/scene147.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.8,
+  "rawKB": 103.9,
   "gzipKB": 41.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene148.json
+++ b/lab/public/bundle/manifest/scene148.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 109.7,
+  "rawKB": 109.8,
   "gzipKB": 43,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene149.json
+++ b/lab/public/bundle/manifest/scene149.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 109.1,
-  "gzipKB": 44.5,
+  "rawKB": 109.3,
+  "gzipKB": 44.6,
   "ignoredRawKB": 6.8,
   "runtimeChunks": [
     "scene149-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene15.json
+++ b/lab/public/bundle/manifest/scene15.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 47.4,
-  "gzipKB": 19,
+  "rawKB": 47.6,
+  "gzipKB": 19.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene15-standard-renderable-DjpuOYV2.js",

--- a/lab/public/bundle/manifest/scene150.json
+++ b/lab/public/bundle/manifest/scene150.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 55.3,
+  "rawKB": 55.5,
   "gzipKB": 21.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene151.json
+++ b/lab/public/bundle/manifest/scene151.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 55.6,
-  "gzipKB": 21.7,
+  "rawKB": 55.7,
+  "gzipKB": 21.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene151-standard-renderable-C822zhOt.js",

--- a/lab/public/bundle/manifest/scene152.json
+++ b/lab/public/bundle/manifest/scene152.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 94,
+  "rawKB": 94.2,
   "gzipKB": 39.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene154.json
+++ b/lab/public/bundle/manifest/scene154.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 55.7,
-  "gzipKB": 21.7,
+  "rawKB": 55.9,
+  "gzipKB": 21.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene154-standard-renderable-B0H1CD6L.js",

--- a/lab/public/bundle/manifest/scene155.json
+++ b/lab/public/bundle/manifest/scene155.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 58.2,
-  "gzipKB": 22.6,
+  "rawKB": 58.3,
+  "gzipKB": 22.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene155-standard-renderable-CDfPDID1.js",

--- a/lab/public/bundle/manifest/scene156.json
+++ b/lab/public/bundle/manifest/scene156.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 58.9,
-  "gzipKB": 22.8,
+  "rawKB": 59.1,
+  "gzipKB": 22.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene156-standard-renderable-DJlsSdaM.js",

--- a/lab/public/bundle/manifest/scene157.json
+++ b/lab/public/bundle/manifest/scene157.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 95.4,
-  "gzipKB": 38.8,
+  "rawKB": 95.6,
+  "gzipKB": 38.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene157-create-skeleton-CkTxS2Cs.js",

--- a/lab/public/bundle/manifest/scene158.json
+++ b/lab/public/bundle/manifest/scene158.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 95.9,
+  "rawKB": 96,
   "gzipKB": 39,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 38.1,
+  "rawKB": 38.3,
   "gzipKB": 15,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene16.json
+++ b/lab/public/bundle/manifest/scene16.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 48.9,
-  "gzipKB": 19.6,
+  "rawKB": 49,
+  "gzipKB": 19.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene16-standard-renderable-CXUbe7VR.js",

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 40.2,
+  "rawKB": 40.4,
   "gzipKB": 15.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 38.5,
+  "rawKB": 38.6,
   "gzipKB": 15.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 38.2,
+  "rawKB": 38.3,
   "gzipKB": 15,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 37.9,
-  "gzipKB": 14.8,
+  "rawKB": 38,
+  "gzipKB": 14.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene163-shader-renderable-1Kvp4_7Y.js",

--- a/lab/public/bundle/manifest/scene164.json
+++ b/lab/public/bundle/manifest/scene164.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 98.5,
+  "rawKB": 98.7,
   "gzipKB": 40.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 42.9,
+  "rawKB": 43.1,
   "gzipKB": 17,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene17.json
+++ b/lab/public/bundle/manifest/scene17.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 85.9,
+  "rawKB": 86.1,
   "gzipKB": 35.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene170.json
+++ b/lab/public/bundle/manifest/scene170.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 51.6,
-  "gzipKB": 20.4,
+  "rawKB": 51.8,
+  "gzipKB": 20.5,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [
     "scene170-recast-navigation-CYBQI-zY-Dry_z7x_.js",

--- a/lab/public/bundle/manifest/scene171.json
+++ b/lab/public/bundle/manifest/scene171.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 96.5,
+  "rawKB": 96.6,
   "gzipKB": 39.3,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene172.json
+++ b/lab/public/bundle/manifest/scene172.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 60,
-  "gzipKB": 23.5,
+  "rawKB": 60.1,
+  "gzipKB": 23.6,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [
     "scene172-recast-navigation-CYBQI-zY-Dry_z7x_.js",

--- a/lab/public/bundle/manifest/scene173.json
+++ b/lab/public/bundle/manifest/scene173.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 62.1,
-  "gzipKB": 24.2,
+  "rawKB": 62.3,
+  "gzipKB": 24.3,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [
     "scene173-recast-navigation-CYBQI-zY-Dry_z7x_.js",

--- a/lab/public/bundle/manifest/scene174.json
+++ b/lab/public/bundle/manifest/scene174.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 97.1,
-  "gzipKB": 39.6,
+  "rawKB": 97.3,
+  "gzipKB": 39.7,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [
     "scene174-generate-mipmaps-oyz7Zcb3.js",

--- a/lab/public/bundle/manifest/scene175.json
+++ b/lab/public/bundle/manifest/scene175.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 95.4,
+  "rawKB": 95.6,
   "gzipKB": 39,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene176.json
+++ b/lab/public/bundle/manifest/scene176.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 104,
-  "gzipKB": 41.8,
+  "rawKB": 104.2,
+  "gzipKB": 41.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene176-generate-mipmaps-Dse5kXpK.js",

--- a/lab/public/bundle/manifest/scene177.json
+++ b/lab/public/bundle/manifest/scene177.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 69.7,
-  "gzipKB": 28.3,
+  "rawKB": 69.8,
+  "gzipKB": 28.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene177-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene178.json
+++ b/lab/public/bundle/manifest/scene178.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 87.9,
-  "gzipKB": 35.7,
+  "rawKB": 88,
+  "gzipKB": 35.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene178-generate-mipmaps-MoaS2Mzr.js",

--- a/lab/public/bundle/manifest/scene179.json
+++ b/lab/public/bundle/manifest/scene179.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 73,
-  "gzipKB": 29.8,
+  "rawKB": 73.1,
+  "gzipKB": 29.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene179-alpha-test-fragment-BaX_J1Vy.js",

--- a/lab/public/bundle/manifest/scene18.json
+++ b/lab/public/bundle/manifest/scene18.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.8,
+  "rawKB": 60.9,
   "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene181.json
+++ b/lab/public/bundle/manifest/scene181.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 44,
-  "gzipKB": 16.4,
+  "rawKB": 44.2,
+  "gzipKB": 16.5,
   "ignoredRawKB": 680.2,
   "runtimeChunks": [
     "scene181-text-shaper-Cie-Mnk-.js",

--- a/lab/public/bundle/manifest/scene19.json
+++ b/lab/public/bundle/manifest/scene19.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 70.2,
+  "rawKB": 70.4,
   "gzipKB": 28.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene2.json
+++ b/lab/public/bundle/manifest/scene2.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 47.1,
+  "rawKB": 47.2,
   "gzipKB": 18.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene20.json
+++ b/lab/public/bundle/manifest/scene20.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 78.8,
-  "gzipKB": 33,
+  "rawKB": 78.9,
+  "gzipKB": 33.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene20-background-dds-skybox-DlAfEH4G.js",

--- a/lab/public/bundle/manifest/scene200.json
+++ b/lab/public/bundle/manifest/scene200.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 46.8,
-  "gzipKB": 18.7,
+  "rawKB": 47,
+  "gzipKB": 18.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene200-standard-renderable-CmdaDWAN.js",

--- a/lab/public/bundle/manifest/scene201.json
+++ b/lab/public/bundle/manifest/scene201.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 48.7,
+  "rawKB": 48.8,
   "gzipKB": 19.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene202.json
+++ b/lab/public/bundle/manifest/scene202.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49.4,
+  "rawKB": 49.6,
   "gzipKB": 20.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene203.json
+++ b/lab/public/bundle/manifest/scene203.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49.7,
+  "rawKB": 49.8,
   "gzipKB": 20.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene204.json
+++ b/lab/public/bundle/manifest/scene204.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 51.1,
+  "rawKB": 51.3,
   "gzipKB": 20.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene205.json
+++ b/lab/public/bundle/manifest/scene205.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62,
+  "rawKB": 62.2,
   "gzipKB": 25.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene206.json
+++ b/lab/public/bundle/manifest/scene206.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62.3,
+  "rawKB": 62.5,
   "gzipKB": 25.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene207.json
+++ b/lab/public/bundle/manifest/scene207.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 59.7,
-  "gzipKB": 24,
+  "rawKB": 59.9,
+  "gzipKB": 24.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene207-_mat4-storage-f64-B_0HYOAx.js",

--- a/lab/public/bundle/manifest/scene209.json
+++ b/lab/public/bundle/manifest/scene209.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 54.4,
+  "rawKB": 54.5,
   "gzipKB": 22.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene21.json
+++ b/lab/public/bundle/manifest/scene21.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 86.2,
-  "gzipKB": 35.1,
+  "rawKB": 86.4,
+  "gzipKB": 35.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene21-background-hdr-skybox-DwM1Bej-.js",

--- a/lab/public/bundle/manifest/scene210.json
+++ b/lab/public/bundle/manifest/scene210.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 76.8,
+  "rawKB": 77,
   "gzipKB": 31.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene211.json
+++ b/lab/public/bundle/manifest/scene211.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.2,
+  "rawKB": 90.4,
   "gzipKB": 38,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene212.json
+++ b/lab/public/bundle/manifest/scene212.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 104.4,
+  "rawKB": 104.5,
   "gzipKB": 41.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 46.1,
+  "rawKB": 46.2,
   "gzipKB": 17.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene214.json
+++ b/lab/public/bundle/manifest/scene214.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 68.3,
-  "gzipKB": 27.1,
+  "rawKB": 68.5,
+  "gzipKB": 27.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene214-material-view-Dua1bl7W.js",

--- a/lab/public/bundle/manifest/scene215.json
+++ b/lab/public/bundle/manifest/scene215.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 79.5,
+  "rawKB": 79.7,
   "gzipKB": 32,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene216.json
+++ b/lab/public/bundle/manifest/scene216.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 53.8,
+  "rawKB": 53.9,
   "gzipKB": 22.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene217.json
+++ b/lab/public/bundle/manifest/scene217.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 78.2,
-  "gzipKB": 31.5,
+  "rawKB": 78.4,
+  "gzipKB": 31.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene217-multilight-wgsl-D_ZZ-Nk7.js",

--- a/lab/public/bundle/manifest/scene218.json
+++ b/lab/public/bundle/manifest/scene218.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92.4,
+  "rawKB": 92.6,
   "gzipKB": 38.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene219.json
+++ b/lab/public/bundle/manifest/scene219.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 95,
+  "rawKB": 95.1,
   "gzipKB": 39.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene22.json
+++ b/lab/public/bundle/manifest/scene22.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 97.7,
+  "rawKB": 97.9,
   "gzipKB": 39.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 100.9,
-  "gzipKB": 38.1,
+  "rawKB": 101,
+  "gzipKB": 38.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene221-shader-renderable-BwWfZ-Ps.js",

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 112,
+  "rawKB": 112.1,
   "gzipKB": 41.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene223.json
+++ b/lab/public/bundle/manifest/scene223.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 64,
+  "rawKB": 64.2,
   "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene224.json
+++ b/lab/public/bundle/manifest/scene224.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 82,
+  "rawKB": 82.1,
   "gzipKB": 30.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene225.json
+++ b/lab/public/bundle/manifest/scene225.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 58.3,
-  "gzipKB": 23.4,
+  "rawKB": 58.4,
+  "gzipKB": 23.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene225-standard-renderable-DKiRZ8hQ.js",

--- a/lab/public/bundle/manifest/scene227.json
+++ b/lab/public/bundle/manifest/scene227.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 48.4,
+  "rawKB": 48.6,
   "gzipKB": 19.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene228.json
+++ b/lab/public/bundle/manifest/scene228.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.3,
+  "rawKB": 50.4,
   "gzipKB": 20,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene229.json
+++ b/lab/public/bundle/manifest/scene229.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 68,
+  "rawKB": 68.2,
   "gzipKB": 28.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene23.json
+++ b/lab/public/bundle/manifest/scene23.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 78.7,
+  "rawKB": 78.9,
   "gzipKB": 32.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene24.json
+++ b/lab/public/bundle/manifest/scene24.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59,
+  "rawKB": 59.2,
   "gzipKB": 24.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 90.8,
-  "gzipKB": 37.9,
+  "rawKB": 90.9,
+  "gzipKB": 38,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene240-flat-normal-wgsl-Cm9mM4tC.js",

--- a/lab/public/bundle/manifest/scene241.json
+++ b/lab/public/bundle/manifest/scene241.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 161.7,
-  "gzipKB": 66,
+  "rawKB": 161.8,
+  "gzipKB": 66.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene241-alpha-test-fragment-BpzeKSEk.js",

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 96.9,
+  "rawKB": 97.1,
   "gzipKB": 40.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene243.json
+++ b/lab/public/bundle/manifest/scene243.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 97.2,
-  "gzipKB": 40.9,
+  "rawKB": 97.4,
+  "gzipKB": 41,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene243-create-morph-targets-C_lcfVOA.js",

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 133.5,
-  "gzipKB": 53.9,
+  "rawKB": 133.7,
+  "gzipKB": 54,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene244-animation-pointer-ext-CZbMTIy3.js",

--- a/lab/public/bundle/manifest/scene245.json
+++ b/lab/public/bundle/manifest/scene245.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 100.3,
-  "gzipKB": 42.5,
+  "rawKB": 100.5,
+  "gzipKB": 42.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene245-create-skeleton-nuOFOS6J.js",

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 99.2,
+  "rawKB": 99.3,
   "gzipKB": 42.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 84,
+  "rawKB": 84.1,
   "gzipKB": 34.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene248.json
+++ b/lab/public/bundle/manifest/scene248.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 77.2,
-  "gzipKB": 31.8,
+  "rawKB": 77.3,
+  "gzipKB": 31.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene248-generate-mipmaps-gW6SEOHu.js",

--- a/lab/public/bundle/manifest/scene249.json
+++ b/lab/public/bundle/manifest/scene249.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 78.5,
-  "gzipKB": 32.4,
+  "rawKB": 78.6,
+  "gzipKB": 32.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene249-alpha-test-fragment-CTxEv-3J.js",

--- a/lab/public/bundle/manifest/scene25.json
+++ b/lab/public/bundle/manifest/scene25.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 52.1,
-  "gzipKB": 20.7,
+  "rawKB": 52.2,
+  "gzipKB": 20.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene25-standard-renderable-0EV0Ofua.js",

--- a/lab/public/bundle/manifest/scene251.json
+++ b/lab/public/bundle/manifest/scene251.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 89.6,
-  "gzipKB": 37,
+  "rawKB": 89.7,
+  "gzipKB": 37.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene251-create-skeleton-QaTYEW_C.js",

--- a/lab/public/bundle/manifest/scene252.json
+++ b/lab/public/bundle/manifest/scene252.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 49.1,
-  "gzipKB": 19.8,
+  "rawKB": 49.2,
+  "gzipKB": 19.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene252-morph-fragment-core-BW8kE7zi.js",

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 152.7,
-  "gzipKB": 64.4,
+  "rawKB": 152.9,
+  "gzipKB": 64.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene253-alpha-test-fragment-CBuxkQtx.js",

--- a/lab/public/bundle/manifest/scene254.json
+++ b/lab/public/bundle/manifest/scene254.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 92.2,
-  "gzipKB": 38.2,
+  "rawKB": 92.3,
+  "gzipKB": 38.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene254-generate-mipmaps-CYwo5pXb.js",

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 93.8,
+  "rawKB": 94,
   "gzipKB": 39.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene257.json
+++ b/lab/public/bundle/manifest/scene257.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 79.8,
-  "gzipKB": 32.9,
+  "rawKB": 80,
+  "gzipKB": 33,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene257-flat-normal-wgsl-Cm9mM4tC.js",

--- a/lab/public/bundle/manifest/scene258.json
+++ b/lab/public/bundle/manifest/scene258.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 82.9,
+  "rawKB": 83,
   "gzipKB": 34.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene259.json
+++ b/lab/public/bundle/manifest/scene259.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 77.2,
+  "rawKB": 77.3,
   "gzipKB": 31.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene26.json
+++ b/lab/public/bundle/manifest/scene26.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.2,
+  "rawKB": 90.4,
   "gzipKB": 36.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene260.json
+++ b/lab/public/bundle/manifest/scene260.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 79.8,
+  "rawKB": 80,
   "gzipKB": 32.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene261.json
+++ b/lab/public/bundle/manifest/scene261.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 54.5,
+  "rawKB": 54.6,
   "gzipKB": 21.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene27.json
+++ b/lab/public/bundle/manifest/scene27.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 82.7,
+  "rawKB": 82.9,
   "gzipKB": 33.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 86.5,
-  "gzipKB": 35.2,
+  "rawKB": 86.6,
+  "gzipKB": 35.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene28-clearcoat-fragment-AiyWBFX1.js",

--- a/lab/public/bundle/manifest/scene29.json
+++ b/lab/public/bundle/manifest/scene29.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.1,
+  "rawKB": 90.3,
   "gzipKB": 37.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene3.json
+++ b/lab/public/bundle/manifest/scene3.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 54,
-  "gzipKB": 21.6,
+  "rawKB": 54.1,
+  "gzipKB": 21.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene3-scene-uniforms-FTYH6Ct0.js",

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.8,
+  "rawKB": 104,
   "gzipKB": 42.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene31.json
+++ b/lab/public/bundle/manifest/scene31.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 80.1,
+  "rawKB": 80.3,
   "gzipKB": 32.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 80,
+  "rawKB": 80.1,
   "gzipKB": 32.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene33.json
+++ b/lab/public/bundle/manifest/scene33.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 103.9,
-  "gzipKB": 42.6,
+  "rawKB": 104,
+  "gzipKB": 42.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene33-generate-mipmaps-Z_0Gnbub.js",

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 96.8,
+  "rawKB": 96.9,
   "gzipKB": 39.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene35.json
+++ b/lab/public/bundle/manifest/scene35.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 83.2,
-  "gzipKB": 34.2,
+  "rawKB": 83.4,
+  "gzipKB": 34.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene35-generate-mipmaps-Dw2dswCB.js",

--- a/lab/public/bundle/manifest/scene36.json
+++ b/lab/public/bundle/manifest/scene36.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 51.7,
+  "rawKB": 51.8,
   "gzipKB": 20.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene37.json
+++ b/lab/public/bundle/manifest/scene37.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 97.1,
-  "gzipKB": 39.7,
+  "rawKB": 97.3,
+  "gzipKB": 39.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene37-generate-mipmaps-BikX-asb.js",

--- a/lab/public/bundle/manifest/scene38.json
+++ b/lab/public/bundle/manifest/scene38.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 61.3,
-  "gzipKB": 24.2,
+  "rawKB": 61.5,
+  "gzipKB": 24.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene38-standard-renderable-DkWPKKU6.js",

--- a/lab/public/bundle/manifest/scene39.json
+++ b/lab/public/bundle/manifest/scene39.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 108.5,
+  "rawKB": 108.7,
   "gzipKB": 45.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene4.json
+++ b/lab/public/bundle/manifest/scene4.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 72.7,
-  "gzipKB": 28.6,
+  "rawKB": 72.8,
+  "gzipKB": 28.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene4-esm-shadow-view-7yqUFA1x.js",

--- a/lab/public/bundle/manifest/scene40.json
+++ b/lab/public/bundle/manifest/scene40.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49.7,
+  "rawKB": 49.8,
   "gzipKB": 20,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene41.json
+++ b/lab/public/bundle/manifest/scene41.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 93,
+  "rawKB": 93.1,
   "gzipKB": 37,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene42.json
+++ b/lab/public/bundle/manifest/scene42.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 51.3,
+  "rawKB": 51.4,
   "gzipKB": 20.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene43.json
+++ b/lab/public/bundle/manifest/scene43.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 58.1,
+  "rawKB": 58.3,
   "gzipKB": 23.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene44.json
+++ b/lab/public/bundle/manifest/scene44.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.2,
+  "rawKB": 50.4,
   "gzipKB": 20.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene45.json
+++ b/lab/public/bundle/manifest/scene45.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 51.3,
-  "gzipKB": 20.4,
+  "rawKB": 51.5,
+  "gzipKB": 20.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene45-standard-renderable-BieL1U6W.js",

--- a/lab/public/bundle/manifest/scene46.json
+++ b/lab/public/bundle/manifest/scene46.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 54.5,
+  "rawKB": 54.6,
   "gzipKB": 21.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene47.json
+++ b/lab/public/bundle/manifest/scene47.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 92.3,
-  "gzipKB": 36.8,
+  "rawKB": 92.4,
+  "gzipKB": 36.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene47-generate-mipmaps-CmIGpFd5.js",

--- a/lab/public/bundle/manifest/scene48.json
+++ b/lab/public/bundle/manifest/scene48.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 54.4,
+  "rawKB": 54.5,
   "gzipKB": 21.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 92.9,
-  "gzipKB": 35,
+  "rawKB": 93.1,
+  "gzipKB": 35.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene49-standard-renderable-ytL-ZaT7.js",

--- a/lab/public/bundle/manifest/scene5.json
+++ b/lab/public/bundle/manifest/scene5.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 91.6,
+  "rawKB": 91.7,
   "gzipKB": 38.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 57.5,
+  "rawKB": 57.6,
   "gzipKB": 23.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 57.6,
+  "rawKB": 57.7,
   "gzipKB": 23,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene54.json
+++ b/lab/public/bundle/manifest/scene54.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60,
+  "rawKB": 60.1,
   "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene55.json
+++ b/lab/public/bundle/manifest/scene55.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 31.4,
-  "gzipKB": 13,
+  "rawKB": 31.5,
+  "gzipKB": 13.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene55-billboard-renderable-5MnzUtlV.js",

--- a/lab/public/bundle/manifest/scene56.json
+++ b/lab/public/bundle/manifest/scene56.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.3,
+  "rawKB": 60.4,
   "gzipKB": 24.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene57.json
+++ b/lab/public/bundle/manifest/scene57.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 60.1,
-  "gzipKB": 24.3,
+  "rawKB": 60.3,
+  "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene57-billboard-renderable-CUrr_OIJ.js",

--- a/lab/public/bundle/manifest/scene59.json
+++ b/lab/public/bundle/manifest/scene59.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 63.2,
+  "rawKB": 63.3,
   "gzipKB": 25.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene6.json
+++ b/lab/public/bundle/manifest/scene6.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 72.9,
+  "rawKB": 73.1,
   "gzipKB": 30.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene60.json
+++ b/lab/public/bundle/manifest/scene60.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 55.5,
-  "gzipKB": 22.7,
+  "rawKB": 55.6,
+  "gzipKB": 22.8,
   "ignoredRawKB": 4,
   "runtimeChunks": [
     "scene60-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene61.json
+++ b/lab/public/bundle/manifest/scene61.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 54.4,
+  "rawKB": 54.5,
   "gzipKB": 23.3,
   "ignoredRawKB": 7.3,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene62.json
+++ b/lab/public/bundle/manifest/scene62.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 60,
-  "gzipKB": 25.3,
+  "rawKB": 60.2,
+  "gzipKB": 25.4,
   "ignoredRawKB": 5.3,
   "runtimeChunks": [
     "scene62-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene63.json
+++ b/lab/public/bundle/manifest/scene63.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 58.7,
+  "rawKB": 58.8,
   "gzipKB": 24.6,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene64.json
+++ b/lab/public/bundle/manifest/scene64.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 56.7,
-  "gzipKB": 23.5,
+  "rawKB": 56.8,
+  "gzipKB": 23.6,
   "ignoredRawKB": 4.3,
   "runtimeChunks": [
     "scene64-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene65.json
+++ b/lab/public/bundle/manifest/scene65.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 74.5,
-  "gzipKB": 30.6,
+  "rawKB": 74.7,
+  "gzipKB": 30.7,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
     "scene65-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene66.json
+++ b/lab/public/bundle/manifest/scene66.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89,
+  "rawKB": 89.2,
   "gzipKB": 41,
   "ignoredRawKB": 5.5,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene67.json
+++ b/lab/public/bundle/manifest/scene67.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 76.4,
-  "gzipKB": 32.2,
+  "rawKB": 76.6,
+  "gzipKB": 32.3,
   "ignoredRawKB": 9.6,
   "runtimeChunks": [
     "scene67-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene68.json
+++ b/lab/public/bundle/manifest/scene68.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 91.1,
-  "gzipKB": 35.8,
+  "rawKB": 91.2,
+  "gzipKB": 35.9,
   "ignoredRawKB": 11.4,
   "runtimeChunks": [
     "scene68-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene69.json
+++ b/lab/public/bundle/manifest/scene69.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.5,
+  "rawKB": 90.7,
   "gzipKB": 36.1,
   "ignoredRawKB": 13.3,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene7.json
+++ b/lab/public/bundle/manifest/scene7.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 105.7,
-  "gzipKB": 44.7,
+  "rawKB": 105.9,
+  "gzipKB": 44.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene7-background-ground-SAvSHzNE.js",

--- a/lab/public/bundle/manifest/scene70.json
+++ b/lab/public/bundle/manifest/scene70.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.8,
+  "rawKB": 91,
   "gzipKB": 36.7,
   "ignoredRawKB": 14.9,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene71.json
+++ b/lab/public/bundle/manifest/scene71.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.7,
+  "rawKB": 90.8,
   "gzipKB": 36.1,
   "ignoredRawKB": 12.9,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene72.json
+++ b/lab/public/bundle/manifest/scene72.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 108.4,
-  "gzipKB": 43.8,
+  "rawKB": 108.5,
+  "gzipKB": 43.9,
   "ignoredRawKB": 3.3,
   "runtimeChunks": [
     "scene72-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene73.json
+++ b/lab/public/bundle/manifest/scene73.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 143.8,
-  "gzipKB": 58,
+  "rawKB": 143.9,
+  "gzipKB": 58.1,
   "ignoredRawKB": 3.3,
   "runtimeChunks": [
     "scene73-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene75.json
+++ b/lab/public/bundle/manifest/scene75.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.4,
+  "rawKB": 50.5,
   "gzipKB": 20.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene77.json
+++ b/lab/public/bundle/manifest/scene77.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 59.5,
-  "gzipKB": 25.5,
+  "rawKB": 59.7,
+  "gzipKB": 25.6,
   "ignoredRawKB": 7,
   "runtimeChunks": [
     "scene77-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene78.json
+++ b/lab/public/bundle/manifest/scene78.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 57.6,
+  "rawKB": 57.7,
   "gzipKB": 27.4,
   "ignoredRawKB": 9.7,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene79.json
+++ b/lab/public/bundle/manifest/scene79.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 61.2,
+  "rawKB": 61.3,
   "gzipKB": 27.6,
   "ignoredRawKB": 8.1,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene8.json
+++ b/lab/public/bundle/manifest/scene8.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 74.6,
+  "rawKB": 74.7,
   "gzipKB": 29.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene80.json
+++ b/lab/public/bundle/manifest/scene80.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 60.6,
-  "gzipKB": 26.6,
+  "rawKB": 60.7,
+  "gzipKB": 26.7,
   "ignoredRawKB": 6,
   "runtimeChunks": [
     "scene80-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene81.json
+++ b/lab/public/bundle/manifest/scene81.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 66.6,
+  "rawKB": 66.7,
   "gzipKB": 29.8,
   "ignoredRawKB": 7,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene82.json
+++ b/lab/public/bundle/manifest/scene82.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 66.3,
-  "gzipKB": 29.7,
+  "rawKB": 66.5,
+  "gzipKB": 29.8,
   "ignoredRawKB": 8.4,
   "runtimeChunks": [
     "scene82-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene83.json
+++ b/lab/public/bundle/manifest/scene83.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 70.4,
-  "gzipKB": 33.2,
+  "rawKB": 70.5,
+  "gzipKB": 33.3,
   "ignoredRawKB": 11.4,
   "runtimeChunks": [
     "scene83-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene84.json
+++ b/lab/public/bundle/manifest/scene84.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 84.6,
-  "gzipKB": 36.2,
+  "rawKB": 84.8,
+  "gzipKB": 36.3,
   "ignoredRawKB": 5.5,
   "runtimeChunks": [
     "scene84-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene85.json
+++ b/lab/public/bundle/manifest/scene85.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.3,
+  "rawKB": 60.5,
   "gzipKB": 26.3,
   "ignoredRawKB": 6.5,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene86.json
+++ b/lab/public/bundle/manifest/scene86.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 59.8,
-  "gzipKB": 27.1,
+  "rawKB": 59.9,
+  "gzipKB": 27.2,
   "ignoredRawKB": 8,
   "runtimeChunks": [
     "scene86-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene87.json
+++ b/lab/public/bundle/manifest/scene87.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 93.8,
-  "gzipKB": 37.5,
+  "rawKB": 93.9,
+  "gzipKB": 37.6,
   "ignoredRawKB": 12,
   "runtimeChunks": [
     "scene87-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene88.json
+++ b/lab/public/bundle/manifest/scene88.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 60.5,
-  "gzipKB": 26.8,
+  "rawKB": 60.6,
+  "gzipKB": 26.9,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
     "scene88-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene89.json
+++ b/lab/public/bundle/manifest/scene89.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 59.9,
-  "gzipKB": 27,
+  "rawKB": 60,
+  "gzipKB": 27.1,
   "ignoredRawKB": 7.6,
   "runtimeChunks": [
     "scene89-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene9.json
+++ b/lab/public/bundle/manifest/scene9.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 59.6,
-  "gzipKB": 24.1,
+  "rawKB": 59.7,
+  "gzipKB": 24.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene9-generate-mipmaps-xw5BdfZd.js",

--- a/lab/public/bundle/manifest/scene90.json
+++ b/lab/public/bundle/manifest/scene90.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.3,
+  "rawKB": 59.5,
   "gzipKB": 23.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene91.json
+++ b/lab/public/bundle/manifest/scene91.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 58.5,
+  "rawKB": 58.6,
   "gzipKB": 23.4,
   "ignoredRawKB": 1227.9,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene94.json
+++ b/lab/public/bundle/manifest/scene94.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 63.9,
+  "rawKB": 64,
   "gzipKB": 25.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene95.json
+++ b/lab/public/bundle/manifest/scene95.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 65,
+  "rawKB": 65.1,
   "gzipKB": 25.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene98.json
+++ b/lab/public/bundle/manifest/scene98.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 60.3,
-  "gzipKB": 24.4,
+  "rawKB": 60.4,
+  "gzipKB": 24.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene98-billboard-renderable-jlPUXki_.js",

--- a/lab/public/bundle/manifest/scene99.json
+++ b/lab/public/bundle/manifest/scene99.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 91.9,
+  "rawKB": 92.1,
   "gzipKB": 38.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/packages/babylon-lite/src/camera/camera.ts
+++ b/packages/babylon-lite/src/camera/camera.ts
@@ -26,18 +26,35 @@ export interface Camera {
     _viewCache: Mat4Storage;
     /** @internal */
     _viewVer?: number;
-    /** @internal Projection matrix cache. Same allocator as `_viewCache`. */
+    /** @internal Projection matrix cache. Same allocator as `_viewCache`.
+     *  The projection matrix depends only on the projection inputs
+     *  (`fov`, aspect, `nearPlane`, `farPlane`) — never on the world matrix —
+     *  so the cache is keyed on those inputs. This lets runtime changes to the
+     *  public `fov`/`nearPlane`/`farPlane` fields take effect on the next frame
+     *  without needing the camera to move first. */
     _projCache: Mat4Storage;
-    /** @internal */
-    _projVer?: number;
-    /** @internal */
+    /** @internal Aspect ratio the cached projection was built with. */
     _projAspect?: number;
-    /** @internal View-projection matrix cache. Same allocator. */
+    /** @internal `fov` the cached projection was built with. */
+    _projFov?: number;
+    /** @internal `nearPlane` the cached projection was built with. */
+    _projNear?: number;
+    /** @internal `farPlane` the cached projection was built with. */
+    _projFar?: number;
+    /** @internal View-projection matrix cache. Same allocator. Keyed on the
+     *  view inputs (`worldMatrixVersion`) and the projection inputs
+     *  (aspect, `fov`, `nearPlane`, `farPlane`). */
     _vpCache: Mat4Storage;
     /** @internal */
     _vpVer?: number;
     /** @internal */
     _vpAspect?: number;
+    /** @internal `fov` the cached view-projection was built with. */
+    _vpFov?: number;
+    /** @internal `nearPlane` the cached view-projection was built with. */
+    _vpNear?: number;
+    /** @internal `farPlane` the cached view-projection was built with. */
+    _vpFar?: number;
     /** @internal Marker: when set by an LWR-enabled scene, `getViewMatrix`
      *  zeros the view matrix translation column (the GPU sees the camera at
      *  the origin in the eye-relative frame, matching the mesh-world UBO
@@ -100,29 +117,39 @@ export function getViewMatrix(camera: Camera): Mat4 {
     return v as unknown as Mat4;
 }
 
-/** Compute the projection matrix for a camera. Cached per worldMatrixVersion + aspect. */
+/** Compute the projection matrix for a camera. Cached on the projection inputs
+ *  (`fov`, aspect, `nearPlane`, `farPlane`). Because the cache key is the actual
+ *  projection state — not the world-matrix version — mutating the public
+ *  `fov`/`nearPlane`/`farPlane` fields invalidates the cache immediately, so the
+ *  new projection is used on the very next frame without moving the camera. */
 export function getProjectionMatrix(camera: Camera, aspectRatio: number): Mat4 {
-    const ver = camera.worldMatrixVersion;
-    if (camera._projVer === ver && camera._projAspect === aspectRatio) {
+    if (camera._projAspect === aspectRatio && camera._projFov === camera.fov && camera._projNear === camera.nearPlane && camera._projFar === camera.farPlane) {
         return camera._projCache as unknown as Mat4;
     }
     const p = camera._projCache;
     mat4PerspectiveLHToRef(p, camera.fov, aspectRatio, camera.nearPlane, camera.farPlane);
-    camera._projVer = ver;
     camera._projAspect = aspectRatio;
+    camera._projFov = camera.fov;
+    camera._projNear = camera.nearPlane;
+    camera._projFar = camera.farPlane;
     return p as unknown as Mat4;
 }
 
-/** Compute the view-projection matrix for a camera. Cached per worldMatrixVersion + aspect. */
+/** Compute the view-projection matrix for a camera. Cached on the view inputs
+ *  (`worldMatrixVersion`) and the projection inputs (aspect, `fov`,
+ *  `nearPlane`, `farPlane`). */
 export function getViewProjectionMatrix(camera: Camera, aspectRatio: number): Mat4 {
     const ver = camera.worldMatrixVersion;
-    if (camera._vpVer === ver && camera._vpAspect === aspectRatio) {
+    if (camera._vpVer === ver && camera._vpAspect === aspectRatio && camera._vpFov === camera.fov && camera._vpNear === camera.nearPlane && camera._vpFar === camera.farPlane) {
         return camera._vpCache as unknown as Mat4;
     }
     const vp = camera._vpCache;
     mat4MultiplyInto(vp, 0, getProjectionMatrix(camera, aspectRatio) as unknown as Mat4Storage, 0, getViewMatrix(camera) as unknown as Mat4Storage, 0);
     camera._vpVer = ver;
     camera._vpAspect = aspectRatio;
+    camera._vpFov = camera.fov;
+    camera._vpNear = camera.nearPlane;
+    camera._vpFar = camera.farPlane;
     return vp as unknown as Mat4;
 }
 

--- a/packages/babylon-lite/src/shadow/shadow-base.ts
+++ b/packages/babylon-lite/src/shadow/shadow-base.ts
@@ -163,5 +163,12 @@ export function updateShadowCameraBase(camera: Camera, cameraVersion: number, ne
     camera._vpCache = viewProj;
     camera._vpVer = cameraVersion;
     camera._vpAspect = 1;
+    // The shadow view-projection is injected directly (a custom light-space
+    // projection, not the perspective built by getProjectionMatrix). Mirror the
+    // camera's projection inputs into the vp cache key so getViewProjectionMatrix
+    // treats the injected matrix as valid instead of recomputing a perspective vp.
+    camera._vpFov = camera.fov;
+    camera._vpNear = near;
+    camera._vpFar = far;
     (camera as Camera & { _shadowCameraVersion?: number })._shadowCameraVersion = cameraVersion;
 }

--- a/playground/examples/camera-fov-invalidation.ts
+++ b/playground/examples/camera-fov-invalidation.ts
@@ -1,0 +1,78 @@
+/**
+ * Camera FOV cache invalidation — a repro for issue #271.
+ *
+ * The camera never moves, so its `worldMatrixVersion` stays constant for the
+ * whole run. Each frame we only mutate the public projection field
+ * `camera.fov` (and periodically `nearPlane` / `farPlane`). If the projection
+ * cache were still keyed on `worldMatrixVersion` (the pre-fix behaviour) the
+ * rendered projection would be frozen at the initial FOV and nothing would
+ * appear to change. With the fix, `getProjectionMatrix` keys on the actual
+ * projection inputs, so the ring of cubes should visibly "breathe" (zoom in
+ * and out) purely from the per-frame FOV change.
+ */
+import {
+    addToScene,
+    attachControl,
+    createArcRotateCamera,
+    createBox,
+    createDirectionalLight,
+    createHemisphericLight,
+    createSceneContext,
+    createStandardMaterial,
+    createEngine,
+    onBeforeRender,
+    registerScene,
+    startEngine,
+    type Mesh,
+} from "@babylonjs/lite";
+
+const COUNT = 8;
+const RADIUS = 3.5;
+const BASE_FOV = 0.8;
+
+async function main(): Promise<void> {
+    const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
+
+    const engine = await createEngine(canvas);
+    const scene = createSceneContext(engine);
+    scene.clearColor = { r: 0.04, g: 0.05, b: 0.08, a: 1 };
+
+    // Static camera: we deliberately never change alpha/beta/radius/target,
+    // so worldMatrixVersion is fixed and only fov/near/far vary at runtime.
+    const camera = createArcRotateCamera(-Math.PI / 2, 1.2, 12, { x: 0, y: 0, z: 0 });
+    camera.fov = BASE_FOV;
+    scene.camera = camera;
+    attachControl(camera, canvas, scene);
+
+    addToScene(scene, createHemisphericLight([0, 1, 0], 0.6));
+    addToScene(scene, createDirectionalLight([-0.5, -1, -0.4], 1.2));
+
+    const cubes: Mesh[] = [];
+    for (let i = 0; i < COUNT; i++) {
+        const cube = createBox(engine, 1);
+        const mat = createStandardMaterial();
+        const hue = i / COUNT;
+        mat.diffuseColor = [0.5 + 0.5 * Math.sin(hue * 6.28), 0.5 + 0.5 * Math.sin(hue * 6.28 + 2.1), 0.5 + 0.5 * Math.sin(hue * 6.28 + 4.2)];
+        mat.specularColor = [0.3, 0.3, 0.3];
+        cube.material = mat;
+        const angle = (i / COUNT) * Math.PI * 2;
+        cube.position.set(Math.cos(angle) * RADIUS, 0, Math.sin(angle) * RADIUS);
+        addToScene(scene, cube);
+        cubes.push(cube);
+    }
+
+    let t = 0;
+    onBeforeRender(scene, (deltaMs) => {
+        t += deltaMs / 1000;
+        // Pulse the field of view every frame WITHOUT moving the camera.
+        camera.fov = BASE_FOV + Math.sin(t * 1.5) * 0.35;
+        // Also nudge the clip planes periodically to exercise near/far invalidation.
+        camera.nearPlane = 0.1 + (Math.sin(t * 0.7) * 0.5 + 0.5) * 0.4;
+        camera.farPlane = 100;
+    });
+
+    await registerScene(scene);
+    await startEngine(engine);
+}
+
+void main().catch((err) => console.error(err));

--- a/playground/examples/camera-fov-invalidation.ts
+++ b/playground/examples/camera-fov-invalidation.ts
@@ -1,14 +1,16 @@
 /**
  * Camera FOV cache invalidation — a repro for issue #271.
  *
- * The camera never moves, so its `worldMatrixVersion` stays constant for the
- * whole run. Each frame we only mutate the public projection field
- * `camera.fov` (and periodically `nearPlane` / `farPlane`). If the projection
- * cache were still keyed on `worldMatrixVersion` (the pre-fix behaviour) the
- * rendered projection would be frozen at the initial FOV and nothing would
- * appear to change. With the fix, `getProjectionMatrix` keys on the actual
- * projection inputs, so the ring of cubes should visibly "breathe" (zoom in
- * and out) purely from the per-frame FOV change.
+ * As long as you don't orbit the camera, its `worldMatrixVersion` stays
+ * constant for the whole run. Each frame we only mutate the public projection
+ * field `camera.fov` (and periodically `nearPlane` / `farPlane`). If the
+ * projection cache were still keyed on `worldMatrixVersion` (the pre-fix
+ * behaviour) the rendered projection would be frozen at the initial FOV and
+ * nothing would appear to change. With the fix, `getProjectionMatrix` keys on
+ * the actual projection inputs, so the ring of cubes should visibly "breathe"
+ * (zoom in and out) purely from the per-frame FOV change. (Dragging to orbit
+ * bumps `worldMatrixVersion` and would have masked the old bug — keep the
+ * camera still to see the pure repro.)
  */
 import {
     addToScene,
@@ -37,8 +39,13 @@ async function main(): Promise<void> {
     const scene = createSceneContext(engine);
     scene.clearColor = { r: 0.04, g: 0.05, b: 0.08, a: 1 };
 
-    // Static camera: we deliberately never change alpha/beta/radius/target,
-    // so worldMatrixVersion is fixed and only fov/near/far vary at runtime.
+    // The repro relies on the camera staying still: as long as you don't drag
+    // to orbit, alpha/beta/radius/target never change, so worldMatrixVersion is
+    // fixed and ONLY fov/near/far vary at runtime — exactly the case that used
+    // to leave the projection frozen (#271). attachControl is left enabled so
+    // you can still orbit to inspect; note that interacting bumps
+    // worldMatrixVersion and would mask the bug on the old cache. Comment out
+    // the attachControl call below for a strictly stationary repro.
     const camera = createArcRotateCamera(-Math.PI / 2, 1.2, 12, { x: 0, y: 0, z: 0 });
     camera.fov = BASE_FOV;
     scene.camera = camera;

--- a/playground/src/examples.ts
+++ b/playground/src/examples.ts
@@ -17,6 +17,7 @@ import HAVOK_PHYSICS from "../examples/havok-physics.ts?raw";
 import PBR_MATERIAL_GRID from "../examples/pbr-material-grid.ts?raw";
 import SPINNING_POLYHEDRA from "../examples/spinning-polyhedra.ts?raw";
 import GRID_STUDIO from "../examples/grid-studio.ts?raw";
+import CAMERA_FOV_INVALIDATION from "../examples/camera-fov-invalidation.ts?raw";
 
 const BOOMBOX = `import {
     addToScene,
@@ -166,6 +167,7 @@ export const EXAMPLES: Example[] = [
     { id: "boombox", label: "glTF — BoomBox (PBR + environment)", code: BOOMBOX },
     { id: "primitives", label: "Primitives — box + ground", code: PRIMITIVES },
     { id: "spinning-polyhedra", label: "Animation — Spinning Polyhedra", code: SPINNING_POLYHEDRA },
+    { id: "camera-fov-invalidation", label: "Camera — FOV cache invalidation (#271)", code: CAMERA_FOV_INVALIDATION },
     { id: "pbr-material-grid", label: "PBR — Metalness × Roughness grid", code: PBR_MATERIAL_GRID },
     { id: "grid-studio", label: "Grid material — Studio staging", code: GRID_STUDIO },
     {

--- a/tests/lite/unit/camera-projection-cache.test.ts
+++ b/tests/lite/unit/camera-projection-cache.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import { createFreeCamera } from "../../../packages/babylon-lite/src/camera/free-camera";
+import { getProjectionMatrix, getViewProjectionMatrix } from "../../../packages/babylon-lite/src/camera/camera";
+import { _resetMatrixAllocatorForTests } from "../../../packages/babylon-lite/src/math/_matrix-allocator";
+
+// Regression coverage for issue #271: mutating the public projection fields
+// (`fov`, `nearPlane`, `farPlane`) must invalidate the projection /
+// view-projection caches immediately — without needing the camera to move
+// first. The projection matrix is a pure function of (fov, aspect, near, far)
+// and never depends on the world matrix, so the cache is keyed on those inputs.
+
+const ASPECT = 16 / 9;
+
+/** Copy a matrix's elements out (the caches are mutated in place and returned by reference). */
+function snapshot(m: ArrayLike<number>): number[] {
+    return Array.from(m as unknown as number[]);
+}
+
+describe("camera projection cache invalidation (#271)", () => {
+    beforeEach(() => {
+        _resetMatrixAllocatorForTests();
+    });
+
+    it("recomputes the projection matrix when fov changes on a stationary camera", () => {
+        const camera = createFreeCamera({ x: 0, y: 0, z: -10 }, { x: 0, y: 0, z: 0 });
+        const versionBefore = camera.worldMatrixVersion;
+
+        const first = snapshot(getProjectionMatrix(camera, ASPECT));
+
+        camera.fov = camera.fov + 0.5;
+        const second = snapshot(getProjectionMatrix(camera, ASPECT));
+
+        // The camera never moved: worldMatrixVersion is unchanged, yet the
+        // projection must reflect the new fov (element [5] == 1/tan(fov/2)).
+        expect(camera.worldMatrixVersion).toBe(versionBefore);
+        expect(second[5]).not.toBe(first[5]);
+    });
+
+    it("recomputes the projection matrix when nearPlane / farPlane change", () => {
+        const camera = createFreeCamera({ x: 0, y: 0, z: -10 }, { x: 0, y: 0, z: 0 });
+
+        const first = snapshot(getProjectionMatrix(camera, ASPECT));
+
+        camera.nearPlane = camera.nearPlane + 2;
+        camera.farPlane = camera.farPlane * 0.5;
+        const second = snapshot(getProjectionMatrix(camera, ASPECT));
+
+        // Elements [10] and [14] encode the near/far depth mapping.
+        expect(second[10]).not.toBe(first[10]);
+        expect(second[14]).not.toBe(first[14]);
+    });
+
+    it("returns a stable projection matrix when nothing changes", () => {
+        const camera = createFreeCamera({ x: 0, y: 0, z: -10 }, { x: 0, y: 0, z: 0 });
+
+        const first = snapshot(getProjectionMatrix(camera, ASPECT));
+        const second = snapshot(getProjectionMatrix(camera, ASPECT));
+
+        expect(second).toEqual(first);
+    });
+
+    it("recomputes the projection matrix when the aspect ratio changes", () => {
+        const camera = createFreeCamera({ x: 0, y: 0, z: -10 }, { x: 0, y: 0, z: 0 });
+
+        const first = snapshot(getProjectionMatrix(camera, ASPECT));
+        const second = snapshot(getProjectionMatrix(camera, 1));
+
+        // Element [0] == (1/tan(fov/2)) / aspect.
+        expect(second[0]).not.toBe(first[0]);
+    });
+
+    it("propagates a fov change through the view-projection matrix on a stationary camera", () => {
+        const camera = createFreeCamera({ x: 0, y: 0, z: -10 }, { x: 0, y: 0, z: 0 });
+        const versionBefore = camera.worldMatrixVersion;
+
+        const first = snapshot(getViewProjectionMatrix(camera, ASPECT));
+
+        camera.fov = camera.fov + 0.5;
+        const second = snapshot(getViewProjectionMatrix(camera, ASPECT));
+
+        expect(camera.worldMatrixVersion).toBe(versionBefore);
+        expect(second).not.toEqual(first);
+    });
+});


### PR DESCRIPTION
Fixes BabylonJS/Babylon-Lite#271.

## Problem
Changing `camera.fov`, `camera.nearPlane`, or `camera.farPlane` at runtime did not update the rendered projection until the camera moved or the aspect ratio changed.

`getProjectionMatrix()` cached the matrix keyed on `worldMatrixVersion` + aspect. But the perspective projection depends only on `(fov, aspect, nearPlane, farPlane)` — never on the world matrix. Mutating the public projection fields left `worldMatrixVersion` unchanged, so the stale cached matrix was reused. Moving the camera bumped `worldMatrixVersion`, which is why the change 'became visible after moving.'

## Fix
- `getProjectionMatrix` now keys the cache on its real inputs: fov, aspect, nearPlane, farPlane.
- `getViewProjectionMatrix` keeps the view key (worldMatrixVersion) and additionally tracks the projection inputs.
- `updateShadowCameraBase` injects a custom light-space vp matrix directly, so it now also seeds the new vp cache-key fields to keep that injection valid.

No public API change — `camera.fov = …` now takes effect on the next frame.

## Repro / verification
Added a playground example 'Camera — FOV cache invalidation (#271)' that pulses `camera.fov` every frame on a static camera whose worldMatrixVersion never changes. Before the fix the scene was frozen at the initial FOV; with the fix the cubes visibly breathe in/out.

## Testing
- `pnpm run lint` — clean.
- `pnpm build:bundle-scenes` — manifests regenerated/committed; largest delta ~+0.2 KB raw, all within ceilings.
- bundle-size spec — 204 passed.
- `pnpm test:parity` — 418 passed, 2 failed (scene116, scene144). Both reproduce byte-identically on master (verified by stashing the change), so pre-existing and unrelated.