### PR TITLE
test(parity): add REUSE_BROWSER to reuse one browser window across scene specs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,11 @@ const screenX = process.env.SCREEN_X;
 const headless = process.env.HEADLESS === "true";
 const isCI = !!process.env.CI;
 
+// REUSE_BROWSER=true (see tests/lite/parity/parity-fixtures.ts) makes every scene
+// parity spec in a worker share ONE reused page/window instead of opening a fresh
+// browser window per test. In headed local runs this keeps a single window in the
+// background rather than popping hundreds of windows to the foreground.
+
 // Tests run their OWN isolated Vite dev server on a dedicated port — NOT the
 // interactive lab (5174). Sharing that server made the lab unresponsive during
 // test runs (its single Node event loop was busy transforming/serving scene

--- a/tests/lite/parity/parity-fixtures.ts
+++ b/tests/lite/parity/parity-fixtures.ts
@@ -1,0 +1,44 @@
+/**
+ * Parity test fixtures.
+ *
+ * By default this simply re-exports Playwright's `test`/`expect`, so behaviour is
+ * identical to importing straight from `@playwright/test`.
+ *
+ * When `REUSE_BROWSER` is set (`REUSE_BROWSER=true` / `1`), the built-in
+ * per-test `page` fixture is replaced with a single **worker-scoped** page that
+ * is created once and reused by every scene spec that worker runs. In headed
+ * mode this means one browser window per worker is opened once, sinks to the
+ * background, and stays there for the whole run — instead of a fresh window
+ * popping to the foreground (and closing) for each of the ~200 scene specs.
+ *
+ * The reused page is re-navigated by each test's `page.goto(...)`, which resets
+ * the document, so per-test isolation of scene state is preserved. Only the
+ * OS-level window/context is shared. `captureGolden` (compare-core) honours the
+ * same flag and reuses the worker context/page instead of opening its own.
+ */
+import { test as base, expect, type Page } from "@playwright/test";
+
+export const REUSE_BROWSER = process.env.REUSE_BROWSER === "true" || process.env.REUSE_BROWSER === "1";
+
+type ReuseWorkerFixtures = { reusedPage: Page };
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+const reuseTest = base.extend<{}, ReuseWorkerFixtures>({
+    // One page (and therefore one context + one window) per worker, reused across tests.
+    reusedPage: [
+        async ({ browser }, use) => {
+            const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+            const page = await context.newPage();
+            await use(page);
+            await context.close();
+        },
+        { scope: "worker" },
+    ],
+    // Override the built-in test-scoped `page` to hand back the shared worker page.
+    page: async ({ reusedPage }, use) => {
+        await use(reusedPage);
+    },
+});
+
+export const test = REUSE_BROWSER ? reuseTest : base;
+export { expect };

--- a/tests/lite/parity/scenes/scene1-boombox.spec.ts
+++ b/tests/lite/parity/scenes/scene1-boombox.spec.ts
@@ -8,7 +8,7 @@
  * - BoomBox region: MAD ≤ 0.1, ≥99% of pixels within 1 byte
  * - Full image: MAD ≤ 0.5
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene10-pbr-rough.spec.ts
+++ b/tests/lite/parity/scenes/scene10-pbr-rough.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ 1
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene100-physics-collision.spec.ts
+++ b/tests/lite/parity/scenes/scene100-physics-collision.spec.ts
@@ -10,7 +10,7 @@
  *
  * BJS reference: playground #Z8HTUN#1 (+ collision event)
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene101-physics-trigger.spec.ts
+++ b/tests/lite/parity/scenes/scene101-physics-trigger.spec.ts
@@ -11,7 +11,7 @@
  * remain a live DATA comparison: the BJS reference page is launched each run to confirm that
  * BOTH TRIGGER_ENTERED and TRIGGER_EXITED fired by the capture frame, matching Lite.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";

--- a/tests/lite/parity/scenes/scene102-physics-raycast.spec.ts
+++ b/tests/lite/parity/scenes/scene102-physics-raycast.spec.ts
@@ -10,7 +10,7 @@
  * remain a live DATA comparison: the BJS reference page is launched each run and its raycast
  * result is asserted equal to Lite's.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser, Page } from "@playwright/test";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";

--- a/tests/lite/parity/scenes/scene103-thin-instance-raycast.spec.ts
+++ b/tests/lite/parity/scenes/scene103-thin-instance-raycast.spec.ts
@@ -10,7 +10,7 @@
  * indices remain a live DATA comparison: the BJS reference page is launched each run and every ray's
  * `hasHit` + hit instance index is asserted IDENTICAL to Lite's.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser, Page } from "@playwright/test";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";

--- a/tests/lite/parity/scenes/scene104-character-controller.spec.ts
+++ b/tests/lite/parity/scenes/scene104-character-controller.spec.ts
@@ -20,7 +20,7 @@
  * run; the rendered frame is compared against a committed VISUAL golden (`babylon-ref-golden.png`)
  * captured at the pre-contact frame.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Page } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene105-moving-platform.spec.ts
+++ b/tests/lite/parity/scenes/scene105-moving-platform.spec.ts
@@ -24,7 +24,7 @@
  * run; the rendered frame is compared against a committed VISUAL golden (`babylon-ref-golden.png`)
  * captured at the pre-contact frame.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Page } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene106-prestep-motion-types.spec.ts
+++ b/tests/lite/parity/scenes/scene106-prestep-motion-types.spec.ts
@@ -13,7 +13,7 @@
  *
  * The playground's DynamicTexture text labels are intentionally omitted.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Page } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene11-shark.spec.ts
+++ b/tests/lite/parity/scenes/scene11-shark.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ 1
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene110-rtt-override.spec.ts
+++ b/tests/lite/parity/scenes/scene110-rtt-override.spec.ts
@@ -7,7 +7,7 @@
  *
  * Scene id 110 — moved from id 52.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene111-light-selection.spec.ts
+++ b/tests/lite/parity/scenes/scene111-light-selection.spec.ts
@@ -4,7 +4,7 @@
  * Exercises the scene-wide lights UBO and mesh-level light selection across
  * StandardMaterial, PBRMaterial, NodeMaterial, and mixed ESM/PCF shadows.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene112-khr-texture-basisu.spec.ts
+++ b/tests/lite/parity/scenes/scene112-khr-texture-basisu.spec.ts
@@ -4,7 +4,7 @@
  * Loads the FlightHelmetKTX glTF asset from BabylonJS/Assets and validates
  * KHR_texture_basisu plus frame-graph transmission against Babylon.js.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene113-picking-precision.spec.ts
+++ b/tests/lite/parity/scenes/scene113-picking-precision.spec.ts
@@ -4,7 +4,7 @@
  * The scene performs one detailed pick on a sphere and uses the picked point and
  * normal to place visible surface/normal markers.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Page } from "@playwright/test";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";

--- a/tests/lite/parity/scenes/scene114-morph-skeleton-picking.spec.ts
+++ b/tests/lite/parity/scenes/scene114-morph-skeleton-picking.spec.ts
@@ -5,7 +5,7 @@
  * on morphed and skinned geometry, so the golden validates deformation-aware
  * hit selection plus face/barycentric details.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene115-alien-picking-frame100.spec.ts
