### PR TITLE
fix: rename third-party notices file to NOTICE.txt

### DIFF
--- a/packages/babylon-lite/README.md
+++ b/packages/babylon-lite/README.md
@@ -70,7 +70,7 @@ supported runtimes, and limitations.
 the published package. Their license texts — together with those of the
 upstream native components embedded in their WebAssembly (Recast &amp; Detour and
 the Emscripten runtime) — are reproduced in
-[THIRD_PARTY_NOTICES.txt](./THIRD_PARTY_NOTICES.txt).
+[NOTICE.txt](./NOTICE.txt).
 
 Development-only tooling (build, test, and lint frameworks) is **not** part of
 the published package and therefore carries no redistribution obligations.

--- a/packages/babylon-lite/vite.config.ts
+++ b/packages/babylon-lite/vite.config.ts
@@ -21,7 +21,7 @@ import { stripManifoldNodeRequire } from "../../scripts/strip-manifold-node-requ
  *   build/
  *     package.json              exports "." -> ./lib/index.js  (what bundlers resolve)
  *     index.d.ts                shared rolled-up types for both trees
- *     README.md, LICENSE, THIRD_PARTY_NOTICES.txt
+ *     README.md, LICENSE, NOTICE.txt
  *     lib/                      module-granular ES output for BUNDLER consumers
  *       index.js, <mirrors src/ tree>.js, _chunks/vendor/*.js
  *     dist/                     prebundled, minified ES output for BROWSER / CDN use
@@ -246,7 +246,7 @@ const SUPPLEMENTAL_NOTICES: ReadonlyArray<{ title: string; embeddedBy: string; s
 const THIRD_PARTY_NOTICES_DIR = resolve(__dirname, "third-party-notices");
 
 /**
- * Generate THIRD_PARTY_NOTICES.txt by aggregating the license text of every
+ * Generate NOTICE.txt by aggregating the license text of every
  * bundled runtime dependency, plus curated notices for the upstream native
  * components embedded in their WASM. Generated at build time so the notices stay
  * in sync with the actual dependency versions on each release. Fails the build
@@ -288,7 +288,7 @@ function emitThirdPartyNotices(): Plugin {
                 sections.push(`${divider}\n${notice.title}\nEmbedded by: ${notice.embeddedBy}\nSource: ${notice.source}\n${divider}\n\n${licenseText}`);
             }
 
-            writeFileSync(resolve(PACKAGE_ROOT, "THIRD_PARTY_NOTICES.txt"), sections.join("\n\n") + "\n");
+            writeFileSync(resolve(PACKAGE_ROOT, "NOTICE.txt"), sections.join("\n\n") + "\n");
         },
     };
 }
@@ -583,7 +583,7 @@ export default defineConfig(({ mode }) => {
     // Module-granular library build for bundler consumers: one entry per source
     // module — this is the tree a real bundler resolves, and what the bundle-size
     // harness measures. Emits the shared package metadata (package.json, README,
-    // LICENSE, THIRD_PARTY_NOTICES) into the build root. Does NOT emit types (see the
+    // LICENSE, NOTICE.txt) into the build root. Does NOT emit types (see the
     // `dist` pass above). `build:lib` and `build:dist` write to disjoint subdirs +
     // non-conflicting root files, so they can run in either order after a clean.
     return {


### PR DESCRIPTION
## What

Renames the generated third-party notices file from `THIRD_PARTY_NOTICES.txt` to **`NOTICE.txt`**.

## Why

Microsoft's Component Governance tooling expects the notices file to be named `NOTICE.txt` (the default `outputfile` for the CG notice build task, per [the docs](https://docs.opensource.microsoft.com/tools/cg/legal/notice/)). This aligns our published package with that convention for the next release.

## Changes

- **`packages/babylon-lite/vite.config.ts`** — `emitThirdPartyNotices` now writes `NOTICE.txt`; updated the accompanying doc comments.
- **`packages/babylon-lite/README.md`** — updated the link to `[NOTICE.txt](./NOTICE.txt)`.

The content-generation logic is unchanged — the same aggregated license texts ship, just under the new filename. The internal `third-party-notices/` source directory (supplemental upstream license texts) is intentionally left as-is.

## Verification

A build emits `NOTICE.txt` into the package root alongside `LICENSE` and `README.md`.