### PR TITLE
feat(storage)!: add managed storage buffers

### DIFF
--- a/docs/lite/architecture/47-storage-buffer.md
+++ b/docs/lite/architecture/47-storage-buffer.md
@@ -38,7 +38,8 @@ resource liveness and engine ownership. Engine disposal destroys all remaining l
 their wrappers disposed, releases retained CPU bytes, and clears the lazy registry.
 When the first storage buffer is created, the engine also retains its current storage-related WebGPU limits
 (`maxBufferSize`, `maxStorageBufferBindingSize`, and `maxStorageBuffersPerShaderStage`) and requests them
-again during device recovery.
+again during device recovery. Those values are merged with any limits originally supplied to
+`createEngine(..., { requiredLimits })`.
 
 ## Pipeline Configuration
 

--- a/docs/lite/architecture/47-storage-buffer.md
+++ b/docs/lite/architecture/47-storage-buffer.md
@@ -1,0 +1,72 @@
+# Module: Storage Buffer
+> Package path: `packages/babylon-lite/src/resource/storage-buffer.ts`
+
+## Purpose
+
+Expose shader-readable storage allocations without exposing raw WebGPU handles in the public API. The resource has stable identity so its contents can change without rebuilding material bind groups.
+
+## Public API Surface
+
+```ts
+interface StorageBuffer {
+    readonly byteLength: number;
+}
+
+function createStorageBuffer(engine: EngineContext, data: ArrayBufferView, label?: string): StorageBuffer;
+function updateStorageBuffer(engine: EngineContext, buffer: StorageBuffer, data: ArrayBufferView, byteOffset?: number): void;
+function disposeStorageBuffer(buffer: StorageBuffer): void;
+```
+
+`setShaderStorageBuffer(material, name, buffer)` accepts `StorageBuffer | null` for a storage declaration created by `createShaderMaterial`.
+
+This replaces the previous raw `GPUBuffer` parameter. Migrate by wrapping initial data with
+`createStorageBuffer`, updating it through `updateStorageBuffer`, and unbinding it before
+`disposeStorageBuffer`.
+
+## Internal Architecture
+
+`StorageBuffer` is nominally branded plain state containing a public aligned byte capacity, retained CPU bytes,
+and an internal `GPUBuffer`. Creation uses a mapped-at-creation `STORAGE | COPY_DST` allocation. Updates use
+`queue.writeBuffer` and require four-byte-aligned offsets and lengths. The shader material stores the resource
+object; the renderable unwraps the internal handle only while building a bind group.
+Internal identity/lifecycle fields are non-enumerable, and every mutating/binding path verifies that the exact
+wrapper remains registered with its owning engine; shallow copies cannot impersonate a live allocation.
+
+The engine owns a lazy set of live storage buffers. Device-loss recovery recreates each internal handle from
+the retained CPU bytes before scene renderables and bind groups are rebuilt. Bind-group creation rechecks
+resource liveness and engine ownership. Engine disposal destroys all remaining live storage buffers, marks
+their wrappers disposed, releases retained CPU bytes, and clears the lazy registry.
+When the first storage buffer is created, the engine also retains its current storage-related WebGPU limits
+(`maxBufferSize`, `maxStorageBufferBindingSize`, and `maxStorageBuffersPerShaderStage`) and requests them
+again during device recovery.
+
+## Pipeline Configuration
+
+The module creates no pipelines. Shader-material storage declarations continue to create read-only-storage bind-group-layout entries. Rebinding the same resource is a no-op, while binding a different resource increments the material resource version once.
+
+## Shader Logic
+
+None. The declaration's WGSL type remains owned by `ShaderStorageBufferDecl`.
+
+## State Machine / Lifecycle
+
+Create, optionally update any in-bounds range, bind to one or more shader materials, unbind, then dispose.
+Disposal is idempotent. Updating or rebinding a disposed resource throws; a zero-length in-bounds update is a no-op.
+
+## Babylon.js Equivalence Map
+
+Equivalent in role to Babylon.js `StorageBuffer`: a high-level lifetime wrapper around a WebGPU storage allocation, with standalone functions matching Lite's pure-state API convention.
+
+## Dependencies
+
+`EngineContext`, internal GPU flag aliases, and the internal mapped-buffer upload helper.
+
+## Test Specification
+
+Unit tests verify creation flags and alignment, initial mapped upload, bounded aligned updates, hidden handle identity, idempotent disposal, and rejection of use after disposal.
+
+## File Manifest
+
+- `packages/babylon-lite/src/resource/storage-buffer.ts`
+- `tests/lite/unit/storage-buffer.test.ts`
+- `docs/lite/architecture/47-storage-buffer.md`

--- a/lab/public/bundle/manifest/scene10.json
+++ b/lab/public/bundle/manifest/scene10.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 52.7,
+  "rawKB": 52.6,
   "gzipKB": 21.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene103.json
+++ b/lab/public/bundle/manifest/scene103.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62.8,
+  "rawKB": 62.7,
   "gzipKB": 24.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene11.json
+++ b/lab/public/bundle/manifest/scene11.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.1,
+  "rawKB": 89,
   "gzipKB": 37.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene113.json
+++ b/lab/public/bundle/manifest/scene113.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 63.3,
+  "rawKB": 63.2,
   "gzipKB": 24.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene116.json
+++ b/lab/public/bundle/manifest/scene116.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 76.3,
-  "gzipKB": 31.3,
+  "rawKB": 76.2,
+  "gzipKB": 31.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene116-pbr-renderable-k-vWhazx.js",

--- a/lab/public/bundle/manifest/scene121.json
+++ b/lab/public/bundle/manifest/scene121.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 36.2,
+  "rawKB": 36.1,
   "gzipKB": 14.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene123.json
+++ b/lab/public/bundle/manifest/scene123.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 45.3,
-  "gzipKB": 18.5,
+  "gzipKB": 18.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene123-gaussian-splatting-pipeline-sh-DqvbGZYF.js",

--- a/lab/public/bundle/manifest/scene124.json
+++ b/lab/public/bundle/manifest/scene124.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 51.4,
+  "rawKB": 51.3,
   "gzipKB": 20.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene125.json
+++ b/lab/public/bundle/manifest/scene125.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 37.9,
+  "rawKB": 37.8,
   "gzipKB": 15,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -3,7 +3,7 @@
   "gzipKB": 23.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene127-shader-renderable-B8NiOZqq.js",
+    "scene127-shader-renderable-CgDG61Jq.js",
     "scene127-uniform-copy-batch-C6lLhyWE.js",
     "scene127.js"
   ]

--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -3,7 +3,7 @@
   "gzipKB": 23.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene127-shader-renderable-CgDG61Jq.js",
+    "scene127-shader-renderable-C5moVC12.js",
     "scene127-uniform-copy-batch-C6lLhyWE.js",
     "scene127.js"
   ]

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -3,7 +3,7 @@
   "gzipKB": 23.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene128-shader-renderable-BGwL2QSe.js",
+    "scene128-shader-renderable-vMrqJnBj.js",
     "scene128-uniform-copy-batch-B2JNqIj3.js",
     "scene128.js"
   ]

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -3,7 +3,7 @@
   "gzipKB": 23.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene128-shader-renderable-vMrqJnBj.js",
+    "scene128-shader-renderable-Cm1fTjZA.js",
     "scene128-uniform-copy-batch-B2JNqIj3.js",
     "scene128.js"
   ]

--- a/lab/public/bundle/manifest/scene141.json
+++ b/lab/public/bundle/manifest/scene141.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 123.3,
+  "rawKB": 123.2,
   "gzipKB": 50.9,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene143.json
+++ b/lab/public/bundle/manifest/scene143.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 70.8,
+  "rawKB": 70.7,
   "gzipKB": 27.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene152.json
+++ b/lab/public/bundle/manifest/scene152.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 94.2,
+  "rawKB": 94.1,
   "gzipKB": 39.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene157.json
