### PR TITLE
feat(navigation): add findClosestPointWithin with explicit search extents

### DIFF
--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -689,6 +689,7 @@ export {
     createNavMeshFromSources,
     createDebugNavMeshGeometry,
     getClosestPoint,
+    findClosestPointWithin,
     computePath,
     createNavCrowd,
     addAgent,

--- a/packages/babylon-lite/src/navigation/navigation.ts
+++ b/packages/babylon-lite/src/navigation/navigation.ts
@@ -512,6 +512,20 @@ export function getClosestPoint(plugin: NavigationPlugin, position: Vec3): Vec3 
     return { x: res.point.x, y: res.point.y, z: res.point.z };
 }
 
+/** Snap a position to the closest point on the navmesh within a search box, or null when no part of the
+ *  mesh lies inside it. Unlike getClosestPoint — which does not inspect the query's success flag, so a
+ *  position outside its fixed ±1-unit box returns an UNSPECIFIED point (whatever the query left in its
+ *  output) rather than signalling a miss — the search extent is explicit here and a failed query is
+ *  reported as null, so callers can distinguish "snapped" from "nothing nearby". */
+export function findClosestPointWithin(plugin: NavigationPlugin, position: Vec3, halfExtents: Vec3): Vec3 | null {
+    _assertReady(plugin);
+    const res = plugin._navMeshQuery.findClosestPoint(position, { halfExtents });
+    if (!res.success) {
+        return null;
+    }
+    return { x: res.point.x, y: res.point.y, z: res.point.z };
+}
+
 /** Compute a path between two world positions, snapped to the navmesh. */
 export function computePath(plugin: NavigationPlugin, start: Vec3, end: Vec3): Vec3[] {
     _assertReady(plugin);

--- a/tests/lite/unit/navigation.test.ts
+++ b/tests/lite/unit/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createNavMeshFromSources } from "../../../packages/babylon-lite/src/navigation/navigation";
+import { createNavMeshFromSources, findClosestPointWithin } from "../../../packages/babylon-lite/src/navigation/navigation";
 import type { NavigationPlugin, NavMeshSource } from "../../../packages/babylon-lite/src/navigation/navigation";
 
 function createMockPlugin(capture: { positions?: number[]; indices?: number[]; navMeshQueryInput?: unknown }): NavigationPlugin {
@@ -45,5 +45,30 @@ describe("navigation raw sources", () => {
         createNavMeshFromSources(plugin, [{ positions: [0, 0, 0, 1, 0, 0, 0, 0, 1], indices: [0, 1, 2] }], { doNotReverseIndices: true });
 
         expect(capture.indices).toEqual([0, 1, 2]);
+    });
+});
+
+describe("findClosestPointWithin", () => {
+    function makeReadyPlugin(findClosestPoint: (position: unknown, opts: unknown) => unknown): NavigationPlugin {
+        return { _navMesh: { ok: true }, _navMeshQuery: { findClosestPoint } } as unknown as NavigationPlugin;
+    }
+
+    it("returns the snapped point and forwards the caller's halfExtents", () => {
+        let seen: unknown;
+        const plugin = makeReadyPlugin((_position, opts) => {
+            seen = opts;
+            return { success: true, point: { x: 1, y: 2, z: 3 } };
+        });
+
+        const result = findClosestPointWithin(plugin, { x: 1.1, y: 2, z: 3 }, { x: 5, y: 4, z: 5 });
+
+        expect(result).toEqual({ x: 1, y: 2, z: 3 });
+        expect(seen).toEqual({ halfExtents: { x: 5, y: 4, z: 5 } });
+    });
+
+    it("returns null when the query finds nothing inside the box", () => {
+        const plugin = makeReadyPlugin(() => ({ success: false, point: { x: 0, y: 0, z: 0 } }));
+
+        expect(findClosestPointWithin(plugin, { x: 99, y: 0, z: 99 }, { x: 1, y: 1, z: 1 })).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary

Adds `findClosestPointWithin(plugin, position, halfExtents)` to the navigation API.

`getClosestPoint` uses a fixed ±1-unit query box and returns whatever
`NavMeshQuery.findClosestPoint` produces even when the query fails — so a position
more than ~1 unit off the navmesh silently yields an undefined/garbage point.
`findClosestPointWithin` takes the search box `halfExtents` explicitly and returns
`null` when no part of the navmesh lies inside the box, so callers can distinguish
"snapped to the mesh" from "nothing nearby" (validating a placement click, snapping
only within a tolerance, etc.).

## Breaking changes

None. Purely additive — `getClosestPoint` is unchanged. The new export is
tree-shakeable, so scenes that do not import it are byte-identical.

## Bundle size

Zero movement on every scene (verified: `scene1` and all navigation scenes at 0 KB
delta vs `master`). The new function is dead-code-eliminated from every bundle that
does not call it, so no per-scene manifest changed and no ceilings were touched.

## Validation

- Lint / type-check: pass.
- Unit tests: 612 pass, including two new cases for `findClosestPointWithin` (the
  snapped-point + forwarded-`halfExtents` path and the `null`-on-miss path).
- Parity: pass (the only failures are the pre-existing non-deterministic Havok
  physics scenes, which fail on `master` too).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