+++ b/tests/lite/parity/scenes/scene115-alien-picking-frame100.spec.ts
@@ -5,7 +5,7 @@
  * frame 100 (seekTime = 100 / 60), perform the same precise pick at the same
  * CSS canvas coordinate, and move visible markers from the real pick data.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser, Page } from "@playwright/test";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";

--- a/tests/lite/parity/scenes/scene116-shadow-depth-materials.spec.ts
+++ b/tests/lite/parity/scenes/scene116-shadow-depth-materials.spec.ts
@@ -4,7 +4,7 @@
  * Exercises Standard/PBR material views rendered into depth RTTs, then sampled
  * through Standard emissive textures on preview planes.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene12-shader-balls.spec.ts
+++ b/tests/lite/parity/scenes/scene12-shader-balls.spec.ts
@@ -9,7 +9,7 @@
  * Assertions:
  * - Full image MAD ≤ 0.1
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene120-gaussian-splatting.spec.ts
+++ b/tests/lite/parity/scenes/scene120-gaussian-splatting.spec.ts
@@ -10,7 +10,7 @@
  * sort lands, so the screenshot is taken once the splat cloud is
  * settled.  Asserts full-image MAD ≤ `sceneConfig.maxMad`.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene121-gs-update-data.spec.ts
+++ b/tests/lite/parity/scenes/scene121-gs-update-data.spec.ts
@@ -5,7 +5,7 @@
  * 30 000 splats down on Y, calls updateData(), and compares the render
  * against a Babylon.js reference captured from babylon-ref-scene121.html.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene122-gs-sog.spec.ts
+++ b/tests/lite/parity/scenes/scene122-gs-sog.spec.ts
@@ -10,7 +10,7 @@
  * lands so the screenshot captures a settled image. Asserts full-image
  * MAD ≤ `sceneConfig.maxMad`.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene123-gs-spz.spec.ts
+++ b/tests/lite/parity/scenes/scene123-gs-spz.spec.ts
@@ -8,7 +8,7 @@
  * Both engines render with view-dependent SH shading. Asserts full-
  * image MAD ≤ `sceneConfig.maxMad`.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene124-gs-compressed-ply.spec.ts
+++ b/tests/lite/parity/scenes/scene124-gs-compressed-ply.spec.ts
@@ -8,7 +8,7 @@
  *
  * Asserts full-image MAD ≤ `sceneConfig.maxMad`.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene125-gs-bake-transform.spec.ts
+++ b/tests/lite/parity/scenes/scene125-gs-bake-transform.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene126-gs-material-plugin.spec.ts
+++ b/tests/lite/parity/scenes/scene126-gs-material-plugin.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene127-gs-depth-rendering.spec.ts
+++ b/tests/lite/parity/scenes/scene127-gs-depth-rendering.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene128-gs-depth-rendering-alpha.spec.ts
+++ b/tests/lite/parity/scenes/scene128-gs-depth-rendering-alpha.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene129-gs-gpu-picking.spec.ts
+++ b/tests/lite/parity/scenes/scene129-gs-gpu-picking.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene13-pbr-spheres.spec.ts
+++ b/tests/lite/parity/scenes/scene13-pbr-spheres.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ 1
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene14-flight-helmet.spec.ts
+++ b/tests/lite/parity/scenes/scene14-flight-helmet.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ 1
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene140-nme-pcf-alpha-discard-shadows.spec.ts
+++ b/tests/lite/parity/scenes/scene140-nme-pcf-alpha-discard-shadows.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 140 — Scene 66 NME variant with final-alpha discard on shadow casters.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { PNG } from "pngjs";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";

--- a/tests/lite/parity/scenes/scene141-esm-material-casters.spec.ts
+++ b/tests/lite/parity/scenes/scene141-esm-material-casters.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene142-black-and-white-post-process.spec.ts
+++ b/tests/lite/parity/scenes/scene142-black-and-white-post-process.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene143-pipelined-post-processes.spec.ts
+++ b/tests/lite/parity/scenes/scene143-pipelined-post-processes.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene144-bloom-post-process.spec.ts
+++ b/tests/lite/parity/scenes/scene144-bloom-post-process.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene145-geometry-renderer.spec.ts
+++ b/tests/lite/parity/scenes/scene145-geometry-renderer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene146-pbr-geometry-renderer.spec.ts
+++ b/tests/lite/parity/scenes/scene146-pbr-geometry-renderer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene147-circle-of-confusion.spec.ts
+++ b/tests/lite/parity/scenes/scene147-circle-of-confusion.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene148-depth-of-field.spec.ts
+++ b/tests/lite/parity/scenes/scene148-depth-of-field.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene149-node-geometry-renderer.spec.ts
+++ b/tests/lite/parity/scenes/scene149-node-geometry-renderer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene15-spotlights.spec.ts
+++ b/tests/lite/parity/scenes/scene15-spotlights.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ 1 (near pixel-perfect)
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene150-manual-x-slide.spec.ts
+++ b/tests/lite/parity/scenes/scene150-manual-x-slide.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene151-manual-transform.spec.ts
+++ b/tests/lite/parity/scenes/scene151-manual-transform.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene152-gltf-manager.spec.ts
+++ b/tests/lite/parity/scenes/scene152-gltf-manager.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene153-autonomous-manager.spec.ts
+++ b/tests/lite/parity/scenes/scene153-autonomous-manager.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene154-step-time-animation.spec.ts
+++ b/tests/lite/parity/scenes/scene154-step-time-animation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene155-manual-weighted-blend.spec.ts
+++ b/tests/lite/parity/scenes/scene155-manual-weighted-blend.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene156-manual-cross-fade.spec.ts
+++ b/tests/lite/parity/scenes/scene156-manual-cross-fade.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene157-gltf-weighted-blend.spec.ts
+++ b/tests/lite/parity/scenes/scene157-gltf-weighted-blend.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene158-additive-animation-blend.spec.ts
+++ b/tests/lite/parity/scenes/scene158-additive-animation-blend.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene159-shader-material-basic.spec.ts
+++ b/tests/lite/parity/scenes/scene159-shader-material-basic.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene16-culling.spec.ts
+++ b/tests/lite/parity/scenes/scene16-culling.spec.ts
@@ -14,7 +14,7 @@
  * - Full image MAD ≤ scene16 maxMad
  * - ≥95% exact match
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene16-thin-instances.spec.ts
+++ b/tests/lite/parity/scenes/scene16-thin-instances.spec.ts
@@ -8,7 +8,7 @@
  * - Full image MAD ≤ 1
  * - ≥95% exact match
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene160-shader-material-texture.spec.ts
+++ b/tests/lite/parity/scenes/scene160-shader-material-texture.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene161-shader-material-uniform.spec.ts
+++ b/tests/lite/parity/scenes/scene161-shader-material-uniform.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene162-shader-material-defines.spec.ts
+++ b/tests/lite/parity/scenes/scene162-shader-material-defines.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene163-shader-material-alpha.spec.ts
+++ b/tests/lite/parity/scenes/scene163-shader-material-alpha.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene164-device-lost-recovery.spec.ts
+++ b/tests/lite/parity/scenes/scene164-device-lost-recovery.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene165-shader-material-thin-instances.spec.ts
+++ b/tests/lite/parity/scenes/scene165-shader-material-thin-instances.spec.ts
@@ -14,7 +14,7 @@
  * Test 2 — GPU culling: /scene165.html?culling vs the SAME golden (culling only
  *   removes off-screen instances, so the visible image must be identical).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene17-pbr-std-thin-instances.spec.ts
