### PR TITLE
feat(texture): add createTexture3DFromPixels for volumetric / LUT textures

### DIFF
--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -188,6 +188,8 @@ export type { Csg2Solid } from "./mesh/csg2.js";
 // ─── Textures ────────────────────────────────────────────────────────
 export { createSolidTexture2D } from "./texture/solid-texture.js";
 export { createTexture2DFromPixels, updateTexture2DFromPixels, createRenderTexture2D } from "./texture/pixels-texture.js";
+export { createTexture3DFromPixels } from "./texture/pixels-texture.js";
+export type { Texture3D, PixelsTexture3DOptions } from "./texture/pixels-texture.js";
 export type { PixelsTexture2DOptions, RenderTexture2DOptions } from "./texture/pixels-texture.js";
 export { loadKtxTexture2D } from "./texture/ktx-loader.js";
 export { loadBasisTexture2D } from "./texture/basis-loader.js";

--- a/packages/babylon-lite/src/texture/pixels-texture.ts
+++ b/packages/babylon-lite/src/texture/pixels-texture.ts
@@ -158,3 +158,71 @@ export function updateTexture2DFromPixels(engine: EngineContext, tex: Texture2D,
         { width, height }
     );
 }
+
+/** Sampler / format overrides for `createTexture3DFromPixels()`. */
+export interface PixelsTexture3DOptions {
+    /** Address mode U/V/W. Default 'clamp-to-edge' (the right choice for a colour LUT — the cube edges
+     *  must not wrap). */
+    addressMode?: GPUAddressMode;
+    /** Min/mag filter. Default 'linear' so a colour-grading LUT interpolates trilinearly in one sample. */
+    filter?: GPUFilterMode;
+    /** Use sRGB format (rgba8unorm-srgb). Leave false for a linear/display LUT. Default false. */
+    srgb?: boolean;
+}
+
+/** A `Texture2D` handle whose underlying GPU texture is `dimension:"3d"`, plus its depth. Bind it to a
+ *  fullscreen effect with `viewDimension:"3d"` and sample it in WGSL as `texture_3d<f32>`. */
+export type Texture3D = Texture2D & { depth: number };
+
+/**
+ * Create a **3D** texture from a tightly-packed RGBA8 byte buffer — the volumetric analog of
+ * `createTexture2DFromPixels`. The primary use is a colour-grading LUT (a `.cube`/HALD colour cube):
+ * upload the N×N×N RGBA volume once and sample it trilinearly with a single `textureSample`.
+ *
+ * The default sampler is linear with clamp-to-edge on all three axes — exactly what a LUT wants (linear
+ * = trilinear interpolation between grid points; clamp = no wrap at the cube faces). The returned handle
+ * is a `Texture2D` (so it drops straight into `setEffectTexture`) with an extra `depth` field; its `view`
+ * is created with `dimension:"3d"`.
+ *
+ * @param engine - Engine context.
+ * @param data - `width * height * depth * 4` bytes, RGBA8, ordered x fastest, then y, then z (slice-major).
+ * @param width - Cube size along R (\>= 1).
+ * @param height - Cube size along G (\>= 1).
+ * @param depth - Cube size along B (\>= 1).
+ * @param options - Sampler / format overrides.
+ */
+export function createTexture3DFromPixels(engine: EngineContext, data: Uint8Array, width: number, height: number, depth: number, options: PixelsTexture3DOptions = {}): Texture3D {
+    if (width < 1 || height < 1 || depth < 1) {
+        throw new Error(`createTexture3DFromPixels: width/height/depth must be >= 1 (got ${width}x${height}x${depth})`);
+    }
+    const expected = width * height * depth * 4;
+    if (data.length < expected) {
+        throw new Error(`createTexture3DFromPixels: data too short — need ${expected} bytes for ${width}x${height}x${depth} RGBA, got ${data.length}`);
+    }
+
+    const device = engine._device;
+    const format: GPUTextureFormat = options.srgb ? "rgba8unorm-srgb" : "rgba8unorm";
+
+    const texture = device.createTexture({
+        size: { width, height, depthOrArrayLayers: depth },
+        dimension: "3d",
+        format,
+        usage: TU.TEXTURE_BINDING | TU.COPY_DST,
+    });
+
+    device.queue.writeTexture({ texture }, data as Uint8Array<ArrayBuffer>, { bytesPerRow: width * 4, rowsPerImage: height }, { width, height, depthOrArrayLayers: depth });
+
+    const address = options.addressMode ?? "clamp-to-edge";
+    const filter = options.filter ?? "linear";
+    const sampler = getOrCreateSampler(engine, {
+        addressModeU: address,
+        addressModeV: address,
+        addressModeW: address,
+        minFilter: filter,
+        magFilter: filter,
+    });
+
+    const tex: Texture3D = { texture, view: texture.createView({ dimension: "3d" }), sampler, width, height, depth };
+    acquireTexture(tex);
+    return tex;
+}

