### PR TITLE
feat(playground): deployed-version selector + PR engine version stamp

### DIFF
--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -275,13 +275,12 @@ stages:
                       # playground reads to populate its version selector (only
                       # versions with a live /v/<ver>/ snapshot are offered). The
                       # manifest lives at the origin root (/v/versions.json), shared
-                      # by every snapshot. Read-modify-write: fetch the current list
-                      # (empty if absent), add this version, dedupe + sort newest
-                      # first, then re-upload just that file to the /v path. The
-                      # deploy server overlays at the given path, so sibling
-                      # /v/<ver>/ snapshots are left intact. Finally purge the
-                      # manifest (a .json, otherwise cached at the CDN default TTL)
-                      # so the new release shows up promptly.
+                      # by every snapshot. Read-modify-write: fetch the current list,
+                      # add this version, dedupe + sort newest first, then re-upload
+                      # just that file to the /v path. The deploy server overlays at
+                      # the given path, so sibling /v/<ver>/ snapshots are left
+                      # intact. Finally purge the manifest (a .json, otherwise cached
+                      # at the CDN default TTL) so the new release shows up promptly.
                       - script: |
                             set -euo pipefail
 
@@ -290,8 +289,22 @@ stages:
                             WORK="$(Build.ArtifactStagingDirectory)/versions-manifest"
                             mkdir -p "$WORK"
 
-                            CURRENT="$(curl -fsSL "$MANIFEST_URL" || echo '[]')"
-                            printf '%s' "$CURRENT" > "$WORK/current.json"
+                            # Fetch the current manifest, distinguishing "not there yet"
+                            # from a transient failure. A 404 is the first-run empty
+                            # case; any other non-200 (5xx, network error) must NOT be
+                            # treated as empty, or we'd overwrite the manifest with just
+                            # this version and drop older still-deployed releases from
+                            # the selector. On such failures, skip the update (the step
+                            # is continueOnError) and leave the manifest intact — this
+                            # version is picked up by the next successful publish.
+                            HTTP_CODE="$(curl -sS -o "$WORK/current.json" -w '%{http_code}' "$MANIFEST_URL" || echo 000)"
+                            if [ "$HTTP_CODE" = "404" ]; then
+                              echo "No existing manifest (404); starting a new list."
+                              echo '[]' > "$WORK/current.json"
+                            elif [ "$HTTP_CODE" != "200" ]; then
+                              echo "Manifest fetch failed (HTTP $HTTP_CODE); skipping update to avoid clobbering existing versions."
+                              exit 1
+                            fi
 
                             node -e 'const fs=require("fs");const ver=process.argv[1];let list=[];try{const p=JSON.parse(fs.readFileSync(process.argv[2],"utf8"));if(Array.isArray(p))list=p.filter(v=>typeof v==="string");}catch{}if(!list.includes(ver))list.push(ver);const cmp=(a,b)=>{const pa=a.split(".").map(Number),pb=b.split(".").map(Number);for(let i=0;i<3;i++){const d=(pa[i]||0)-(pb[i]||0);if(d)return d;}return 0;};list=list.filter(v=>!v.includes("-")).sort(cmp).reverse();fs.writeFileSync(process.argv[3],JSON.stringify(list)+"\n");' "$VER" "$WORK/current.json" "$WORK/versions.json"
 

--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -270,3 +270,44 @@ stages:
                             storageAccount: $(TOOLS_STORAGE_ACCOUNT)
                             siteName: "Lite Playground v$(PACKAGE_VERSION)"
                             postComment: false