+++ b/tests/lite/parity/scenes/scene17-pbr-std-thin-instances.spec.ts
@@ -4,7 +4,7 @@
  * Mixed PBR and Standard materials with thin instances and per-instance color.
  * Compares against the golden reference image.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene170-navigation-basic.spec.ts
+++ b/tests/lite/parity/scenes/scene170-navigation-basic.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 170 - Navigation Basic Parity Test
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene171-navigation-crowd-path.spec.ts
+++ b/tests/lite/parity/scenes/scene171-navigation-crowd-path.spec.ts
@@ -6,7 +6,7 @@
  * stays at frame-1 positions. Lite uses the same ?freeze=1 flag to skip
  * its own updateNavCrowd loop.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene172-navigation-obstacles.spec.ts
+++ b/tests/lite/parity/scenes/scene172-navigation-obstacles.spec.ts
@@ -6,7 +6,7 @@
  * stays at frame-1 positions. Lite uses the same ?freeze=1 flag to skip
  * its own updateNavCrowd loop.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene173-navigation-dynamic-obstacles.spec.ts
+++ b/tests/lite/parity/scenes/scene173-navigation-dynamic-obstacles.spec.ts
@@ -6,7 +6,7 @@
  * stays at frame-1 positions. Lite uses the same ?freeze=1 flag to skip
  * its own updateNavCrowd loop.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene174-navigation-offmesh.spec.ts
+++ b/tests/lite/parity/scenes/scene174-navigation-offmesh.spec.ts
@@ -6,7 +6,7 @@
  * stays at frame-1 positions. Lite uses the same ?freeze=1 flag to skip
  * its own updateNavCrowd loop.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene175-navigation-raycast.spec.ts
+++ b/tests/lite/parity/scenes/scene175-navigation-raycast.spec.ts
@@ -6,7 +6,7 @@
  * stays at frame-1 positions. Lite uses the same ?freeze=1 flag to skip
  * its own updateNavCrowd loop.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene176-mosquito-amber.spec.ts
+++ b/tests/lite/parity/scenes/scene176-mosquito-amber.spec.ts
@@ -5,7 +5,7 @@
  * against the studio.env HDR environment (IBL + blurred HDR skybox), using
  * frame-graph scene-texture transmission. Reproduces the Babylon.js sandbox view.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene177-pbr-iridescence.spec.ts
+++ b/tests/lite/parity/scenes/scene177-pbr-iridescence.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene178-gltf-iridescence-abalone.spec.ts
+++ b/tests/lite/parity/scenes/scene178-gltf-iridescence-abalone.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene179-clustered-sponza-lights.spec.ts
+++ b/tests/lite/parity/scenes/scene179-clustered-sponza-lights.spec.ts
@@ -4,7 +4,7 @@
  * Port of Babylon.js playground #CSCJO2#89: Khronos Sponza glTF with 1000
  * deterministic small-range point lights rendered through clustered lighting.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene18-spotlight-shadows.spec.ts
+++ b/tests/lite/parity/scenes/scene18-spotlight-shadows.spec.ts
@@ -8,7 +8,7 @@
  * - Full image MAD ≤ 0.03
  * - ≥99% of pixels within 5 bytes
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene19-clearcoat.spec.ts
+++ b/tests/lite/parity/scenes/scene19-clearcoat.spec.ts
@@ -8,7 +8,7 @@
  * - Full image MAD ≤ 1
  * - ≥95% exact match
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene2-sphere.spec.ts
+++ b/tests/lite/parity/scenes/scene2-sphere.spec.ts
@@ -8,7 +8,7 @@
  * - Full image MAD ≤ 1 (near pixel-perfect)
  * - ≥99% of sphere pixels are exact matches
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene20-emissive-grid.spec.ts
+++ b/tests/lite/parity/scenes/scene20-emissive-grid.spec.ts
@@ -10,7 +10,7 @@
  * - Full image MAD ≤ 0.6
  * - ≥5% exact match
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene200-high-precision-jitter-hpm-off.spec.ts
+++ b/tests/lite/parity/scenes/scene200-high-precision-jitter-hpm-off.spec.ts
@@ -6,7 +6,7 @@
  * compares against the BJS reference (also default precision). Both
  * stacks should jitter similarly at world ~5e6.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene201-high-precision-jitter-hpm-on.spec.ts
+++ b/tests/lite/parity/scenes/scene201-high-precision-jitter-hpm-on.spec.ts
@@ -7,7 +7,7 @@
  * origin behind a single flag). Both stacks should render the (~5e6, *, ~5e6)
  * world crisply.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene202-floating-origin-point-light.spec.ts
+++ b/tests/lite/parity/scenes/scene202-floating-origin-point-light.spec.ts
@@ -8,7 +8,7 @@
  * shades with an eye-relative light position — crisp specular highlights
  * with no F32 cancellation jitter.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene203-floating-origin-spot-light.spec.ts
+++ b/tests/lite/parity/scenes/scene203-floating-origin-spot-light.spec.ts
@@ -8,7 +8,7 @@
  * untouched) so the GPU shades with an eye-relative light position — a
  * crisp, stable light cone with no F32 cancellation jitter.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene204-floating-origin-thin-instances.spec.ts
+++ b/tests/lite/parity/scenes/scene204-floating-origin-thin-instances.spec.ts
@@ -8,7 +8,7 @@
  * coordinate is carried by the eye-relative `mesh.world` and instance
  * matrices stay local — crisp instanced geometry with no F32 jitter.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene205-floating-origin-facing-billboards.spec.ts
+++ b/tests/lite/parity/scenes/scene205-floating-origin-facing-billboards.spec.ts
@@ -9,7 +9,7 @@
  * eye-relative positions that match the eye-relative view-projection — crisp,
  * jitter-free cards. Exercises the sorted/transparent billboard upload path.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene206-floating-origin-cutout-billboards.spec.ts
+++ b/tests/lite/parity/scenes/scene206-floating-origin-cutout-billboards.spec.ts
@@ -9,7 +9,7 @@
  * the active camera world position into every anchor and re-uploads when the
  * camera moves — crisp, jitter-free cutout cards at large coordinates.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene207-floating-origin-directional-shadows.spec.ts
+++ b/tests/lite/parity/scenes/scene207-floating-origin-directional-shadows.spec.ts
@@ -10,7 +10,7 @@
  * position and caster AABBs) so the shadow matches the eye-relative mesh world
  * matrices used by both the caster pass and the receiver shader.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene209-floating-origin-physics.spec.ts