+++ b/lab/public/bundle/manifest/scene157.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 95.6,
+  "rawKB": 95.5,
   "gzipKB": 38.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -1,9 +1,9 @@
 {
   "rawKB": 39.7,
-  "gzipKB": 15.5,
+  "gzipKB": 15.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene159-shader-renderable-BVpH5FOO.js",
+    "scene159-shader-renderable-BsuOBMha.js",
     "scene159.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -3,7 +3,7 @@
   "gzipKB": 15.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene159-shader-renderable-BsuOBMha.js",
+    "scene159-shader-renderable-CAII7wq8.js",
     "scene159.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene16.json
+++ b/lab/public/bundle/manifest/scene16.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49.4,
+  "rawKB": 49.3,
   "gzipKB": 19.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -3,7 +3,7 @@
   "gzipKB": 16.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene160-shader-renderable-C4MYGm85.js",
+    "scene160-shader-renderable-onjDzNcV.js",
     "scene160.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 41.8,
+  "rawKB": 41.7,
   "gzipKB": 16.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene160-shader-renderable-onjDzNcV.js",
+    "scene160-shader-renderable-BHJhdNXp.js",
     "scene160.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -1,9 +1,9 @@
 {
   "rawKB": 40.4,
-  "gzipKB": 15.7,
+  "gzipKB": 15.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene161-shader-renderable-bDqTLD4b.js",
+    "scene161-shader-renderable-BTAxp-C0.js",
     "scene161.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 40.4,
+  "rawKB": 40.3,
   "gzipKB": 15.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene161-shader-renderable-BTAxp-C0.js",
+    "scene161-shader-renderable-C_nLERpD.js",
     "scene161.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -3,7 +3,7 @@
   "gzipKB": 15.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene162-shader-renderable-OiGuKAgj.js",
+    "scene162-shader-renderable-wN4UjMFa.js",
     "scene162.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 39.8,
+  "rawKB": 39.7,
   "gzipKB": 15.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene162-shader-renderable-wN4UjMFa.js",
+    "scene162-shader-renderable-C8bEj6dU.js",
     "scene162.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -3,7 +3,7 @@
   "gzipKB": 15.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene163-shader-renderable-C4CWR-Km.js",
+    "scene163-shader-renderable-DMuvkkvJ.js",
     "scene163.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -3,7 +3,7 @@
   "gzipKB": 15.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene163-shader-renderable-BftLUZtF.js",
+    "scene163-shader-renderable-C4CWR-Km.js",
     "scene163.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -1,9 +1,9 @@
 {
   "rawKB": 45.2,
-  "gzipKB": 17.8,
+  "gzipKB": 17.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene165-shader-renderable-n8vFdvyl.js",
+    "scene165-shader-renderable-BQZz1np_.js",
     "scene165-shader-thin-instance-CVyyUQwx.js",
     "scene165-thin-instance-gpu-BE5k2hGl.js",
     "scene165.js"

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 45.2,
+  "rawKB": 45.1,
   "gzipKB": 17.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene165-shader-renderable-BQZz1np_.js",
+    "scene165-shader-renderable-B02kzevN.js",
     "scene165-shader-thin-instance-CVyyUQwx.js",
     "scene165-thin-instance-gpu-BE5k2hGl.js",
     "scene165.js"

--- a/lab/public/bundle/manifest/scene17.json
+++ b/lab/public/bundle/manifest/scene17.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 86.3,
+  "rawKB": 86.2,
   "gzipKB": 35.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene172.json
+++ b/lab/public/bundle/manifest/scene172.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.8,
+  "rawKB": 59.7,
   "gzipKB": 23.4,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene173.json
+++ b/lab/public/bundle/manifest/scene173.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62.4,
+  "rawKB": 62.3,
   "gzipKB": 24.2,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene174.json
+++ b/lab/public/bundle/manifest/scene174.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 96.4,
+  "rawKB": 96.3,
   "gzipKB": 39.4,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene176.json
+++ b/lab/public/bundle/manifest/scene176.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 104.1,
-  "gzipKB": 42,
+  "rawKB": 104,
+  "gzipKB": 41.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene176-generate-mipmaps-LBrT9Lsp.js",

--- a/lab/public/bundle/manifest/scene177.json
+++ b/lab/public/bundle/manifest/scene177.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 69.9,
+  "rawKB": 69.8,
   "gzipKB": 28.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene179.json
+++ b/lab/public/bundle/manifest/scene179.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 73.9,
+  "rawKB": 73.8,
   "gzipKB": 30.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene181.json
+++ b/lab/public/bundle/manifest/scene181.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 44.5,
+  "rawKB": 44.4,
   "gzipKB": 16.6,
   "ignoredRawKB": 680.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene2.json
+++ b/lab/public/bundle/manifest/scene2.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 47,
+  "rawKB": 46.9,
   "gzipKB": 18.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene20.json
+++ b/lab/public/bundle/manifest/scene20.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 78.3,
+  "rawKB": 78.2,
   "gzipKB": 32.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene200.json
+++ b/lab/public/bundle/manifest/scene200.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 46.7,
-  "gzipKB": 18.6,
+  "rawKB": 47.3,
+  "gzipKB": 18.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene200-standard-renderable-BqAuNRMt.js",
+    "scene200-standard-renderable-COd4pRGd.js",
     "scene200.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene201.json
+++ b/lab/public/bundle/manifest/scene201.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 48.5,
+  "rawKB": 48.6,
   "gzipKB": 19.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene202.json
+++ b/lab/public/bundle/manifest/scene202.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49.2,
+  "rawKB": 49.3,
   "gzipKB": 19.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene203.json
+++ b/lab/public/bundle/manifest/scene203.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 49.5,
-  "gzipKB": 20,
+  "rawKB": 49.6,
+  "gzipKB": 20.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene203-_mat4-storage-f64-C0lTlSaC.js",

--- a/lab/public/bundle/manifest/scene204.json
+++ b/lab/public/bundle/manifest/scene204.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 51.6,
+  "rawKB": 51.7,
   "gzipKB": 21,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene205.json
+++ b/lab/public/bundle/manifest/scene205.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62,
+  "rawKB": 62.1,
   "gzipKB": 25.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene206.json
+++ b/lab/public/bundle/manifest/scene206.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62.4,
+  "rawKB": 62.5,
   "gzipKB": 25.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene207.json
+++ b/lab/public/bundle/manifest/scene207.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 59.6,
-  "gzipKB": 23.9,
+  "rawKB": 59.7,
+  "gzipKB": 24,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene207-_mat4-storage-f64-B_0HYOAx.js",

--- a/lab/public/bundle/manifest/scene209.json
+++ b/lab/public/bundle/manifest/scene209.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 54.4,
-  "gzipKB": 22.1,
+  "rawKB": 54.5,
+  "gzipKB": 22.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene209-_mat4-storage-f64-3NavC9Rv.js",

--- a/lab/public/bundle/manifest/scene21.json
+++ b/lab/public/bundle/manifest/scene21.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 85.8,
+  "rawKB": 85.7,
   "gzipKB": 35,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene212.json
+++ b/lab/public/bundle/manifest/scene212.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 104.2,
+  "rawKB": 104.1,
   "gzipKB": 41.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -4,7 +4,7 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene213-shader-pipeline-cache-Dga-Orlp.js",
-    "scene213-shader-renderable-CAXcz69m.js",
+    "scene213-shader-renderable-CUXTjywV.js",
     "scene213-uniform-copy-batch-Be4x2TDU.js",
     "scene213.js"
   ]

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -4,7 +4,7 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene213-shader-pipeline-cache-Dga-Orlp.js",
-    "scene213-shader-renderable-CUXTjywV.js",
+    "scene213-shader-renderable-DyZNJexF.js",
     "scene213-uniform-copy-batch-Be4x2TDU.js",
     "scene213.js"
   ]

--- a/lab/public/bundle/manifest/scene216.json
+++ b/lab/public/bundle/manifest/scene216.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 54,
+  "rawKB": 53.9,
   "gzipKB": 22.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene217.json
+++ b/lab/public/bundle/manifest/scene217.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 77.9,
-  "gzipKB": 31.5,
+  "gzipKB": 31.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene217-multilight-wgsl-hb_hGU0D.js",

--- a/lab/public/bundle/manifest/scene22.json
+++ b/lab/public/bundle/manifest/scene22.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 97.7,
+  "rawKB": 97.6,
   "gzipKB": 39.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 102.6,
+  "rawKB": 102.5,
   "gzipKB": 38.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene221-shader-renderable-BR0SpITz.js",
+    "scene221-shader-renderable-e40HDD0m.js",
     "scene221-standard-renderable-DpESG6NP.js",
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221-ubo-layout-CnrP4RZD.js",

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -1,9 +1,9 @@
 {
   "rawKB": 102.6,
-  "gzipKB": 38.5,
+  "gzipKB": 38.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene221-shader-renderable-BRk2kAJu.js",
+    "scene221-shader-renderable-BR0SpITz.js",
     "scene221-standard-renderable-DpESG6NP.js",
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221-ubo-layout-CnrP4RZD.js",

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -1,11 +1,11 @@
 {
-  "rawKB": 118.7,
+  "rawKB": 118.6,
   "gzipKB": 43.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene222-index-FlPA6jzr.js",
     "scene222-shader-pipeline-cache-CEwSrI-G.js",
-    "scene222-shader-renderable-B8EkJ0tK.js",
+    "scene222-shader-renderable-CDZpSjhF.js",
     "scene222-standard-renderable-V34lXsdm.js",
     "scene222-swapchain-overlay-ilhN4El_.js",
     "scene222-ubo-layout-Cs5YvLYZ.js",

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene222-index-FlPA6jzr.js",
     "scene222-shader-pipeline-cache-CEwSrI-G.js",
-    "scene222-shader-renderable-B6ETENjE.js",
+    "scene222-shader-renderable-B8EkJ0tK.js",
     "scene222-standard-renderable-V34lXsdm.js",
     "scene222-swapchain-overlay-ilhN4El_.js",
     "scene222-ubo-layout-Cs5YvLYZ.js",

--- a/lab/public/bundle/manifest/scene229.json
+++ b/lab/public/bundle/manifest/scene229.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 68,
+  "rawKB": 67.9,
   "gzipKB": 28.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 91.1,
+  "rawKB": 91,
   "gzipKB": 38.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 97.3,
+  "rawKB": 97.2,
   "gzipKB": 40.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 133.8,
+  "rawKB": 133.7,
   "gzipKB": 54.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 99.6,
+  "rawKB": 99.5,
   "gzipKB": 42.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 84.8,
+  "rawKB": 84.7,
   "gzipKB": 35.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene25.json
+++ b/lab/public/bundle/manifest/scene25.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 52,
+  "rawKB": 51.9,
   "gzipKB": 20.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene252.json
+++ b/lab/public/bundle/manifest/scene252.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49,
+  "rawKB": 48.9,
   "gzipKB": 19.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 153.1,
+  "rawKB": 153,
   "gzipKB": 64.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene254.json
+++ b/lab/public/bundle/manifest/scene254.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92.5,
+  "rawKB": 92.4,
   "gzipKB": 38.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 94.2,
+  "rawKB": 94.1,
   "gzipKB": 39.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene258.json
+++ b/lab/public/bundle/manifest/scene258.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 83,
+  "rawKB": 82.9,
   "gzipKB": 34.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene259.json
+++ b/lab/public/bundle/manifest/scene259.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 77.2,
+  "rawKB": 77.1,
   "gzipKB": 32,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene26.json
+++ b/lab/public/bundle/manifest/scene26.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.9,
+  "rawKB": 89.8,
   "gzipKB": 36.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene263.json
+++ b/lab/public/bundle/manifest/scene263.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 44.3,
+  "rawKB": 44.2,
   "gzipKB": 25.2,
   "ignoredRawKB": 27.6,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 86.6,
-  "gzipKB": 35.4,
+  "gzipKB": 35.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene28-clearcoat-fragment-DOT6cYUU.js",

--- a/lab/public/bundle/manifest/scene29.json
+++ b/lab/public/bundle/manifest/scene29.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.3,
+  "rawKB": 90.2,
   "gzipKB": 37.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene3.json
+++ b/lab/public/bundle/manifest/scene3.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 53.8,
+  "rawKB": 53.7,
   "gzipKB": 21.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.8,
+  "rawKB": 103.7,
   "gzipKB": 42.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 79.9,
+  "rawKB": 79.8,
   "gzipKB": 32.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene33.json
+++ b/lab/public/bundle/manifest/scene33.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.8,
+  "rawKB": 103.7,
   "gzipKB": 42.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 96.9,
+  "rawKB": 96.8,
   "gzipKB": 40,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene35.json
+++ b/lab/public/bundle/manifest/scene35.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 83.8,
+  "rawKB": 83.7,
   "gzipKB": 34.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene39.json
+++ b/lab/public/bundle/manifest/scene39.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 108.9,
+  "rawKB": 108.8,
   "gzipKB": 46.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene40.json
+++ b/lab/public/bundle/manifest/scene40.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49.7,
+  "rawKB": 49.6,
   "gzipKB": 19.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene41.json
+++ b/lab/public/bundle/manifest/scene41.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 93.1,
+  "rawKB": 93,
   "gzipKB": 37,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene44.json
+++ b/lab/public/bundle/manifest/scene44.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.2,
+  "rawKB": 50.1,
   "gzipKB": 20,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene45.json
+++ b/lab/public/bundle/manifest/scene45.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 51.5,
+  "rawKB": 51.4,
   "gzipKB": 20.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene48.json
+++ b/lab/public/bundle/manifest/scene48.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 54.5,
+  "rawKB": 54.4,
   "gzipKB": 21.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 93.7,
+  "rawKB": 93.6,
   "gzipKB": 35.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene5.json
+++ b/lab/public/bundle/manifest/scene5.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92,
+  "rawKB": 91.9,
   "gzipKB": 38.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene50.json
+++ b/lab/public/bundle/manifest/scene50.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 15.9,
+  "rawKB": 15.8,
   "gzipKB": 6.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 57.5,
+  "rawKB": 57.4,
   "gzipKB": 23,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 57.4,
-  "gzipKB": 22.9,
+  "gzipKB": 22.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene53-standard-renderable-nci7lPMT.js",

--- a/lab/public/bundle/manifest/scene59.json
+++ b/lab/public/bundle/manifest/scene59.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 63.2,
+  "rawKB": 63.1,
   "gzipKB": 25.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene6.json
+++ b/lab/public/bundle/manifest/scene6.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 72.5,
+  "rawKB": 72.4,
   "gzipKB": 30.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene60.json
+++ b/lab/public/bundle/manifest/scene60.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 55.9,
+  "rawKB": 55.8,
   "gzipKB": 22.9,
   "ignoredRawKB": 4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene62.json
+++ b/lab/public/bundle/manifest/scene62.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.5,
+  "rawKB": 60.4,
   "gzipKB": 25.4,
   "ignoredRawKB": 5.3,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene64.json
+++ b/lab/public/bundle/manifest/scene64.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 57.1,
+  "rawKB": 57,
   "gzipKB": 23.6,
   "ignoredRawKB": 4.3,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene65.json
+++ b/lab/public/bundle/manifest/scene65.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 74.9,
-  "gzipKB": 30.9,
+  "gzipKB": 30.8,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
     "scene65-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene66.json
+++ b/lab/public/bundle/manifest/scene66.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.4,
+  "rawKB": 89.3,
   "gzipKB": 41.1,
   "ignoredRawKB": 5.5,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene68.json
+++ b/lab/public/bundle/manifest/scene68.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 91.5,
+  "rawKB": 91.4,
   "gzipKB": 35.9,
   "ignoredRawKB": 11.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene69.json
+++ b/lab/public/bundle/manifest/scene69.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 90.9,
-  "gzipKB": 36.2,
+  "gzipKB": 36.1,
   "ignoredRawKB": 13.3,
   "runtimeChunks": [
     "scene69-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene71.json
+++ b/lab/public/bundle/manifest/scene71.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 91.1,
+  "rawKB": 91,
   "gzipKB": 36.1,
   "ignoredRawKB": 12.9,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene72.json
+++ b/lab/public/bundle/manifest/scene72.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 108.8,
-  "gzipKB": 44.1,
+  "rawKB": 108.7,
+  "gzipKB": 44,
   "ignoredRawKB": 3.3,
   "runtimeChunks": [
     "scene72-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene73.json
+++ b/lab/public/bundle/manifest/scene73.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 143.7,
+  "rawKB": 143.6,
   "gzipKB": 58.1,
   "ignoredRawKB": 3.3,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene75.json
+++ b/lab/public/bundle/manifest/scene75.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.3,
+  "rawKB": 50.2,
   "gzipKB": 20,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene79.json
+++ b/lab/public/bundle/manifest/scene79.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 61.6,
+  "rawKB": 61.5,
   "gzipKB": 27.7,
   "ignoredRawKB": 8.1,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene80.json
+++ b/lab/public/bundle/manifest/scene80.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 61,
+  "rawKB": 60.9,
   "gzipKB": 26.7,
   "ignoredRawKB": 6,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene81.json
+++ b/lab/public/bundle/manifest/scene81.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 67,
-  "gzipKB": 29.9,
+  "gzipKB": 29.8,
   "ignoredRawKB": 7,
   "runtimeChunks": [
     "scene81-_math-factory-DFVyS8gB.js",

--- a/lab/public/bundle/manifest/scene86.json
+++ b/lab/public/bundle/manifest/scene86.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.2,
+  "rawKB": 60.1,
   "gzipKB": 27.2,
   "ignoredRawKB": 8,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene88.json
+++ b/lab/public/bundle/manifest/scene88.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.9,
+  "rawKB": 60.8,
   "gzipKB": 27,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene9.json
+++ b/lab/public/bundle/manifest/scene9.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.1,
+  "rawKB": 60,
   "gzipKB": 24.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene90.json
+++ b/lab/public/bundle/manifest/scene90.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.2,
+  "rawKB": 59.1,
   "gzipKB": 23.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene92.json
+++ b/lab/public/bundle/manifest/scene92.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 18.9,
+  "rawKB": 18.8,
   "gzipKB": 8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene93.json
+++ b/lab/public/bundle/manifest/scene93.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 20,
+  "rawKB": 19.9,
   "gzipKB": 8.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene95.json
+++ b/lab/public/bundle/manifest/scene95.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 65.1,
+  "rawKB": 65,
   "gzipKB": 25.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene96.json
+++ b/lab/public/bundle/manifest/scene96.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 16.1,
+  "rawKB": 16,
   "gzipKB": 6.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene98.json
+++ b/lab/public/bundle/manifest/scene98.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.3,
+  "rawKB": 60.2,
   "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/packages/babylon-lite/src/engine/device-lost-recovery.ts
+++ b/packages/babylon-lite/src/engine/device-lost-recovery.ts
@@ -187,7 +187,10 @@ async function recoverDevice(engine: EngineContext, state: RecoveryState): Promi
         if (missingFeatures.length > 0) {
             throw new Error(`WebGPU device recovery missing required features: ${missingFeatures.join(", ")}`);
         }
-        engine._device = await adapter.requestDevice({ requiredFeatures: state.requiredFeatures, requiredLimits: engine._storageRequiredLimits });
+        engine._device = await adapter.requestDevice({
+            requiredFeatures: state.requiredFeatures,
+            requiredLimits: { ...engine._options?.requiredLimits, ...engine._storageRequiredLimits },
+        });
         engine._rebuildStorageBuffers?.();
         // Reconfigure every surface's canvas context against the new device and re-acquire
         // its swapchain texture (the previous device's textures are invalid). The rebuilt

--- a/packages/babylon-lite/src/engine/device-lost-recovery.ts
+++ b/packages/babylon-lite/src/engine/device-lost-recovery.ts
@@ -187,7 +187,8 @@ async function recoverDevice(engine: EngineContext, state: RecoveryState): Promi
         if (missingFeatures.length > 0) {
             throw new Error(`WebGPU device recovery missing required features: ${missingFeatures.join(", ")}`);
         }
-        engine._device = await adapter.requestDevice({ requiredFeatures: state.requiredFeatures });
+        engine._device = await adapter.requestDevice({ requiredFeatures: state.requiredFeatures, requiredLimits: engine._storageRequiredLimits });
+        engine._rebuildStorageBuffers?.();
         // Reconfigure every surface's canvas context against the new device and re-acquire
         // its swapchain texture (the previous device's textures are invalid). The rebuilt
         // frame graphs need fresh color attachments. Per-surface `_swapchainCopySrc` is
@@ -205,6 +206,7 @@ async function recoverDevice(engine: EngineContext, state: RecoveryState): Promi
             });
             _refreshScRT(surface);
         }
+
         clearSceneBGLCache();
         resizeEngine(engine);
 

--- a/packages/babylon-lite/src/engine/engine.ts
+++ b/packages/babylon-lite/src/engine/engine.ts
@@ -117,6 +117,8 @@ export interface EngineContext extends SurfaceContext {
 
     /** @internal */
     _device: GPUDevice;
+    /** @internal Original creation options retained for optional subsystems such as recovery. */
+    _options?: EngineOptions;
     /** @internal Live high-level storage allocations owned by this engine. */
     _storageBuffers?: Set<StorageBuffer>;
     /** @internal Storage-related limits retained lazily for device-loss recovery. */
@@ -334,8 +336,8 @@ export async function createEngine(canvas: RenderCanvas, options?: EngineOptions
         canvas.setAttribute("data-engine", versionToLog);
     }
 
-    const useHpm = options?.useHighPrecisionMatrix === true;
-    const useFO = options?.useFloatingOrigin === true;
+    const useHpm = !!options?.useHighPrecisionMatrix;
+    const useFO = !!options?.useFloatingOrigin;
     if (useFO && !useHpm) {
         throw new Error("Babylon Lite: useFloatingOrigin requires useHighPrecisionMatrix on the engine.");
     }
@@ -391,6 +393,7 @@ export async function createEngine(canvas: RenderCanvas, options?: EngineOptions
             surfaces, // public readonly view of `_surfaces` (same underlying array)
             _surfaces: surfaces,
             _device: device,
+            _options: options,
             drawCallCount: 0,
             gpuFrameTimeMs: 0,
             useHighPrecisionMatrix: useHpm,

--- a/packages/babylon-lite/src/engine/engine.ts
+++ b/packages/babylon-lite/src/engine/engine.ts
@@ -1,4 +1,5 @@
 import type { Mesh } from "../mesh/mesh.js";
+import type { StorageBuffer } from "../resource/storage-buffer.js";
 import type { Texture2D, Texture2DOptions } from "../texture/texture-2d.js";
 import { _setHpmAllocator } from "../math/_matrix-allocator.js";
 import type { SurfaceContext, SurfaceOptions } from "./surface.js";
@@ -116,6 +117,14 @@ export interface EngineContext extends SurfaceContext {
 
     /** @internal */
     _device: GPUDevice;
+    /** @internal Live high-level storage allocations owned by this engine. */
+    _storageBuffers?: Set<StorageBuffer>;
+    /** @internal Storage-related limits retained lazily for device-loss recovery. */
+    _storageRequiredLimits?: Record<string, GPUSize64>;
+    /** @internal Installed lazily by the storage-buffer module. */
+    _rebuildStorageBuffers?: () => void;
+    /** @internal Installed lazily by the storage-buffer module. */
+    _disposeStorageBuffers?: () => void;
     /** @internal Shared 1×1 white texture used as the default baseColor / ORM for
      *  factor-only PBR materials (created via `createPbrMaterial` without textures).
      *  A white ORM yields `metallic = metallicFactor`, `roughness = roughnessFactor`,
@@ -482,6 +491,7 @@ export function disposeEngine(engine: EngineContext): void {
     }
     surfaces.length = 0;
     disposeGpuResourceRetirements(engine);
+    engine._disposeStorageBuffers?.();
     engine._device.destroy();
 }
 

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -195,6 +195,10 @@ export type { CsgSolid } from "./mesh/csg.js";
 export { initializeCsg2Async, isCsg2Ready, createCsg2FromMesh, csg2Subtract, csg2Intersect, csg2Add, createMeshFromCsg2, createMeshesFromCsg2, disposeCsg2 } from "./mesh/csg2.js";
 export type { Csg2Solid } from "./mesh/csg2.js";
 
+// ─── Resources ───────────────────────────────────────────────────────
+export { createStorageBuffer, updateStorageBuffer, disposeStorageBuffer } from "./resource/storage-buffer.js";
+export type { StorageBuffer } from "./resource/storage-buffer.js";
+
 // ─── Textures ────────────────────────────────────────────────────────
 export { createSolidTexture2D } from "./texture/solid-texture.js";
 export { createTexture2DFromPixels, updateTexture2DFromPixels, createRenderTexture2D } from "./texture/pixels-texture.js";

--- a/packages/babylon-lite/src/material/shader/shader-material.ts
+++ b/packages/babylon-lite/src/material/shader/shader-material.ts
@@ -1,6 +1,7 @@
 import { F32 } from "../../engine/typed-arrays.js";
 import type { Material, StencilState } from "../material.js";
 import type { Texture2D } from "../../texture/texture-2d.js";
+import type { StorageBuffer } from "../../resource/storage-buffer.js";
 import type { Mat4 } from "../../math/types.js";
 import { getShaderGroupBuilder } from "./shader-group-builder.js";
 import { bumpVisibilityEpoch } from "../../engine/engine.js";
@@ -113,7 +114,7 @@ export interface ShaderTextureSlot {
 
 export interface ShaderStorageBufferSlot {
     readonly decl: ShaderStorageBufferDecl;
-    current: GPUBuffer | null;
+    current: StorageBuffer | null;
 }
 
 /** A custom WGSL material: compiled from user-supplied vertex/fragment sources
@@ -463,13 +464,22 @@ export function setShaderTexture(material: ShaderMaterial, name: string, texture
 }
 
 /** Bind (or clear) a declared read-only storage buffer. */
-export function setShaderStorageBuffer(material: ShaderMaterial, name: string, buffer: GPUBuffer | null): void {
+export function setShaderStorageBuffer(material: ShaderMaterial, name: string, buffer: StorageBuffer | null): void {
     const slot = material._storageBufferSlots.get(name);
     if (!slot) {
         throw new Error(`ShaderMaterial: storage buffer "${name}" was not declared.`);
     }
+    if (buffer && !("_engine" in buffer)) {
+        throw new Error("setShaderStorageBuffer requires a StorageBuffer created by createStorageBuffer; raw GPUBuffer is not supported.");
+    }
+    if (buffer?._destroyed) {
+        throw new Error(`ShaderMaterial: storage buffer "${name}" has been disposed.`);
+    }
+    if (buffer && !buffer._engine._storageBuffers?.has(buffer)) {
+        throw new Error("setShaderStorageBuffer requires a live StorageBuffer created by createStorageBuffer.");
+    }
     // See setShaderTexture: only invalidate the bind groups when the bound buffer HANDLE changes; re-binding the
-    // same GPUBuffer is a no-op (contents update live), so an unconditional bump churned the descriptor heap.
+    // same StorageBuffer is a no-op (contents update live), so an unconditional bump churned the descriptor heap.
     if (slot.current !== buffer) {
         slot.current = buffer;
         material._resourceVersion++;

--- a/packages/babylon-lite/src/material/shader/shader-renderable.ts
+++ b/packages/babylon-lite/src/material/shader/shader-renderable.ts
@@ -435,8 +435,8 @@ function createShaderBindGroup(engine: EngineContext, material: ShaderMaterial, 
         const slot = material._storageBufferSlots.get(storage.name);
         const storageBuffer = slot?.current;
         const buffer = storageBuffer?._buffer;
-        if (!buffer || storageBuffer._engine !== engine) {
-            throw new Error(`ShaderMaterial: storage buffer "${storage.name}" is invalid for this engine.`);
+        if (!buffer || !engine._storageBuffers?.has(storageBuffer)) {
+            throw new Error(`ShaderMaterial storage "${storage.name}" is invalid.`);
         }
         entries.push({ binding: nextBinding++, resource: { buffer } });
     }

--- a/packages/babylon-lite/src/material/shader/shader-renderable.ts
+++ b/packages/babylon-lite/src/material/shader/shader-renderable.ts
@@ -433,9 +433,10 @@ function createShaderBindGroup(engine: EngineContext, material: ShaderMaterial, 
     }
     for (const storage of material.storageBufferDecls) {
         const slot = material._storageBufferSlots.get(storage.name);
-        const buffer = slot?.current;
-        if (!buffer) {
-            throw new Error(`ShaderMaterial: storage buffer "${storage.name}" has no GPUBuffer. Call setShaderStorageBuffer() before rendering.`);
+        const storageBuffer = slot?.current;
+        const buffer = storageBuffer?._buffer;
+        if (!buffer || storageBuffer._engine !== engine) {
+            throw new Error(`ShaderMaterial: storage buffer "${storage.name}" is invalid for this engine.`);
         }
         entries.push({ binding: nextBinding++, resource: { buffer } });
     }
@@ -456,7 +457,10 @@ function collectShaderStorageBuffers(material: ShaderMaterial): GPUBuffer[] {
     const buffers: GPUBuffer[] = [];
     for (const slot of material._storageBufferSlots.values()) {
         if (slot.current) {
-            buffers.push(slot.current);
+            const buffer = slot.current._buffer;
+            if (buffer) {
+                buffers.push(buffer);
+            }
         }
     }
     return buffers;

--- a/packages/babylon-lite/src/resource/storage-buffer.ts
+++ b/packages/babylon-lite/src/resource/storage-buffer.ts
@@ -1,0 +1,133 @@
+import { BU } from "../engine/gpu-flags.js";
+import type { EngineContext } from "../engine/engine.js";
+import { align, createMappedBuffer } from "./gpu-buffers.js";
+
+declare const storageBufferBrand: unique symbol;
+
+/** A GPU storage allocation exposed without leaking its WebGPU handle. */
+export interface StorageBuffer {
+    /** Opaque nominal brand. */
+    readonly [storageBufferBrand]: true;
+    /** Writable capacity in bytes, padded to WebGPU's four-byte alignment. */
+    readonly byteLength: number;
+    /** @internal */
+    _buffer: GPUBuffer | null;
+    /** @internal */
+    _destroyed: boolean;
+    /** @internal */
+    _data: Uint8Array | null;
+    /** @internal */
+    readonly _engine: EngineContext;
+    /** @internal */
+    readonly _label?: string;
+}
+
+/** Create a read-only shader storage buffer initialized from `data`. */
+export function createStorageBuffer(engine: EngineContext, data: ArrayBufferView, label?: string): StorageBuffer {
+    const byteLength = align(Math.max(data.byteLength, 4), 4);
+    const bytes = new Uint8Array(byteLength);
+    bytes.set(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+    const storage = { byteLength } as StorageBuffer;
+    Object.defineProperties(storage, {
+        _buffer: { value: createMappedBuffer(engine, bytes, BU.STORAGE, label), writable: true },
+        _destroyed: { value: false, writable: true },
+        _data: { value: bytes, writable: true },
+        _engine: { value: engine },
+        _label: { value: label },
+    });
+    (engine._storageBuffers ??= new Set()).add(storage);
+    if (!engine._storageRequiredLimits) {
+        const limits = engine._device.limits;
+        if (limits) {
+            engine._storageRequiredLimits = {
+                maxBufferSize: limits.maxBufferSize,
+                maxStorageBufferBindingSize: limits.maxStorageBufferBindingSize,
+                maxStorageBuffersPerShaderStage: limits.maxStorageBuffersPerShaderStage,
+            };
+        }
+    }
+    engine._rebuildStorageBuffers ??= () => _rebuildStorageBuffers(engine);
+    engine._disposeStorageBuffers ??= () => _disposeStorageBuffers(engine);
+    return storage;
+}
+
+/** @internal Resolve a live handle for one engine while building a bind group. */
+export function _getStorageBufferHandle(engine: EngineContext, buffer: StorageBuffer): GPUBuffer {
+    if (buffer._destroyed || !buffer._data) {
+        throw new Error("StorageBuffer has been disposed.");
+    }
+    if (buffer._engine !== engine) {
+        throw new Error("StorageBuffer belongs to a different engine.");
+    }
+    if (!engine._storageBuffers?.has(buffer)) {
+        throw new Error("StorageBuffer is not a live registered allocation.");
+    }
+    return buffer._buffer!;
+}
+
+/** Replace a byte range without changing the storage buffer's binding identity. */
+export function updateStorageBuffer(engine: EngineContext, buffer: StorageBuffer, data: ArrayBufferView, byteOffset = 0): void {
+    if (buffer._destroyed) {
+        throw new Error("StorageBuffer has been disposed.");
+    }
+    if (!("_engine" in buffer)) {
+        throw new Error("StorageBuffer is not a live registered allocation.");
+    }
+    if (buffer._engine !== engine) {
+        throw new Error("StorageBuffer belongs to a different engine.");
+    }
+    if (!engine._storageBuffers?.has(buffer)) {
+        throw new Error("StorageBuffer is not a live registered allocation.");
+    }
+    if (!Number.isInteger(byteOffset) || byteOffset < 0 || (byteOffset & 3) !== 0) {
+        throw new Error("StorageBuffer byteOffset must be a non-negative multiple of 4.");
+    }
+    if ((data.byteLength & 3) !== 0) {
+        throw new Error("StorageBuffer update data must have a byte length that is a multiple of 4.");
+    }
+    if (byteOffset + data.byteLength > buffer.byteLength) {
+        throw new Error(`StorageBuffer update exceeds its ${buffer.byteLength}-byte capacity.`);
+    }
+    if (data.byteLength === 0) {
+        return;
+    }
+    engine._device.queue.writeBuffer(buffer._buffer!, byteOffset, data.buffer as ArrayBuffer, data.byteOffset, data.byteLength);
+    buffer._data!.set(new Uint8Array(data.buffer, data.byteOffset, data.byteLength), byteOffset);
+}
+
+/** Destroy a storage buffer. Repeated disposal is a no-op. */
+export function disposeStorageBuffer(buffer: StorageBuffer): void {
+    if (buffer._destroyed) {
+        return;
+    }
+    if (!("_engine" in buffer) || !buffer._engine._storageBuffers?.has(buffer)) {
+        throw new Error("StorageBuffer is not a live registered allocation.");
+    }
+    buffer._buffer?.destroy();
+    buffer._buffer = null;
+    buffer._engine._storageBuffers.delete(buffer);
+    buffer._data = null;
+    buffer._destroyed = true;
+    if (buffer._engine._storageBuffers.size === 0) {
+        buffer._engine._storageBuffers = undefined;
+        buffer._engine._storageRequiredLimits = undefined;
+        buffer._engine._rebuildStorageBuffers = undefined;
+        buffer._engine._disposeStorageBuffers = undefined;
+    }
+}
+
+/** @internal Rebuild every live storage allocation after the engine device changes. */
+export function _rebuildStorageBuffers(engine: EngineContext): void {
+    for (const buffer of engine._storageBuffers ?? []) {
+        if (!buffer._destroyed && buffer._data) {
+            buffer._buffer = createMappedBuffer(engine, buffer._data, BU.STORAGE, buffer._label);
+        }
+    }
+}
+
+/** @internal Dispose all live storage allocations before their engine device is destroyed. */
+export function _disposeStorageBuffers(engine: EngineContext): void {
+    for (const buffer of [...(engine._storageBuffers ?? [])]) {
+        disposeStorageBuffer(buffer);
+    }
+}

--- a/tests/lite/unit/storage-buffer-lifecycle.test.ts
+++ b/tests/lite/unit/storage-buffer-lifecycle.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine.js";
+import { disposeEngine } from "../../../packages/babylon-lite/src/engine/engine.js";
+import { createShaderMaterial, setShaderStorageBuffer } from "../../../packages/babylon-lite/src/material/shader/shader-material.js";
+import { buildShaderMaterialRenderables } from "../../../packages/babylon-lite/src/material/shader/shader-renderable.js";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh.js";
+import { initMeshTransform } from "../../../packages/babylon-lite/src/mesh/mesh.js";
+import { _getStorageBufferHandle, createStorageBuffer, disposeStorageBuffer } from "../../../packages/babylon-lite/src/resource/storage-buffer.js";
+import { updateStorageBuffer } from "../../../packages/babylon-lite/src/resource/storage-buffer.js";
+import type { StorageBuffer } from "../../../packages/babylon-lite/src/resource/storage-buffer.js";
+import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core.js";
+
+const gpuGlobals = globalThis as Omit<typeof globalThis, "GPUBufferUsage"> & {
+    GPUBufferUsage?: { STORAGE: number; COPY_DST: number };
+    GPUShaderStage?: { VERTEX: number; FRAGMENT: number };
+};
+gpuGlobals.GPUBufferUsage ??= { STORAGE: 0x80, COPY_DST: 0x8 } as unknown as GPUBufferUsage;
+gpuGlobals.GPUShaderStage ??= { VERTEX: 1, FRAGMENT: 2 } as unknown as GPUShaderStage;
+
+function makeEngine(): { engine: EngineContext; rawBuffer: GPUBuffer & { destroy: ReturnType<typeof vi.fn> }; deviceDestroy: ReturnType<typeof vi.fn> } {
+    const rawBuffer = {
+        destroy: vi.fn(),
+        getMappedRange: vi.fn(() => new ArrayBuffer(16)),
+        unmap: vi.fn(),
+    } as unknown as GPUBuffer & { destroy: ReturnType<typeof vi.fn> };
+    const deviceDestroy = vi.fn();
+    const surface = {
+        _renderingContexts: [],
+        _context: { unconfigure: vi.fn() },
+    };
+    const engine = {
+        _device: {
+            createBuffer: vi.fn(() => rawBuffer),
+            queue: { writeBuffer: vi.fn() },
+            destroy: deviceDestroy,
+            limits: {
+                maxBufferSize: 1024,
+                maxStorageBufferBindingSize: 512,
+                maxStorageBuffersPerShaderStage: 8,
+            },
+        },
+        _surfaces: [surface],
+        surfaces: [surface],
+        _retirements: [],
+        _renderFn: null,
+        _animFrameId: 0,
+    } as unknown as EngineContext;
+    return { engine, rawBuffer, deviceDestroy };
+}
+
+function makeRenderableFixture() {
+    const buffers: GPUBuffer[] = [];
+    const createBindGroup = vi.fn((descriptor: GPUBindGroupDescriptor) => descriptor as unknown as GPUBindGroup);
+    const device = {
+        createBuffer: vi.fn((descriptor: GPUBufferDescriptor) => {
+            const mapped = new ArrayBuffer(Number(descriptor.size));
+            const buffer = {
+                size: descriptor.size,
+                destroy: vi.fn(),
+                getMappedRange: () => mapped,
+                unmap: vi.fn(),
+            } as unknown as GPUBuffer;
+            buffers.push(buffer);
+            return buffer;
+        }),
+        createBindGroupLayout: vi.fn((descriptor: GPUBindGroupLayoutDescriptor) => descriptor as unknown as GPUBindGroupLayout),
+        createPipelineLayout: vi.fn((descriptor: GPUPipelineLayoutDescriptor) => descriptor as unknown as GPUPipelineLayout),
+        createBindGroup,
+        queue: { writeBuffer: vi.fn() },
+        limits: {
+            maxBufferSize: 1024,
+            maxStorageBufferBindingSize: 512,
+            maxStorageBuffersPerShaderStage: 8,
+        },
+    } as unknown as GPUDevice;
+    const engine = {
+        _device: device,
+        canvas: { width: 1, height: 1 },
+    } as unknown as EngineContext;
+    const material = createShaderMaterial({
+        vertexSource: "@vertex fn mainVertex(input: VertexInput) -> @builtin(position) vec4f { return vec4f(input.position, 1); }",
+        fragmentSource: "@fragment fn mainFragment() -> @location(0) vec4f { return vec4f(1); }",
+        attributes: ["position"],
+        storageBuffers: [{ name: "cells", type: "array<f32>" }],
+    });
+    const mesh = {
+        name: "storage",
+        children: [],
+        material,
+        receiveShadows: false,
+        _gpu: {
+            positionBuffer: {} as GPUBuffer,
+            normalBuffer: {} as GPUBuffer,
+            uvBuffer: {} as GPUBuffer,
+            indexBuffer: {} as GPUBuffer,
+            indexCount: 3,
+            indexFormat: "uint32",
+        },
+    } as unknown as Mesh;
+    initMeshTransform(mesh);
+    const scene = {
+        surface: { engine },
+        camera: null,
+        _meshDisposables: new Map(),
+        _meshAuxDisposables: new Map(),
+    } as unknown as SceneContext;
+    return { buffers, createBindGroup, device, engine, material, mesh, scene };
+}
+
+describe("StorageBuffer lifecycle", () => {
+    it("rejects binding through a different engine", () => {
+        const first = makeEngine();
+        const second = makeEngine();
+        const storage = createStorageBuffer(first.engine, new Float32Array(1));
+
+        expect(() => _getStorageBufferHandle(second.engine, storage)).toThrow("different engine");
+    });
+
+    it("disposes live storage allocations with the engine", () => {
+        const { engine, rawBuffer, deviceDestroy } = makeEngine();
+        const storage = createStorageBuffer(engine, new Float32Array(1));
+
+        disposeEngine(engine);
+
+        expect(rawBuffer.destroy).toHaveBeenCalledOnce();
+        expect(deviceDestroy).toHaveBeenCalledOnce();
+        expect(storage._destroyed).toBe(true);
+        expect(storage._data).toBeNull();
+        expect(engine._storageBuffers).toBeUndefined();
+        expect(engine._storageRequiredLimits).toBeUndefined();
+    });
+
+    it("builds ShaderMaterial bind groups with the live recovered handle", () => {
+        const fixture = makeRenderableFixture();
+        const storage = createStorageBuffer(fixture.engine, new Float32Array(4));
+        const initialHandle = storage._buffer;
+        expect(fixture.engine._storageRequiredLimits).toEqual({
+            maxBufferSize: 1024,
+            maxStorageBufferBindingSize: 512,
+            maxStorageBuffersPerShaderStage: 8,
+        });
+        setShaderStorageBuffer(fixture.material, "cells", storage);
+
+        buildShaderMaterialRenderables(fixture.scene, [fixture.mesh]);
+        const initialDescriptor = fixture.createBindGroup.mock.calls.at(-1)![0];
+        expect((Array.from(initialDescriptor.entries).at(-1)!.resource as GPUBufferBinding).buffer).toBe(initialHandle);
+
+        const replacement = makeRenderableFixture();
+        fixture.engine._device = replacement.device;
+        fixture.engine._rebuildStorageBuffers!();
+        buildShaderMaterialRenderables(fixture.scene, [fixture.mesh]);
+        const recoveredDescriptor = replacement.createBindGroup.mock.calls.at(-1)![0];
+        expect((Array.from(recoveredDescriptor.entries).at(-1)!.resource as GPUBufferBinding).buffer).toBe(storage._buffer);
+        expect(storage._buffer).not.toBe(initialHandle);
+    });
+
+    it("rejects wrong-engine and disposed resources through the render path", () => {
+        const owner = makeRenderableFixture();
+        const other = makeRenderableFixture();
+        const storage = createStorageBuffer(owner.engine, new Float32Array(4));
+        setShaderStorageBuffer(other.material, "cells", storage);
+
+        expect(() => buildShaderMaterialRenderables(other.scene, [other.mesh])).toThrow("invalid for this engine");
+
+        setShaderStorageBuffer(owner.material, "cells", storage);
+        disposeStorageBuffer(storage);
+        expect(() => buildShaderMaterialRenderables(owner.scene, [owner.mesh])).toThrow("invalid for this engine");
+    });
+
+    it("does not allow shallow copies to impersonate registered storage", () => {
+        const { engine, rawBuffer } = makeEngine();
+        const storage = createStorageBuffer(engine, new Float32Array(1));
+        const copy: StorageBuffer = { ...storage };
+
+        expect(Object.keys(storage)).toEqual(["byteLength"]);
+        expect(() => updateStorageBuffer(engine, copy, new Float32Array(1))).toThrow("live registered allocation");
+        expect(() => disposeStorageBuffer(copy)).toThrow("live registered allocation");
+        expect(rawBuffer.destroy).not.toHaveBeenCalled();
+        expect(engine._storageBuffers?.has(storage)).toBe(true);
+    });
+});

--- a/tests/lite/unit/storage-buffer-lifecycle.test.ts
+++ b/tests/lite/unit/storage-buffer-lifecycle.test.ts
@@ -161,11 +161,11 @@ describe("StorageBuffer lifecycle", () => {
         const storage = createStorageBuffer(owner.engine, new Float32Array(4));
         setShaderStorageBuffer(other.material, "cells", storage);
 
-        expect(() => buildShaderMaterialRenderables(other.scene, [other.mesh])).toThrow("invalid for this engine");
+        expect(() => buildShaderMaterialRenderables(other.scene, [other.mesh])).toThrow("is invalid");
 
         setShaderStorageBuffer(owner.material, "cells", storage);
         disposeStorageBuffer(storage);
-        expect(() => buildShaderMaterialRenderables(owner.scene, [owner.mesh])).toThrow("invalid for this engine");
+        expect(() => buildShaderMaterialRenderables(owner.scene, [owner.mesh])).toThrow("is invalid");
     });
 
     it("does not allow shallow copies to impersonate registered storage", () => {
@@ -178,5 +178,14 @@ describe("StorageBuffer lifecycle", () => {
         expect(() => disposeStorageBuffer(copy)).toThrow("live registered allocation");
         expect(rawBuffer.destroy).not.toHaveBeenCalled();
         expect(engine._storageBuffers?.has(storage)).toBe(true);
+    });
+
+    it("rejects an unregistered wrapper through the production bind path", () => {
+        const fixture = makeRenderableFixture();
+        const storage = createStorageBuffer(fixture.engine, new Float32Array(1));
+        setShaderStorageBuffer(fixture.material, "cells", storage);
+        fixture.engine._storageBuffers!.delete(storage);
+
+        expect(() => buildShaderMaterialRenderables(fixture.scene, [fixture.mesh])).toThrow("is invalid");
     });
 });

--- a/tests/lite/unit/storage-buffer.test.ts
+++ b/tests/lite/unit/storage-buffer.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine.js";
+import { createShaderMaterial, setShaderStorageBuffer } from "../../../packages/babylon-lite/src/material/shader/shader-material.js";
+import { _rebuildStorageBuffers, createStorageBuffer, disposeStorageBuffer, updateStorageBuffer } from "../../../packages/babylon-lite/src/resource/storage-buffer.js";
+import type { StorageBuffer } from "../../../packages/babylon-lite/src/resource/storage-buffer.js";
+
+const gpuGlobals = globalThis as Omit<typeof globalThis, "GPUBufferUsage"> & {
+    GPUBufferUsage?: { STORAGE: number; COPY_DST: number };
+};
+gpuGlobals.GPUBufferUsage ??= { STORAGE: 0x80, COPY_DST: 0x8 } as unknown as GPUBufferUsage;
+
+function makeEngine() {
+    const rawBuffer = {
+        destroy: vi.fn(),
+        getMappedRange: vi.fn(() => new ArrayBuffer(16)),
+        unmap: vi.fn(),
+    };
+    const device = {
+        createBuffer: vi.fn(() => rawBuffer),
+        queue: { writeBuffer: vi.fn() },
+    };
+    return { engine: { _device: device } as unknown as EngineContext, device, rawBuffer };
+}
+
+describe("StorageBuffer", () => {
+    it("creates an initialized storage allocation without exposing it as the public value", () => {
+        const { engine, device, rawBuffer } = makeEngine();
+        const storage = createStorageBuffer(engine, new Float32Array([1, 2, 3]), "cells");
+
+        expect(storage.byteLength).toBe(12);
+        expect(storage).not.toBe(rawBuffer);
+        expect(storage._buffer).toBe(rawBuffer);
+        expect(device.createBuffer).toHaveBeenCalledWith({
+            label: "cells",
+            size: 12,
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+            mappedAtCreation: true,
+        });
+        expect(rawBuffer.unmap).toHaveBeenCalledOnce();
+    });
+
+    it("updates aligned in-bounds ranges and rejects invalid writes", () => {
+        const { engine, device } = makeEngine();
+        const storage = createStorageBuffer(engine, new Float32Array(4));
+        const update = new Float32Array([4, 5]);
+
+        updateStorageBuffer(engine, storage, update, 4);
+        expect(device.queue.writeBuffer).toHaveBeenCalledWith(storage._buffer, 4, update.buffer, update.byteOffset, update.byteLength);
+        device.queue.writeBuffer.mockClear();
+        updateStorageBuffer(engine, storage, new Uint8Array(0), storage.byteLength);
+        expect(device.queue.writeBuffer).not.toHaveBeenCalled();
+        expect(() => updateStorageBuffer(engine, storage, update, 12)).toThrow(/exceeds/);
+        expect(() => updateStorageBuffer(engine, storage, new Uint8Array(3))).toThrow(/multiple of 4/);
+        expect(() => updateStorageBuffer(makeEngine().engine, storage, update)).toThrow(/different engine/);
+    });
+
+    it("disposes idempotently and rejects later updates", () => {
+        const { engine, rawBuffer } = makeEngine();
+        const storage = createStorageBuffer(engine, new Float32Array(1));
+
+        disposeStorageBuffer(storage);
+        disposeStorageBuffer(storage);
+        expect(rawBuffer.destroy).toHaveBeenCalledOnce();
+        expect(() => updateStorageBuffer(engine, storage, new Float32Array(1))).toThrow(/disposed/);
+    });
+
+    it("binds through ShaderMaterial identity and rejects disposed resources", () => {
+        const { engine } = makeEngine();
+        const storage = createStorageBuffer(engine, new Float32Array(4));
+        const material = createShaderMaterial({
+            vertexSource: "@vertex fn mainVertex(input: VertexInput) -> @builtin(position) vec4f { return vec4f(input.position, 1); }",
+            fragmentSource: "@fragment fn mainFragment() -> @location(0) vec4f { return vec4f(1); }",
+            attributes: ["position"],
+            storageBuffers: [{ name: "cells", type: "array<f32>" }],
+        });
+
+        setShaderStorageBuffer(material, "cells", storage);
+        const version = material._resourceVersion;
+        expect(material._storageBufferSlots.get("cells")!.current).toBe(storage);
+
+        setShaderStorageBuffer(material, "cells", storage);
+        expect(material._resourceVersion).toBe(version);
+
+        disposeStorageBuffer(storage);
+        expect(() => setShaderStorageBuffer(material, "cells", storage)).toThrow(/disposed/);
+        setShaderStorageBuffer(material, "cells", null);
+        expect(material._storageBufferSlots.get("cells")!.current).toBeNull();
+    });
+
+    it("rejects raw GPUBuffer values with a clear migration error", () => {
+        const { rawBuffer } = makeEngine();
+        const material = createShaderMaterial({
+            vertexSource: "@vertex fn mainVertex(input: VertexInput) -> @builtin(position) vec4f { return vec4f(input.position, 1); }",
+            fragmentSource: "@fragment fn mainFragment() -> @location(0) vec4f { return vec4f(1); }",
+            attributes: ["position"],
+            storageBuffers: [{ name: "cells", type: "array<f32>" }],
+        });
+
+        expect(() => setShaderStorageBuffer(material, "cells", rawBuffer as unknown as StorageBuffer)).toThrow(
+            "setShaderStorageBuffer requires a StorageBuffer created by createStorageBuffer; raw GPUBuffer is not supported."
+        );
+        expect(material._storageBufferSlots.get("cells")!.current).toBeNull();
+    });
+
+    it("rebuilds its GPU handle from retained bytes after a device change", () => {
+        const firstMapped = new ArrayBuffer(8);
+        const firstBuffer = { destroy: vi.fn(), getMappedRange: () => firstMapped, unmap: vi.fn() } as unknown as GPUBuffer;
+        const secondMapped = new ArrayBuffer(8);
+        const secondBuffer = { destroy: vi.fn(), getMappedRange: () => secondMapped, unmap: vi.fn() } as unknown as GPUBuffer;
+        const engine = {
+            _device: {
+                createBuffer: vi.fn(() => firstBuffer),
+                queue: { writeBuffer: vi.fn() },
+            },
+        } as unknown as EngineContext;
+        const storage = createStorageBuffer(engine, new Float32Array([1, 2]));
+        updateStorageBuffer(engine, storage, new Float32Array([9]), 4);
+
+        engine._device = {
+            createBuffer: vi.fn(() => secondBuffer),
+            queue: { writeBuffer: vi.fn() },
+        } as unknown as GPUDevice;
+        _rebuildStorageBuffers(engine);
+
+        expect(storage._buffer).toBe(secondBuffer);
+        expect(Array.from(new Float32Array(secondMapped))).toEqual([1, 9]);
+    });
+
+    it("is nominally branded", () => {
+        // @ts-expect-error Plain public-shape objects must not satisfy the opaque handle type.
+        const forged: StorageBuffer = { byteLength: 4 };
+        expect(forged.byteLength).toBe(4);
+    });
+});


### PR DESCRIPTION
## Summary
- add an opaque, engine-owned `StorageBuffer` resource with aligned updates, disposal, and device-loss recovery
- bind storage buffers through `ShaderMaterial` without exposing raw WebGPU handles
- reject legacy raw `GPUBuffer` values immediately with a clear migration error
- retain storage-related device limits, validate engine ownership/liveness, and clean resources on engine disposal
- add architecture docs, regression/lifecycle tests, and regenerated bundle manifests

## Validation
- 830 unit tests passed
- full lint/typecheck passed
- all bundle-size ceilings passed with no ceiling changes
- 426 parity tests passed; only the known local physics flakes 47, 104, 105, and 106 failed
- visually inspected ShaderMaterial scenes 159 and 165

BREAKING CHANGE: `setShaderStorageBuffer` now requires a `StorageBuffer` created by `createStorageBuffer` instead of a raw `GPUBuffer`. Use `updateStorageBuffer` for writes and unbind before `disposeStorageBuffer`.