+
+                      # Record this release in the deployed-versions manifest the
+                      # playground reads to populate its version selector (only
+                      # versions with a live /v/<ver>/ snapshot are offered). The
+                      # manifest lives at the origin root (/v/versions.json), shared
+                      # by every snapshot. Read-modify-write: fetch the current list
+                      # (empty if absent), add this version, dedupe + sort newest
+                      # first, then re-upload just that file to the /v path. The
+                      # deploy server overlays at the given path, so sibling
+                      # /v/<ver>/ snapshots are left intact. Finally purge the
+                      # manifest (a .json, otherwise cached at the CDN default TTL)
+                      # so the new release shows up promptly.
+                      - script: |
+                            set -euo pipefail
+
+                            VER="$(PACKAGE_VERSION)"
+                            MANIFEST_URL="https://liteplayground.babylonjs.com/v/versions.json"
+                            WORK="$(Build.ArtifactStagingDirectory)/versions-manifest"
+                            mkdir -p "$WORK"
+
+                            CURRENT="$(curl -fsSL "$MANIFEST_URL" || echo '[]')"
+                            printf '%s' "$CURRENT" > "$WORK/current.json"
+
+                            node -e 'const fs=require("fs");const ver=process.argv[1];let list=[];try{const p=JSON.parse(fs.readFileSync(process.argv[2],"utf8"));if(Array.isArray(p))list=p.filter(v=>typeof v==="string");}catch{}if(!list.includes(ver))list.push(ver);const cmp=(a,b)=>{const pa=a.split(".").map(Number),pb=b.split(".").map(Number);for(let i=0;i<3;i++){const d=(pa[i]||0)-(pb[i]||0);if(d)return d;}return 0;};list=list.filter(v=>!v.includes("-")).sort(cmp).reverse();fs.writeFileSync(process.argv[3],JSON.stringify(list)+"\n");' "$VER" "$WORK/current.json" "$WORK/versions.json"
+
+                            echo "Updated manifest:"; cat "$WORK/versions.json"
+
+                            (cd "$WORK" && zip -j versions.zip versions.json)
+
+                            curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD)" --fail-with-body -i -X POST \
+                              -H "Content-Type: multipart/form-data" \
+                              -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
+                              -F "path=litePlayground/v" \
+                              -F "storageAccount=$(TOOLS_STORAGE_ACCOUNT)" \
+                              -F "zip=@$WORK/versions.zip"
+
+                            curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=lite-playground&profileName=$(CDN_PROFILE_TOOLS)" --fail-with-body -i -X POST \
+                              -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                        displayName: "Update deployed-versions manifest"
+                        condition: succeeded()
+                        continueOnError: true