+++ b/tests/lite/parity/scenes/scene209-floating-origin-physics.spec.ts
@@ -8,7 +8,7 @@
  * The body settles to a deterministic resting pose, so the screenshot is
  * stable regardless of exact stepping — mirroring the scene40 settle pattern.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene21-sheen-cloth.spec.ts
+++ b/tests/lite/parity/scenes/scene21-sheen-cloth.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ maxMad from scene-config.json
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene210-xmp-metadata-cube.spec.ts
+++ b/tests/lite/parity/scenes/scene210-xmp-metadata-cube.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene211-meshopt-brainstem.spec.ts
+++ b/tests/lite/parity/scenes/scene211-meshopt-brainstem.spec.ts
@@ -5,7 +5,7 @@
  * time (via ?seekTime=0.5) so the skinned pose is identical. The meshopt-compressed
  * + quantized buffers are decoded in dynamic-imported loader features.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene212-gltf-dispersion.spec.ts
+++ b/tests/lite/parity/scenes/scene212-gltf-dispersion.spec.ts
@@ -6,7 +6,7 @@
  * chromatic refraction against the studio.env HDR environment, using
  * frame-graph scene-texture transmission.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene213-gridmaterial.spec.ts
+++ b/tests/lite/parity/scenes/scene213-gridmaterial.spec.ts
@@ -13,7 +13,7 @@
  * BJS oracle on the same machine as the Lite render keeps the comparison
  * apples-to-apples across platforms (e.g. local Windows vs CI macOS).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene214-cascaded-shadows.spec.ts
+++ b/tests/lite/parity/scenes/scene214-cascaded-shadows.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene215-cascaded-shadows-pbr.spec.ts
+++ b/tests/lite/parity/scenes/scene215-cascaded-shadows-pbr.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene216-pbr-fog.spec.ts
+++ b/tests/lite/parity/scenes/scene216-pbr-fog.spec.ts
@@ -9,7 +9,7 @@
  * Assertions:
  * - Full image MAD ≤ scene-config maxMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene217-material-plugin.spec.ts
+++ b/tests/lite/parity/scenes/scene217-material-plugin.spec.ts
@@ -6,7 +6,7 @@
  * CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR (Lite slot BC), compared against a Babylon.js
  * golden produced by an equivalent `MaterialPluginBase` plugin.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene218-vat.spec.ts
+++ b/tests/lite/parity/scenes/scene218-vat.spec.ts
@@ -9,7 +9,7 @@
  * Assertions:
  * - Full image MAD ≤ scene-config maxMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene219-vat-instanced.spec.ts
+++ b/tests/lite/parity/scenes/scene219-vat-instanced.spec.ts
@@ -11,7 +11,7 @@
  * Assertions:
  * - Full image MAD ≤ scene-config maxMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene22-pbr-shadows.spec.ts
+++ b/tests/lite/parity/scenes/scene22-pbr-shadows.spec.ts
@@ -8,7 +8,7 @@
  * - Full image MAD ≤ threshold from scene-config.json
  * - ≥99% of pixels within 5 bytes
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene221-pointer-drags.spec.ts
+++ b/tests/lite/parity/scenes/scene221-pointer-drags.spec.ts
@@ -7,7 +7,7 @@
  *    derived fields are correctly populated for both engines' pickers).
  * 3. Compares the post-drag rendered frame against the captured golden.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as fs from "fs";
 import * as path from "path";
 import type { Page } from "@playwright/test";

--- a/tests/lite/parity/scenes/scene222-composite-gizmos.spec.ts
+++ b/tests/lite/parity/scenes/scene222-composite-gizmos.spec.ts
@@ -17,7 +17,7 @@
  * are tolerated; the parity comparison still validates that BJS and Lite end
  * up in the same final pose given the same pointer events.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as fs from "fs";
 import * as path from "path";
 import type { Page } from "@playwright/test";

--- a/tests/lite/parity/scenes/scene223-camera-light-gizmos.spec.ts
+++ b/tests/lite/parity/scenes/scene223-camera-light-gizmos.spec.ts
@@ -5,7 +5,7 @@
  * over a ground plane.  No scripted interaction; we just wait for the
  * scene to settle and compare the captured frame against the BJS reference.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as fs from "fs";
 import * as path from "path";
 import { attachCompareArtifacts, compareImages, getSceneConfig } from "../compare-utils";

--- a/tests/lite/parity/scenes/scene224-bounding-box-gizmo.spec.ts
+++ b/tests/lite/parity/scenes/scene224-bounding-box-gizmo.spec.ts
@@ -21,7 +21,7 @@
  * rotation-anchor geometry — which is the part this scene is meant to
  * cover.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as fs from "fs";
 import * as path from "path";
 import type { Page } from "@playwright/test";

--- a/tests/lite/parity/scenes/scene225-geospatial-camera.spec.ts
+++ b/tests/lite/parity/scenes/scene225-geospatial-camera.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene229-triangle-without-indices.spec.ts
+++ b/tests/lite/parity/scenes/scene229-triangle-without-indices.spec.ts
@@ -4,7 +4,7 @@
  * The glTF primitive intentionally omits `indices`. Lite should synthesize an
  * identity index buffer at load time and keep the indexed GPU draw path.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig, waitForCanvasReady } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene23-anisotropy.spec.ts
+++ b/tests/lite/parity/scenes/scene23-anisotropy.spec.ts
@@ -9,7 +9,7 @@
  * Assertions:
  * - Full image MAD ≤ maxMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene24-hillvalley.spec.ts
