### PR TITLE
feat(mesh): add public getMeshGeometry helper

### DIFF
--- a/docs/lite/architecture/00-overview.md
+++ b/docs/lite/architecture/00-overview.md
@@ -370,6 +370,15 @@ createTube(engine: Engine, options: TubeOptions): Mesh
 createExtrudeShape(engine: Engine, options: ExtrudeShapeOptions): Mesh
 createGround(engine: Engine, options?: GroundOptions): Mesh
 createGroundFromHeightMap(engine: Engine, url: string, options: GroundOptions): Promise<Mesh>
+getMeshGeometry(mesh: Mesh): {
+    positions: Float32Array;
+    normals: Float32Array;
+    indices: Uint32Array;
+    uvs?: Float32Array;
+    uvs2?: Float32Array;
+    tangents?: Float32Array;
+    colors?: Float32Array;
+} | null
 
 // Materials
 createStandardMaterial(): StandardMaterialProps

--- a/docs/lite/architecture/48-mesh-geometry-access.md
+++ b/docs/lite/architecture/48-mesh-geometry-access.md
@@ -1,0 +1,77 @@
+# Module: Mesh Geometry Access
+
+> Package path: `packages/babylon-lite/src/mesh/get-mesh-geometry.ts`
+
+## Purpose
+
+Expose the CPU-side geometry already retained by a mesh without exposing internal fields or GPU
+resources. Each call returns independent typed-array copies so callers can inspect or modify the
+result without mutating picking, device-loss recovery, or future geometry updates on the mesh.
+
+## Public API Surface
+
+```ts
+export function getMeshGeometry(mesh: Mesh): {
+    positions: Float32Array;
+    normals: Float32Array;
+    indices: Uint32Array;
+    uvs?: Float32Array;
+    uvs2?: Float32Array;
+    tangents?: Float32Array;
+    colors?: Float32Array;
+} | null;
+```
+
+Positions, normals, and indices are the required geometry. The function returns `null` when any of
+them is not retained on the CPU. UV, UV2, tangent, and color arrays are included only when the mesh
+already retains them. The helper does not cause loaders or factories to retain additional data.
+
+## Internal Architecture
+
+The helper reads the mesh's internal CPU arrays once and copies each available array with typed-array
+`slice()`. It never returns an internal array reference. Reading an interleaved glTF mesh can invoke
+its existing lazy CPU accessor, which de-strides and caches a tight internal array; the helper still
+returns a second, caller-owned copy.
+
+The module has no runtime imports beyond the erased `Mesh` type import and has no module-level state
+or side effects. Consumers that do not import `getMeshGeometry` retain no code from this module.
+
+## Pipeline Configuration
+
+None. The helper does not access or modify GPU buffers, bind groups, pipelines, draw state, bounds, or
+materials.
+
+## Shader Logic
+
+None.
+
+## State Machine / Lifecycle
+
+1. A loader or factory creates a mesh and retains any CPU geometry needed by existing engine features.
+2. `getMeshGeometry(mesh)` checks for required retained arrays.
+3. If required data is unavailable, it returns `null`.
+4. Otherwise it returns copies of required arrays and every retained optional array.
+5. Callers may mutate or pass those copies to another API without changing the source mesh.
+
+## Babylon.js Equivalence Map
+
+Equivalent in purpose to reading positions, normals, UV sets, tangents, colors, and indices through
+Babylon.js mesh vertex-data accessors, while presenting them as one tree-shakable Lite helper.
+
+## Dependencies
+
+- `Mesh` for retained CPU geometry.
+
+## Test Specification
+
+- Return exact copies of complete retained geometry.
+- Verify no returned typed array aliases its internal source.
+- Return `undefined` for unavailable optional attributes.
+- Return `null` when any required array is unavailable.
+- Exercise lazy getter-backed arrays used by interleaved glTF meshes.
+
+## File Manifest
+
+- `packages/babylon-lite/src/mesh/get-mesh-geometry.ts`: implementation.
+- `packages/babylon-lite/src/index.ts`: public export.
+- `tests/lite/unit/get-mesh-geometry.test.ts`: unit coverage.

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -180,6 +180,7 @@ export {
     invalidateRenderBundles,
 } from "./mesh/mesh-factories.js";
 export type { MeshGeometryCapacityResult } from "./mesh/mesh-factories.js";
+export { getMeshGeometry } from "./mesh/get-mesh-geometry.js";
 export { createBoxData } from "./mesh/create-box.js";
 export type { BoxData } from "./mesh/create-box.js";
 export { createSphereData } from "./mesh/create-sphere.js";

--- a/packages/babylon-lite/src/mesh/get-mesh-geometry.ts
+++ b/packages/babylon-lite/src/mesh/get-mesh-geometry.ts
@@ -1,0 +1,34 @@
+import type { Mesh } from "./mesh.js";
+
+/** Return caller-owned copies of the CPU geometry retained by a mesh.
+ *  Returns `null` when positions, normals, or indices are unavailable. */
+export function getMeshGeometry(mesh: Mesh): {
+    positions: Float32Array;
+    normals: Float32Array;
+    indices: Uint32Array;
+    uvs?: Float32Array;
+    uvs2?: Float32Array;
+    tangents?: Float32Array;
+    colors?: Float32Array;
+} | null {
+    const positions = mesh._cpuPositions;
+    const normals = mesh._cpuNormals;
+    const indices = mesh._cpuIndices;
+    if (!positions || !normals || !indices) {
+        return null;
+    }
+
+    const uvs = mesh._cpuUvs;
+    const uvs2 = mesh._cpuUv2s;
+    const tangents = mesh._cpuTangents;
+    const colors = mesh._cpuColors;
+    return {
+        positions: positions.slice(),
+        normals: normals.slice(),
+        indices: indices.slice(),
+        ...(uvs ? { uvs: uvs.slice() } : {}),
+        ...(uvs2 ? { uvs2: uvs2.slice() } : {}),
+        ...(tangents ? { tangents: tangents.slice() } : {}),
+        ...(colors ? { colors: colors.slice() } : {}),
+    };
+}

