### PR TITLE
docs: clarify attachControl cleanup lifecycle

### DIFF
--- a/packages/babylon-lite/src/camera/arc-rotate-controls.ts
+++ b/packages/babylon-lite/src/camera/arc-rotate-controls.ts
@@ -153,7 +153,39 @@ export function setCameraLimits(camera: ArcRotateCamera, limits: ArcRotateCamera
  * self-clamps in its setters, so this loop carries no limit code.
  *
  * Camera stays plain data — this function reads/writes its properties.
- * Returns a cleanup function to remove all listeners and the beforeRender hook.
+ *
+ * ## Lifecycle / cleanup (important)
+ *
+ * The returned function detaches everything this call attached: it removes the
+ * canvas DOM listeners (pointer/wheel/touch/gesture) and, when a `scene` was
+ * supplied, its `_beforeRender` inertia hook. It is idempotent — calling it more
+ * than once is safe (the hook is removed only if still present, and removing a
+ * DOM listener twice is a no-op).
+ *
+ * The controls are **not** automatically tied to the scene's lifetime. Passing a
+ * `scene` only enables inertia (it registers the per-frame hook); it does **not**
+ * register this cleanup for scene disposal. Because the DOM listeners live on the
+ * `canvas` rather than on the scene, {@link disposeScene} clears scene-owned state
+ * (including `_beforeRender`) but does **not** remove the canvas listeners added
+ * here. The caller owns the controls' lifetime and must detach them explicitly:
+ *
+ * ```ts
+ * const detachCameraControl = attachControl(camera, canvas, scene);
+ * // Later — detach controls yourself before/after disposing the scene:
+ * detachCameraControl();
+ * disposeScene(scene);
+ * ```
+ *
+ * To tie the controls to the scene so `disposeScene(scene)` also detaches them,
+ * register the returned cleanup with {@link onSceneDispose}:
+ *
+ * ```ts
+ * onSceneDispose(scene, attachControl(camera, canvas, scene));
+ * // Now disposeScene(scene) removes the canvas listeners too.
+ * ```
+ *
+ * @returns A cleanup function that removes all canvas listeners and the
+ * `_beforeRender` inertia hook. Safe to call multiple times.
  */
 export function attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement, scene?: SceneContext, options?: AttachControlOptions): () => void {
     const angularSensibility = camera.angularSensibility ?? 1000; // Babylon default; HIGHER = slower orbit

--- a/packages/babylon-lite/src/camera/arc-rotate-controls.ts
+++ b/packages/babylon-lite/src/camera/arc-rotate-controls.ts
@@ -154,10 +154,10 @@ export function setCameraLimits(camera: ArcRotateCamera, limits: ArcRotateCamera
  *
  * Camera stays plain data — this function reads/writes its properties.
  *
- * ## Lifecycle / cleanup (important)
+ * ### Lifecycle / cleanup (important)
  *
  * The returned function detaches everything this call attached: it removes the
- * canvas DOM listeners (pointer/wheel/touch/gesture) and, when a `scene` was
+ * canvas DOM listeners (pointer/wheel/contextmenu/touch/gesture) and, when a `scene` was
  * supplied, its `_beforeRender` inertia hook. It is idempotent — calling it more
  * than once is safe (the hook is removed only if still present, and removing a
  * DOM listener twice is a no-op).


### PR DESCRIPTION
Addresses #322.

The maintainers confirmed in the issue thread that `attachControl` not tying its cleanup to `disposeScene` is the intended (current) behavior. The remaining ask from the reporter was to document the controls-disposal nuance in typedoc so consumers understand their responsibility for the controls lifecycle.

## Change

Documentation-only. Expands the JSDoc on `attachControl` with a **Lifecycle / cleanup** section that clarifies:

- The returned function detaches everything (canvas DOM listeners + the scene `_beforeRender` inertia hook) and is idempotent.
- Passing a `scene` **only enables inertia** — it does **not** register the cleanup for scene disposal.
- Because the DOM listeners live on the `canvas`, `disposeScene(scene)` does **not** remove them, so the caller owns the controls lifetime.
- Shows both usage patterns: explicit `detachCameraControl()` before `disposeScene`, and tying controls to the scene via `onSceneDispose(scene, attachControl(camera, canvas, scene))`.

No runtime/behavior changes; comments only.