+++ b/tests/lite/parity/scenes/scene24-hillvalley.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ maxMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene240-animated-triangle.spec.ts
+++ b/tests/lite/parity/scenes/scene240-animated-triangle.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 240 — AnimatedTriangle (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene241-animation-pointer-uvs.spec.ts
+++ b/tests/lite/parity/scenes/scene241-animation-pointer-uvs.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 241 — AnimationPointerUVs (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene242-emissive-fireflies.spec.ts
+++ b/tests/lite/parity/scenes/scene242-emissive-fireflies.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 242 — EmissiveFireflies (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene243-morph-stress-test.spec.ts
+++ b/tests/lite/parity/scenes/scene243-morph-stress-test.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 243 — MorphStressTest (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene244-pot-of-coals-animation-pointer.spec.ts
+++ b/tests/lite/parity/scenes/scene244-pot-of-coals-animation-pointer.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 244 — PotOfCoalsAnimationPointer (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene245-recursive-skeletons.spec.ts
+++ b/tests/lite/parity/scenes/scene245-recursive-skeletons.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 245 — RecursiveSkeletons (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene246-simple-skin.spec.ts
+++ b/tests/lite/parity/scenes/scene246-simple-skin.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 246 — SimpleSkin (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene247-teapots-galore.spec.ts
+++ b/tests/lite/parity/scenes/scene247-teapots-galore.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 247 — TeapotsGalore (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene248-texture-settings-test.spec.ts
+++ b/tests/lite/parity/scenes/scene248-texture-settings-test.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 248 — TextureSettingsTest (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene249-vertex-color-alpha-clip-test.spec.ts
+++ b/tests/lite/parity/scenes/scene249-vertex-color-alpha-clip-test.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 249 — VertexColorAlphaClipTest (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene25-ktx-texture.spec.ts
+++ b/tests/lite/parity/scenes/scene25-ktx-texture.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ maxMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene251-animation-mask.spec.ts
+++ b/tests/lite/parity/scenes/scene251-animation-mask.spec.ts
@@ -8,7 +8,7 @@
  * so its goToFrame poses only the retained bones), so both engines render the
  * identical masked pose, frozen at a deterministic frame.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene252-standard-material-morph.spec.ts
+++ b/tests/lite/parity/scenes/scene252-standard-material-morph.spec.ts
@@ -7,7 +7,7 @@
  *
  * Validates that StandardMaterial honors morph targets in Lite.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene253-animate-all-the-things.spec.ts
+++ b/tests/lite/parity/scenes/scene253-animate-all-the-things.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Scene 253 — AnimateAllTheThings (cx20 gltf-test parity).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene254-signed-accessor-animation.spec.ts
+++ b/tests/lite/parity/scenes/scene254-signed-accessor-animation.spec.ts
@@ -12,7 +12,7 @@
  * - Full image MAD ≤ maxMad
  * - Rotated cube region MAD ≤ maxRegionMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene255-skin-weights-byte.spec.ts
+++ b/tests/lite/parity/scenes/scene255-skin-weights-byte.spec.ts
@@ -12,7 +12,7 @@
  * - Full image MAD ≤ maxMad
  * - Deformed-plane region MAD ≤ maxRegionMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene257-negative-node-scale.spec.ts
+++ b/tests/lite/parity/scenes/scene257-negative-node-scale.spec.ts
@@ -14,7 +14,7 @@
  * - Full image MAD ≤ maxMad
  * - Foreground region MAD ≤ maxRegionMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene258-interleaved-uv.spec.ts
+++ b/tests/lite/parity/scenes/scene258-interleaved-uv.spec.ts
@@ -14,7 +14,7 @@
  * - Full image MAD ≤ maxMad
  * - Plane region MAD ≤ maxRegionMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene259-material-emissive.spec.ts
+++ b/tests/lite/parity/scenes/scene259-material-emissive.spec.ts
@@ -14,7 +14,7 @@
  * - Full image MAD ≤ maxMad
  * - Plane region MAD ≤ maxRegionMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene26-pbr-subsurface.spec.ts
+++ b/tests/lite/parity/scenes/scene26-pbr-subsurface.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ maxMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene260-triangle-strip.spec.ts
+++ b/tests/lite/parity/scenes/scene260-triangle-strip.spec.ts
@@ -15,7 +15,7 @@
  * - Full image MAD ≤ maxMad
  * - Strip region MAD ≤ maxRegionMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene261-temporal-anti-aliasing.spec.ts
+++ b/tests/lite/parity/scenes/scene261-temporal-anti-aliasing.spec.ts
@@ -4,7 +4,7 @@
 // `createTaaPostProcessTask` → swapchain), lets the temporal accumulation converge over
 // many frames, then freezes and screenshots. Asserts the converged Lite output matches
 // the Babylon.js `TAARenderingPipeline` golden within the scene's full-image MAD ceiling.
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene262-npe-size.spec.ts
+++ b/tests/lite/parity/scenes/scene262-npe-size.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene263-npe-sphere.spec.ts
+++ b/tests/lite/parity/scenes/scene263-npe-sphere.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene27-material-variants.spec.ts
+++ b/tests/lite/parity/scenes/scene27-material-variants.spec.ts
@@ -7,7 +7,7 @@
  * Assertions:
  * - Full image MAD ≤ maxMad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene28-clearcoat-gltf.spec.ts
+++ b/tests/lite/parity/scenes/scene28-clearcoat-gltf.spec.ts
@@ -5,7 +5,7 @@
  * default environment (IBL only, no skybox / no ground). Matches
  * Babylon playground #YG3BBF#33.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene29-sheen-cloth-gltf.spec.ts
+++ b/tests/lite/parity/scenes/scene29-sheen-cloth-gltf.spec.ts
@@ -5,7 +5,7 @@
  * default environment (IBL only, no skybox / no ground). Matches Babylon
  * playground #YG3BBF#2.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene3-fog.spec.ts
+++ b/tests/lite/parity/scenes/scene3-fog.spec.ts
@@ -12,7 +12,7 @@
  * - Full image MAD ≤ 1 (pixel-perfect)
  * - ≥99% exact match
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene30-volume-testing.spec.ts
+++ b/tests/lite/parity/scenes/scene30-volume-testing.spec.ts
@@ -5,7 +5,7 @@
  * Matches Babylon playground #YG3BBF#16 using frame-graph scene-texture
  * transmission for KHR_materials_transmission.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene31-emissive-strength.spec.ts
+++ b/tests/lite/parity/scenes/scene31-emissive-strength.spec.ts
@@ -5,7 +5,7 @@
  * factors) against the default IBL environment (no skybox / no ground).
  * Matches Babylon playground #YG3BBF#52.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene32-unlit.spec.ts
+++ b/tests/lite/parity/scenes/scene32-unlit.spec.ts
@@ -4,7 +4,7 @@
  * UnlitTest.glb (KHR_materials_unlit) with default environment (IBL only,
  * no skybox / no ground). Matches Babylon playground #YG3BBF#53.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene33-lights-punctual.spec.ts
+++ b/tests/lite/parity/scenes/scene33-lights-punctual.spec.ts
@@ -10,7 +10,7 @@
  * residual screen-space-approximation noise. Scene 30 covers the dedicated
  * transmission + volume + IOR setup.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene34-node-visibility.spec.ts
+++ b/tests/lite/parity/scenes/scene34-node-visibility.spec.ts
@@ -9,7 +9,7 @@
  * Deterministic capture: seekTime=0 freezes every animation group at
  * frame 0 so both BJS and Lite render an identical visibility state.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene35-gltf-instancing.spec.ts
+++ b/tests/lite/parity/scenes/scene35-gltf-instancing.spec.ts
@@ -6,7 +6,7 @@
  * single node. Rendered against the default IBL environment (no skybox,
  * no ground). Matches Babylon playground #YG3BBF#57.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene36-basis-texture.spec.ts
+++ b/tests/lite/parity/scenes/scene36-basis-texture.spec.ts
@@ -6,7 +6,7 @@
  * format depends on GPU features, so pixel-level parity is marked skipParity
  * in scene-config.json until goldens are generated per-target.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene37-sheen-sofa.spec.ts
+++ b/tests/lite/parity/scenes/scene37-sheen-sofa.spec.ts
@@ -6,7 +6,7 @@
  * IBL environment (no skybox, no ground). Matches Babylon playground
  * #YG3BBF#58.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene38-procedural-builders.spec.ts
+++ b/tests/lite/parity/scenes/scene38-procedural-builders.spec.ts
@@ -5,7 +5,7 @@
  * extruded shape using the new Lite builders and compares against the
  * equivalent BJS MeshBuilder reference.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene39-animation-pointer-waterfall.spec.ts
+++ b/tests/lite/parity/scenes/scene39-animation-pointer-waterfall.spec.ts
@@ -14,7 +14,7 @@
  * Deterministic capture: seekTime freezes every animation group at frame
  * seekTime*60 so both BJS and Lite render an identical animated pose.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene4-shadows.spec.ts
+++ b/tests/lite/parity/scenes/scene4-shadows.spec.ts
@@ -9,7 +9,7 @@
  * - Full image MAD ≤ 0.03
  * - ≥99% of pixels within 5 bytes
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene40-physics.spec.ts
+++ b/tests/lite/parity/scenes/scene40-physics.spec.ts
@@ -6,7 +6,7 @@
  *
  * BJS reference: playground #Z8HTUN#1
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene41-physics-shapes.spec.ts
+++ b/tests/lite/parity/scenes/scene41-physics-shapes.spec.ts
@@ -4,7 +4,7 @@
  * Captures Babylon.js and Babylon Lite after a short deterministic fixed-step
  * simulation and compares the PhysicsViewer wireframe overlay.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene42-physics-clone.spec.ts
+++ b/tests/lite/parity/scenes/scene42-physics-clone.spec.ts
@@ -3,7 +3,7 @@
  *
  * Captures Babylon.js and Babylon Lite at fixed physics frame 300.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene43-parametric-proximity.spec.ts
+++ b/tests/lite/parity/scenes/scene43-parametric-proximity.spec.ts
@@ -3,7 +3,7 @@
  *
  * Captures Babylon.js and Babylon Lite at fixed animation frame 300.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene44-physics-sleeping-towers.spec.ts
+++ b/tests/lite/parity/scenes/scene44-physics-sleeping-towers.spec.ts
@@ -3,7 +3,7 @@
  *
  * Drops small boxes after 2 seconds and captures Babylon.js / Babylon Lite at 5 seconds.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene45-physics-filtering.spec.ts
+++ b/tests/lite/parity/scenes/scene45-physics-filtering.spec.ts
@@ -3,7 +3,7 @@
  *
  * Captures Babylon.js and Babylon Lite after 3 seconds.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene46-constraint-viewer.spec.ts
+++ b/tests/lite/parity/scenes/scene46-constraint-viewer.spec.ts
@@ -3,7 +3,7 @@
  *
  * Captures Babylon.js and Babylon Lite at fixed physics frame 10.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene47-physics-heightfield.spec.ts
+++ b/tests/lite/parity/scenes/scene47-physics-heightfield.spec.ts
@@ -5,7 +5,7 @@
  * simulation in which two rows of shapes fall onto a heightfield derived from
  * heightMap.png, then compares the settled frame.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene48-physics-center-of-mass.spec.ts
+++ b/tests/lite/parity/scenes/scene48-physics-center-of-mass.spec.ts
@@ -6,7 +6,7 @@
  * physics steps after the kick. The scene self-determines the capture frame,
  * so the spec just waits on the `captureReady` flag (no fixed ?captureFrame).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene49-physics-shape-queries.spec.ts
+++ b/tests/lite/parity/scenes/scene49-physics-shape-queries.spec.ts
@@ -7,7 +7,7 @@
  * The static scene self-determines its capture frame (once the broadphase exists and
  * both queries report hits), so the spec just waits on the `captureReady` flag.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";

--- a/tests/lite/parity/scenes/scene5-alien.spec.ts
+++ b/tests/lite/parity/scenes/scene5-alien.spec.ts
@@ -4,7 +4,7 @@
  * Both the golden reference and Babylon Lite seek to exactly 0.5 s of
  * animation time (via ?seekTime=0.5) so the skeleton pose is identical.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene50-sprite-grid.spec.ts
+++ b/tests/lite/parity/scenes/scene50-sprite-grid.spec.ts
@@ -6,7 +6,7 @@
  * Golden is captured automatically from the BJS reference page on first run
  * (or when RECAPTURE_GOLDEN=1 is set).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene51-sprite-grid.spec.ts
+++ b/tests/lite/parity/scenes/scene51-sprite-grid.spec.ts
@@ -11,7 +11,7 @@
  * Golden is captured automatically from the BJS reference page on first
  * run (or when `RECAPTURE_GOLDEN=1` is set).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene52-hud-on-3d.spec.ts
+++ b/tests/lite/parity/scenes/scene52-hud-on-3d.spec.ts
@@ -5,7 +5,7 @@
  * reference scene that renders the same StandardMaterial sphere and the same
  * pixel-space sprite HUD through BJS SpriteRenderer.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene53-depth-hosted-sprites.spec.ts
+++ b/tests/lite/parity/scenes/scene53-depth-hosted-sprites.spec.ts
@@ -5,7 +5,7 @@
  * SpriteManager reference with world-space sprite positions derived from the
  * same projected pixel centers and NDC depths.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene54-facing-billboards.spec.ts
+++ b/tests/lite/parity/scenes/scene54-facing-billboards.spec.ts
@@ -5,7 +5,7 @@
  * against Babylon.js SpriteManager using the same atlas, world positions,
  * sizes, colors, rotations, and depth-tested transparent composition.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene55-billboard-sorting.spec.ts
+++ b/tests/lite/parity/scenes/scene55-billboard-sorting.spec.ts
@@ -4,7 +4,7 @@
  * Compares Babylon Lite's CPU-sorted transparent billboard upload against a
  * Babylon.js SpriteManager reference whose sprite array is already far-to-near.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene56-axis-locked-billboards.spec.ts
+++ b/tests/lite/parity/scenes/scene56-axis-locked-billboards.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene57-cutout-billboards.spec.ts
+++ b/tests/lite/parity/scenes/scene57-cutout-billboards.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene58-sprite-animation.spec.ts
+++ b/tests/lite/parity/scenes/scene58-sprite-animation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene59-billboard-animation.spec.ts
+++ b/tests/lite/parity/scenes/scene59-billboard-animation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene6-pbr-sphere.spec.ts
+++ b/tests/lite/parity/scenes/scene6-pbr-sphere.spec.ts
@@ -8,7 +8,7 @@
  * - Full image MAD ≤ 5
  * - ≥80% of pixels within 5 of reference
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene60-nme-flat.spec.ts
+++ b/tests/lite/parity/scenes/scene60-nme-flat.spec.ts
@@ -4,7 +4,7 @@
  * Both BJS and Lite parse the SAME inline NME JSON. A sphere rendered with
  * Color4(0.85, 0.2, 0.2, 1) on a black background.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene61-nme-normal.spec.ts
+++ b/tests/lite/parity/scenes/scene61-nme-normal.spec.ts
@@ -4,7 +4,7 @@
  * Both BJS and Lite parse the SAME inline NME JSON. A sphere where the
  * fragment colour is `normal * 0.5 + 0.5` on a black background.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene62-nme-texture.spec.ts
+++ b/tests/lite/parity/scenes/scene62-nme-texture.spec.ts
@@ -4,7 +4,7 @@
  * Both BJS and Lite parse the SAME inline NME JSON and inject the SAME
  * crate image URL. A sphere textured with `crate.png` on a black background.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene63-nme-light.spec.ts
+++ b/tests/lite/parity/scenes/scene63-nme-light.spec.ts
@@ -4,7 +4,7 @@
  * Both BJS and Lite parse the SAME inline NME JSON and add one DirectionalLight
  * with identical direction. Sphere is lit via LightBlock.diffuseOutput on black.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene64-nme-morph.spec.ts
+++ b/tests/lite/parity/scenes/scene64-nme-morph.spec.ts
@@ -5,7 +5,7 @@
  * shifts every vertex of a sphere upward along +Y at weight=1.0. Rendered
  * with flat colour so parity depends only on the morphed silhouette.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene65-nme-shadow.spec.ts
+++ b/tests/lite/parity/scenes/scene65-nme-shadow.spec.ts
@@ -6,7 +6,7 @@
  * BJS uses a classic ShadowGenerator on the DirectionalLight — the LightBlock
  * in the NME graph auto-applies the shadow factor in both engines.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene66-nme-big.spec.ts
+++ b/tests/lite/parity/scenes/scene66-nme-big.spec.ts
@@ -10,7 +10,7 @@
  * Morph scramble deltas come from a shared deterministic mulberry32 seed
  * and weight is pinned via `?freeze=1` for capture reproducibility.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene67-nme-pbr-core.spec.ts
+++ b/tests/lite/parity/scenes/scene67-nme-pbr-core.spec.ts
@@ -5,7 +5,7 @@
  * uses ReflectionBlock/IBL plus direct lights on a saturated matte base.
  * This is the foundation scene for the scene67-72 PBR-NME phase.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene68-nme-pbr-clearcoat.spec.ts
+++ b/tests/lite/parity/scenes/scene68-nme-pbr-clearcoat.spec.ts
@@ -4,7 +4,7 @@
  * Same NME JSON parsed by both BJS and Lite. Adds a glossy ClearCoatBlock
  * on a dark navy base with intensity=1.0, roughness=0.02, IOR=1.5.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene69-nme-pbr-sheen.spec.ts
+++ b/tests/lite/parity/scenes/scene69-nme-pbr-sheen.spec.ts
@@ -4,7 +4,7 @@
  * Same NME JSON parsed by both BJS and Lite. Adds a hot magenta SheenBlock
  * on a dark purple base while keeping softened clearcoat connected.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene7-chibirex.spec.ts
+++ b/tests/lite/parity/scenes/scene7-chibirex.spec.ts
@@ -6,7 +6,7 @@
  *
  * Thresholds: MAD ≤ 1.0 (current ~0.63), ≥99% of pixels within 5 bytes.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene70-nme-pbr-aniso.spec.ts
+++ b/tests/lite/parity/scenes/scene70-nme-pbr-aniso.spec.ts
@@ -4,7 +4,7 @@
  * Same NME JSON parsed by both BJS and Lite. Uses non-zero AnisotropyBlock
  * intensity on a metallic sphere so the stretched highlight is visible.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene71-nme-pbr-subsurface.spec.ts
+++ b/tests/lite/parity/scenes/scene71-nme-pbr-subsurface.spec.ts
@@ -4,7 +4,7 @@
  * Same NME JSON parsed by both BJS and Lite. Adds SubSurfaceBlock translucency
  * plus a modest RefractionBlock input with matching back-light scene setup.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene72-nme-pbr-full.spec.ts
+++ b/tests/lite/parity/scenes/scene72-nme-pbr-full.spec.ts
@@ -7,7 +7,7 @@
  *
  * This is the full visual parity coverage scene for the PBR-MR NME stack.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene73-wheel-nme-viewport.spec.ts
+++ b/tests/lite/parity/scenes/scene73-wheel-nme-viewport.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene74-effect-renderer.spec.ts
+++ b/tests/lite/parity/scenes/scene74-effect-renderer.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene75-effect-rtt-sphere.spec.ts
+++ b/tests/lite/parity/scenes/scene75-effect-rtt-sphere.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene76-effect-texture.spec.ts
+++ b/tests/lite/parity/scenes/scene76-effect-texture.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene77-nme-compat.spec.ts
+++ b/tests/lite/parity/scenes/scene77-nme-compat.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene78-nme-math.spec.ts
+++ b/tests/lite/parity/scenes/scene78-nme-math.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene79-nme-modes.spec.ts
+++ b/tests/lite/parity/scenes/scene79-nme-modes.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene8-glass-sphere.spec.ts
+++ b/tests/lite/parity/scenes/scene8-glass-sphere.spec.ts
@@ -7,7 +7,7 @@
  * Scene features: HDR environment (room.hdr), PBR glass sphere with
  * alpha=0.5, roughness=0, custom exposure/contrast.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene80-nme-color.spec.ts
+++ b/tests/lite/parity/scenes/scene80-nme-color.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene81-nme-uv-projection.spec.ts
+++ b/tests/lite/parity/scenes/scene81-nme-uv-projection.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene82-nme-noise.spec.ts
+++ b/tests/lite/parity/scenes/scene82-nme-noise.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene83-nme-normals.spec.ts
+++ b/tests/lite/parity/scenes/scene83-nme-normals.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene84-nme-fragment-screen.spec.ts
+++ b/tests/lite/parity/scenes/scene84-nme-fragment-screen.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene85-nme-matrix.spec.ts
+++ b/tests/lite/parity/scenes/scene85-nme-matrix.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene86-nme-scene-state.spec.ts
+++ b/tests/lite/parity/scenes/scene86-nme-scene-state.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene87-nme-iridescence-image.spec.ts
+++ b/tests/lite/parity/scenes/scene87-nme-iridescence-image.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene88-nme-loop.spec.ts
+++ b/tests/lite/parity/scenes/scene88-nme-loop.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene89-nme-storage.spec.ts
+++ b/tests/lite/parity/scenes/scene89-nme-storage.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene9-sponza.spec.ts
+++ b/tests/lite/parity/scenes/scene9-sponza.spec.ts
@@ -8,7 +8,7 @@
  * Assertions:
  * - Full image MAD ≤ 1
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene90-csg.spec.ts
+++ b/tests/lite/parity/scenes/scene90-csg.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene91-csg2.spec.ts
+++ b/tests/lite/parity/scenes/scene91-csg2.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene92-sprite-customshader-params.spec.ts
+++ b/tests/lite/parity/scenes/scene92-sprite-customshader-params.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene93-sprite-customshader-palette.spec.ts
+++ b/tests/lite/parity/scenes/scene93-sprite-customshader-palette.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene94-billboard-customshader-params.spec.ts
+++ b/tests/lite/parity/scenes/scene94-billboard-customshader-params.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene95-billboard-customshader-palette.spec.ts
+++ b/tests/lite/parity/scenes/scene95-billboard-customshader-palette.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene96-sprite-uvoffset-parallax.spec.ts
+++ b/tests/lite/parity/scenes/scene96-sprite-uvoffset-parallax.spec.ts
@@ -9,7 +9,7 @@
  * Golden is captured automatically from the BJS reference page on first run
  * (or when RECAPTURE_GOLDEN=1 is set).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene97-sprite-multiply-blend.spec.ts
+++ b/tests/lite/parity/scenes/scene97-sprite-multiply-blend.spec.ts
@@ -9,7 +9,7 @@
  * Golden is captured automatically from the BJS reference page on first run
  * (or when RECAPTURE_GOLDEN=1 is set).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene98-billboard-additive-blend.spec.ts
+++ b/tests/lite/parity/scenes/scene98-billboard-additive-blend.spec.ts
@@ -9,7 +9,7 @@
  * Golden is captured automatically from the BJS reference page on first run
  * (or when RECAPTURE_GOLDEN=1 is set).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene99-bone-control.spec.ts
+++ b/tests/lite/parity/scenes/scene99-bone-control.spec.ts
@@ -9,7 +9,7 @@
  * degenerate and disappear. Validates the opt-in bone-control eager-bake pipeline
  * (skin extraction → hierarchy world matrices → bone texture → skinning) against BJS.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, compareRegion, getSceneConfig } from "../compare-utils";
 

--- a/tests/shared/compare-core.ts
+++ b/tests/shared/compare-core.ts
@@ -312,10 +312,14 @@ export async function captureGolden(browser: Browser, opts: CaptureGoldenOptions
     // When REUSE_BROWSER is set, reuse the worker's existing context/page (kept
     // alive by the parity fixtures) instead of opening a new window. The test
     // re-navigates the same page to the lite scene afterwards, so sharing it is
-    // safe. Otherwise open a fresh, isolated context as before.
-    const reuse = process.env.REUSE_BROWSER === "true" || process.env.REUSE_BROWSER === "1";
-    const context = reuse ? (browser.contexts()[0] ?? (await browser.newContext({ viewport: { width: 1280, height: 720 } }))) : await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = reuse ? (context.pages()[0] ?? (await context.newPage())) : await context.newPage();
+    // safe. Only reuse when a worker-owned context+page actually exist; otherwise
+    // fall back to a fresh, isolated context we own (and tear down) as before.
+    const wantReuse = process.env.REUSE_BROWSER === "true" || process.env.REUSE_BROWSER === "1";
+    const existingContext = wantReuse ? browser.contexts()[0] : undefined;
+    const existingPage = existingContext?.pages()[0];
+    const reuse = !!existingContext && !!existingPage;
+    const context = existingContext ?? (await browser.newContext({ viewport: { width: 1280, height: 720 } }));
+    const bjsPage = existingPage ?? (await context.newPage());
     const urlParams = opts.seekTime !== undefined ? `?seekTime=${opts.seekTime}${opts.queryParams ? `&${opts.queryParams}` : ""}` : opts.queryParams ? `?${opts.queryParams}` : "";
     await bjsPage.goto(cfg.refUrl(opts.sceneId, urlParams));
 

--- a/tests/shared/compare-core.ts
+++ b/tests/shared/compare-core.ts
@@ -309,9 +309,13 @@ export async function captureGolden(browser: Browser, opts: CaptureGoldenOptions
     const timeout = opts.timeout ?? 60_000;
     const settleMs = opts.settleMs ?? 1500;
 
-    // Open the BJS ref page in a fresh context to avoid interfering with the lite page.
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    // When REUSE_BROWSER is set, reuse the worker's existing context/page (kept
+    // alive by the parity fixtures) instead of opening a new window. The test
+    // re-navigates the same page to the lite scene afterwards, so sharing it is
+    // safe. Otherwise open a fresh, isolated context as before.
+    const reuse = process.env.REUSE_BROWSER === "true" || process.env.REUSE_BROWSER === "1";
+    const context = reuse ? (browser.contexts()[0] ?? (await browser.newContext({ viewport: { width: 1280, height: 720 } }))) : await browser.newContext({ viewport: { width: 1280, height: 720 } });
+    const bjsPage = reuse ? (context.pages()[0] ?? (await context.newPage())) : await context.newPage();
     const urlParams = opts.seekTime !== undefined ? `?seekTime=${opts.seekTime}${opts.queryParams ? `&${opts.queryParams}` : ""}` : opts.queryParams ? `?${opts.queryParams}` : "";
     await bjsPage.goto(cfg.refUrl(opts.sceneId, urlParams));
 
@@ -347,8 +351,12 @@ export async function captureGolden(browser: Browser, opts: CaptureGoldenOptions
     fs.mkdirSync(refDir, { recursive: true });
     await bjsPage.locator("canvas").screenshot({ path: goldenPath });
 
-    await bjsPage.close();
-    await context.close();
+    // Only tear down the context/page when we own it. In reuse mode the worker
+    // fixture owns the shared context and the calling test still needs the page.
+    if (!reuse) {
+        await bjsPage.close();
+        await context.close();
+    }
 
     return goldenPath;
 }


### PR DESCRIPTION
## Problem

Running the scene parity suite headed (the local default) opened a **fresh browser window per scene spec** — Playwright creates a new browser context per test, and each context is a new OS window. With `workers: 2` × ~207 scenes, that's hundreds of windows popping to the foreground and closing, stealing focus and making the machine unusable during a run. `captureGolden` compounds it by opening its own extra context when recapturing goldens.

## Solution

Add an opt-in env var **`REUSE_BROWSER=true`** that routes every scene parity spec through a **worker-scoped shared page**, so each worker opens **one** window, sinks it to the background, and reuses it for every scene it runs. Each test still does its own `page.goto(...)`, so per-scene isolation of scene state is preserved — only the OS window/context is shared.

- **`tests/lite/parity/parity-fixtures.ts`** (new) — when `REUSE_BROWSER` is set, overrides the built-in test-scoped `page` fixture with a worker-scoped page created once and reused. When unset, it simply re-exports Playwright's `test`/`expect`, so default behaviour is byte-for-byte unchanged.
- **`tests/shared/compare-core.ts`** — `captureGolden` reuses the worker context/page under the flag instead of opening its own window (and skips tearing it down since the worker fixture owns it).
- Swapped the import in all 207 scene specs from `@playwright/test` to `../parity-fixtures` (mechanical, one line each).
- Documented the knob inline in `playwright.config.ts` alongside `HEADLESS`/`SCREEN_X`.

## Usage

```bash
REUSE_BROWSER=true pnpm test:parity                                    # 2 windows (workers: 2)
REUSE_BROWSER=true npx playwright test tests/lite/parity --workers=1   # 1 window
```

Without the flag, behaviour is exactly as before (a fresh window per scene).

## Validation

- Ran 5 scenes with `REUSE_BROWSER=true --workers=1` — all passed sharing a single reused window (17.7s). The reuse shows clearly in timings: scene 1 = 7.0s (one-time window launch + dev-server warmup), subsequent scenes ~0.9s each.
- Ran a scene on the default (non-reuse) path — unchanged.
- `tsc` green for both `tests/lite` and `tests/gl` projects; eslint clean on changed files.
- Per repo guidance, the full parity suite was not required since no engine code (`packages/babylon-lite/src/**`) changed — this is test-infra only.