### PR TITLE
feat: expose CSM texture and picking fragment coordinates

### DIFF
--- a/docs/lite/architecture/17-cascaded-shadow.md
+++ b/docs/lite/architecture/17-cascaded-shadow.md
@@ -37,6 +37,10 @@ interface CsmDirectionalShadowGeneratorConfig {
 }
 
 function createCsmDirectionalShadowGenerator(engine: EngineContext, light: DirectionalLight, cfg?: CsmDirectionalShadowGeneratorConfig): ShadowGenerator;
+
+function getCsmReceiverTexture(shadowGenerator: ShadowGenerator): Texture2D;
+
+function onCsmReceiverUpdate(shadowGenerator: ShadowGenerator, callback: (data: Float32Array) => void): () => void;
 ```
 
 Usage mirrors the other directional generators:
@@ -50,17 +54,39 @@ setShadowTaskCasterMeshes(light.shadowGenerator, casterMeshes);
 await registerSceneWithShadowSupport(scene);
 ```
 
+Custom `ShaderMaterial` receivers use the same public generator without reading its
+internal WebGPU resources:
+
+```ts
+const material = createShaderMaterial({
+    // ...sources, attributes, and uniforms...
+    samplers: [{ name: "csmShadow", sampleType: "depth", viewDimension: "2d-array", comparison: true }],
+});
+setShaderTexture(material, "csmShadow", getCsmReceiverTexture(light.shadowGenerator));
+onCsmReceiverUpdate(light.shadowGenerator, (data) => {
+    // Mirror the documented 80-float receiver layout into the custom material.
+});
+```
+
+`getCsmReceiverTexture` accepts only a generator created by
+`createCsmDirectionalShadowGenerator`; other shadow techniques throw. It returns a
+borrowed `Texture2D` whose view is explicitly `"2d-array"`, whose sampler is the
+generator's comparison sampler, and whose sample type is depth. The same wrapper
+object is returned for every call on one generator. It shares the generator's
+lifetime and must not be released or disposed independently.
+
 ## Internal Architecture
 
 ### `ShadowGenerator` extensions (shared interface, type-only)
 
 - `_shadowType` union widened `"esm" | "pcf"` → `"esm" | "pcf" | "csm"`.
-- `_depthView: GPUTextureView` — pre-created receiver-facing view. ESM/PCF set a 2d
-  view, CSM sets a `dimension:"2d-array"` view. Receiver renderables bind
-  `sg._depthView` (instead of `sg._depthTexture.createView()`) so they stay
-  texture-dimension-agnostic with no per-type branch.
 - `_csmCascadeCount?: number` — number of cascades, read by the receiver renderable
   to bake the cascade-select loop bound.
+- `_csmReceiverTexture?: Texture2D` — lazily created borrowed public wrapper for
+  custom receivers. It creates exactly one explicit 2d-array view, is cached on
+  the generator rather than in module state, and establishes one generator-owned
+  texture reference so ShaderMaterial acquire/release cycles cannot destroy the
+  shared shadow map.
 
 ### Receiver UBO layout (`_shadowUBO`, 320 bytes / 80 f32)
 
@@ -83,6 +109,11 @@ the baked cascade count.
 caster render targets use a single-layer view
 (`createView({dimension:"2d", baseArrayLayer:i, arrayLayerCount:1})`). Comparison
 sampler `compare:"less"`, linear filtering.
+
+Built-in material receivers bind the generator's internal texture and sampler through
+their material pipeline. Custom `ShaderMaterial` receivers obtain the equivalent
+borrowed `Texture2D` only through `getCsmReceiverTexture`; raw `GPUTexture`,
+`GPUTextureView`, and `GPUSampler` handles never cross that public boundary.
 
 ## Pipeline Configuration
 
