### PR TITLE
test: make REUSE_BROWSER coalesce every browser test into one window per worker

### DIFF
--- a/tests/gl/parity/gl-parity.spec.ts
+++ b/tests/gl/parity/gl-parity.spec.ts
@@ -15,7 +15,7 @@
  * stamp canvas.dataset.animationFrozen="true", so a screenshot of either is
  * directly comparable.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../../shared/reuse-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig, loadSceneConfigAll } from "./compare-utils";
 

--- a/tests/gl/perf/gl-perf-raf.spec.ts
+++ b/tests/gl/perf/gl-perf-raf.spec.ts
@@ -21,7 +21,7 @@
  * NOTE: Measures CPU-side time only (JS execution + command encoding + GL
  * submission). GPU execution is async and not captured.
  */
-import { test } from "@playwright/test";
+import { test, acquireContext } from "../../shared/reuse-fixtures";
 import { writeFileSync, mkdirSync, readFileSync, existsSync } from "fs";
 import { resolve } from "path";
 import type { BrowserContext } from "@playwright/test";
@@ -223,7 +223,7 @@ const manifest: Manifest = loadExistingManifest();
 test.describe("GL RAF Performance Benchmark", () => {
     for (const scene of SCENES) {
         test(`${scene.label}`, async ({ browser }) => {
-            const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+            const { context, release } = await acquireContext(browser);
 
             const liteUrl = `/gl/scene${scene.id}.html`;
             const bjsUrl = `/gl/babylon-ref-scene${scene.id}.html`;
@@ -235,7 +235,7 @@ test.describe("GL RAF Performance Benchmark", () => {
             const lite = await measurePage(context, liteUrl, DURATION_MS);
             const bjs = await measurePage(context, bjsUrl, DURATION_MS);
 
-            await context.close();
+            await release();
 
             manifest[scene.name] = { lite, bjs };
 

--- a/tests/gl/perf/gl-perf-regression.spec.ts
+++ b/tests/gl/perf/gl-perf-regression.spec.ts
@@ -32,7 +32,7 @@
  *       PERF_DURATION=5      — measurement duration in seconds (default: 5)
  *       PERF_REGRESSION_PCT=5 — allowed % regression vs baseline (default: 5)
  */
-import { test, expect } from "@playwright/test";
+import { test, expect, acquireContext } from "../../shared/reuse-fixtures";
 import { writeFileSync, mkdirSync, readFileSync, existsSync } from "fs";
 import { resolve } from "path";
 import type { BrowserContext } from "@playwright/test";
@@ -248,7 +248,7 @@ test.describe("GL Perf Regression (lite-gl vs Babylon ref)", () => {
 
     for (const scene of SCENES) {
         test(`${scene.label}`, async ({ browser }) => {
-            const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+            const { context, release } = await acquireContext(browser);
 
             const currentUrl = `/gl/scene${scene.id}.html`;
             const baselineUrl = `/gl/babylon-ref-scene${scene.id}.html`;
@@ -303,7 +303,7 @@ test.describe("GL Perf Regression (lite-gl vs Babylon ref)", () => {
                     ).toBeLessThanOrEqual(limitMs);
                 }
             } finally {
-                await context.close();
+                await release();
             }
         });
     }

--- a/tests/lite/parity/bundle-size.spec.ts
+++ b/tests/lite/parity/bundle-size.spec.ts
@@ -17,7 +17,7 @@
  * If lab/public/bundle/master-manifest.json is available, bundle-size increases
  * relative to master are emitted as warnings only; ceilings remain the blocker.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./parity-fixtures";
 import { existsSync, readFileSync } from "fs";
 import { resolve } from "path";
 
@@ -85,25 +85,26 @@ for (const scene of SCENES) {
         page.on("response", onResponse);
 
         // Navigate to the bundle page and wait for the scene to finish rendering
-        await page.goto(`/bundle-scene${scene.id}.html`, { waitUntil: "domcontentloaded" });
+        page.on("response", onResponse);
         let readyTimedOut = false;
         try {
+            await page.goto(`/bundle-scene${scene.id}.html`, { waitUntil: "domcontentloaded" });
             await page.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", undefined, { timeout: 20_000 });
         } catch {
             // Some heavy scenes fetch all runtime JS but do not mark the canvas ready in cloud browsers.
             readyTimedOut = true;
+        } finally {
+            // Always detach the listener — the page is shared across tests under
+            // REUSE_BROWSER, so a leaked listener would accumulate. Do NOT close the
+            // page; in default mode Playwright tears it down in fixture teardown.
+            page.off("response", onResponse);
         }
         if (readyTimedOut) {
-            page.off("response", onResponse);
-            await page.close();
             const sceneKey = `scene${scene.id}`;
             const files = BUNDLE_MANIFEST?.[sceneKey]?.runtimeChunks;
             expect(files, `bundle manifest must contain runtime chunks for ${sceneKey}`).toBeTruthy();
             runtimeFiles.length = 0;
             runtimeFiles.push(...files!);
-        } else {
-            page.off("response", onResponse);
-            await page.close();
         }
         for (const file of Array.from(new Set(runtimeFiles))) {
             jsPayloads.push({ url: `/bundle/${file}`, file, body: readFileSync(resolve(__dirname, "../../../lab/public/bundle", file)) });

--- a/tests/lite/parity/bundle-size.spec.ts
+++ b/tests/lite/parity/bundle-size.spec.ts
@@ -85,7 +85,6 @@ for (const scene of SCENES) {
         page.on("response", onResponse);
 
         // Navigate to the bundle page and wait for the scene to finish rendering
-        page.on("response", onResponse);
         let readyTimedOut = false;
         try {
             await page.goto(`/bundle-scene${scene.id}.html`, { waitUntil: "domcontentloaded" });

--- a/tests/lite/parity/parity-fixtures.ts
+++ b/tests/lite/parity/parity-fixtures.ts
@@ -1,44 +1,10 @@
 /**
  * Parity test fixtures.
  *
- * By default this simply re-exports Playwright's `test`/`expect`, so behaviour is
- * identical to importing straight from `@playwright/test`.
- *
- * When `REUSE_BROWSER` is set (`REUSE_BROWSER=true` / `1`), the built-in
- * per-test `page` fixture is replaced with a single **worker-scoped** page that
- * is created once and reused by every scene spec that worker runs. In headed
- * mode this means one browser window per worker is opened once, sinks to the
- * background, and stays there for the whole run — instead of a fresh window
- * popping to the foreground (and closing) for each of the ~200 scene specs.
- *
- * The reused page is re-navigated by each test's `page.goto(...)`, which resets
- * the document, so per-test isolation of scene state is preserved. Only the
- * OS-level window/context is shared. `captureGolden` (compare-core) honours the
- * same flag and reuses the worker context/page instead of opening its own.
+ * Thin re-export of the shared browser-reuse fixtures so the ~200 parity specs
+ * that import from here keep working unchanged. See
+ * `tests/shared/reuse-fixtures.ts` for the actual `REUSE_BROWSER` behaviour and
+ * the `acquireReferencePage` / `acquireContext` helpers used by specs that open
+ * their own reference/oracle windows.
  */
-import { test as base, expect, type Page } from "@playwright/test";
-
-export const REUSE_BROWSER = process.env.REUSE_BROWSER === "true" || process.env.REUSE_BROWSER === "1";
-
-type ReuseWorkerFixtures = { reusedPage: Page };
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-const reuseTest = base.extend<{}, ReuseWorkerFixtures>({
-    // One page (and therefore one context + one window) per worker, reused across tests.
-    reusedPage: [
-        async ({ browser }, use) => {
-            const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-            const page = await context.newPage();
-            await use(page);
-            await context.close();
-        },
-        { scope: "worker" },
-    ],
-    // Override the built-in test-scoped `page` to hand back the shared worker page.
-    page: async ({ reusedPage }, use) => {
-        await use(reusedPage);
-    },
-});
-
-export const test = REUSE_BROWSER ? reuseTest : base;
-export { expect };
+export { test, expect, REUSE_BROWSER, acquireReferencePage, acquireContext, reusedContext } from "../../shared/reuse-fixtures";

--- a/tests/lite/parity/scenes/scene101-physics-trigger.spec.ts
+++ b/tests/lite/parity/scenes/scene101-physics-trigger.spec.ts
@@ -11,7 +11,7 @@
  * remain a live DATA comparison: the BJS reference page is launched each run to confirm that
  * BOTH TRIGGER_ENTERED and TRIGGER_EXITED fired by the capture frame, matching Lite.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";
@@ -25,8 +25,7 @@ test.skip(!!sceneConfig.skipParity, "Scene 101 skipped via skipParity in scene-c
 
 /** Launch the BJS reference page live to read the trigger-event DATA at the capture frame. */
 async function captureBjsData(browser: Browser): Promise<{ entered: string | undefined; exited: string | undefined }> {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene101.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 101 BJS reference" });
@@ -35,8 +34,7 @@ async function captureBjsData(browser: Browser): Promise<{ entered: string | und
     const entered = await bjsPage.locator("canvas").evaluate((el) => (el as HTMLCanvasElement).dataset.entered);
     const exited = await bjsPage.locator("canvas").evaluate((el) => (el as HTMLCanvasElement).dataset.exited);
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return { entered, exited };
 }
 

--- a/tests/lite/parity/scenes/scene102-physics-raycast.spec.ts
+++ b/tests/lite/parity/scenes/scene102-physics-raycast.spec.ts
@@ -10,7 +10,7 @@
  * remain a live DATA comparison: the BJS reference page is launched each run and its raycast
  * result is asserted equal to Lite's.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser, Page } from "@playwright/test";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";
@@ -28,16 +28,14 @@ async function readRayResult(page: Page): Promise<string | undefined> {
 
 /** Launch the BJS reference page live to read the raycast result DATA at the capture frame. */
 async function captureBjsData(browser: Browser): Promise<string | undefined> {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene102.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 102 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: `Scene 102 BJS reference at frame ${CAPTURE_FRAME}`, flag: "captureReady", pollMs: 100 });
     const rayResult = await readRayResult(bjsPage);
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return rayResult;
 }
 

--- a/tests/lite/parity/scenes/scene103-thin-instance-raycast.spec.ts
+++ b/tests/lite/parity/scenes/scene103-thin-instance-raycast.spec.ts
@@ -10,7 +10,7 @@
  * indices remain a live DATA comparison: the BJS reference page is launched each run and every ray's
  * `hasHit` + hit instance index is asserted IDENTICAL to Lite's.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser, Page } from "@playwright/test";
 import * as path from "path";
 import { captureGolden, compareImages, getSceneConfig, waitForCanvasReady } from "../compare-utils";
@@ -34,16 +34,14 @@ async function readRayHits(page: Page): Promise<string | undefined> {
 
 /** Launch the BJS reference page live to read the raycast-hit DATA at the capture frame. */
 async function captureBjsData(browser: Browser): Promise<string | undefined> {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene103.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 103 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: `Scene 103 BJS reference at frame ${CAPTURE_FRAME}`, flag: "captureReady", pollMs: 100 });
     const rayHits = await readRayHits(bjsPage);
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return rayHits;
 }
 

--- a/tests/lite/parity/scenes/scene104-character-controller.spec.ts
+++ b/tests/lite/parity/scenes/scene104-character-controller.spec.ts
@@ -20,7 +20,7 @@
  * run; the rendered frame is compared against a committed VISUAL golden (`babylon-ref-golden.png`)
  * captured at the pre-contact frame.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Page } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -72,11 +72,9 @@ test("Scene 104 — Character controller level walk + collision detection matche
     const goldenPath = await captureGolden(browser, { sceneId: 104, queryParams: `captureFrame=${VISUAL_FRAME}`, waitFlag: "captureReady" });
 
     // ── Babylon.js reference (live DATA) at the collision frame ──
-    const bjsContext = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await bjsContext.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
     const bjs = await capture(bjsPage, "/babylon-ref-scene104.html", COLLISION_FRAME, "Scene 104 BJS reference (collisions)");
-    await bjsPage.close();
-    await bjsContext.close();
+    await release();
 
     // ── Lite: collision frame (data) + pre-contact frame (visual) ──
     const lite = await capture(page, "/scene104.html", COLLISION_FRAME, "Scene 104 Lite (collisions)");

--- a/tests/lite/parity/scenes/scene105-moving-platform.spec.ts
+++ b/tests/lite/parity/scenes/scene105-moving-platform.spec.ts
@@ -24,7 +24,7 @@
  * run; the rendered frame is compared against a committed VISUAL golden (`babylon-ref-golden.png`)
  * captured at the pre-contact frame.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Page } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -80,11 +80,9 @@ test("Scene 105 — Character controller + moving platform matches Babylon.js", 
     const goldenPath = await captureGolden(browser, { sceneId: 105, queryParams: `captureFrame=${VISUAL_FRAME}`, waitFlag: "captureReady" });
 
     // ── Babylon.js reference (live DATA) at the collision frame ──
-    const bjsContext = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await bjsContext.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
     const bjs = await capture(bjsPage, "/babylon-ref-scene105.html", COLLISION_FRAME, "Scene 105 BJS reference (collisions)");
-    await bjsPage.close();
-    await bjsContext.close();
+    await release();
 
     // ── Lite: collision frame (data) + pre-contact frame (visual) ──
     const lite = await capture(page, "/scene105.html", COLLISION_FRAME, "Scene 105 Lite (collisions)");

--- a/tests/lite/parity/scenes/scene115-alien-picking-frame100.spec.ts
+++ b/tests/lite/parity/scenes/scene115-alien-picking-frame100.spec.ts
@@ -5,7 +5,7 @@
  * frame 100 (seekTime = 100 / 60), perform the same precise pick at the same
  * CSS canvas coordinate, and move visible markers from the real pick data.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser, Page } from "@playwright/test";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
@@ -90,14 +90,12 @@ function expectMarkerState(state: PickState, label: string): void {
 }
 
 async function readBjsPickState(browser: Browser): Promise<PickState> {
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
     try {
         await bjsPage.goto(`/babylon-ref-scene${SCENE_ID}.html?seekTime=${SEEK_TIME}`);
         return await readPickState(bjsPage);
     } finally {
-        await bjsPage.close();
-        await context.close();
+        await release();
     }
 }
 

--- a/tests/lite/parity/scenes/scene117-sprite-2d-picking.spec.ts
+++ b/tests/lite/parity/scenes/scene117-sprite-2d-picking.spec.ts
@@ -6,7 +6,7 @@
  * ThinSprite (Babylon has no 2D-sprite pick), so the pixels match while the `dataset` state
  * proves Lite's `pickSprite2D` resolved the correct sprite.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Page } from "@playwright/test";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";

--- a/tests/lite/parity/scenes/scene118-billboard-picking.spec.ts
+++ b/tests/lite/parity/scenes/scene118-billboard-picking.spec.ts
@@ -4,7 +4,7 @@
  * The scene picks the centre camera-facing billboard via `pickBillboardSprite` and floats a
  * small marker mesh in front of it. The BJS oracle does the same with `scene.pickSprite`.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import type { Page } from "@playwright/test";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";

--- a/tests/lite/parity/scenes/scene221-pointer-drags.spec.ts
+++ b/tests/lite/parity/scenes/scene221-pointer-drags.spec.ts
@@ -7,7 +7,7 @@
  *    derived fields are correctly populated for both engines' pickers).
  * 3. Compares the post-drag rendered frame against the captured golden.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import * as fs from "fs";
 import * as path from "path";
 import type { Page } from "@playwright/test";
@@ -131,8 +131,7 @@ test("Scene 221 — Rotation gizmo camembert visible mid-drag", async ({ page },
     const browser = page.context().browser()!;
 
     if (!fs.existsSync(ROTATION_GOLDEN_REF) || process.env.RECAPTURE_GOLDEN) {
-        const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-        const bjsPage = await ctx.newPage();
+        const { page: bjsPage, release } = await acquireReferencePage(browser);
         await bjsPage.goto("/babylon-ref-scene221.html");
         await bjsPage.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 30_000 });
         await bjsPage.waitForFunction(() => !document.getElementById("babylonjsLoadingDiv"), { timeout: 10_000 }).catch(() => undefined);
@@ -140,8 +139,7 @@ test("Scene 221 — Rotation gizmo camembert visible mid-drag", async ({ page },
         await performRotationMidDrag(bjsPage);
         await bjsPage.locator("canvas").screenshot({ path: ROTATION_GOLDEN_REF });
         await bjsPage.mouse.up().catch(() => undefined);
-        await bjsPage.close();
-        await ctx.close();
+        await release();
     }
 
     await page.goto("/scene221.html");
@@ -169,8 +167,7 @@ test("Scene 221 — Pointer Drags matches Babylon.js reference (post scripted dr
 
     // ── Capture golden by driving the BJS reference page through the drag set ──
     if (!fs.existsSync(GOLDEN_REF) || process.env.RECAPTURE_GOLDEN) {
-        const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-        const bjsPage = await ctx.newPage();
+        const { page: bjsPage, release } = await acquireReferencePage(browser);
         await bjsPage.goto("/babylon-ref-scene221.html");
         await bjsPage.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 30_000 });
         await bjsPage.waitForFunction(() => !document.getElementById("babylonjsLoadingDiv"), { timeout: 10_000 }).catch(() => undefined);
@@ -179,8 +176,7 @@ test("Scene 221 — Pointer Drags matches Babylon.js reference (post scripted dr
         await bjsPage.waitForTimeout(200);
         fs.mkdirSync(REFERENCE_DIR, { recursive: true });
         await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
-        await bjsPage.close();
-        await ctx.close();
+        await release();
     }
 
     // ── Drive Lite through the same drag set and capture ──

--- a/tests/lite/parity/scenes/scene222-composite-gizmos.spec.ts
+++ b/tests/lite/parity/scenes/scene222-composite-gizmos.spec.ts
@@ -17,7 +17,7 @@
  * are tolerated; the parity comparison still validates that BJS and Lite end
  * up in the same final pose given the same pointer events.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import * as fs from "fs";
 import * as path from "path";
 import type { Page } from "@playwright/test";
@@ -136,8 +136,7 @@ test("Scene 222 — Composite Gizmos matches Babylon.js reference (local→world
     const browser = page.context().browser()!;
 
     if (!fs.existsSync(GOLDEN_REF) || process.env.RECAPTURE_GOLDEN) {
-        const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-        const bjsPage = await ctx.newPage();
+        const { page: bjsPage, release } = await acquireReferencePage(browser);
         await bjsPage.goto("/babylon-ref-scene222.html");
         await bjsPage.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 30_000 });
         await bjsPage.waitForFunction(() => !document.getElementById("babylonjsLoadingDiv"), { timeout: 10_000 }).catch(() => undefined);
@@ -146,8 +145,7 @@ test("Scene 222 — Composite Gizmos matches Babylon.js reference (local→world
         await bjsPage.waitForTimeout(300);
         fs.mkdirSync(REFERENCE_DIR, { recursive: true });
         await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
-        await bjsPage.close();
-        await ctx.close();
+        await release();
     }
 
     await page.goto("/scene222.html");

--- a/tests/lite/parity/scenes/scene223-camera-light-gizmos.spec.ts
+++ b/tests/lite/parity/scenes/scene223-camera-light-gizmos.spec.ts
@@ -5,7 +5,7 @@
  * over a ground plane.  No scripted interaction; we just wait for the
  * scene to settle and compare the captured frame against the BJS reference.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import * as fs from "fs";
 import * as path from "path";
 import { attachCompareArtifacts, compareImages, getSceneConfig } from "../compare-utils";
@@ -21,16 +21,14 @@ test("Scene 223 — Camera + Light Gizmos match Babylon.js reference", async ({ 
     const browser = page.context().browser()!;
 
     if (!fs.existsSync(GOLDEN_REF) || process.env.RECAPTURE_GOLDEN) {
-        const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-        const bjsPage = await ctx.newPage();
+        const { page: bjsPage, release } = await acquireReferencePage(browser);
         await bjsPage.goto("/babylon-ref-scene223.html");
         await bjsPage.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 30_000 });
         await bjsPage.waitForFunction(() => !document.getElementById("babylonjsLoadingDiv"), { timeout: 10_000 }).catch(() => undefined);
         await bjsPage.waitForTimeout(500);
         fs.mkdirSync(REFERENCE_DIR, { recursive: true });
         await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
-        await bjsPage.close();
-        await ctx.close();
+        await release();
     }
 
     await page.goto("/scene223.html");

--- a/tests/lite/parity/scenes/scene224-bounding-box-gizmo.spec.ts
+++ b/tests/lite/parity/scenes/scene224-bounding-box-gizmo.spec.ts
@@ -21,7 +21,7 @@
  * rotation-anchor geometry — which is the part this scene is meant to
  * cover.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import * as fs from "fs";
 import * as path from "path";
 import type { Page } from "@playwright/test";
@@ -87,8 +87,7 @@ test("Scene 224 — Bounding Box Gizmo matches Babylon.js reference (determinist
     const browser = page.context().browser()!;
 
     if (!fs.existsSync(GOLDEN_REF) || process.env.RECAPTURE_GOLDEN) {
-        const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-        const bjsPage = await ctx.newPage();
+        const { page: bjsPage, release } = await acquireReferencePage(browser);
         await bjsPage.goto("/babylon-ref-scene224.html?nocam=1");
         await bjsPage.waitForFunction(() => document.querySelector("canvas")?.dataset.ready === "true", { timeout: 30_000 });
         await bjsPage.waitForFunction(() => !document.getElementById("babylonjsLoadingDiv"), { timeout: 10_000 }).catch(() => undefined);
@@ -99,8 +98,7 @@ test("Scene 224 — Bounding Box Gizmo matches Babylon.js reference (determinist
         console.log(`BJS  root: x=${bjsAfter.px.toFixed(3)} qw=${bjsAfter.qw.toFixed(3)} sx=${bjsAfter.sx.toFixed(3)}`);
         fs.mkdirSync(REFERENCE_DIR, { recursive: true });
         await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
-        await bjsPage.close();
-        await ctx.close();
+        await release();
     }
 
     await page.goto("/scene224.html?nocam=1");

--- a/tests/lite/parity/scenes/scene264-npe-change-size.spec.ts
+++ b/tests/lite/parity/scenes/scene264-npe-change-size.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity-fixtures";
 import * as path from "path";
 import { attachCompareArtifacts, captureGolden, compareImages, getSceneConfig } from "../compare-utils";
 

--- a/tests/lite/parity/scenes/scene40-physics.spec.ts
+++ b/tests/lite/parity/scenes/scene40-physics.spec.ts
@@ -6,7 +6,7 @@
  *
  * BJS reference: playground #Z8HTUN#1
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -22,16 +22,14 @@ test.skip(!!sceneConfig.skipParity, "Scene 40 skipped via skipParity in scene-co
 
 async function captureBjsReference(browser: Browser): Promise<string> {
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene40.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 40 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: `Scene 40 BJS reference at frame ${CAPTURE_FRAME}`, flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: LIVE_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return LIVE_REF;
 }
 

--- a/tests/lite/parity/scenes/scene41-physics-shapes.spec.ts
+++ b/tests/lite/parity/scenes/scene41-physics-shapes.spec.ts
@@ -4,7 +4,7 @@
  * Captures Babylon.js and Babylon Lite after a short deterministic fixed-step
  * simulation and compares the PhysicsViewer wireframe overlay.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -24,16 +24,14 @@ async function captureBjsReference(browser: Browser): Promise<string> {
     }
 
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene41.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 41 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: `Scene 41 BJS reference at frame ${CAPTURE_FRAME}`, flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return GOLDEN_REF;
 }
 

--- a/tests/lite/parity/scenes/scene42-physics-clone.spec.ts
+++ b/tests/lite/parity/scenes/scene42-physics-clone.spec.ts
@@ -3,7 +3,7 @@
  *
  * Captures Babylon.js and Babylon Lite at fixed physics frame 300.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -23,16 +23,14 @@ async function captureBjsReference(browser: Browser): Promise<string> {
     }
 
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene42.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 42 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: `Scene 42 BJS reference at frame ${CAPTURE_FRAME}`, flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return GOLDEN_REF;
 }
 

--- a/tests/lite/parity/scenes/scene43-parametric-proximity.spec.ts
+++ b/tests/lite/parity/scenes/scene43-parametric-proximity.spec.ts
@@ -3,7 +3,7 @@
  *
  * Captures Babylon.js and Babylon Lite at fixed animation frame 300.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -23,16 +23,14 @@ async function captureBjsReference(browser: Browser): Promise<string> {
     }
 
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene43.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 43 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: `Scene 43 BJS reference at frame ${CAPTURE_FRAME}`, flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return GOLDEN_REF;
 }
 

--- a/tests/lite/parity/scenes/scene44-physics-sleeping-towers.spec.ts
+++ b/tests/lite/parity/scenes/scene44-physics-sleeping-towers.spec.ts
@@ -3,7 +3,7 @@
  *
  * Drops small boxes after 2 seconds and captures Babylon.js / Babylon Lite at 5 seconds.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -23,16 +23,14 @@ async function captureBjsReference(browser: Browser): Promise<string> {
     }
 
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene44.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 44 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: `Scene 44 BJS reference after ${CAPTURE_AFTER_SECONDS}s`, flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return GOLDEN_REF;
 }
 

--- a/tests/lite/parity/scenes/scene45-physics-filtering.spec.ts
+++ b/tests/lite/parity/scenes/scene45-physics-filtering.spec.ts
@@ -3,7 +3,7 @@
  *
  * Captures Babylon.js and Babylon Lite after 3 seconds.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -23,16 +23,14 @@ async function captureBjsReference(browser: Browser): Promise<string> {
     }
 
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene45.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 45 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: `Scene 45 BJS reference after ${CAPTURE_AFTER_SECONDS}s`, flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return GOLDEN_REF;
 }
 

--- a/tests/lite/parity/scenes/scene46-constraint-viewer.spec.ts
+++ b/tests/lite/parity/scenes/scene46-constraint-viewer.spec.ts
@@ -3,7 +3,7 @@
  *
  * Captures Babylon.js and Babylon Lite at fixed physics frame 10.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -23,16 +23,14 @@ async function captureBjsReference(browser: Browser): Promise<string> {
     }
 
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene46.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 46 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: `Scene 46 BJS reference at frame ${CAPTURE_FRAME}`, flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return GOLDEN_REF;
 }
 

--- a/tests/lite/parity/scenes/scene47-physics-heightfield.spec.ts
+++ b/tests/lite/parity/scenes/scene47-physics-heightfield.spec.ts
@@ -5,7 +5,7 @@
  * simulation in which two rows of shapes fall onto a heightfield derived from
  * heightMap.png, then compares the settled frame.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -25,16 +25,14 @@ async function captureBjsReference(browser: Browser): Promise<string> {
     }
 
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene47.html${CAPTURE_QUERY}`);
     await waitForCanvasReady(bjsPage, { timeout: 60_000, label: "Scene 47 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 60_000, label: `Scene 47 BJS reference at frame ${CAPTURE_FRAME}`, flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return GOLDEN_REF;
 }
 

--- a/tests/lite/parity/scenes/scene48-physics-center-of-mass.spec.ts
+++ b/tests/lite/parity/scenes/scene48-physics-center-of-mass.spec.ts
@@ -6,7 +6,7 @@
  * physics steps after the kick. The scene self-determines the capture frame,
  * so the spec just waits on the `captureReady` flag (no fixed ?captureFrame).
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -24,16 +24,14 @@ async function captureBjsReference(browser: Browser): Promise<string> {
     }
 
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene48.html?capture=1`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 48 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 48 BJS reference after kick", flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return GOLDEN_REF;
 }
 

--- a/tests/lite/parity/scenes/scene49-physics-shape-queries.spec.ts
+++ b/tests/lite/parity/scenes/scene49-physics-shape-queries.spec.ts
@@ -7,7 +7,7 @@
  * The static scene self-determines its capture frame (once the broadphase exists and
  * both queries report hits), so the spec just waits on the `captureReady` flag.
  */
-import { test, expect } from "../parity-fixtures";
+import { test, expect, acquireReferencePage } from "../parity-fixtures";
 import type { Browser } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
@@ -25,16 +25,14 @@ async function captureBjsReference(browser: Browser): Promise<string> {
     }
 
     fs.mkdirSync(REFERENCE_DIR, { recursive: true });
-    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
-    const bjsPage = await context.newPage();
+    const { page: bjsPage, release } = await acquireReferencePage(browser);
 
     await bjsPage.goto(`/babylon-ref-scene49.html?capture=1`);
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 49 BJS reference" });
     await waitForCanvasReady(bjsPage, { timeout: 50_000, label: "Scene 49 BJS reference queries", flag: "captureReady", pollMs: 100 });
     await bjsPage.locator("canvas").screenshot({ path: GOLDEN_REF });
 
-    await bjsPage.close();
-    await context.close();
+    await release();
     return GOLDEN_REF;
 }
 

--- a/tests/lite/perf/perf-raf.spec.ts
+++ b/tests/lite/perf/perf-raf.spec.ts
@@ -20,7 +20,7 @@
  * NOTE: Measures CPU-side time only (JS execution + command encoding +
  * queue submission). GPU execution is async and not captured.
  */
-import { test } from "@playwright/test";
+import { test, acquireContext } from "../parity/parity-fixtures";
 import { writeFileSync, mkdirSync, readFileSync, existsSync } from "fs";
 import { resolve } from "path";
 import type { BrowserContext } from "@playwright/test";
@@ -216,7 +216,7 @@ const manifest: Manifest = loadExistingManifest();
 test.describe("RAF Performance Benchmark", () => {
     for (const scene of SCENES) {
         test(`${scene.label}`, async ({ browser }) => {
-            const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+            const { context, release } = await acquireContext(browser);
 
             const liteUrl = `/${scene.name}.html`;
             const bjsUrl = `/babylon-ref-${scene.name}.html`;
@@ -230,7 +230,7 @@ test.describe("RAF Performance Benchmark", () => {
             const lite = await measurePage(context, liteUrl, DURATION_MS);
             const bjs = await measurePage(context, bjsUrl, DURATION_MS);
 
-            await context.close();
+            await release();
 
             manifest[scene.name] = { lite, bjs };
 

--- a/tests/lite/perf/perf-regression.spec.ts
+++ b/tests/lite/perf/perf-regression.spec.ts
@@ -26,7 +26,7 @@
  *
  * Run:  npx playwright test --config playwright.perf.config.ts tests/lite/perf/perf-regression.spec.ts
  */
-import { test, expect } from "@playwright/test";
+import { test, expect, acquireContext } from "../parity/parity-fixtures";
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "fs";
 import { resolve } from "path";
 import type { BrowserContext, Page } from "@playwright/test";
@@ -298,7 +298,7 @@ if (!hasBaseline) {
                     skipWithWarning(`[NOT A PERFORMANCE ISSUE] Baseline bundle missing for scene ${scene.id} (${scene.name}) — likely a newly added scene`, testName);
                 }
 
-                const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+                const { context, release } = await acquireContext(browser);
 
                 const currentUrl = `/lite/bundle-scene${scene.id}.html`;
                 const baselineUrl = `/lite/bundle-baseline-scene${scene.id}.html`;
@@ -310,7 +310,7 @@ if (!hasBaseline) {
                     try {
                         return await measurePage(context, url, RUNS_PER_SCENE);
                     } catch (e) {
-                        await context.close();
+                        await release();
                         skipWithWarning(`[NOT A PERFORMANCE ISSUE] ${label} scene failed to load/render: ${(e as Error).message}`, testName);
                     }
                 };
@@ -325,7 +325,7 @@ if (!hasBaseline) {
                     baseline = await measure("Baseline", baselineUrl);
                 }
 
-                await context.close();
+                await release();
 
                 const avgDeltaPct = baseline.avgMs > 0 ? ((current.avgMs - baseline.avgMs) / baseline.avgMs) * 100 : 0;
                 const p95DeltaPct = baseline.p95Ms > 0 ? ((current.p95Ms - baseline.p95Ms) / baseline.p95Ms) * 100 : 0;

--- a/tests/lite/plumbing/billboard-pick.spec.ts
+++ b/tests/lite/plumbing/billboard-pick.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity/parity-fixtures";
 
 test.describe("GPU Billboard Picking", () => {
     test("pickBillboardSprite hits a clear billboard, misses a corner, and respects mesh occlusion", async ({ page }) => {

--- a/tests/lite/plumbing/dispose.spec.ts
+++ b/tests/lite/plumbing/dispose.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity/parity-fixtures";
 
 test.describe("Dispose", () => {
     test("scene.dispose() + engine.dispose() release GPU resources without errors", async ({ page }) => {

--- a/tests/lite/plumbing/material-swap.spec.ts
+++ b/tests/lite/plumbing/material-swap.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity/parity-fixtures";
 import * as path from "path";
 import * as fs from "fs";
 import { PNG } from "pngjs";

--- a/tests/lite/plumbing/memory-leak.spec.ts
+++ b/tests/lite/plumbing/memory-leak.spec.ts
@@ -16,7 +16,7 @@
  *   4. Asserts heap growth from cycle 2→N is within tolerance
  *      (cycle 1→2 is excluded as JIT/cache warmup)
  */
-import { test, expect } from "@playwright/test";
+import { test, expect, acquireReferencePage } from "../parity/parity-fixtures";
 import type { CDPSession } from "@playwright/test";
 
 // ── Configuration ──────────────────────────────────────────────────
@@ -62,8 +62,7 @@ async function getJSHeapUsed(cdp: CDPSession): Promise<number> {
 test.describe("Memory Leak Detection", () => {
     for (const scene of SCENES) {
         test(`${scene.label} — no leak across ${CYCLES} cycles`, async ({ browser }) => {
-            const context = await browser.newContext({ viewport: { width: 800, height: 600 } });
-            const page = await context.newPage();
+            const { page, release } = await acquireReferencePage(browser, { width: 800, height: 600 });
             const cdp = await page.context().newCDPSession(page);
             await cdp.send("Performance.enable");
             await cdp.send("HeapProfiler.enable");
@@ -94,8 +93,7 @@ test.describe("Memory Leak Detection", () => {
 
             await cdp.send("HeapProfiler.disable");
             await cdp.send("Performance.disable");
-            await page.close();
-            await context.close();
+            await release();
 
             // Report
             const heapKB = heapSizes.map((h) => (h / 1024).toFixed(0));

--- a/tests/lite/plumbing/picking.spec.ts
+++ b/tests/lite/plumbing/picking.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../parity/parity-fixtures";
 
 test.describe("GPU Picking", () => {
     test("pickAsync hits a sphere at canvas center and misses at corner", async ({ page }) => {

--- a/tests/shared/reuse-fixtures.ts
+++ b/tests/shared/reuse-fixtures.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared browser-reuse fixtures and helpers.
+ *
+ * By default this re-exports Playwright's `test`/`expect`, so behaviour is
+ * identical to importing straight from `@playwright/test`.
+ *
+ * When `REUSE_BROWSER` is set (`REUSE_BROWSER=true` / `1`), EVERY browser-based
+ * test (parity, bundle-size, plumbing, perf, GL) shares a single browser window
+ * per Playwright worker instead of opening a fresh window per test. In headed
+ * local runs this keeps one window in the background rather than popping hundreds
+ * of windows to the foreground (and stealing focus) while you work elsewhere.
+ *
+ * There are three window sources in the suite; all three now funnel through here
+ * so REUSE_BROWSER coalesces them into that one window:
+ *   1. The per-test `page` fixture — overridden below to a worker-scoped page.
+ *   2. Reference/oracle captures that open their own `browser.newContext()` — use
+ *      {@link acquireReferencePage}.
+ *   3. Perf harnesses that drive a raw `browser.newContext()` — use
+ *      {@link acquireContext}.
+ *
+ * The single window is created once and reused until the Playwright run (CLI
+ * invocation) finishes. A new CLI invocation naturally starts its own window.
+ */
+import { test as base, expect } from "@playwright/test";
+import type { Browser, BrowserContext, Page } from "@playwright/test";
+
+export const REUSE_BROWSER = process.env.REUSE_BROWSER === "true" || process.env.REUSE_BROWSER === "1";
+
+const DEFAULT_VIEWPORT = { width: 1280, height: 720 } as const;
+
+type Viewport = { width: number; height: number };
+
+/**
+ * The single worker-shared context (one OS window) in REUSE_BROWSER mode, or
+ * `undefined` when reuse is off. Because Playwright's `browser` fixture is
+ * worker-scoped, the first context on the browser is always THE shared window
+ * for that worker.
+ */
+export function reusedContext(browser: Browser): BrowserContext | undefined {
+    return REUSE_BROWSER ? browser.contexts()[0] : undefined;
+}
+
+/**
+ * Acquire a browser context for reference/perf work.
+ *
+ * In reuse mode this returns the worker's single shared context (creating it if
+ * this is the first caller in a worker that hasn't used the `page` fixture yet)
+ * and a no-op `release()` so the window stays open for the rest of the run.
+ * Otherwise it opens a fresh isolated context and `release()` tears it down, so
+ * non-reuse behaviour is byte-for-byte what the callers did before.
+ */
+export async function acquireContext(browser: Browser, viewport: Viewport = DEFAULT_VIEWPORT): Promise<{ context: BrowserContext; release: () => Promise<void> }> {
+    if (REUSE_BROWSER) {
+        const context = browser.contexts()[0] ?? (await browser.newContext({ viewport }));
+        return { context, release: async () => {} };
+    }
+    const context = await browser.newContext({ viewport });
+    return { context, release: async () => void (await context.close()) };
+}
+
+/**
+ * Acquire a page for reference/oracle captures.
+ *
+ * In reuse mode this hands back a live page inside the worker's single shared
+ * window (reusing the current tab, or opening one more tab in the SAME window —
+ * never a new window) with a no-op `release()`. Otherwise it opens a fresh
+ * isolated context+page and `release()` closes them, matching the previous
+ * per-spec `browser.newContext()` + `context.close()` behaviour.
+ */
+export async function acquireReferencePage(browser: Browser, viewport: Viewport = DEFAULT_VIEWPORT): Promise<{ page: Page; release: () => Promise<void> }> {
+    if (REUSE_BROWSER) {
+        const context = browser.contexts()[0] ?? (await browser.newContext({ viewport }));
+        const page = context.pages().find((p) => !p.isClosed()) ?? (await context.newPage());
+        return { page, release: async () => {} };
+    }
+    const context = await browser.newContext({ viewport });
+    const page = await context.newPage();
+    return { page, release: async () => void (await context.close()) };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+const reuseTest = base.extend<{}, { reuseContext: BrowserContext }>({
+    // One context (one OS window) per worker, reused across every test the worker runs.
+    reuseContext: [
+        async ({ browser }, use) => {
+            const context = browser.contexts()[0] ?? (await browser.newContext({ viewport: { width: 1280, height: 720 } }));
+            await use(context);
+            await context.close();
+        },
+        { scope: "worker" },
+    ],
+    // Override the built-in test-scoped `page` with a page that lives in the shared
+    // worker window. It is reused across tests (each test re-navigates it via
+    // page.goto, which resets the document). If a test closes its page (e.g.
+    // bundle-size), the next test transparently opens a fresh tab in the SAME
+    // window rather than a new window.
+    page: async ({ reuseContext }, use) => {
+        const live = reuseContext.pages().find((p) => !p.isClosed());
+        const page = live ?? (await reuseContext.newPage());
+        await use(page);
+        // Intentionally left open — the next test in this worker reuses it.
+    },
+});
+
+export const test = REUSE_BROWSER ? reuseTest : base;
+export { expect };

--- a/tests/shared/reuse-fixtures.ts
+++ b/tests/shared/reuse-fixtures.ts
@@ -61,17 +61,30 @@ export async function acquireContext(browser: Browser, viewport: Viewport = DEFA
 /**
  * Acquire a page for reference/oracle captures.
  *
- * In reuse mode this hands back a live page inside the worker's single shared
- * window (reusing the current tab, or opening one more tab in the SAME window —
- * never a new window) with a no-op `release()`. Otherwise it opens a fresh
- * isolated context+page and `release()` closes them, matching the previous
- * per-spec `browser.newContext()` + `context.close()` behaviour.
+ * In reuse mode this opens a DEDICATED tab inside the worker's single shared
+ * window (never a new window) and applies the requested viewport to it, so the
+ * caller gets the viewport it asked for and never has to share the test's own
+ * `page`. `release()` closes just that tab — but only while another page keeps
+ * the window alive, so the single shared window is never torn down. Otherwise it
+ * opens a fresh isolated context+page and `release()` closes them, matching the
+ * previous per-spec `browser.newContext()` + `context.close()` behaviour.
  */
 export async function acquireReferencePage(browser: Browser, viewport: Viewport = DEFAULT_VIEWPORT): Promise<{ page: Page; release: () => Promise<void> }> {
     if (REUSE_BROWSER) {
         const context = browser.contexts()[0] ?? (await browser.newContext({ viewport }));
-        const page = context.pages().find((p) => !p.isClosed()) ?? (await context.newPage());
-        return { page, release: async () => {} };
+        const page = await context.newPage();
+        await page.setViewportSize(viewport);
+        return {
+            page,
+            release: async () => {
+                // Close our dedicated tab, but keep the window alive: never close
+                // the last remaining page, or the single shared window would go away
+                // and the next test would have to open a new one.
+                if (!page.isClosed() && context.pages().length > 1) {
+                    await page.close();
+                }
+            },
+        };
     }
     const context = await browser.newContext({ viewport });
     const page = await context.newPage();


### PR DESCRIPTION
## Problem

`REUSE_BROWSER` was intended as an opt-in that runs all browser-based tests in a single, reused, background window so headed local runs don't pop a fresh window (stealing focus) for every test. In practice it only worked *partly* — new windows kept appearing constantly during a run.

The flag was honored by the ~207 standard parity specs (via `parity-fixtures` + `captureGolden`), but **three other window sources bypassed it entirely** and opened a fresh OS window per test:

1. **Specs importing `test` directly from `@playwright/test`** — `bundle-size.spec.ts`, `scene117/118/264`, and the `plumbing/*` specs used the default per-test `page` fixture, which creates a new context (= new window) for **every test**. `bundle-size.spec.ts` alone opened ~130 windows in one run — the main source of "a new window every few tests".
2. **~20 physics/gizmo/pointer parity specs** opened their **own** `browser.newContext()` to capture the Babylon.js reference oracle — an extra window per test, on top of the reused one.
3. **`perf` / `gl-perf` / `memory-leak` specs** drove raw `browser.newContext()` per test.

## Fix

Funnel **all** window creation through a single shared module, `tests/shared/reuse-fixtures.ts`:

- A **worker-scoped shared context** (one window per Playwright worker) with a resilient `page` fixture. The page is reused across tests; if a test closes it (as `bundle-size` does), the next test transparently opens a fresh **tab in the same window** rather than a new window.
- **`acquireReferencePage()` / `acquireContext()`** helpers for specs that need their own reference/oracle or perf context. In `REUSE_BROWSER` mode they reuse the worker's single window; when the flag is off they fall back to the exact previous *isolated-context-and-teardown* behavior, so **default local runs and CI are unchanged, byte-for-byte**.

`parity-fixtures.ts` is now a thin re-export of the shared module, so the 207 existing specs are untouched. Every spec that previously did `browser.newContext()` now calls a helper; `bundle-size.spec.ts` no longer closes its page and always detaches its `response` listener in a `finally` block (the page is shared now, so a leaked listener would accumulate across tests).

## Behavior after this change

With `REUSE_BROWSER=1`, **windows == Playwright worker count**, each created once and reused for all of that worker's tests:

- Default `playwright.config.ts` (`workers: 2`) → **2 windows**, both reused.
- `--workers=1` → **exactly 1 window**.
- **No per-test windows.** A new window only appears per worker, or on the failure path if a worker process is respawned (e.g. a retry after a hard crash) — i.e. occasionally, never on every test.

Nothing changes when the flag is unset.

## Window-source audit

`grep` across `tests/` for `newContext` / `launch` / `launchPersistentContext` / `chromium|firefox|webkit` confirms the only real context-creation sites left are:

- `tests/shared/reuse-fixtures.ts` — guarded by `browser.contexts()[0] ?? newContext()`.
- `tests/shared/compare-core.ts` (`captureGolden`) — already guarded by `existingContext = wantReuse ? browser.contexts()[0] : undefined`.

(Remaining hits are a unit-test mock and `newPage` calls, which open **tabs**, not windows.)

## Validation

- **Full `pnpm test`** (build + 430 parity specs, default **non-reuse** mode): green except the pre-existing `scene116-shadow-depth-materials` MAD failure, which **fails identically on a clean tree** (stashed) and is unrelated to this change (purely a browser-lifecycle change, no rendering impact).
- **`REUSE_BROWSER=1 --workers=1` headed** run of `bundle-size.spec.ts` + physics-oracle (`scene40/42`) + standard (`scene225/26`) — 214 tests, **held at exactly one window the entire run**; all passed.
- `tsc` for `tests/lite` and `tests/gl` clean; `eslint` on all specs clean.

## Notes

- No golden references, bundle-size ceilings, or perf thresholds were changed.
- Files touched are all under `tests/` (35 modified + 1 new shared module).