### PR TITLE
feat(audio): add media stream output

### DIFF
--- a/docs/lite/architecture/41-audio-engine.md
+++ b/docs/lite/architecture/41-audio-engine.md
@@ -321,6 +321,30 @@ Other deltas:
 - **Unmute UI.** `createUnmuteUI(engine, { parentElement? })` plus
   `setUnmuteUIEnabled(ui, enabled)` and `disposeUnmuteUI(ui)` (capitalized `UI`,
   and a richer handle than `{ dispose() }`).
+- **Media-stream output (Lite-only).** The final post-master mix can be mirrored
+  into browser media pipelines without affecting speaker output:
+
+  ```typescript
+  export interface AudioEngineMediaStream {
+      readonly stream: MediaStream;
+      /** @internal */ readonly _engine: AudioEngine;
+      /** @internal */ readonly _source: GainNode;
+      /** @internal */ readonly _destination: MediaStreamAudioDestinationNode;
+      /** @internal */ readonly _engineDisposer: () => void;
+      /** @internal */ _registered: boolean;
+      /** @internal */ _disposed: boolean;
+      /** @internal */ _dispose(): void;
+  }
+
+  export function createAudioEngineMediaStream(engine: AudioEngine): AudioEngineMediaStream;
+  export function disposeAudioEngineMediaStream(output: AudioEngineMediaStream): void;
+  ```
+
+  Creation requires a real-time `AudioContext`, connects a
+  `MediaStreamAudioDestinationNode` in parallel with the audible destination,
+  and registers idempotent engine-owned cleanup. Disposal disconnects only this
+  tap, stops every track in its stream, and unregisters the engine cleanup
+  closure so repeated recording sessions do not accumulate retained handles.
 - **Visualizer (Lite-only, no AudioV2 counterpart).** A small canvas-2D
   waveform/bars helper for the demo and manual use:
   `createAudioVisualizer(host, canvas, options?)`,
@@ -421,6 +445,15 @@ createAudioEngineAsync
 disposeAudioEngine
   → run every fn in engine._disposers (removes listeners, clears interval/RAF)
   → close ctx unless it was provided/offline