--- a/tests/lite/unit/pixels-texture-3d.test.ts
+++ b/tests/lite/unit/pixels-texture-3d.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { createTexture3DFromPixels } from "../../../packages/babylon-lite/src/texture/pixels-texture";
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+
+interface Captured {
+    createDesc?: GPUTextureDescriptor;
+    writeSize?: GPUExtent3DStrict;
+    writeLayout?: GPUTexelCopyBufferLayout;
+    viewDesc?: GPUTextureViewDescriptor;
+    samplerDesc?: GPUSamplerDescriptor;
+}
+
+function makeEngine(cap: Captured): EngineContext {
+    const device = {
+        createTexture: (desc: GPUTextureDescriptor) => {
+            cap.createDesc = desc;
+            return { createView: (v?: GPUTextureViewDescriptor) => ((cap.viewDesc = v), { _kind: "view" }), destroy: () => undefined } as unknown as GPUTexture;
+        },
+        queue: {
+            writeTexture: (_dst: unknown, _data: unknown, layout: GPUTexelCopyBufferLayout, size: GPUExtent3DStrict) => {
+                cap.writeLayout = layout;
+                cap.writeSize = size;
+            },
+        },
+        createSampler: (desc: GPUSamplerDescriptor) => ((cap.samplerDesc = desc), { _kind: "sampler" } as unknown as GPUSampler),
+    };
+    return { _device: device as unknown as GPUDevice } as unknown as EngineContext;
+}
+
+describe("createTexture3DFromPixels", () => {
+    it("uploads a 3D texture and returns a handle with depth + a 3d view", () => {
+        const cap: Captured = {};
+        const engine = makeEngine(cap);
+        const data = new Uint8Array(2 * 2 * 2 * 4);
+
+        const tex = createTexture3DFromPixels(engine, data, 2, 2, 2);
+
+        expect(cap.createDesc?.dimension).toBe("3d");
+        expect(cap.createDesc?.size).toEqual({ width: 2, height: 2, depthOrArrayLayers: 2 });
+        expect(cap.createDesc?.format).toBe("rgba8unorm");
+        expect(cap.writeLayout).toEqual({ bytesPerRow: 2 * 4, rowsPerImage: 2 });
+        expect(cap.writeSize).toEqual({ width: 2, height: 2, depthOrArrayLayers: 2 });
+        expect(cap.viewDesc).toEqual({ dimension: "3d" });
+        expect(tex.depth).toBe(2);
+        expect(tex.width).toBe(2);
+        expect(tex.height).toBe(2);
+    });
+
+    it("defaults to a linear clamp-to-edge sampler on all three axes", () => {
+        const cap: Captured = {};
+        createTexture3DFromPixels(makeEngine(cap), new Uint8Array(4), 1, 1, 1);
+
+        expect(cap.samplerDesc).toMatchObject({
+            addressModeU: "clamp-to-edge",
+            addressModeV: "clamp-to-edge",
+            addressModeW: "clamp-to-edge",
+            minFilter: "linear",
+            magFilter: "linear",
+        });
+    });
+
+    it("honors srgb, filter and addressMode overrides", () => {
+        const cap: Captured = {};
+        createTexture3DFromPixels(makeEngine(cap), new Uint8Array(4), 1, 1, 1, { srgb: true, filter: "nearest", addressMode: "repeat" });
+
+        expect(cap.createDesc?.format).toBe("rgba8unorm-srgb");
+        expect(cap.samplerDesc).toMatchObject({ addressModeW: "repeat", minFilter: "nearest", magFilter: "nearest" });
+    });
+
+    it("throws on a degenerate dimension", () => {
+        expect(() => createTexture3DFromPixels(makeEngine({}), new Uint8Array(4), 0, 1, 1)).toThrow(/>= 1/);
+    });
+
+    it("throws when the buffer is too short for width*height*depth*4", () => {
+        expect(() => createTexture3DFromPixels(makeEngine({}), new Uint8Array(4 * 2 * 2 * 2 - 1), 2, 2, 2)).toThrow(/data too short/);
+    });
+});


### PR DESCRIPTION
## Summary

Adds `createTexture3DFromPixels(engine, data, width, height, depth, options?)` — the
volumetric analog of `createTexture2DFromPixels`.

Upload a tightly-packed RGBA8 `width*height*depth*4` byte buffer into a
`dimension:"3d"` GPU texture and get back a `Texture3D` (a `Texture2D` handle with
an extra `depth`, whose `view` is a 3D view), so it drops straight into
`setEffectTexture` and samples in WGSL as `texture_3d<f32>`.

The primary use is a colour-grading LUT (a `.cube`/HALD colour cube): the default
sampler is linear + clamp-to-edge on all three axes — trilinear interpolation
between grid points with no wrap at the cube faces — so a single `textureSample`
grades a colour. `srgb`, `filter`, and `addressMode` are overridable. Validates the
dimensions and that the buffer is long enough for `width*height*depth*4` bytes.

## Breaking changes

None. Purely additive — the new `createTexture3DFromPixels` / `Texture3D` /
`PixelsTexture3DOptions` exports mirror the existing `createTexture2DFromPixels`
API, and the function is tree-shakeable, so scenes that do not import it are
byte-identical.

## Bundle size

Zero movement on every scene (verified: `scene1` at 0 KB delta, no per-scene
manifest changed). No scene uses a 3D texture, so the new function is
dead-code-eliminated from every bundle and no ceilings were touched.

## Validation

- Lint / type-check: pass.
- Unit tests: 643 pass, including five new cases for `createTexture3DFromPixels`
  (the 3D upload + 3d view, the linear/clamp sampler defaults, the srgb/filter/
  addressMode overrides, and both validation error paths).
- Parity: pass (the only failures are the pre-existing non-deterministic Havok
  physics scenes, which fail on `master` too).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
