### PR TITLE
fix(release): cap auto releases at minor and skip the burned 2.0.0 version

### DIFF
--- a/scripts/prepare-npm-release.ts
+++ b/scripts/prepare-npm-release.ts
@@ -5,6 +5,8 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 
 import {
+    applyBurnedVersionException,
+    BURNED_VERSION,
     bumpVersion,
     detectBreakingChanges,
     maxVersion,
@@ -198,7 +200,18 @@ if (breakingChangesDetected && requestedReleaseType === "auto") {
 // ever produced by an explicit 'major' request, so an accidental breaking commit
 // on master can no longer trigger a surprise major release.
 const resolvedReleaseType: ResolvedReleaseType = resolveReleaseType(requestedReleaseType);
-const nextVersion = bumpVersion(resolutionBaseVersion, resolvedReleaseType);
+// ONE-TIME EXCEPTION: skip the burned 2.0.0 version (published by accident and
+// deprecated; npm forbids reusing it) so the first intentional major lands on
+// 2.0.1. See applyBurnedVersionException in scripts/release-version.ts.
+const computedVersion = bumpVersion(resolutionBaseVersion, resolvedReleaseType);
+const nextVersion = applyBurnedVersionException(computedVersion);
+
+if (nextVersion !== computedVersion) {
+    console.log(
+        `##vso[task.logissue type=warning]Version ${BURNED_VERSION} was published in error and deprecated; ` +
+            `npm forbids reusing it. Releasing ${nextVersion} instead (one-time exception).`
+    );
+}
 
 if (isVersionPublished(nextVersion)) {
     throw new Error(`${PACKAGE_NAME}@${nextVersion} is already published. Refusing to overwrite an existing npm version.`);

--- a/scripts/prepare-npm-release.ts
+++ b/scripts/prepare-npm-release.ts
@@ -4,8 +4,17 @@ import { execFileSync } from "child_process";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
-type ReleaseType = "auto" | "patch" | "minor" | "major";
-type ResolvedReleaseType = Exclude<ReleaseType, "auto">;
+import {
+    bumpVersion,
+    detectBreakingChanges,
+    maxVersion,
+    parseExplicitReleaseType,
+    parseReleaseType,
+    resolveReleaseType,
+    type ReleaseType,
+    type ResolvedReleaseType,
+} from "./release-version";
+
 type ReleaseConfig = {
     type?: unknown;
     nonce?: unknown;
@@ -53,20 +62,6 @@ function run(command: string, args: string[], options: { allowFailure?: boolean 
     }
 }
 
-function parseReleaseType(value: string | undefined): ReleaseType {
-    if (value === "patch" || value === "minor" || value === "major" || value === "auto") {
-        return value;
-    }
-    throw new Error(`Unsupported release type '${value}'. Expected auto, patch, minor, or major.`);
-}
-
-function parseExplicitReleaseType(value: unknown): ResolvedReleaseType {
-    if (value === "patch" || value === "minor" || value === "major") {
-        return value;
-    }
-    throw new Error(`Unsupported release config type '${String(value)}'. Expected patch, minor, or major.`);
-}
-
 function readReleaseConfig(): { releaseType: ResolvedReleaseType; nonce: number } {
     const config = JSON.parse(readFileSync(RELEASE_CONFIG_PATH, "utf-8")) as ReleaseConfig;
     const releaseType = parseExplicitReleaseType(config.type);
@@ -93,44 +88,6 @@ function resolveRequestedReleaseType(): { releaseType: ReleaseType; source: stri
     }
 
     return { releaseType: parseReleaseType(process.env.RELEASE_TYPE ?? "auto"), source: "RELEASE_TYPE" };
-}
-
-function parseVersion(version: string): [number, number, number] {
-    const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
-    if (!match) {
-        throw new Error(`Unsupported semver version '${version}'. Expected x.y.z.`);
-    }
-    return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function compareVersions(a: [number, number, number], b: [number, number, number]): number {
-    for (let i = 0; i < 3; i++) {
-        if (a[i] !== b[i]) {
-            return a[i]! - b[i]!;
-        }
-    }
-    return 0;
-}
-
-function maxVersion(a: string, b: string): string {
-    if (!a) {
-        return b;
-    }
-    if (!b) {
-        return a;
-    }
-    return compareVersions(parseVersion(a), parseVersion(b)) >= 0 ? a : b;
-}
-
-function bumpVersion(version: string, releaseType: ResolvedReleaseType): string {
-    const [major, minor, patch] = parseVersion(version);
-    if (releaseType === "major") {
-        return `${major + 1}.0.0`;
-    }
-    if (releaseType === "minor") {
-        return `${major}.${minor + 1}.0`;
-    }
-    return `${major}.${minor}.${patch + 1}`;
 }
 
 function getLatestPublishedVersion(fallbackVersion: string): string {
@@ -188,7 +145,7 @@ function getPreviousReleaseTag(latestPublishedVersion: string): string {
 function hasBreakingChanges(previousReleaseTag: string): boolean {
     const logRange = previousReleaseTag ? `${previousReleaseTag}..HEAD` : "HEAD";
     const commitMessages = run("git", ["log", "--format=%B", logRange], { allowFailure: true });
-    return /^BREAKING[ -]CHANGE:/m.test(commitMessages) || /^[a-z]+(?:\([^)]+\))?!:/m.test(commitMessages);
+    return detectBreakingChanges(commitMessages);
 }
 
 const requested = resolveRequestedReleaseType();
@@ -221,9 +178,15 @@ if (currentBuildId && latestPublishedBuildId === currentBuildId) {
 const previousReleaseTag = getPreviousReleaseTag(resolutionBaseVersion);
 const breakingChangesDetected = hasBreakingChanges(previousReleaseTag);
 
-if (breakingChangesDetected && requestedReleaseType !== "auto" && requestedReleaseType !== "major") {
+if (breakingChangesDetected && requestedReleaseType === "auto") {
     // Azure Pipelines parses `##vso[task.logissue ...]` from stdout, so use console.log (not
     // console.warn, which writes to stderr and may not be picked up as an annotation).
+    console.log(
+        `##vso[task.logissue type=warning]Breaking changes were detected since ${previousReleaseTag || "the start of history"}. ` +
+            `Auto releases never emit a major, so this is being released as a minor. ` +
+            `A major release must be requested explicitly (manual 'major' run or config/release.json type 'major').`
+    );
+} else if (breakingChangesDetected && requestedReleaseType !== "major") {
     console.log(
         `##vso[task.logissue type=warning]Breaking changes were detected since ${previousReleaseTag || "the start of history"}. ` +
             `A ${requestedReleaseType} release will hide those changes from the next auto release. ` +
@@ -231,7 +194,10 @@ if (breakingChangesDetected && requestedReleaseType !== "auto" && requestedRelea
     );
 }
 
-const resolvedReleaseType: ResolvedReleaseType = requestedReleaseType === "auto" ? (breakingChangesDetected ? "major" : "minor") : requestedReleaseType;
+// Auto never self-promotes to a major (see resolveReleaseType). A major is only
+// ever produced by an explicit 'major' request, so an accidental breaking commit
+// on master can no longer trigger a surprise major release.
+const resolvedReleaseType: ResolvedReleaseType = resolveReleaseType(requestedReleaseType);
 const nextVersion = bumpVersion(resolutionBaseVersion, resolvedReleaseType);
 
 if (isVersionPublished(nextVersion)) {

--- a/scripts/release-version.ts
+++ b/scripts/release-version.ts
@@ -1,0 +1,88 @@
+/// <reference types="node" />
+
+/**
+ * Pure, IO-free version-resolution helpers shared by the npm publish pipeline
+ * (`scripts/prepare-npm-release.ts`) and its unit tests. Keeping the decision
+ * logic here — separate from the git/npm side effects — makes the release-type
+ * policy testable and guards against regressions such as an accidental major.
+ */
+
+export type ReleaseType = "auto" | "patch" | "minor" | "major";
+export type ResolvedReleaseType = Exclude<ReleaseType, "auto">;
+
+export function parseReleaseType(value: string | undefined): ReleaseType {
+    if (value === "patch" || value === "minor" || value === "major" || value === "auto") {
+        return value;
+    }
+    throw new Error(`Unsupported release type '${value}'. Expected auto, patch, minor, or major.`);
+}
+
+export function parseExplicitReleaseType(value: unknown): ResolvedReleaseType {
+    if (value === "patch" || value === "minor" || value === "major") {
+        return value;
+    }
+    throw new Error(`Unsupported release config type '${String(value)}'. Expected patch, minor, or major.`);
+}
+
+export function parseVersion(version: string): [number, number, number] {
+    const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+    if (!match) {
+        throw new Error(`Unsupported semver version '${version}'. Expected x.y.z.`);
+    }
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function compareVersions(a: [number, number, number], b: [number, number, number]): number {
+    for (let i = 0; i < 3; i++) {
+        if (a[i] !== b[i]) {
+            return a[i]! - b[i]!;
+        }
+    }
+    return 0;
+}
+
+export function maxVersion(a: string, b: string): string {
+    if (!a) {
+        return b;
+    }
+    if (!b) {
+        return a;
+    }
+    return compareVersions(parseVersion(a), parseVersion(b)) >= 0 ? a : b;
+}
+
+export function bumpVersion(version: string, releaseType: ResolvedReleaseType): string {
+    const [major, minor, patch] = parseVersion(version);
+    if (releaseType === "major") {
+        return `${major + 1}.0.0`;
+    }
+    if (releaseType === "minor") {
+        return `${major}.${minor + 1}.0`;
+    }
+    return `${major}.${minor}.${patch + 1}`;
+}
+
+export function detectBreakingChanges(commitMessages: string): boolean {
+    return /^BREAKING[ -]CHANGE:/m.test(commitMessages) || /^[a-z]+(?:\([^)]+\))?!:/m.test(commitMessages);
+}
+
+/**
+ * Resolve the concrete release type that will be published.
+ *
+ * Policy: `auto` (used by the weekly scheduled run and any unattended release)
+ * NEVER self-promotes to a major, even when breaking-change markers are present
+ * in the commit range. Auto always resolves to `minor`. A major release is a
+ * deliberate, human-owned decision that must be requested explicitly — either a
+ * manual `major` pipeline run or `config/release.json` `type: "major"`.
+ *
+ * This is the guard that keeps an accidental breaking commit on master from
+ * triggering a surprise major (as happened with the 2.0.0 release). Breaking
+ * markers are still surfaced to the operator via a warning at the call site and
+ * recorded in the changelog; they simply no longer drive the version bump.
+ */
+export function resolveReleaseType(requested: ReleaseType): ResolvedReleaseType {
+    if (requested === "auto") {
+        return "minor";
+    }
+    return requested;
+}

--- a/scripts/release-version.ts
+++ b/scripts/release-version.ts
@@ -86,3 +86,22 @@ export function resolveReleaseType(requested: ReleaseType): ResolvedReleaseType 
     }
     return requested;
 }
+
+// ---------------------------------------------------------------------------
+// ONE-TIME EXCEPTION — the burned 2.0.0 version.
+//
+// 2.0.0 was published to npm by accident (an unintended major produced by a
+// scheduled `auto` run before the auto->major promotion was removed) and has
+// since been deprecated. npm forbids reusing a published version number, so the
+// first *intentional* major bump — which would naturally compute 2.0.0 — must
+// skip the burned version and release 2.0.1 instead. This exception is specific
+// to 2.0.0 and exists only to bridge past that accident; it can be deleted once
+// the 2.x line has moved beyond 2.0.x.
+// ---------------------------------------------------------------------------
+export const BURNED_VERSION = "2.0.0";
+export const BURNED_VERSION_REPLACEMENT = "2.0.1";
+
+export function applyBurnedVersionException(version: string): string {
+    return version === BURNED_VERSION ? BURNED_VERSION_REPLACEMENT : version;
+}
+

--- a/tests/lite/unit/release-version.test.ts
+++ b/tests/lite/unit/release-version.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { bumpVersion, detectBreakingChanges, parseReleaseType, resolveReleaseType } from "../../../scripts/release-version";
+import { applyBurnedVersionException, bumpVersion, detectBreakingChanges, parseReleaseType, resolveReleaseType } from "../../../scripts/release-version";
 
 describe("release version resolution", () => {
     describe("resolveReleaseType — auto never emits a major", () => {
@@ -40,6 +40,26 @@ describe("release version resolution", () => {
         it("resolves 1.10.0 to 1.11.0 for an auto release with breaking changes", () => {
             const resolved = resolveReleaseType("auto");
             expect(bumpVersion("1.10.0", resolved)).toBe("1.11.0");
+        });
+    });
+
+    describe("applyBurnedVersionException — one-time 2.0.0 skip", () => {
+        it("skips the burned 2.0.0 and returns 2.0.1", () => {
+            // 2.0.0 was published in error and deprecated; npm forbids reuse, so the
+            // first intentional major must land on 2.0.1 instead.
+            expect(applyBurnedVersionException("2.0.0")).toBe("2.0.1");
+        });
+
+        it("leaves every other version untouched", () => {
+            expect(applyBurnedVersionException("1.11.0")).toBe("1.11.0");
+            expect(applyBurnedVersionException("2.0.1")).toBe("2.0.1");
+            expect(applyBurnedVersionException("2.1.0")).toBe("2.1.0");
+            expect(applyBurnedVersionException("3.0.0")).toBe("3.0.0");
+        });
+
+        it("turns an explicit major from the 1.x line into 2.0.1", () => {
+            const resolved = resolveReleaseType("major");
+            expect(applyBurnedVersionException(bumpVersion("1.11.0", resolved))).toBe("2.0.1");
         });
     });
 

--- a/tests/lite/unit/release-version.test.ts
+++ b/tests/lite/unit/release-version.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { bumpVersion, detectBreakingChanges, parseReleaseType, resolveReleaseType } from "../../../scripts/release-version";
+
+describe("release version resolution", () => {
+    describe("resolveReleaseType — auto never emits a major", () => {
+        it("resolves auto to minor even when breaking changes are present", () => {
+            // Regression guard for the accidental 2.0.0 release: a breaking commit
+            // on master must NOT let the scheduled/auto run self-promote to a major.
+            expect(resolveReleaseType("auto")).toBe("minor");
+        });
+
+        it("resolves auto to minor when no breaking changes are present", () => {
+            expect(resolveReleaseType("auto")).toBe("minor");
+        });
+
+        it("passes explicit requests through unchanged", () => {
+            expect(resolveReleaseType("patch")).toBe("patch");
+            expect(resolveReleaseType("minor")).toBe("minor");
+            // A major is still possible, but only when a human requests it explicitly.
+            expect(resolveReleaseType("major")).toBe("major");
+        });
+    });
+
+    describe("bumpVersion", () => {
+        it("bumps a minor release", () => {
+            expect(bumpVersion("1.10.0", "minor")).toBe("1.11.0");
+        });
+
+        it("bumps a patch release", () => {
+            expect(bumpVersion("1.10.0", "patch")).toBe("1.10.1");
+        });
+
+        it("bumps a major release", () => {
+            expect(bumpVersion("1.10.0", "major")).toBe("2.0.0");
+        });
+    });
+
+    describe("auto + breaking on the 1.x line stays on 1.x", () => {
+        it("resolves 1.10.0 to 1.11.0 for an auto release with breaking changes", () => {
+            const resolved = resolveReleaseType("auto");
+            expect(bumpVersion("1.10.0", resolved)).toBe("1.11.0");
+        });
+    });
+
+    describe("detectBreakingChanges", () => {
+        it("detects a bang marker in a conventional-commit subject", () => {
+            expect(detectBreakingChanges("feat(storage)!: add managed storage buffers")).toBe(true);
+        });
+
+        it("detects a BREAKING CHANGE footer", () => {
+            expect(detectBreakingChanges("feat: something\n\nBREAKING CHANGE: describe the migration")).toBe(true);
+        });
+
+        it("detects a BREAKING-CHANGE (hyphenated) footer", () => {
+            expect(detectBreakingChanges("BREAKING-CHANGE: hyphenated variant")).toBe(true);
+        });
+
+        it("returns false for non-breaking commits", () => {
+            expect(detectBreakingChanges("feat: add feature\nfix: correct a bug\nchore: tidy up")).toBe(false);
+        });
+    });
+
+    describe("parseReleaseType", () => {
+        it("accepts the four supported values", () => {
+            expect(parseReleaseType("auto")).toBe("auto");
+            expect(parseReleaseType("patch")).toBe("patch");
+            expect(parseReleaseType("minor")).toBe("minor");
+            expect(parseReleaseType("major")).toBe("major");
+        });
+
+        it("rejects unknown values", () => {
+            expect(() => parseReleaseType("nightly")).toThrow();
+        });
+    });
+});


### PR DESCRIPTION
## Why

`@babylonjs/lite@2.0.0` was published by accident. The weekly scheduled publish hardcodes `RELEASE_TYPE=auto`, and `auto` previously resolved to **major** whenever a breaking-change marker was present in the commit range. A `feat(storage)!:` commit on master therefore triggered an unintended `2.0.0` release.

The prior "no major" safeguards only affected the *manual-run* default and an *explicit patch/minor* warning — nothing ever capped the `auto` path that the schedule actually uses.

## What changed

- **`auto` never self-promotes to a major.** `resolveReleaseType()` now always resolves `auto` → `minor`. A major must be requested explicitly (a manual `major` run, or `config/release.json` `type: "major"`), so an accidental breaking commit on master can no longer produce a surprise major. Breaking markers are still detected, warned about, and fed to the changelog.
- **One-time exception for the burned `2.0.0`.** `2.0.0` is published + deprecated and npm forbids reusing a version, so the first *intentional* major bump — which naturally computes `2.0.0` — is remapped to **`2.0.1`**. This is clearly commented as bridging past the accident and can be deleted once the 2.x line moves beyond `2.0.x`. The pipeline logs a warning when it triggers.
- Pure version-resolution logic extracted to `scripts/release-version.ts` and covered by `tests/lite/unit/release-version.test.ts` (16 tests) to lock in the policy.

Note: this applies uniformly to the `@babylonjs/lite-gl` pipeline too, which also runs `auto` on schedule.

## Behavior after this change

| Trigger | Base | Result |
| --- | --- | --- |
| Weekly schedule / `auto` | 1.10.0 | **1.11.0** (minor, even with breaking markers) |
| Explicit `major` | 1.x | **2.0.1** (skips burned 2.0.0) |
| Explicit `patch` / `minor` | — | unchanged |

Verified live against the repo: a simulated scheduled run resolves to `1.11.0`; a simulated explicit `major` resolves to `2.0.1`.

## Validation

- `pnpm test:unit` — 120 files / 842 tests green (16 new).
- `pnpm lint` (eslint + all tsc projects) — clean.