--- a/playground/src/base.ts
+++ b/playground/src/base.ts
@@ -34,6 +34,25 @@ export function stripBase(pathname: string): string {
     return pathname.replace(/^\//, "");
 }
 
+/**
+ * The fixed release version of the current deploy, derived from the deploy base:
+ * a `/v/<ver>/` snapshot reports `<ver>`. The root nightly build and per-PR
+ * snapshots (`/pr/<N>/`) are source builds, not fixed releases, so they report
+ * `null` (i.e. "nightly"). Drives the version selector's current selection.
+ */
+export function currentDeployVersion(): string | null {
+    const match = BASE.match(/^\/v\/([^/]+)\/$/);
+    return match ? match[1]! : null;
+}
+
+/**
+ * Deploy base for a selectable engine version: the root (`/`) for nightly, or the
+ * immutable `/v/<ver>/` snapshot for a fixed release. Pass `null` for nightly.
+ */
+export function baseForVersion(version: string | null): string {
+    return version ? `/v/${version}/` : "/";
+}
+
 // Same-origin asset extensions worth treating as deploy-base-relative when they
 // appear as a quoted root-absolute path (e.g. `"/brdf-lut.png"`) in code. Shared
 // with the download bundler (see download.ts) so both recognise the same set.

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -19,8 +19,8 @@ import {
     type Project,
 } from "./snippets";
 import { getEmbedMode, decodeCodeHash, openInPlaygroundUrl, EmbedHost } from "./embed";
-import { NIGHTLY, engineUrlForVersion, fetchPublishedVersions } from "./versions";
-import { BASE } from "./base";
+import { NIGHTLY, NIGHTLY_ENGINE_URL, fetchDeployedVersions } from "./versions";
+import { BASE, stripBase, currentDeployVersion, baseForVersion } from "./base";
 
 const editorContainer = document.getElementById("editor") as HTMLElement;
 const fileTabsContainer = document.getElementById("fileTabs") as HTMLElement;
@@ -67,9 +67,12 @@ let currentMeta: SnippetMeta = {};
 // Host bridge, only created in embed mode (see below).
 let embedHost: EmbedHost | null = null;
 
-// The engine version the runner loads (`"nightly"` self-hosted by default, or a
-// published version from the CDN).
-let currentVersion = NIGHTLY;
+// The fixed release this deploy runs, or `NIGHTLY` for the root/PR source builds.
+// Derived from the deploy base (a `/v/<ver>/` snapshot pins `<ver>`) and fixed for
+// the page's lifetime: the selector switches versions by navigating to another
+// snapshot, not by hot-swapping here. Drives the selector's current option and the
+// CDN pin baked into downloaded projects.
+const currentVersion = currentDeployVersion() ?? NIGHTLY;
 
 function appendConsole(level: string, text: string): void {
     const line = document.createElement("div");
@@ -188,7 +191,7 @@ async function run(): Promise<void> {
         setLoading(true, "Running…");
         appendConsole("system", "Running…");
         runStartedAt = performance.now();
-        await runner.run(code, await engineUrlForVersion(currentVersion));
+        await runner.run(code, NIGHTLY_ENGINE_URL);
     } catch (err) {
         setLoading(false);
         runStartedAt = null;
@@ -463,7 +466,13 @@ downloadBtn.addEventListener("click", () => {
         });
 });
 
-// Engine version selector: "Nightly" plus published releases (loaded from the CDN).
+// Engine version selector: "Nightly" (this deploy's self-hosted source build) plus
+// the fixed releases that have a deployed `/v/<ver>/` snapshot. PRs are never
+// listed — a PR is a source build and shows as "Nightly". Switching version isn't
+// a hot-swap: each option is its own same-origin snapshot, so selecting one
+// navigates there. In-progress work survives the navigation via the shared
+// same-origin autosave; a saved snippet's path is carried across so its permalink
+// stays intact.
 function addVersionOption(value: string, label: string): void {
     const option = document.createElement("option");
     option.value = value;
@@ -474,16 +483,37 @@ addVersionOption(NIGHTLY, "Nightly (latest source)");
 versionEl.value = NIGHTLY;
 
 versionEl.addEventListener("change", () => {
-    currentVersion = versionEl.value;
-    void run();
+    const selected = versionEl.value;
+    if (selected === currentVersion) {
+        return;
+    }
+    const targetBase = baseForVersion(selected === NIGHTLY ? null : selected);
+    if (targetBase === BASE) {
+        // Already on this snapshot's origin (e.g. picking Nightly from a PR build,
+        // which is itself nightly-equivalent) — nothing to navigate to.
+        versionEl.value = currentVersion;
+        return;
+    }
+    // Persist current work synchronously so it restores after the reload (autosave
+    // is otherwise debounced), then carry any snippet route across to the target
+    // snapshot so a permalink stays a permalink.
+    writeAutosave();
+    const rest = stripBase(location.pathname);
+    const suffix = rest === "index.html" ? "" : rest;
+    location.href = `${targetBase}${suffix}${location.search}`;
 });
 
 void (async () => {
-    const versions = await fetchPublishedVersions();
+    const versions = await fetchDeployedVersions();
+    // Ensure the running snapshot's own version is selectable even if the manifest
+    // hasn't listed it yet (e.g. just-deployed, or manifest cache still warming).
+    if (currentVersion !== NIGHTLY && !versions.includes(currentVersion)) {
+        versions.unshift(currentVersion);
+    }
     for (const version of versions) {
         addVersionOption(version, `v${version}`);
     }
-    // Keep the current selection (defaults to nightly) after populating.
+    // Reflect the deploy we're actually running (defaults to nightly).
     versionEl.value = currentVersion;
 })();
 

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -496,11 +496,13 @@ versionEl.addEventListener("change", () => {
     }
     // Persist current work synchronously so it restores after the reload (autosave
     // is otherwise debounced), then carry any snippet route across to the target
-    // snapshot so a permalink stays a permalink.
+    // snapshot so a permalink stays a permalink. Preserve the query and hash too so
+    // an inline `#code=` payload or a legacy `#ID[#REV]` snippet link survives the
+    // switch rather than relying on autosave alone.
     writeAutosave();
     const rest = stripBase(location.pathname);
     const suffix = rest === "index.html" ? "" : rest;
-    location.href = `${targetBase}${suffix}${location.search}`;
+    location.href = `${targetBase}${suffix}${location.search}${location.hash}`;
 });
 
 void (async () => {

--- a/playground/src/versions.ts
+++ b/playground/src/versions.ts
@@ -1,11 +1,16 @@
 // Engine version selection for the playground runtime.
 //
-// The runner resolves the bare `@babylonjs/lite` import to an engine bundle URL
-// chosen here: the self-hosted "nightly" bundle (built from workspace source and
-// served alongside the app) by default, or a specific published release loaded on
-// demand from a public ESM CDN. Switching versions only changes the import URL — no
-// redeploy is needed to target a released version. The CDN (esm.sh, with an automatic
-// jsDelivr fallback) is selected by `./cdn`.
+// Every deploy runs its own self-hosted engine bundle (built from the source that
+// deploy was cut from and served under its base): nightly at the root, the PR
+// build under `/pr/<N>/`, and the exact release under `/v/<ver>/`. The runner
+// always imports that self-hosted bundle, so the engine and the surrounding
+// playground UI are always a matched pair. The version selector therefore doesn't
+// hot-swap an engine URL — it navigates between these snapshots (see main.ts). The
+// list of switchable fixed releases is the `/v/versions.json` manifest, written by
+// the npm-publish pipeline as versioned snapshots are deployed.
+//
+// The CDN (esm.sh, with an automatic jsDelivr fallback, selected by `./cdn`) is
+// used only to pin a *downloaded* project's import map to a public release.
 
 import { getCdn } from "./cdn";
 import { withBase } from "./base";
@@ -16,19 +21,11 @@ export const NIGHTLY = "nightly";
 /** URL of the self-hosted nightly engine bundle (served under the app's deploy base). */
 export const NIGHTLY_ENGINE_URL = withBase("engine/dev/index.js");
 
-const REGISTRY_URL = "https://registry.npmjs.org/@babylonjs/lite";
-
-/** How many recent published versions to offer in the selector. */
-const MAX_VERSIONS = 20;
-
-/** Resolve the engine bundle URL for a selected version (`"nightly"` or a semver). */
-export async function engineUrlForVersion(version: string): Promise<string> {
-    if (version === NIGHTLY) {
-        return NIGHTLY_ENGINE_URL;
-    }
-    const cdn = await getCdn();
-    return cdn.engineUrl(version);
-}
+/**
+ * Location of the deployed-versions manifest, always at the origin root so every
+ * snapshot (root nightly, `/pr/<N>/`, `/v/<ver>/`) reads the same shared list.
+ */
+const VERSIONS_MANIFEST_URL = "/v/versions.json";
 
 /**
  * The CDN specifier baked into a *downloaded* project's import map. The self-hosted
@@ -42,20 +39,23 @@ export async function downloadEngineUrl(version: string): Promise<string> {
 }
 
 /**
- * Fetch the list of published `@babylonjs/lite` versions, newest first, excluding
- * pre-releases. Returns an empty list if the registry can't be reached so the
- * selector can still offer nightly.
+ * Fetch the fixed `@babylonjs/lite` versions that have a deployed playground
+ * snapshot under `/v/<ver>/`, newest first. The manifest is written by the
+ * npm-publish pipeline after each versioned snapshot deploys, so the selector
+ * only ever offers versions the user can actually switch to. Returns an empty
+ * list when the manifest is missing or unreachable, so the selector still offers
+ * Nightly.
  */
-export async function fetchPublishedVersions(): Promise<string[]> {
+export async function fetchDeployedVersions(): Promise<string[]> {
     try {
-        const response = await fetch(REGISTRY_URL, { headers: { Accept: "application/vnd.npm.install-v1+json" } });
+        const response = await fetch(VERSIONS_MANIFEST_URL, { headers: { Accept: "application/json" } });
         if (!response.ok) {
             return [];
         }
-        const data = (await response.json()) as { versions?: Record<string, unknown> };
-        const versions = Object.keys(data.versions ?? {}).filter((version) => !version.includes("-"));
+        const data = (await response.json()) as unknown;
+        const versions = Array.isArray(data) ? data.filter((v): v is string => typeof v === "string" && !v.includes("-")) : [];
         versions.sort(compareSemver);
-        return versions.reverse().slice(0, MAX_VERSIONS);
+        return versions.reverse();
     } catch {
         return [];
     }

--- a/playground/vite.engine.config.ts
+++ b/playground/vite.engine.config.ts
@@ -4,37 +4,46 @@ import { execSync } from "child_process";
 import { readFileSync } from "fs";
 
 /**
- * Resolve the version the self-hosted "nightly" engine should report. The engine's
- * runtime `VERSION` is baked in via the `__BL_VERSION__` define; without it the
- * engine falls back to its source `package.json` (0.1.0), which is stale because
- * the real version is only stamped during the npm publish pipeline.
+ * Resolve the version string the self-hosted engine reports at runtime (baked in via
+ * the `__BL_VERSION__` define and logged as `Babylon Lite v<version>`). Without it the
+ * engine falls back to its source `package.json` (0.1.0), which is stale because the
+ * real version is only stamped during the npm publish pipeline.
  *
- * So that nightly reflects the latest *published* release, resolve the base version
- * from (in order): an explicit `PACKAGE_VERSION` env (set by the deploy pipeline),
- * the newest `npm-lite-v*` git tag, then the engine source `package.json`. The
- * result is suffixed `-nightly` to mark it as a tracking build (not an exact release).
+ * The stamp reflects which deploy this engine belongs to:
+ *   • A published version snapshot (`PACKAGE_VERSION` set) reports that exact release.
+ *   • A per-PR snapshot (`PLAYGROUND_BASE=/pr/<N>/`) reports `<base>-pr-<N>`, so the
+ *     console banner makes clear it's that PR's build.
+ *   • The root nightly build reports `<base>-nightly` to mark it as a tracking build.
+ *
+ * The base `<MAJOR.MINOR.PATCH>` is resolved from (in order): an explicit
+ * `PACKAGE_VERSION` env, the newest `npm-lite-v*` git tag, then the engine source
+ * `package.json`.
  */
-function resolveNightlyVersion(): string {
+function resolveEngineVersion(): string {
+    const prNumber = process.env.PLAYGROUND_BASE?.match(/^\/pr\/(\d+)\//)?.[1];
     const fromEnv = process.env.PACKAGE_VERSION?.trim();
-    if (fromEnv) {
+    // A published version snapshot pins the exact release it ships (no suffix).
+    if (fromEnv && !prNumber) {
         return fromEnv;
     }
-    let base: string | undefined;
-    try {
-        const tags = execSync('git tag --list "npm-lite-v*"', { cwd: __dirname, encoding: "utf8" })
-            .split("\n")
-            .map((tag) => tag.trim().replace(/^npm-lite-v/, ""))
-            .filter(Boolean);
-        base = tags.sort(compareSemver).at(-1);
-    } catch {
-        base = undefined;
+    let base: string | undefined = fromEnv;
+    if (!base) {
+        try {
+            const tags = execSync('git tag --list "npm-lite-v*"', { cwd: __dirname, encoding: "utf8" })
+                .split("\n")
+                .map((tag) => tag.trim().replace(/^npm-lite-v/, ""))
+                .filter(Boolean);
+            base = tags.sort(compareSemver).at(-1);
+        } catch {
+            base = undefined;
+        }
     }
     if (!base) {
         const pkgPath = resolve(__dirname, "../packages/babylon-lite/package.json");
         const { version } = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };
         base = version ?? "0.1.0";
     }
-    return `${base}-nightly`;
+    return prNumber ? `${base}-pr-${prNumber}` : `${base}-nightly`;
 }
 
 /** Ascending semver comparison sufficient for `MAJOR.MINOR.PATCH` release tags. */
@@ -50,7 +59,7 @@ function compareSemver(a: string, b: string): number {
     return 0;
 }
 
-const NIGHTLY_VERSION = resolveNightlyVersion();
+const ENGINE_VERSION = resolveEngineVersion();
 
 // Quiet the benign "Module … has been externalized for browser compatibility"
 // warnings emitted while bundling the engine: the wasm glue in manifold-3d /
@@ -77,11 +86,12 @@ logger.warn = (msg, options) => {
 export default defineConfig({
     publicDir: false,
     customLogger: logger,
-    // Stamp the engine's runtime VERSION so nightly reports e.g. `1.4.0-nightly`
-    // instead of the stale source fallback (0.1.0). Mirrors the engine's own
-    // `__BL_VERSION__` define used by the npm publish build.
+    // Stamp the engine's runtime VERSION so the build reports e.g. `1.4.0-nightly`,
+    // `1.4.0-pr-387`, or an exact `1.4.0`, instead of the stale source fallback
+    // (0.1.0). Mirrors the engine's own `__BL_VERSION__` define used by the npm
+    // publish build.
     define: {
-        __BL_VERSION__: JSON.stringify(NIGHTLY_VERSION),
+        __BL_VERSION__: JSON.stringify(ENGINE_VERSION),
     },
     build: {
         outDir: resolve(__dirname, "public/engine/dev"),


### PR DESCRIPTION
Follow-up to the per-PR / per-version playground snapshots (#387).

## What & why

### 1. Version selector lists only *deployed* versions
Previously the engine version dropdown listed **every** published `@babylonjs/lite` release (fetched from the npm registry) and picking one hot-swapped the engine bundle via a public CDN. That can break: the playground UI may use newer `babylon-lite` features than an old release ships, so pairing the current playground with an arbitrary old engine fails.

Now the dropdown offers **Nightly + only the fixed versions that have a live `/v/<ver>/` playground snapshot** (read from a new same-origin `/v/versions.json` manifest). Currently that list is empty, so only Nightly shows until the first version is published. Selecting a fixed version **navigates to that immutable, self-consistent snapshot** rather than hot-swapping an engine — so the engine and the surrounding playground UI are always a matched pair.

- PRs are **never** listed — a PR is a source build and shows as "Nightly".
- In-progress work survives the navigation via the shared same-origin autosave; a saved snippet's path is carried across so its permalink stays intact.
- The runner always loads the current snapshot's self-hosted engine.

### 2. PR builds stamp the engine version as `…-pr-<N>`
The engine logs `Babylon Lite v<version>` on start. A per-PR snapshot now reports `<base>-pr-<N>` (e.g. **`Babylon Lite v1.10.0-pr-387`**), derived from `PLAYGROUND_BASE=/pr/<N>/`, so the console banner makes clear exactly which PR build is running. Version snapshots stay exact (`1.10.0`); root nightly stays `<base>-nightly`.

## Changes
- **`playground/src/versions.ts`** — replace the npm-registry `fetchPublishedVersions()` with `fetchDeployedVersions()` reading `/v/versions.json` (empty on 404, so Nightly is always offered).
- **`playground/src/base.ts`** — add `currentDeployVersion()` / `baseForVersion()`.
- **`playground/src/main.ts`** — populate the selector from the manifest, preselect the running snapshot's version, and navigate between snapshots on change.
- **`playground/vite.engine.config.ts`** — stamp the engine `__BL_VERSION__` per deploy (`-pr-<N>` for PRs).
- **`azure-pipelines-npm-publish.yml`** — after deploying a version snapshot, read-modify-write `/v/versions.json` (append, dedupe, sort desc) and purge it so the selector picks up each release.

## Validation
- `tsc --noEmit` ✅, eslint on touched files ✅, playground build ✅
- Engine build with `PLAYGROUND_BASE=/pr/999/` stamps `1.10.0-pr-999` ✅
- Manifest merge/sort/dedupe script unit-checked (empty, add, dedupe, semver order, corrupt input, pre-release stripping) ✅
- `azure-pipelines-npm-publish.yml` parses ✅

## Note
The `/v/versions.json` pipeline step reads the current manifest from the public origin, so it can only be validated end-to-end by a real publish run. It mirrors the existing deploy-server curl pattern and relies on the deploy server overlaying at the target path (sibling `/v/<ver>/` snapshots are left intact — the same behavior nightly already relies on).