@@ -193,6 +224,15 @@ For `p = (i+1)/N`: `log = minZ*ratio^p`, `uniform = minZ + range*p`,
 cameraVersion`; recomputes splits + matrices, writes the 320-byte UBO (bumping
 `_version`), updates each cascade camera, executes all cascade tasks.
 
+The custom-receiver texture wrapper is lazy and generator-scoped. The first
+`getCsmReceiverTexture` call validates the CSM technique, creates the array view, and
+caches the wrapper. It also anchors the generator's texture ownership in the shared
+ref-count pool; receiver materials may acquire and release the wrapper without
+destroying the generator-owned depth array. Later calls preserve object/view identity.
+Shadow-map recreation is not supported by the current fixed generator configuration;
+therefore the wrapper remains valid until the generator's GPU resources are disposed
+with the scene.
+
 ## Babylon.js Equivalence Map
 
 | Babylon.js                              | Babylon Lite                                |
@@ -245,9 +285,15 @@ map back to the same authored world-space distance across changing fitted depth
 ranges, preserve a tightly fitted far caster after the projection reserves bias
 headroom, and produce no bias for invalid or collapsed inputs.
 
+`tests/lite/unit/csm-receiver-texture.test.ts` proves that the public custom-receiver
+adapter creates one explicit 2d-array depth wrapper, reuses the generator texture and
+comparison sampler without exposing them in its signature, preserves wrapper identity,
+survives a ShaderMaterial acquire/release cycle, and rejects ESM/PCF generators.
+
 ## File Manifest
 
-- `shadow/csm-directional-shadow-generator.ts` — public factory + texture/UBO/sampler.
+- `shadow/csm-directional-shadow-generator.ts` — public factory, custom-receiver
+  `Texture2D` adapter, update subscription, and texture/UBO/sampler ownership.
 - `shadow/csm-shadow-task-hooks.ts` — cascade math + N-layer caster render hooks.
 - `shader/fragments/csm-shadow-fragment-core.ts` — receiver WGSL codegen.
 - `material/standard/fragments/std-csm-shadow-fragment.ts` — Standard-family wrapper.

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 93.7,
+  "rawKB": 93.6,
   "gzipKB": 35.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -291,8 +291,7 @@ export type { LinearDepthMaterialOptions } from "./render/linear-depth-material.
 export { createEsmDirectionalShadowGenerator } from "./shadow/esm-directional-shadow-generator.js";
 export { createPcfSpotlightShadowGenerator } from "./shadow/pcf-spotlight-shadow-generator.js";
 export { createPcfDirectionalShadowGenerator } from "./shadow/pcf-directional-shadow-generator.js";
-export { createCsmDirectionalShadowGenerator } from "./shadow/csm-directional-shadow-generator.js";
-export { onCsmReceiverUpdate } from "./shadow/csm-directional-shadow-generator.js";
+export { createCsmDirectionalShadowGenerator, getCsmReceiverTexture, onCsmReceiverUpdate } from "./shadow/csm-directional-shadow-generator.js";
 export { setShadowTaskCasterMeshes } from "./frame-graph/shadow-inputs.js";
 
 // ─── Animation ───────────────────────────────────────────────────────

--- a/packages/babylon-lite/src/picking/gpu-picker.ts
+++ b/packages/babylon-lite/src/picking/gpu-picker.ts
@@ -136,9 +136,10 @@ export interface PickOptions {
      *
      *  `fn shouldDiscardPick(input: PickDiscardInput) -> bool`
      *
-     *  The input exposes only generic picker data: `worldPos`, `pickId`, `thinInstanceIndex`,
-     *  `hasThinInstance`, and `instanceExtras` (the original thin-instance matrix w lanes, zero for
-     *  non-instanced meshes). Storage entries are uploaded and bound by Lite for the current pick only. */
+     *  The input exposes only generic picker data: `worldPos`, `fragmentCoord` (framebuffer pixel
+     *  coordinates), `pickId`, `thinInstanceIndex`, `hasThinInstance`, and `instanceExtras` (the
+     *  original thin-instance matrix w lanes, zero for non-instanced meshes). Storage entries are
+     *  uploaded and bound by Lite for the current pick only. */
     discard?: PickDiscardRule;
     /** Dev-only diagnostics: logs the pick ray, pixel, pick id/depth and resolved mesh. */
     debugLabel?: string;

--- a/packages/babylon-lite/src/picking/picking-shader.ts
+++ b/packages/babylon-lite/src/picking/picking-shader.ts
@@ -9,6 +9,7 @@ export interface PickingShaderOptions {
 const PICK_DISCARD_INPUT = /* wgsl */ `
 struct PickDiscardInput {
 worldPos: vec3f,
+fragmentCoord: vec2f,
 pickId: u32,
 thinInstanceIndex: u32,
 hasThinInstance: u32,
@@ -38,7 +39,7 @@ function pickDiscardStorageDecls(opts?: PickingShaderOptions): string {
 
 const PICK_FS = /* wgsl */ `
 struct VsOut {
-@builtin(position) position: vec4f,
+@builtin(position) p: vec4f,
 @location(0) @interpolate(flat) pickId: u32,
 @location(1) worldPos: vec3f,
 @location(2) @interpolate(flat) thinInstanceIndex: u32,
@@ -47,13 +48,12 @@ struct VsOut {
 };
 struct FsOut { @location(0) color: vec4f, @location(1) depth: vec4f };
 @fragment fn fs(input: VsOut) -> FsOut {
-let discardInput = PickDiscardInput(input.worldPos, input.pickId, input.thinInstanceIndex, input.hasThinInstance, input.instanceExtras);
-if (shouldDiscardPick(discardInput)) { discard; }
+if (shouldDiscardPick(PickDiscardInput(input.worldPos, input.p.xy, input.pickId, input.thinInstanceIndex, input.hasThinInstance, input.instanceExtras))) { discard; }
 let id = input.pickId;
 let r = f32((id >> 16u) & 0xFFu) / 255.0;
 let g = f32((id >> 8u) & 0xFFu) / 255.0;
 let b = f32(id & 0xFFu) / 255.0;
-return FsOut(vec4f(r, g, b, 1.0), vec4f(input.position.z, 0.0, 0.0, 0.0));
+return FsOut(vec4f(r, g, b, 1.0), vec4f(input.p.z, 0.0, 0.0, 0.0));
 }
 `;
 
@@ -75,7 +75,7 @@ ${PICK_FS}
 @vertex fn vs(@location(0) position: vec3f) -> VsOut {
 var out: VsOut;
 let wp = (mesh.world * vec4f(position, 1.0)).xyz;
-out.position = scene.viewProjection * vec4f(wp, 1.0);
+out.p = scene.viewProjection * vec4f(wp, 1.0);
 out.pickId = mesh.pickId;
 out.worldPos = wp;
 out.thinInstanceIndex = 0xffffffffu;
@@ -115,7 +115,7 @@ vec4f(m[3].xyz, 1.0),
 );
 var out: VsOut;
 let wp = (world * vec4f(position, 1.0)).xyz;
-out.position = scene.viewProjection * vec4f(wp, 1.0);
+out.p = scene.viewProjection * vec4f(wp, 1.0);
 out.pickId = tiMesh.baseMeshPickId + instanceIndex;
 out.worldPos = wp;
 out.thinInstanceIndex = instanceIndex;

--- a/packages/babylon-lite/src/shadow/csm-directional-shadow-generator.ts
+++ b/packages/babylon-lite/src/shadow/csm-directional-shadow-generator.ts
@@ -16,8 +16,10 @@
 import type { DirectionalLight } from "../light/directional-light.js";
 import type { EngineContext } from "../engine/engine.js";
 import type { ShadowGenerator } from "./shadow-generator.js";
+import type { Texture2D } from "../texture/texture-2d.js";
 import { createShadowParamsUBO } from "./shadow-base.js";
 import { createUniformBuffer } from "../resource/gpu-buffers.js";
+import { acquireTexture } from "../resource/gpu-pool.js";
 import { ensureCsmShadowTaskState, preloadCsmShadowTaskState, renderCsmShadowMap, type CsmConfig, type CsmTaskState } from "./csm-shadow-task-hooks.js";
 import { setCsmStdReceiverFactory, setCsmPbrReceiverFactory } from "./csm-receiver-registry.js";
 import { createStdCsmShadowFragment } from "../material/standard/fragments/std-csm-shadow-fragment.js";
@@ -127,6 +129,39 @@ export function createCsmDirectionalShadowGenerator(engine: EngineContext, _ligh
     };
     sg._renderShadowMap = (eng, state) => renderCsmShadowMap(eng, sg, state as CsmTaskState, csmCfg);
     return sg;
+}
+
+/**
+ * Returns the borrowed depth-array texture wrapper used by a custom CSM receiver.
+ *
+ * The wrapper shares the generator's texture and comparison sampler, is cached per
+ * generator, and remains valid for the generator's lifetime. Callers must not dispose
+ * or release it independently.
+ *
+ * @param sg - A cascaded-shadow generator from {@link createCsmDirectionalShadowGenerator}.
+ * @returns A stable `Texture2D` with a 2d-array depth view.
+ */
+export function getCsmReceiverTexture(sg: ShadowGenerator): Texture2D {
+    if (sg._shadowType !== "csm") {
+        throw new Error("getCsmReceiverTexture requires a CSM shadow generator");
+    }
+    if (sg._csmReceiverTexture) {
+        return sg._csmReceiverTexture;
+    }
+    const texture = sg._depthTexture;
+    const receiverTexture: Texture2D = {
+        texture,
+        view: texture.createView({ dimension: "2d-array" }),
+        sampler: sg._depthSampler,
+        width: texture.width,
+        height: texture.height,
+        _sampleType: "depth",
+    };
+    // ShaderMaterial packets acquire/release every bound Texture2D. Keep the
+    // generator's ownership ref so removing one receiver cannot destroy the map.
+    acquireTexture(receiverTexture);
+    sg._csmReceiverTexture = receiverTexture;
+    return receiverTexture;
 }
 
 /**

--- a/packages/babylon-lite/src/shadow/shadow-generator.ts
+++ b/packages/babylon-lite/src/shadow/shadow-generator.ts
@@ -27,6 +27,8 @@ export interface ShadowGenerator {
     _depthTexture: GPUTexture;
     /** @internal Number of cascades — set by the CSM generator, undefined otherwise. */
     _csmCascadeCount?: number;
+    /** @internal Lazily-created borrowed Texture2D wrapper for custom CSM receivers. */
+    _csmReceiverTexture?: import("../texture/texture-2d.js").Texture2D;
     /** @internal Receiver-facing shadow map sampler. */
     _depthSampler: GPUSampler;
     /** @internal */

--- a/packages/babylon-lite/src/shadow/shadow-generator.ts
+++ b/packages/babylon-lite/src/shadow/shadow-generator.ts
@@ -1,3 +1,5 @@
+import type { Texture2D } from "../texture/texture-2d.js";
+
 interface ShadowGeneratorRuntimeConfig {
     _mapSize: number;
     _bias: number;
@@ -28,7 +30,7 @@ export interface ShadowGenerator {
     /** @internal Number of cascades — set by the CSM generator, undefined otherwise. */
     _csmCascadeCount?: number;
     /** @internal Lazily-created borrowed Texture2D wrapper for custom CSM receivers. */
-    _csmReceiverTexture?: import("../texture/texture-2d.js").Texture2D;
+    _csmReceiverTexture?: Texture2D;
     /** @internal Receiver-facing shadow map sampler. */
     _depthSampler: GPUSampler;
     /** @internal */

--- a/tests/lite/unit/csm-receiver-texture.test.ts
+++ b/tests/lite/unit/csm-receiver-texture.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getCsmReceiverTexture } from "../../../packages/babylon-lite/src/shadow/csm-directional-shadow-generator";
+import { acquireTexture, releaseTexture } from "../../../packages/babylon-lite/src/resource/gpu-pool";
+import type { ShadowGenerator } from "../../../packages/babylon-lite/src/shadow/shadow-generator";
+
+function fakeShadowGenerator(type: ShadowGenerator["_shadowType"] = "csm") {
+    const view = { label: "csm-array-view" };
+    const texture = {
+        width: 2048,
+        height: 2048,
+        createView: vi.fn(() => view),
+        destroy: vi.fn(),
+    };
+    const sampler = { label: "csm-comparison-sampler" };
+    const generator = {
+        _shadowType: type,
+        _depthTexture: texture,
+        _depthSampler: sampler,
+    } as unknown as ShadowGenerator;
+    return { generator, texture, sampler, view };
+}
+
+describe("CSM receiver texture", () => {
+    it("creates one stable borrowed 2d-array depth wrapper", () => {
+        const { generator, texture, sampler, view } = fakeShadowGenerator();
+
+        const first = getCsmReceiverTexture(generator);
+        const second = getCsmReceiverTexture(generator);
+
+        expect(first).toBe(second);
+        expect(first.texture).toBe(texture);
+        expect(first.view).toBe(view);
+        expect(first.sampler).toBe(sampler);
+        expect(first.width).toBe(2048);
+        expect(first.height).toBe(2048);
+        expect(first._sampleType).toBe("depth");
+        expect(texture.createView).toHaveBeenCalledTimes(1);
+        expect(texture.createView).toHaveBeenCalledWith({ dimension: "2d-array" });
+    });
+
+    it("retains generator ownership across a ShaderMaterial acquire/release cycle", () => {
+        const { generator, texture } = fakeShadowGenerator();
+        const receiverTexture = getCsmReceiverTexture(generator);
+
+        acquireTexture(receiverTexture);
+        expect(releaseTexture(receiverTexture)).toBe(false);
+        expect(texture.destroy).not.toHaveBeenCalled();
+    });
+
+    it.each(["esm", "pcf"] as const)("rejects a %s generator", (type) => {
+        const { generator, texture } = fakeShadowGenerator(type);
+
+        expect(() => getCsmReceiverTexture(generator)).toThrow("requires a CSM shadow generator");
+        expect(texture.createView).not.toHaveBeenCalled();
+    });
+});

--- a/tests/lite/unit/picking-discard-api.test.ts
+++ b/tests/lite/unit/picking-discard-api.test.ts
@@ -198,6 +198,7 @@ describe("picking discard shader API", () => {
         const thin = pickingThinInstanceShaderSource();
 
         expect(regular).toContain("struct PickDiscardInput");
+        expect(regular).toContain("fragmentCoord: vec2f");
         expect(regular).toContain("fn shouldDiscardPick(input: PickDiscardInput) -> bool");
         expect(regular).toContain("return false;");
         expect(regular).toContain("out.hasThinInstance = 0u;");
@@ -221,7 +222,10 @@ return input.hasThinInstance == 1u && input.instanceExtras.x > 4.0;
 
         expect(regular).toContain(discardWgsl);
         expect(thin).toContain(discardWgsl);
-        expect(regular).toContain("let discardInput = PickDiscardInput(input.worldPos, input.pickId, input.thinInstanceIndex, input.hasThinInstance, input.instanceExtras);");
+        const discardCall =
+            "if (shouldDiscardPick(PickDiscardInput(input.worldPos, input.p.xy, input.pickId, input.thinInstanceIndex, input.hasThinInstance, input.instanceExtras))) { discard; }";
+        expect(regular).toContain(discardCall);
+        expect(thin).toContain(discardCall);
         expect(thin).toContain("let world = mat4x4f(");
         expect(thin).toContain("vec4f(m[0].xyz, 0.0)");
         expect(thin).toContain("vec4f(m[3].xyz, 1.0)");


### PR DESCRIPTION
## Summary
- expose `getCsmReceiverTexture()` as a stable borrowed depth-array `Texture2D` for custom `ShaderMaterial` CSM receivers
- retain the generator-owned texture reference across material acquire/release cycles
- expose `fragmentCoord` to custom GPU-picking discard WGSL for regular and thin-instance meshes
- keep default picker bundles within existing ceilings by compacting the private picking shader varyings
- document the CSM sampler contract and add regression coverage for both APIs

## Validation
- `pnpm run lint`
- `pnpm test:unit` (`867` tests passed)
- `pnpm validate:bundle-manifest` (`214` scenes checked)
- `pnpm test`: every bundle ceiling passed; parity completed with `427` passes and only the local baseline failures in Scenes 47, 104, 105, 106, and 265
- visually compared CSM Scenes 214/215 and picking Scenes 49/115 against their goldens

## Bundle size
- Scene 1: `88.2 KiB` on both this branch and `master` (`+0.0 KiB`)
- Scene 49: `93.6 KiB`, down from `93.7 KiB`
- Scene 115 remains under its existing `126.72 KiB` ceiling