+
+createAudioEngineMediaStream
+  → require a real-time AudioContext
+  → create MediaStreamAudioDestinationNode
+  → connect mainOut GainNode → media-stream destination (speaker path remains connected)
+  → register idempotent tap disposal in engine._disposers
+disposeAudioEngineMediaStream
+  → disconnect only the media-stream destination
+  → stop every MediaStreamTrack owned by the tap
 ```
 
 All global hooks (`document` click listener, `setInterval`, spatial `requestAnimationFrame`) are registered into `engine._disposers` so disposal is leak-free. **Nothing is registered at module load** — the engine handle owns it all.
@@ -452,6 +485,7 @@ last instance ends (non-looping full play, or explicit stop).
 | `createStreamingSoundAsync`        | `CreateStreamingSoundAsync` + `_WebAudioStreamingSound`      |
 | `createMicrophoneSoundSourceAsync` | `_WebAudioSoundSource` (getUserMedia)                        |
 | `createUnmuteUi`                   | `_WebAudioUnmuteUI` (parentElement injected, no EngineStore) |
+| `createAudioEngineMediaStream`     | Lite-only `MediaStreamAudioDestinationNode` post-master tap  |
 
 Behavior (node types, parameter mappings, ramp curves, panner/listener math)
 is identical. Only ownership, side-effect timing, and call syntax change.
@@ -462,7 +496,8 @@ is identical. Only ownership, side-effect timing, and call syntax change.
 
 - **Web Audio API** (`AudioContext`, `GainNode`, `PannerNode`,
   `StereoPannerNode`, `AnalyserNode`, `AudioBufferSourceNode`,
-  `MediaElementAudioSourceNode`, `MediaStreamAudioSourceNode`).
+  `MediaElementAudioSourceNode`, `MediaStreamAudioSourceNode`,
+  `MediaStreamAudioDestinationNode`).
 - **Lite `math/`** — `Vec3`, `Quat`, `Mat4` (spatial only; static/streaming/bus
   pull no math).
 - **`fetch()`** — same plain pattern as every other Lite loader (no WebRequest).
@@ -474,8 +509,9 @@ is identical. Only ownership, side-effect timing, and call syntax change.
 
 - `audio/index.ts` re-exports only side-effect-free modules; nothing runs at import.
 - Feature modules (`spatial/`, `streaming/`, `analyzer/`, `microphone/`,
-  `unmute-ui/`) are reachable only through their own factory functions, so an
-  app using just `createSoundAsync` + `playSound` drops every other module.
+  `media-stream-output/`, `unmute-ui/`) are reachable only through their own
+  factory functions, so an app using just `createSoundAsync` + `playSound`
+  drops every other module.
 - The sub-node `ensureXSubNode` registration is wired through the option parser,
   not a global registry — unused sub-nodes are eliminated.
 - Lazy-init for all caches (ramp curves, file-extension regex). **No
@@ -532,7 +568,9 @@ optionally, draw that PCM to a canvas for a deterministic _visual_ gate.
    mutation, no `document`/`setInterval`/`new AudioContext` at import time
    (guards the zero-side-effect pillar).
 6. **Disposal** — `disposeAudioEngine` removes the click listener, clears the
-   resume interval/RAF, and closes only contexts it created.
+   resume interval/RAF, stops registered media-stream output tracks, and closes
+   only contexts it created. `disposeAudioEngineMediaStream` disconnects only
+   its tap, stops its tracks, and is idempotent.
 
 ### Tier 2 — Output correctness (`OfflineAudioContext` → PCM), opt-in (native) ★ primary correctness tier
 
@@ -606,6 +644,7 @@ packages/babylon-lite/src/audio/
   stereo.ts                 # StereoPannerNode sub-node
   analyzer.ts               # AnalyserNode (frequency + time-domain readback)
   sound-source.ts           # createSoundSourceAsync / microphone (getUserMedia)
+  media-stream-output.ts     # post-master MediaStream tap (recording / WebRTC)
   unmute-ui.ts              # DOM button (parentElement injected)
   visualizer.ts             # runtime canvas waveform/bars (demo + manual; Lite-only)
   host-types.ts             # AudioGraphHost union + shared sub-graph host plumbing

--- a/packages/babylon-lite/src/audio/index.ts
+++ b/packages/babylon-lite/src/audio/index.ts
@@ -6,6 +6,8 @@
 
 export { createAudioEngineAsync, disposeAudioEngine, unlockAudioEngineAsync, setMasterVolume, getMasterVolume } from "./audio-engine.js";
 export type { AudioEngine, AudioEngineOptions, AudioEngineState } from "./audio-engine.js";
+export { createAudioEngineMediaStream, disposeAudioEngineMediaStream } from "./media-stream-output.js";
+export type { AudioEngineMediaStream } from "./media-stream-output.js";
 
 export { createSoundAsync, playSound, pauseSound, resumeSound, stopSound, disposeSound, setSoundVolume, SoundState } from "./static-sound.js";
 export type { StaticSound, StaticSoundOptions, StaticSoundPlayOptions, StaticSoundStopOptions } from "./static-sound.js";

--- a/packages/babylon-lite/src/audio/media-stream-output.ts
+++ b/packages/babylon-lite/src/audio/media-stream-output.ts
@@ -1,0 +1,79 @@
+/**
+ * Media-stream output — opt-in tap of the audio engine's final master mix.
+ *
+ * The tap mirrors the post-master signal into a MediaStream without changing
+ * the normal speaker output. Consumers can use that stream for recording,
+ * WebRTC, or other browser media pipelines, then dispose the tap independently.
+ */
+
+import type { AudioEngine } from "./audio-engine.js";
+
+/** Pure-state handle for a MediaStream carrying the audio engine's final master mix. */
+export interface AudioEngineMediaStream {
+    /** One live audio track containing the post-master engine output. */
+    readonly stream: MediaStream;
+    /** @internal */ readonly _engine: AudioEngine;
+    /** @internal */ readonly _source: GainNode;
+    /** @internal */ readonly _destination: MediaStreamAudioDestinationNode;
+    /** @internal */ readonly _engineDisposer: () => void;
+    /** @internal */ _registered: boolean;
+    /** @internal */ _disposed: boolean;
+    /** @internal */ _dispose(): void;
+}
+
+/**
+ * Mirrors an engine's final master output into a MediaStream.
+ *
+ * Real-time Web Audio is required because OfflineAudioContext has no
+ * MediaStream destination. The engine's audible destination remains connected.
+ */
+export function createAudioEngineMediaStream(engine: AudioEngine): AudioEngineMediaStream {
+    const context = engine._ctx;
+    if (engine._isOffline || typeof (context as AudioContext).createMediaStreamDestination !== "function") {
+        throw new Error("Audio engine media streams require a real-time AudioContext.");
+    }
+
+    const source = engine._mainOut._gain;
+    const destination = (context as AudioContext).createMediaStreamDestination();
+    source.connect(destination);
+
+    const output: AudioEngineMediaStream = {
+        stream: destination.stream,
+        _engine: engine,
+        _source: source,
+        _destination: destination,
+        _engineDisposer: () => {
+            output._registered = false;
+            disposeAudioEngineMediaStream(output);
+        },
+        _registered: true,
+        _disposed: false,
+        _dispose: () => disposeAudioEngineMediaStream(output),
+    };
+
+    engine._disposers.push(output._engineDisposer);
+    return output;
+}
+
+/**
+ * Disconnects a media-stream tap and stops every track owned by its stream.
+ * Safe to call more than once.
+ */
+export function disposeAudioEngineMediaStream(output: AudioEngineMediaStream): void {
+    if (output._disposed) {
+        return;
+    }
+
+    output._disposed = true;
+    if (output._registered) {
+        output._registered = false;
+        const disposerIndex = output._engine._disposers.indexOf(output._engineDisposer);
+        if (disposerIndex !== -1) {
+            output._engine._disposers.splice(disposerIndex, 1);
+        }
+    }
+    output._source.disconnect(output._destination);
+    for (const track of output.stream.getTracks()) {
+        track.stop();
+    }
+}

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -767,6 +767,8 @@ export type { NavigationPlugin, NavCrowd, NavMeshParameters, NavMeshSource, Agen
 // ─── Audio (AudioV2 port) ────────────────────────────────────────────
 export { createAudioEngineAsync, disposeAudioEngine, unlockAudioEngineAsync, setMasterVolume, getMasterVolume } from "./audio/audio-engine.js";
 export type { AudioEngine, AudioEngineOptions, AudioEngineState } from "./audio/audio-engine.js";
+export { createAudioEngineMediaStream, disposeAudioEngineMediaStream } from "./audio/media-stream-output.js";
+export type { AudioEngineMediaStream } from "./audio/media-stream-output.js";
 export { createSoundAsync, playSound, pauseSound, resumeSound, stopSound, disposeSound, setSoundVolume, SoundState } from "./audio/static-sound.js";
 export type { StaticSound, StaticSoundOptions, StaticSoundPlayOptions, StaticSoundStopOptions } from "./audio/static-sound.js";
 export {

--- a/tests/lite/unit/audio/media-stream-output.test.ts
+++ b/tests/lite/unit/audio/media-stream-output.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAudioEngineAsync, disposeAudioEngine } from "../../../../packages/babylon-lite/src/audio/audio-engine.js";
+import { createAudioEngineMediaStream, disposeAudioEngineMediaStream } from "../../../../packages/babylon-lite/src/audio/media-stream-output.js";
+import { installWebAudioMock, MockAudioContext, MockOfflineAudioContext, uninstallWebAudioMock } from "./web-audio-mock.js";
+import type { MockGainNode } from "./web-audio-mock.js";
+
+describe("media-stream-output", () => {
+    beforeEach(() => installWebAudioMock());
+    afterEach(() => uninstallWebAudioMock());
+
+    it("mirrors the post-master output without disconnecting the speaker destination", async () => {
+        const context = new MockAudioContext();
+        const engine = await createAudioEngineAsync({ audioContext: context as unknown as BaseAudioContext });
+        const output = createAudioEngineMediaStream(engine);
+        const destination = context.mediaStreamDestinations[0]!;
+        const mainOut = engine._mainOut._gain as unknown as MockGainNode;
+
+        expect(output.stream).toBe(destination.stream);
+        expect(mainOut.connections.has(context.destination as never)).toBe(true);
+        expect(mainOut.connections.has(destination as never)).toBe(true);
+
+        disposeAudioEngineMediaStream(output);
+        disposeAudioEngine(engine);
+    });
+
+    it("disconnects and stops its tracks exactly once", async () => {
+        const context = new MockAudioContext();
+        const engine = await createAudioEngineAsync({ audioContext: context as unknown as BaseAudioContext });
+        const output = createAudioEngineMediaStream(engine);
+        const destination = context.mediaStreamDestinations[0]!;
+        const mainOut = engine._mainOut._gain as unknown as MockGainNode;
+        const track = destination.stream.tracks[0]!;
+
+        expect(engine._disposers).toContain(output._engineDisposer);
+        disposeAudioEngineMediaStream(output);
+        disposeAudioEngineMediaStream(output);
+
+        expect(mainOut.connections.has(destination as never)).toBe(false);
+        expect(track.stopped).toBe(true);
+        expect(engine._disposers).not.toContain(output._engineDisposer);
+
+        disposeAudioEngine(engine);
+    });
+
+    it("stops every registered output when the engine is disposed", async () => {
+        const context = new MockAudioContext();
+        const engine = await createAudioEngineAsync({ audioContext: context as unknown as BaseAudioContext });
+        createAudioEngineMediaStream(engine);
+        createAudioEngineMediaStream(engine);
+        const tracks = context.mediaStreamDestinations.map((destination) => destination.stream.tracks[0]!);
+
+        disposeAudioEngine(engine);
+
+        expect(tracks.every((track) => track.stopped)).toBe(true);
+    });
+
+    it("rejects offline audio contexts", async () => {
+        const context = new MockOfflineAudioContext();
+        const engine = await createAudioEngineAsync({ audioContext: context as unknown as BaseAudioContext });
+
+        expect(() => createAudioEngineMediaStream(engine)).toThrow("Audio engine media streams require a real-time AudioContext.");
+
+        disposeAudioEngine(engine);
+    });
+});

--- a/tests/lite/unit/audio/web-audio-mock.ts
+++ b/tests/lite/unit/audio/web-audio-mock.ts
@@ -200,6 +200,13 @@ export class MockBaseAudioContext {
 
 export class MockAudioContext extends MockBaseAudioContext {
     public state: "running" | "suspended" | "closed" = "running";
+    public readonly mediaStreamDestinations: MockMediaStreamAudioDestinationNode[] = [];
+
+    public createMediaStreamDestination(): MockMediaStreamAudioDestinationNode {
+        const destination = new MockMediaStreamAudioDestinationNode(this);
+        this.mediaStreamDestinations.push(destination);
+        return destination;
+    }
 
     public addEventListener(type: string, cb: () => void): void {
         if (type === "statechange") {
@@ -344,6 +351,14 @@ export class MockMediaStream {
     public constructor(public readonly tracks: MockMediaStreamTrack[] = [new MockMediaStreamTrack()]) {}
     public getTracks(): MockMediaStreamTrack[] {
         return this.tracks;
+    }
+}
+
+export class MockMediaStreamAudioDestinationNode extends MockAudioNode {
+    public readonly stream = new MockMediaStream();
+
+    public constructor(public readonly context: MockBaseAudioContext) {
+        super();
     }
 }
 


### PR DESCRIPTION
## Summary
- expose an opt-in post-master `MediaStream` for recording and WebRTC without changing speaker output
- add standalone, idempotent disposal that unregisters engine cleanup and stops owned tracks
- document the public API and cover wiring, manual disposal, engine disposal, and offline rejection

## Validation
- `pnpm run lint`
- `pnpm exec vitest run --project unit tests/lite/unit/audio/media-stream-output.test.ts` (4 passed)
- `pnpm test` (bundle-size gate passed; 427 parity tests passed; only the known unrelated scenes 47, 104, 105, 106, and 265 failed)
- Chromium smoke check against the built package: one live audio track is created and becomes ended after disposal