--- a/tests/lite/unit/get-mesh-geometry.test.ts
+++ b/tests/lite/unit/get-mesh-geometry.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getMeshGeometry } from "../../../packages/babylon-lite/src/mesh/get-mesh-geometry";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
+
+function completeMesh(): Mesh {
+    return {
+        _cpuPositions: new Float32Array([0, 1, 2, 3, 4, 5]),
+        _cpuNormals: new Float32Array([0, 0, 1, 0, 1, 0]),
+        _cpuIndices: new Uint32Array([0, 1, 0]),
+        _cpuUvs: new Float32Array([0, 0, 1, 1]),
+        _cpuUv2s: new Float32Array([0.25, 0.5, 0.75, 1]),
+        _cpuTangents: new Float32Array([1, 0, 0, 1, 0, 1, 0, -1]),
+        _cpuColors: new Float32Array([1, 0, 0, 1, 0, 1, 0, 0.5]),
+    } as unknown as Mesh;
+}
+
+describe("getMeshGeometry", () => {
+    it("returns exact caller-owned copies of every retained attribute", () => {
+        const mesh = completeMesh();
+        const geometry = getMeshGeometry(mesh);
+
+        expect(geometry).toEqual({
+            positions: mesh._cpuPositions,
+            normals: mesh._cpuNormals,
+            indices: mesh._cpuIndices,
+            uvs: mesh._cpuUvs,
+            uvs2: mesh._cpuUv2s,
+            tangents: mesh._cpuTangents,
+            colors: mesh._cpuColors,
+        });
+        expect(geometry).not.toBeNull();
+        expect(geometry!.positions).not.toBe(mesh._cpuPositions);
+        expect(geometry!.normals).not.toBe(mesh._cpuNormals);
+        expect(geometry!.indices).not.toBe(mesh._cpuIndices);
+        expect(geometry!.uvs).not.toBe(mesh._cpuUvs);
+        expect(geometry!.uvs2).not.toBe(mesh._cpuUv2s);
+        expect(geometry!.tangents).not.toBe(mesh._cpuTangents);
+        expect(geometry!.colors).not.toBe(mesh._cpuColors);
+
+        geometry!.positions[0] = 99;
+        geometry!.uvs![0] = 0.75;
+        expect(mesh._cpuPositions![0]).toBe(0);
+        expect(mesh._cpuUvs![0]).toBe(0);
+    });
+
+    it("allows UV access through the public result and omits unavailable optional attributes", () => {
+        const mesh = completeMesh();
+        mesh._cpuUv2s = null;
+        mesh._cpuTangents = null;
+        mesh._cpuColors = null;
+
+        const geometry = getMeshGeometry(mesh);
+        const uvs = geometry?.uvs;
+
+        expect(Array.from(uvs ?? [])).toEqual([0, 0, 1, 1]);
+        expect(geometry?.uvs2).toBeUndefined();
+        expect(geometry?.tangents).toBeUndefined();
+        expect(geometry?.colors).toBeUndefined();
+        expect(Object.hasOwn(geometry!, "uvs2")).toBe(false);
+        expect(Object.hasOwn(geometry!, "tangents")).toBe(false);
+        expect(Object.hasOwn(geometry!, "colors")).toBe(false);
+    });
+
+    it.each(["_cpuPositions", "_cpuNormals", "_cpuIndices"] as const)("returns null when required geometry %s is unavailable", (field) => {
+        const mesh = completeMesh();
+        mesh[field] = undefined;
+
+        expect(getMeshGeometry(mesh)).toBeNull();
+    });
+
+    it("materializes lazy CPU accessors once and still returns independent copies", () => {
+        const positions = new Float32Array([0, 1, 2]);
+        const normals = new Float32Array([0, 0, 1]);
+        const indices = new Uint32Array([0]);
+        const readPositions = vi.fn(() => positions);
+        const readNormals = vi.fn(() => normals);
+        const mesh = { _cpuIndices: indices } as unknown as Mesh;
+        Object.defineProperties(mesh, {
+            _cpuPositions: { get: readPositions },
+            _cpuNormals: { get: readNormals },
+        });
+
+        const geometry = getMeshGeometry(mesh);
+
+        expect(readPositions).toHaveBeenCalledTimes(1);
+        expect(readNormals).toHaveBeenCalledTimes(1);
+        expect(geometry?.positions).toEqual(positions);
+        expect(geometry?.positions).not.toBe(positions);
+        expect(geometry?.normals).not.toBe(normals);
+        expect(geometry?.indices).not.toBe(indices);
+    });
+});


### PR DESCRIPTION
## Summary

- Add the public, tree-shakable `getMeshGeometry(mesh)` helper.
- Return independent copies of retained CPU-side geometry.
- Add documentation and unit coverage.

## Testing

- Unit tests: 873 passed
- No-WebGPU tests: 6 passed
- Build, declaration, and tree-shaking tests: 23 passed
- Bundle-size ceilings passed

Forum discussion: https://forum.babylonjs.com/t/add-public-getmeshgeometry-to-babylon-lite-api/63812