### PR TITLE
feat(shader): add opt-in uniform range updates

### DIFF
--- a/docs/lite/architecture/24-shader-material.md
+++ b/docs/lite/architecture/24-shader-material.md
@@ -193,9 +193,20 @@ export type ShaderUniformValue = number | readonly number[] | Float32Array;
 
 export function setShaderUniform(material: ShaderMaterial, name: string, value: ShaderUniformValue): void;
 export function setShaderTexture(material: ShaderMaterial, name: string, texture: Texture2D | null): void;
+export function enableShaderUniformRangeUpdates(scene: SceneContext, material: ShaderMaterial): void;
 ```
 
 `setShaderUniform` validates that the name exists, the declared type is custom or settable, and the supplied float count matches the declaration. It increments `_uniformVersion` and `_uboVersion`.
+
+`enableShaderUniformRangeUpdates` is an opt-in for materials with large custom UBOs and one or a few animated
+values. After the custom UBO has been packed once, each changed custom value is written directly into the
+material's retained packed `ArrayBuffer`. The opt-in updater widens one pending byte range across all changes made
+before the next frame, then uploads only that 4-byte-aligned range through `queue.writeBuffer` from a scene
+before-render callback. The first upload and every packed-buffer recreation
+remain whole-buffer writes. System uniforms have no custom offset and therefore produce no custom-UBO upload.
+Enabling is idempotent per scene, and the same material may be registered with multiple scenes.
+Materials that do not opt in keep the original renderable-owned whole-buffer path and pull in zero range-update
+implementation bytes.
 
 `setShaderTexture` validates that the sampler exists, stores the `Texture2D | null`, and increments `_resourceVersion`. The renderable rebuilds the group-1 bind group when the resource version changes.
 

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -222,6 +222,7 @@ export {
     setShaderVector3,
     setShaderMatrix,
 } from "./material/shader/shader-material.js";
+export { enableShaderUniformRangeUpdates } from "./material/shader/shader-uniform-range.js";
 export { createShaderNoColorMaterialView } from "./material/shader/no-color-view.js";
 export { createShaderNormalMaterialView } from "./material/shader/normal-view.js";
 export type { ShaderNormalViewConfig } from "./material/shader/normal-view.js";

--- a/packages/babylon-lite/src/material/shader/shader-uniform-range.ts
+++ b/packages/babylon-lite/src/material/shader/shader-uniform-range.ts
@@ -33,10 +33,10 @@ export function enableShaderUniformRangeUpdates(scene: SceneContext, material: S
 
 function installRangeUpdater(material: RangeShaderMaterialState): void {
     const dirty = new Set<string>();
+    let dirtyVersion = -1;
     const mark = (name: string) => {
         if (dirty.size === 0) {
-            material._uniformVersion++;
-            material._uboVersion = material._uniformVersion;
+            dirtyVersion = material._uniformVersion;
         }
         dirty.add(name);
     };
@@ -53,9 +53,15 @@ function installRangeUpdater(material: RangeShaderMaterialState): void {
         if (!spec || !data || !buffer) {
             return;
         }
-        if (material._shaderCustomVersion === material._uniformVersion) {
+        const directMutation = material._uniformVersion === dirtyVersion;
+        if (!directMutation && material._shaderCustomVersion === material._uniformVersion) {
             dirty.clear();
+            dirtyVersion = -1;
             return;
+        }
+        if (directMutation) {
+            material._uniformVersion++;
+            material._uboVersion = material._uniformVersion;
         }
         let min = 0x7fffffff;
         let max = -1;
@@ -73,6 +79,7 @@ function installRangeUpdater(material: RangeShaderMaterialState): void {
             engine._device.queue.writeBuffer(buffer, min, data, min, max - min);
         }
         dirty.clear();
+        dirtyVersion = -1;
         material._shaderCustomVersion = material._uniformVersion;
     };
 }

--- a/packages/babylon-lite/src/material/shader/shader-uniform-range.ts
+++ b/packages/babylon-lite/src/material/shader/shader-uniform-range.ts
@@ -1,0 +1,119 @@
+import { F32, I32, U32 } from "../../engine/typed-arrays.js";
+import type { EngineContext } from "../../engine/engine.js";
+import type { SceneContext } from "../../scene/scene-core.js";
+import type { UboSpec } from "../../shader/fragment-types.js";
+import type { ShaderMaterial } from "./shader-material.js";
+
+interface RangeShaderMaterialState extends ShaderMaterial {
+    _shaderCustomSpec?: UboSpec | null;
+    _shaderCustomData?: ArrayBuffer | null;
+    _shaderCustomUbo?: GPUBuffer | null;
+    _shaderCustomVersion?: number;
+    _rangeUniformUpdate?: (engine: EngineContext) => void;
+    _rangeUniformScenes?: WeakMap<SceneContext, (deltaMs: number) => void>;
+}
+
+/** Opt one ShaderMaterial into direct packed-value landing and one ranged upload before each frame. */
+export function enableShaderUniformRangeUpdates(scene: SceneContext, material: ShaderMaterial): void {
+    const state = material as RangeShaderMaterialState;
+    if (!state._rangeUniformUpdate) {
+        installRangeUpdater(state);
+    }
+    const registrations = (state._rangeUniformScenes ??= new WeakMap());
+    let callback = registrations.get(scene);
+    if (!callback) {
+        callback = () => state._rangeUniformUpdate!(scene.surface.engine);
+        registrations.set(scene, callback);
+    }
+    if (!scene._beforeRender.includes(callback)) {
+        // Public onBeforeRender() callbacks use unshift(), so this remains after their uniform mutations.
+        scene._beforeRender.push(callback);
+    }
+}
+
+function installRangeUpdater(material: RangeShaderMaterialState): void {
+    const dirty = new Set<string>();
+    const mark = (name: string) => {
+        if (dirty.size === 0) {
+            material._uniformVersion++;
+            material._uboVersion = material._uniformVersion;
+        }
+        dirty.add(name);
+    };
+    for (const [name, slot] of material._uniformValues) {
+        (slot as { value: Float32Array }).value = trackValue(slot.value, name, mark);
+    }
+    material._rangeUniformUpdate = (engine) => {
+        if (dirty.size === 0) {
+            return;
+        }
+        const spec = material._shaderCustomSpec;
+        const data = material._shaderCustomData;
+        const buffer = material._shaderCustomUbo;
+        if (!spec || !data || !buffer) {
+            return;
+        }
+        if (material._shaderCustomVersion === material._uniformVersion) {
+            dirty.clear();
+            return;
+        }
+        let min = 0x7fffffff;
+        let max = -1;
+        for (const name of dirty) {
+            const slot = material._uniformValues.get(name)!;
+            const offset = spec._offsets.get(name);
+            if (offset === undefined) {
+                continue;
+            }
+            writeTypedValue(data, offset, slot.decl.type, slot.value);
+            min = Math.min(min, offset);
+            max = Math.max(max, offset + slot.value.length * 4);
+        }
+        if (max > min) {
+            engine._device.queue.writeBuffer(buffer, min, data, min, max - min);
+        }
+        dirty.clear();
+        material._shaderCustomVersion = material._uniformVersion;
+    };
+}
+
+function trackValue(target: Float32Array, name: string, mark: (name: string) => void): Float32Array {
+    const proxy = new Proxy(target, {
+        get(array, key) {
+            const value = Reflect.get(array, key, array) as unknown;
+            if (typeof value !== "function") {
+                return value;
+            }
+            const fn = value as (...args: unknown[]) => unknown;
+            if (key === "subarray") {
+                return (...args: unknown[]) => trackValue(fn.apply(array, args) as Float32Array, name, mark);
+            }
+            if (key === "set" || key === "fill" || key === "copyWithin" || key === "reverse" || key === "sort") {
+                return (...args: unknown[]) => {
+                    const result = fn.apply(array, args);
+                    mark(name);
+                    return result === array ? proxy : result;
+                };
+            }
+            return fn.bind(array);
+        },
+        set(array, key, value) {
+            const written = Reflect.set(array, key, value, array);
+            if (typeof key === "string" && Number.isInteger(Number(key))) {
+                mark(name);
+            }
+            return written;
+        },
+    });
+    return proxy;
+}
+
+function writeTypedValue(data: ArrayBuffer, offset: number, type: string, value: Float32Array): void {
+    if (type === "u32") {
+        new U32(data, offset, 1)[0] = value[0]!;
+    } else if (type === "i32") {
+        new I32(data, offset, 1)[0] = value[0]!;
+    } else {
+        new F32(data, offset, value.length).set(value);
+    }
+}

--- a/tests/lite/unit/shader-uniform-range-update.test.ts
+++ b/tests/lite/unit/shader-uniform-range-update.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import type { RenderTargetSignature } from "../../../packages/babylon-lite/src/engine/render-target";
+import { createShaderMaterial, setShaderFloat, setShaderUniform } from "../../../packages/babylon-lite/src/material/shader/shader-material";
+import { buildShaderMaterialRenderables } from "../../../packages/babylon-lite/src/material/shader/shader-renderable";
+import { enableShaderUniformRangeUpdates } from "../../../packages/babylon-lite/src/material/shader/shader-uniform-range";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
+import { initMeshTransform } from "../../../packages/babylon-lite/src/mesh/mesh";
+import type { UniformCopyBatch } from "../../../packages/babylon-lite/src/render/uniform-copy-batch";
+import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
+import type { UboSpec } from "../../../packages/babylon-lite/src/shader/fragment-types";
+
+const gpuGlobals = globalThis as Omit<typeof globalThis, "GPUBufferUsage" | "GPUShaderStage"> & {
+    GPUBufferUsage?: { UNIFORM: number; COPY_DST: number };
+    GPUShaderStage?: { VERTEX: number; FRAGMENT: number };
+};
+gpuGlobals.GPUBufferUsage ??= { UNIFORM: 0x40, COPY_DST: 0x8 } as unknown as GPUBufferUsage;
+gpuGlobals.GPUShaderStage ??= { VERTEX: 1, FRAGMENT: 2 } as unknown as GPUShaderStage;
+
+interface FakeBuffer extends GPUBuffer {
+    _label?: string;
+}
+
+function fixture(getUniformBatch?: () => UniformCopyBatch, enabled = true) {
+    const buffers: FakeBuffer[] = [];
+    const writeBuffer = vi.fn();
+    const device = {
+        createBuffer: vi.fn((descriptor: GPUBufferDescriptor) => {
+            const buffer = {
+                _label: descriptor.label,
+                size: descriptor.size,
+                destroy: vi.fn(),
+            } as unknown as FakeBuffer;
+            buffers.push(buffer);
+            return buffer;
+        }),
+        createBindGroupLayout: vi.fn((descriptor: GPUBindGroupLayoutDescriptor) => descriptor as unknown as GPUBindGroupLayout),
+        createPipelineLayout: vi.fn((descriptor: GPUPipelineLayoutDescriptor) => descriptor as unknown as GPUPipelineLayout),
+        createBindGroup: vi.fn((descriptor: GPUBindGroupDescriptor) => descriptor as unknown as GPUBindGroup),
+        createShaderModule: vi.fn((descriptor: GPUShaderModuleDescriptor) => descriptor as unknown as GPUShaderModule),
+        createRenderPipeline: vi.fn((descriptor: GPURenderPipelineDescriptor) => descriptor as unknown as GPURenderPipeline),
+        queue: { writeBuffer },
+    } as unknown as GPUDevice;
+    const engine = {
+        _device: device,
+        canvas: { width: 64, height: 64 },
+    } as unknown as EngineContext;
+    const material = createShaderMaterial({
+        vertexSource: "@vertex fn mainVertex(input: VertexInput) -> @builtin(position) vec4f { return vec4f(input.position, 1); }",
+        fragmentSource: "@fragment fn mainFragment() -> @location(0) vec4f { return vec4f(material.tint, material.amount); }",
+        attributes: ["position"],
+        uniforms: [
+            { name: "amount", type: "f32" },
+            { name: "count", type: "u32" },
+            { name: "delta", type: "i32" },
+            { name: "tint", type: "vec3<f32>" },
+        ],
+    });
+    const mesh = {
+        name: "range",
+        children: [],
+        material,
+        receiveShadows: false,
+        _gpu: {
+            positionBuffer: {} as GPUBuffer,
+            normalBuffer: {} as GPUBuffer,
+            uvBuffer: {} as GPUBuffer,
+            indexBuffer: {} as GPUBuffer,
+            indexCount: 3,
+            indexFormat: "uint32",
+        },
+    } as unknown as Mesh;
+    initMeshTransform(mesh);
+    const scene = {
+        surface: { engine },
+        camera: null,
+        _beforeRender: [],
+        _meshDisposables: new Map(),
+        _meshAuxDisposables: new Map(),
+    } as unknown as SceneContext;
+    if (enabled) {
+        enableShaderUniformRangeUpdates(scene, material);
+    }
+    const result = buildShaderMaterialRenderables(scene, [mesh], getUniformBatch ? () => getUniformBatch() : undefined);
+    const binding = result.renderables[0]!.bind(engine, { _colorFormat: "rgba8unorm", _sampleCount: 1 } as RenderTargetSignature);
+    const customBuffer = buffers.find((buffer) => buffer._label === "shader-custom-ubo")!;
+    const customSpec = (material as unknown as { _shaderCustomSpec: UboSpec })._shaderCustomSpec;
+    writeBuffer.mockClear();
+    return { binding, customBuffer, customSpec, engine, material, scene, writeBuffer };
+}
+
+describe("ShaderMaterial ranged custom UBO updates", () => {
+    it("keeps whole-buffer updates when the optimization is not enabled", () => {
+        const { binding, customBuffer, customSpec, material, writeBuffer } = fixture(undefined, false);
+
+        setShaderFloat(material, "amount", 0.25);
+        binding.update!({ targetWidth: 64, targetHeight: 64 });
+
+        const customWrite = writeBuffer.mock.calls.find((call) => call[0] === customBuffer)!;
+        expect(customWrite[1]).toBe(0);
+        expect((customWrite[2] as Uint8Array).byteLength).toBe(customSpec._totalBytes);
+    });
+
+    it("uploads only one changed scalar and skips unchanged values", () => {
+        const { binding, customBuffer, customSpec, material, scene, writeBuffer } = fixture();
+        const amountOffset = customSpec._offsets.get("amount")!;
+
+        setShaderFloat(material, "amount", 0.25);
+        scene._beforeRender[0]!(0);
+        binding.update!({ targetWidth: 64, targetHeight: 64 });
+
+        const customWrite = writeBuffer.mock.calls.find((call) => call[0] === customBuffer)!;
+        expect(customWrite[1]).toBe(amountOffset);
+        expect(customWrite[4]).toBe(4);
+        expect(new Float32Array(customWrite[2] as ArrayBuffer, customWrite[3] as number, 1)[0]).toBe(0.25);
+
+        writeBuffer.mockClear();
+        setShaderFloat(material, "amount", 0.25);
+        binding.update!({ targetWidth: 64, targetHeight: 64 });
+        expect(writeBuffer.mock.calls.some((call) => call[0] === customBuffer)).toBe(false);
+    });
+
+    it("lands integer values and merges separated changes into one valid span", () => {
+        const { binding, customBuffer, customSpec, material, scene, writeBuffer } = fixture();
+        const countOffset = customSpec._offsets.get("count")!;
+        const tintOffset = customSpec._offsets.get("tint")!;
+
+        setShaderUniform(material, "count", 7);
+        setShaderUniform(material, "delta", -3);
+        setShaderUniform(material, "tint", [0.1, 0.2, 0.3]);
+        scene._beforeRender[0]!(0);
+        binding.update!({ targetWidth: 64, targetHeight: 64 });
+
+        const customWrite = writeBuffer.mock.calls.find((call) => call[0] === customBuffer)!;
+        const data = customWrite[2] as ArrayBuffer;
+        const sourceOffset = customWrite[3] as number;
+        expect(customWrite[1]).toBe(countOffset);
+        expect(customWrite[4]).toBe(tintOffset + 12 - countOffset);
+        expect(new Uint32Array(data, sourceOffset, 1)[0]).toBe(7);
+        expect(new Int32Array(data, sourceOffset + 4, 1)[0]).toBe(-3);
+    });
+
+    it("flushes directly before render without duplicating the custom UBO through UniformCopyBatch", () => {
+        const queue = vi.fn();
+        const batch = {
+            queue,
+            reset: vi.fn(),
+            flush: vi.fn(),
+            destroy: vi.fn(),
+        } as unknown as UniformCopyBatch;
+        const { binding, customBuffer, customSpec, material, scene, writeBuffer } = fixture(() => batch);
+        const amountOffset = customSpec._offsets.get("amount")!;
+
+        setShaderFloat(material, "amount", 0.5);
+        scene._beforeRender[0]!(0);
+        binding.update!({ targetWidth: 64, targetHeight: 64 });
+
+        const customCopies = queue.mock.calls.filter((call) => call[0] === customBuffer);
+        expect(customCopies).toHaveLength(0);
+        const customWrite = writeBuffer.mock.calls.find((call) => call[0] === customBuffer)!;
+        expect(customWrite[1]).toBe(amountOffset);
+        expect(customWrite[4]).toBe(4);
+    });
+
+    it("runs after public before-render uniform setters regardless of enable order", () => {
+        const first = fixture(undefined, false);
+        first.scene._beforeRender.unshift(() => setShaderFloat(first.material, "amount", 0.6));
+        enableShaderUniformRangeUpdates(first.scene, first.material);
+        first.writeBuffer.mockClear();
+        for (const callback of first.scene._beforeRender) {
+            callback(0);
+        }
+        expect(first.writeBuffer.mock.calls.find((call) => call[0] === first.customBuffer)![4]).toBe(4);
+
+        const second = fixture();
+        second.scene._beforeRender.unshift(() => setShaderFloat(second.material, "amount", 0.7));
+        second.writeBuffer.mockClear();
+        for (const callback of second.scene._beforeRender) {
+            callback(0);
+        }
+        expect(second.writeBuffer.mock.calls.find((call) => call[0] === second.customBuffer)![4]).toBe(4);
+    });
+
+    it("preserves typed-array methods and tracks direct mutating methods", () => {
+        const { customBuffer, material, scene, writeBuffer } = fixture();
+        const tint = material._uniformValues.get("tint")!.value;
+
+        expect(() => [...tint]).not.toThrow();
+        expect(tint.slice(0, 1)[0]).toBe(0);
+        tint.set([0.2, 0.4, 0.6]);
+        tint.subarray(1).fill(0.8);
+        scene._beforeRender[0]!(0);
+
+        const customWrite = writeBuffer.mock.calls.find((call) => call[0] === customBuffer)!;
+        expect(customWrite[4]).toBe(12);
+    });
+
+    it("registers once per scene and can re-register after scene callbacks are cleared", () => {
+        const first = fixture();
+        const secondScene = {
+            ...first.scene,
+            _beforeRender: [],
+        } as SceneContext;
+
+        enableShaderUniformRangeUpdates(first.scene, first.material);
+        enableShaderUniformRangeUpdates(secondScene, first.material);
+        expect(first.scene._beforeRender).toHaveLength(1);
+        expect(secondScene._beforeRender).toHaveLength(1);
+
+        first.scene._beforeRender.length = 0;
+        enableShaderUniformRangeUpdates(first.scene, first.material);
+        expect(first.scene._beforeRender).toHaveLength(1);
+    });
+});

--- a/tests/lite/unit/shader-uniform-range-update.test.ts
+++ b/tests/lite/unit/shader-uniform-range-update.test.ts
@@ -196,6 +196,16 @@ describe("ShaderMaterial ranged custom UBO updates", () => {
         expect(customWrite[4]).toBe(12);
     });
 
+    it("preserves one version increment per public uniform setter", () => {
+        const { material } = fixture();
+        const version = material._uniformVersion;
+
+        setShaderUniform(material, "tint", [0.2, 0.4, 0.6]);
+
+        expect(material._uniformVersion).toBe(version + 1);
+        expect(material._uboVersion).toBe(material._uniformVersion);
+    });
+
     it("registers once per scene and can re-register after scene callbacks are cleared", () => {
         const first = fixture();
         const secondScene = {


### PR DESCRIPTION
## Summary
- add explicit `enableShaderUniformRangeUpdates(scene, material)` opt-in for ShaderMaterial custom UBOs
- land changed uniform values into retained packed CPU data and upload one merged byte range before rendering
- preserve typed-array behavior, repeated enablement, multi-scene registration, and device-recovery/full-upload fallback
- keep all non-opted scene bundle manifests byte-identical

## Validation
- `pnpm run lint`
- `pnpm test:unit`
- `pnpm test:bundle-size`
- `pnpm test`: 427 parity/bundle tests passed; the only local failures were existing scenes 47, 104, 105, 106, plus scene 265, which reproduces identically on clean `origin/master`
- visually inspected ShaderMaterial scenes 159 and 165, including the culling render