### PR TITLE
refactor(loader): unify glTF mesh construction

### DIFF
--- a/docs/lite/architecture/04-loaders.md
+++ b/docs/lite/architecture/04-loaders.md
@@ -179,7 +179,6 @@ loadFeatureModules(json)              // dynamic imports, e.g. KHR_texture_basis
   └── material hooks                  // feature-owned texture/material/metadata overrides
   ↓
 extractAllMeshes(json, binChunk)       // for each node with mesh
-  ├── primitive cache                   // repeated mesh references share immutable CPU geometry
   ├── resolveAccessor() × N             // positions, normals, tangents, UVs, indices
   ├── extractMaterial()                 // PBR factors + textures
   │     └── resolveImage() × 5         // parallel image decode
@@ -188,7 +187,10 @@ extractAllMeshes(json, binChunk)       // for each node with mesh
 GltfMeshData[]
   ↓
 uploadMeshes(device, meshDatas)
-  ├── primitive GPU cache               // one MeshGPU upload retained by every node owner
+  ├── repeated-primitive gate           // dynamically imports gltf-share only when needed
+  │     ├── canonicalize CPU geometry   // repeated active nodes retain the same arrays
+  │     └── primitive GPU cache         // one MeshGPU upload retained by every active owner
+  ├── shared mesh builders              // identical instance assembly on normal/shared paths
   ├── uploadTexture() × 4              // → Texture2D objects (cached per bitmap + sRGB)
   ├── runMatExts()                     // feature-owned material overrides, e.g. KTX2 textures
   ├── createBufferFromData() × 5       // pos, norm, tan, uv, idx
@@ -205,7 +207,7 @@ AssetContainer { entities: [root], animationGroups }
 
 **Texture caching**: Textures are cached per bitmap identity + sRGB flag to avoid duplicate GPU uploads. The hot-path cache uses a numeric key (`bitmapId * 2 + +srgb`) so plain-image glTF assets do not pay string-key overhead. Feature modules can maintain their own caches for extension-owned image sources.
 
-**Geometry sharing**: A glTF mesh may be instantiated by multiple nodes. The loader creates a distinct Lite `Mesh` for every node/primitive pair so transforms, bounds, metadata, winding, skins, and morph state remain independent. Instances reachable from the selected/default glTF scene share one `MeshGPU` and the same retained CPU attribute arrays when they reference the same immutable primitive. Nodes reachable only from inactive scenes are excluded from that shared ownership group, so they do not increment the active geometry's `_refCount` or pin its buffers. `MeshGPU` ownership is reference-counted so removing one active instance cannot dispose buffers still used by another; device-lost recovery rebuilds each shared geometry only once and preserves the ownership count.
+**Geometry sharing**: A glTF mesh may be instantiated by multiple nodes. The loader creates a distinct Lite `Mesh` for every node/primitive pair so transforms, bounds, metadata, winding, skins, and morph state remain independent. Normal and repeated-primitive paths use the same internal mesh builders; the lazy `gltf-share` module only canonicalizes immutable geometry, manages ownership, and installs shared recovery. Instances reachable from the selected/default glTF scene share one `MeshGPU` and the same retained CPU attribute arrays when they reference the same immutable primitive. Nodes reachable only from inactive scenes are excluded from that shared ownership group, so they do not increment the active geometry's `_refCount` or pin its buffers. `MeshGPU` ownership is reference-counted so removing one active instance cannot dispose buffers still used by another; device-lost recovery rebuilds each shared geometry only once and preserves the ownership count.
 
 **Animation support**: `loadGltf` extracts glTF animations, creates `AnimationGroup[]` via `createAnimationGroups()`, and returns them in `AssetContainer.animationGroups`. `addToScene()` registers playback with the scene-owned animation manager. Each group exposes `currentTime` (seconds), `goToFrame()` for frame-based seeking, and lightweight `targetedAnimations` metadata for inspecting affected node/path pairs.
 

--- a/lab/public/bundle/manifest/scene1.json
+++ b/lab/public/bundle/manifest/scene1.json
@@ -3,8 +3,8 @@
   "gzipKB": 36.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene1-background-dds-skybox-RwpiacJv.js",
-    "scene1-background-ground-MTubtEem.js",
+    "scene1-background-dds-skybox-wX-C3BEm.js",
+    "scene1-background-ground-DHmASNBQ.js",
     "scene1-cubemap-skybox-material-DWAnfyQj.js",
     "scene1-generate-mipmaps-Cf-suNqz.js",
     "scene1-gltf-glb-parser-DB5JpdYq.js",

--- a/lab/public/bundle/manifest/scene104.json
+++ b/lab/public/bundle/manifest/scene104.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 101.1,
+  "rawKB": 101.2,
   "gzipKB": 39.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene11.json
+++ b/lab/public/bundle/manifest/scene11.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 88.8,
+  "rawKB": 88.9,
   "gzipKB": 37.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene112.json
+++ b/lab/public/bundle/manifest/scene112.json
@@ -3,8 +3,8 @@
   "gzipKB": 48.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene112-background-dds-skybox-MtX-zqND.js",
-    "scene112-background-ground-CiYdVHeL.js",
+    "scene112-background-dds-skybox-vaJnVIfb.js",
+    "scene112-background-ground-Dj363E_j.js",
     "scene112-cubemap-skybox-material-DMG4K46o.js",
     "scene112-generate-mipmaps-pWw2s9cL.js",
     "scene112-gltf-ext-basisu-vL7eBFsY.js",

--- a/lab/public/bundle/manifest/scene113.json
+++ b/lab/public/bundle/manifest/scene113.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 61.9,
+  "rawKB": 61.7,
   "gzipKB": 24.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene113-picking-pipeline-B1Xs6TII.js",
+    "scene113-picking-detailed-pipeline-BYOwfqFv.js",
     "scene113-standard-renderable-CJNkvTuK.js",
     "scene113.js"
   ]

--- a/lab/public/bundle/manifest/scene113.json
+++ b/lab/public/bundle/manifest/scene113.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 61.7,
+  "rawKB": 61.9,
   "gzipKB": 24.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene113-picking-detailed-pipeline-BYOwfqFv.js",
+    "scene113-picking-pipeline-B1Xs6TII.js",
     "scene113-standard-renderable-CJNkvTuK.js",
     "scene113.js"
   ]

--- a/lab/public/bundle/manifest/scene114.json
+++ b/lab/public/bundle/manifest/scene114.json
@@ -1,13 +1,12 @@
 {
-  "rawKB": 83.9,
-  "gzipKB": 33.8,
+  "rawKB": 81.2,
+  "gzipKB": 32.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene114-deformed-geometry-Brq5fz01.js",
     "scene114-morph-fragment-BvNmwfXk.js",
     "scene114-pbr-renderable-Cw6_JBi-.js",
     "scene114-pbr-template-ext-CiHpOV5G.js",
-    "scene114-picking-detailed-pipeline-B3GkgFFa.js",
     "scene114-picking-pipeline-2gjcXSVW.js",
     "scene114-singlelight-hemispheric-wgsl-CG69Vj-D.js",
     "scene114-skeleton-fragment-BVln8Ycm.js",

--- a/lab/public/bundle/manifest/scene114.json
+++ b/lab/public/bundle/manifest/scene114.json
@@ -1,12 +1,13 @@
 {
-  "rawKB": 81.2,
-  "gzipKB": 32.5,
+  "rawKB": 83.9,
+  "gzipKB": 33.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene114-deformed-geometry-Brq5fz01.js",
     "scene114-morph-fragment-BvNmwfXk.js",
     "scene114-pbr-renderable-Cw6_JBi-.js",
     "scene114-pbr-template-ext-CiHpOV5G.js",
+    "scene114-picking-detailed-pipeline-B3GkgFFa.js",
     "scene114-picking-pipeline-2gjcXSVW.js",
     "scene114-singlelight-hemispheric-wgsl-CG69Vj-D.js",
     "scene114-skeleton-fragment-BVln8Ycm.js",

--- a/lab/public/bundle/manifest/scene115.json
+++ b/lab/public/bundle/manifest/scene115.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 126.9,
+  "rawKB": 126.7,
   "gzipKB": 53.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -18,7 +18,7 @@
     "scene115-morph-fragment-core-BI6CqbCA.js",
     "scene115-pbr-renderable-D9ZC1YM4.js",
     "scene115-pbr-template-ext-CiHpOV5G.js",
-    "scene115-picking-pipeline-C9DxnZjR.js",
+    "scene115-picking-detailed-pipeline-CH9kgEac.js",
     "scene115-shader-composer-DishuYLa.js",
     "scene115-singlelight-hemispheric-wgsl-DWNiaetL.js",
     "scene115-skeleton-fragment-qFN-M46d.js",

--- a/lab/public/bundle/manifest/scene115.json
+++ b/lab/public/bundle/manifest/scene115.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 126.7,
+  "rawKB": 126.9,
   "gzipKB": 53.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -18,7 +18,7 @@
     "scene115-morph-fragment-core-BI6CqbCA.js",
     "scene115-pbr-renderable-D9ZC1YM4.js",
     "scene115-pbr-template-ext-CiHpOV5G.js",
-    "scene115-picking-detailed-pipeline-CH9kgEac.js",
+    "scene115-picking-pipeline-C9DxnZjR.js",
     "scene115-shader-composer-DishuYLa.js",
     "scene115-singlelight-hemispheric-wgsl-DWNiaetL.js",
     "scene115-skeleton-fragment-qFN-M46d.js",

--- a/lab/public/bundle/manifest/scene13.json
+++ b/lab/public/bundle/manifest/scene13.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 83.7,
+  "rawKB": 83.8,
   "gzipKB": 34.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene13-background-ground-i19635W1.js",
+    "scene13-background-ground-BtYC9A0x.js",
     "scene13-generate-mipmaps-CtVZJxfl.js",
     "scene13-gltf-glb-parser-Cmo3v_yx.js",
     "scene13-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene14.json
+++ b/lab/public/bundle/manifest/scene14.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 88.2,
+  "rawKB": 88.3,
   "gzipKB": 37,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene14-background-dds-skybox-5O3e6QVu.js",
-    "scene14-background-ground-DSqziL3M.js",
+    "scene14-background-dds-skybox-BZFherw9.js",
+    "scene14-background-ground-DWapkJab.js",
     "scene14-cubemap-skybox-material-D__KQ7QQ.js",
     "scene14-generate-mipmaps-DC9Kvgcn.js",
     "scene14-gltf-glb-parser-BUKpGZyL.js",

--- a/lab/public/bundle/manifest/scene144.json
+++ b/lab/public/bundle/manifest/scene144.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 111.5,
+  "rawKB": 111.6,
   "gzipKB": 45.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene146.json
+++ b/lab/public/bundle/manifest/scene146.json
@@ -4,8 +4,8 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene146-alpha-test-fragment-BzpCe4sy.js",
-    "scene146-background-ground-DEt7W0A7.js",
-    "scene146-background-solid-skybox-D9QiSZay.js",
+    "scene146-background-ground-CVAnjtJc.js",
+    "scene146-background-solid-skybox-DKxhD5-1.js",
     "scene146-generate-mipmaps-8fGshmNU.js",
     "scene146-gltf-json-asset-BMcym_1w.js",
     "scene146-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene147.json
+++ b/lab/public/bundle/manifest/scene147.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.5,
+  "rawKB": 103.6,
   "gzipKB": 41.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene174.json
+++ b/lab/public/bundle/manifest/scene174.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 96,
+  "rawKB": 96.1,
   "gzipKB": 39.4,
   "ignoredRawKB": 1485.2,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene21.json
+++ b/lab/public/bundle/manifest/scene21.json
@@ -3,7 +3,7 @@
   "gzipKB": 35.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene21-background-hdr-skybox-BGucnmpL.js",
+    "scene21-background-hdr-skybox-Dz5EiTm5.js",
     "scene21-cubemap-skybox-material-EC0oWalF.js",
     "scene21-generate-mipmaps-CILcKAb-.js",
     "scene21-gltf-glb-parser-Cib2_PL6.js",

--- a/lab/public/bundle/manifest/scene210.json
+++ b/lab/public/bundle/manifest/scene210.json
@@ -7,7 +7,7 @@
     "scene210-gltf-feature-registry-Cdkqe6tK.js",
     "scene210-gltf-feature-xmp-S8Tl-XNQ.js",
     "scene210-gltf-glb-parser-CNJGkGT-.js",
-    "scene210-gltf-interleave-CO8CmrLl.js",
+    "scene210-gltf-interleave-C_9dpKt3.js",
     "scene210-gltf-normals-DYhLwXNX.js",
     "scene210-pbr-renderable-0RU7iXoQ.js",
     "scene210-singlelight-hemispheric-wgsl-B1ByCXeR.js",

--- a/lab/public/bundle/manifest/scene211.json
+++ b/lab/public/bundle/manifest/scene211.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.5,
+  "rawKB": 90.6,
   "gzipKB": 38.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene218.json
+++ b/lab/public/bundle/manifest/scene218.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 94.3,
+  "rawKB": 94.4,
   "gzipKB": 39.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 91,
-  "gzipKB": 38.1,
+  "rawKB": 91.1,
+  "gzipKB": 38.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene240-flat-normal-wgsl-Cm9mM4tC.js",

--- a/lab/public/bundle/manifest/scene241.json
+++ b/lab/public/bundle/manifest/scene241.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 161.6,
+  "rawKB": 161.7,
   "gzipKB": 66.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 97.3,
-  "gzipKB": 40.3,
+  "gzipKB": 40.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene242-animation-pointer-basecolor-C0cq9A_I.js",

--- a/lab/public/bundle/manifest/scene243.json
+++ b/lab/public/bundle/manifest/scene243.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 97.4,
+  "rawKB": 97.5,
   "gzipKB": 41.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 133.5,
+  "rawKB": 133.6,
   "gzipKB": 54.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene245.json
+++ b/lab/public/bundle/manifest/scene245.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 102.7,
-  "gzipKB": 43.8,
+  "rawKB": 102,
+  "gzipKB": 43.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene245-create-skeleton-B1d1Zvek.js",
@@ -10,10 +10,10 @@
     "scene245-gltf-feature-animations-BgkqawnH.js",
     "scene245-gltf-feature-registry-ByfGwAN4.js",
     "scene245-gltf-feature-skeleton-DphJXmV5.js",
-    "scene245-gltf-interleave-pwzxRH6Z.js",
+    "scene245-gltf-interleave-KM-jw4Ig.js",
     "scene245-gltf-json-asset-IYSPgSvM.js",
     "scene245-gltf-normals-DYhLwXNX.js",
-    "scene245-gltf-share-BgbpAwNb.js",
+    "scene245-gltf-share-ldcC3-jB.js",
     "scene245-gltf-strided-attribute-CGKc0Sx6.js",
     "scene245-ibl-fragment-CeRrvT96.js",
     "scene245-pbr-renderable-DAlbvHXk.js",

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 99.5,
+  "rawKB": 99.6,
   "gzipKB": 42.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -10,7 +10,7 @@
     "scene246-gltf-feature-animations-DCiBFaYd.js",
     "scene246-gltf-feature-registry-CLmyOwku.js",
     "scene246-gltf-feature-skeleton-RaxrHYJ1.js",
-    "scene246-gltf-interleave-DVKyPNpn.js",
+    "scene246-gltf-interleave-Cx5yld1W.js",
     "scene246-gltf-json-asset-BUmDT4Zv.js",
     "scene246-gltf-multi-buffer-Dm-ko9S6.js",
     "scene246-gltf-normals-DYhLwXNX.js",

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 86.8,
-  "gzipKB": 36.4,
+  "rawKB": 85.9,
+  "gzipKB": 36.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene247-generate-mipmaps-Crazqgzv.js",
@@ -9,7 +9,7 @@
     "scene247-gltf-feature-registry-DNZZcqH_.js",
     "scene247-gltf-json-asset-CC12cr5P.js",
     "scene247-gltf-multi-buffer-DU6jeHHD.js",
-    "scene247-gltf-share-BqleEBo2.js",
+    "scene247-gltf-share-ch49n_RP.js",
     "scene247-ibl-fragment-CeRrvT96.js",
     "scene247-pbr-renderable-BlQSZPUb.js",
     "scene247-rgbd-decode-BGfzKZhs.js",

--- a/lab/public/bundle/manifest/scene248.json
+++ b/lab/public/bundle/manifest/scene248.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 76.9,
+  "rawKB": 77,
   "gzipKB": 31.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene249.json
+++ b/lab/public/bundle/manifest/scene249.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 78.5,
-  "gzipKB": 32.6,
+  "gzipKB": 32.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene249-alpha-test-fragment-CKYD57ds.js",

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 154.5,
-  "gzipKB": 65.5,
+  "rawKB": 153.7,
+  "gzipKB": 65.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene253-alpha-test-fragment-BidgZtWl.js",
@@ -30,7 +30,7 @@
     "scene253-gltf-light-pointer-state-B7kFTRxK.js",
     "scene253-gltf-pbr-builder-ext-DLs5F1kM.js",
     "scene253-gltf-sampler-desc-BhDXLt_f.js",
-    "scene253-gltf-share-DxRtIf6S.js",
+    "scene253-gltf-share-DOWwQNCV.js",
     "scene253-ibl-fragment-CeRrvT96.js",
     "scene253-iridescence-fragment-khU0FmJi.js",
     "scene253-light-base-CUObfFW2.js",

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 94.2,
-  "gzipKB": 39.5,
+  "gzipKB": 39.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene255-create-skeleton-B2bD2bod.js",

--- a/lab/public/bundle/manifest/scene257.json
+++ b/lab/public/bundle/manifest/scene257.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 80.1,
+  "rawKB": 80.2,
   "gzipKB": 33.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene258.json
+++ b/lab/public/bundle/manifest/scene258.json
@@ -1,11 +1,11 @@
 {
   "rawKB": 83,
-  "gzipKB": 34.9,
+  "gzipKB": 35,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene258-flat-normal-wgsl-Cm9mM4tC.js",
     "scene258-generate-mipmaps-DoX-rlWy.js",
-    "scene258-gltf-interleave-D0H4lj0k.js",
+    "scene258-gltf-interleave-lHttiyyP.js",
     "scene258-gltf-json-asset-DA60Z31d.js",
     "scene258-gltf-normals-DYhLwXNX.js",
     "scene258-gltf-uv-denorm-BTmmiHmh.js",

--- a/lab/public/bundle/manifest/scene259.json
+++ b/lab/public/bundle/manifest/scene259.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 77.1,
+  "rawKB": 77.2,
   "gzipKB": 32.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene266.json
+++ b/lab/public/bundle/manifest/scene266.json
@@ -1,13 +1,13 @@
 {
-  "rawKB": 80.9,
-  "gzipKB": 33.5,
+  "rawKB": 80.1,
+  "gzipKB": 33.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene266-generate-mipmaps-B4wJ9izW.js",
     "scene266-gltf-feature-primitive-BMqT3MMH.js",
     "scene266-gltf-feature-registry-Dt3RK1LZ.js",
     "scene266-gltf-glb-parser-Dw-ypNQm.js",
-    "scene266-gltf-share-B7IboYMp.js",
+    "scene266-gltf-share-CrYKSasW.js",
     "scene266-ibl-fragment-CeRrvT96.js",
     "scene266-pbr-renderable-C3wc5zeK.js",
     "scene266-rgbd-decode-BlUmJD6L.js",

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 86.7,
+  "rawKB": 86.8,
   "gzipKB": 35.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 103.5,
-  "gzipKB": 42.9,
+  "rawKB": 103.6,
+  "gzipKB": 43,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene30-alpha-test-fragment-Cd5Rw-y2.js",

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 79.9,
+  "rawKB": 80,
   "gzipKB": 33,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 98.8,
-  "gzipKB": 41.1,
+  "rawKB": 98,
+  "gzipKB": 40.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene34-generate-mipmaps-C244DQVV.js",
@@ -11,7 +11,7 @@
     "scene34-gltf-feature-registry-PtHZkjmW.js",
     "scene34-gltf-glb-parser-dD25--im.js",
     "scene34-gltf-sampler-denorm-CkBtIouA.js",
-    "scene34-gltf-share-eaLDfRqX.js",
+    "scene34-gltf-share-cR436n7p.js",
     "scene34-ibl-fragment-CeRrvT96.js",
     "scene34-pbr-renderable-Bnca2yB1.js",
     "scene34-rgbd-decode-EQ-YQ9oq.js",

--- a/lab/public/bundle/manifest/scene37.json
+++ b/lab/public/bundle/manifest/scene37.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 97,
+  "rawKB": 97.1,
   "gzipKB": 39.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene39.json
+++ b/lab/public/bundle/manifest/scene39.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 110.6,
-  "gzipKB": 47.1,
+  "rawKB": 109.8,
+  "gzipKB": 46.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene39-alpha-test-fragment-BFJcVJvD.js",
@@ -17,7 +17,7 @@
     "scene39-gltf-light-pointer-state-B7kFTRxK.js",
     "scene39-gltf-pbr-builder-ext-CZ259SGY.js",
     "scene39-gltf-sampler-desc-C5JVqTJ4.js",
-    "scene39-gltf-share-B3CDmp9P.js",
+    "scene39-gltf-share-B_tV4Eom.js",
     "scene39-ibl-fragment-CeRrvT96.js",
     "scene39-light-base-C4xznHLe.js",
     "scene39-light-matrix-CBTBdGsb.js",

--- a/lab/public/bundle/manifest/scene47.json
+++ b/lab/public/bundle/manifest/scene47.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 91.2,
+  "rawKB": 91.3,
   "gzipKB": 36.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene7.json
+++ b/lab/public/bundle/manifest/scene7.json
@@ -3,8 +3,8 @@
   "gzipKB": 44.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene7-background-ground-C6Q2wt-_.js",
-    "scene7-background-solid-skybox-DjtkVI-E.js",
+    "scene7-background-ground-xk_lrMSs.js",
+    "scene7-background-solid-skybox-BfqLb6xI.js",
     "scene7-create-skeleton-BmmRSwUy.js",
     "scene7-generate-mipmaps-BbgUE81Y.js",
     "scene7-gltf-animation-DIyf0usL.js",

--- a/lab/public/bundle/manifest/scene99.json
+++ b/lab/public/bundle/manifest/scene99.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92,
+  "rawKB": 92.1,
   "gzipKB": 38.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
@@ -349,8 +349,8 @@ function buildInterleavedGpu(engine: EngineContext, m: GltfMeshData): MeshGPU {
  *  retention) so the core loader's tight path stays byte-identical to the
  *  non-interleaved engine — keeping interleave bytes out of every glTF scene that
  *  doesn't use it. */
-export function buildInterleavedMesh(engine: EngineContext, m: GltfMeshData, index: number, material: PbrMaterialProps, name?: string): Mesh {
-    const gpu = buildInterleavedGpu(engine, m);
+export function buildInterleavedMesh(engine: EngineContext, m: GltfMeshData, index: number, material: PbrMaterialProps, name?: string, source?: Mesh): Mesh {
+    const gpu = source?._gpu ?? buildInterleavedGpu(engine, m);
 
     // AABB: fold strided positions straight from the slice; tight positions normally.
     const [boundMin, boundMax] = m._vb!._p ? computeAabbStrided(m._vb!._p, m._worldMatrix) : computeAabb(m._positions!, m._worldMatrix);
@@ -368,7 +368,7 @@ export function buildInterleavedMesh(engine: EngineContext, m: GltfMeshData, ind
 
     // Lazy CPU geometry: the de-strided tight copy is built only on first read.
     installLazyCpu(mesh, m);
-    mesh._cpuIndices = m._indices instanceof U32 ? m._indices : new U32(m._indices);
+    mesh._cpuIndices = source?._cpuIndices ?? (m._indices instanceof U32 ? m._indices : new U32(m._indices));
     engine._dlr?.m(mesh, m._uv2s, m._tangents, m._colors, m._indices, gpu.indexFormat);
 
     return mesh as Mesh;

--- a/packages/babylon-lite/src/loader-gltf/gltf-share.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-share.ts
@@ -1,10 +1,5 @@
-import { BU } from "../engine/gpu-flags.js";
-import { U32 } from "../engine/typed-arrays.js";
-import { computeAabb } from "../math/compute-aabb.js";
 import type { Mesh, MeshGPU } from "../mesh/mesh.js";
-import { initMeshTransform } from "../mesh/mesh.js";
 import type { PbrMaterialProps } from "../material/pbr/pbr-material.js";
-import { createMappedBuffer } from "../resource/gpu-buffers.js";
 import { retain } from "../resource/ref-count.js";
 import type { GltfFeature, GltfLoadCtx } from "./gltf-feature.js";
 import type { GltfMaterialData } from "./gltf-material.js";
@@ -15,6 +10,7 @@ import type { GltfMeshData } from "./load-gltf.js";
 export async function share(
     meshDatas: GltfMeshData[],
     buildMaterial: (material: GltfMaterialData) => Promise<PbrMaterialProps>,
+    buildTightMesh: (engine: GltfLoadCtx["_engine"], meshData: GltfMeshData, material: PbrMaterialProps, name: string, source?: Mesh) => Mesh,
     meshFeatures: GltfFeature[],
     ctx: GltfLoadCtx
 ): Promise<Mesh[]> {
@@ -28,62 +24,10 @@ export async function share(
     // Keep lookup + insertion synchronous so two owners can never both upload.
     const meshes = meshDatas.map((m, i): Mesh => {
         const material = materials[i]!;
-        const meshName = json.meshes[json.nodes[m._nodeIndex].mesh].name;
+        const meshName = json.meshes[json.nodes[m._nodeIndex].mesh].name || `gltf_mesh_${i}`;
         const active = activeNodes.has(m._nodeIndex);
         const source = active ? geometryCache.get(m._primitive) : undefined;
-        let mesh: Mesh;
-
-        if (m._vb) {
-            if (source) {
-                const [boundMin, boundMax] = m._vb._p ? interleave!.computeAabbStrided(m._vb._p, m._worldMatrix) : computeAabb(m._positions!, m._worldMatrix);
-                mesh = {
-                    name: meshName || `gltf_mesh_${i}`,
-                    material,
-                    receiveShadows: false,
-                    boundMin,
-                    boundMax,
-                    _gpu: source._gpu,
-                    _flatNormal: m._flatNormal,
-                } as unknown as Mesh;
-                initMeshTransform(mesh);
-                interleave!.installLazyCpu(mesh, m);
-                mesh._cpuIndices = source._cpuIndices;
-                engine._dlr?.m(mesh, m._uv2s, m._tangents, m._colors, m._indices, source._gpu.indexFormat);
-            } else {
-                mesh = interleave!.buildInterleavedMesh(engine, m, i, material, meshName);
-            }
-        } else {
-            const [boundMin, boundMax] = computeAabb(m._positions!, m._worldMatrix);
-            const gpu: MeshGPU =
-                source?._gpu ??
-                ({
-                    positionBuffer: createMappedBuffer(engine, m._positions!, BU.VERTEX),
-                    normalBuffer: createMappedBuffer(engine, m._normals!, BU.VERTEX),
-                    tangentBuffer: m._tangents ? createMappedBuffer(engine, m._tangents, BU.VERTEX) : null,
-                    uvBuffer: createMappedBuffer(engine, m._uvs!, BU.VERTEX),
-                    uv2Buffer: m._uv2s ? createMappedBuffer(engine, m._uv2s, BU.VERTEX) : null,
-                    colorBuffer: m._colors ? createMappedBuffer(engine, m._colors, BU.VERTEX) : null,
-                    indexBuffer: createMappedBuffer(engine, m._indices, BU.INDEX),
-                    indexCount: m._indexCount,
-                    indexFormat: (m._indices instanceof U32 ? "uint32" : "uint16") as GPUIndexFormat,
-                } satisfies MeshGPU);
-
-            mesh = {
-                name: meshName || `gltf_mesh_${i}`,
-                material,
-                receiveShadows: false,
-                boundMin,
-                boundMax,
-                _gpu: gpu,
-                _flatNormal: m._flatNormal,
-            } as unknown as Mesh;
-            initMeshTransform(mesh);
-            mesh._cpuPositions = m._positions!;
-            mesh._cpuNormals = m._normals!;
-            mesh._cpuUvs = m._uvs!;
-            mesh._cpuIndices = source?._cpuIndices ?? (m._indices instanceof U32 ? m._indices : new U32(m._indices));
-            engine._dlr?.m(mesh, m._uv2s, m._tangents, m._colors, m._indices, gpu.indexFormat);
-        }
+        const mesh = m._vb ? interleave!.buildInterleavedMesh(engine, m, i, material, meshName, source) : buildTightMesh(engine, m, material, meshName, source);
 
         if (source) {
             _installSharedRecovery(source._gpu);
@@ -95,7 +39,7 @@ export async function share(
     });
 
     if (meshFeatures.length > 0) {
-        await Promise.all(meshes.flatMap((mesh, i) => meshFeatures.map((f) => f.applyMesh!(meshDatas[i]!, mesh, ctx))));
+        await Promise.all(meshes.flatMap((mesh, i) => meshFeatures.map((feature) => feature.applyMesh!(meshDatas[i]!, mesh, ctx))));
     }
     return meshes;
 }

--- a/packages/babylon-lite/src/loader-gltf/load-gltf.ts
+++ b/packages/babylon-lite/src/loader-gltf/load-gltf.ts
@@ -87,6 +87,44 @@ export interface GltfMeshData {
     _decoded?: DecodedPrimitive;
 }
 
+/** Build one tightly-packed glTF mesh, optionally reusing a prior instance's
+ * immutable CPU/GPU geometry. Instance state and world-space bounds stay unique. */
+function buildTightGltfMesh(engine: EngineContext, meshData: GltfMeshData, material: PbrMaterialProps, name: string, source?: Mesh): Mesh {
+    const [boundMin, boundMax] = computeAabb(meshData._positions!, meshData._worldMatrix);
+    const indices = meshData._indices;
+    const uint32 = indices instanceof U32;
+    const gpu: MeshGPU = source
+        ? source._gpu
+        : ({
+              positionBuffer: createMappedBuffer(engine, meshData._positions!, BU.VERTEX),
+              normalBuffer: createMappedBuffer(engine, meshData._normals!, BU.VERTEX),
+              tangentBuffer: meshData._tangents ? createMappedBuffer(engine, meshData._tangents, BU.VERTEX) : null,
+              uvBuffer: createMappedBuffer(engine, meshData._uvs!, BU.VERTEX),
+              uv2Buffer: meshData._uv2s ? createMappedBuffer(engine, meshData._uv2s, BU.VERTEX) : null,
+              colorBuffer: meshData._colors ? createMappedBuffer(engine, meshData._colors, BU.VERTEX) : null,
+              indexBuffer: createMappedBuffer(engine, indices, BU.INDEX),
+              indexCount: meshData._indexCount,
+              indexFormat: (uint32 ? "uint32" : "uint16") as GPUIndexFormat,
+          } satisfies MeshGPU);
+
+    const mesh = {
+        name,
+        material,
+        receiveShadows: false,
+        boundMin,
+        boundMax,
+        _gpu: gpu,
+        _flatNormal: meshData._flatNormal,
+    } as unknown as Mesh;
+    initMeshTransform(mesh);
+    mesh._cpuPositions = meshData._positions!;
+    mesh._cpuNormals = meshData._normals!;
+    mesh._cpuUvs = meshData._uvs!;
+    mesh._cpuIndices = source ? source._cpuIndices : uint32 ? indices : new U32(indices);
+    engine._dlr?.m(mesh, meshData._uv2s, meshData._tangents, meshData._colors, indices, gpu.indexFormat);
+    return mesh;
+}
+
 /**
  * Load a glTF/GLB asset, parse it, and upload mesh + material data to GPU.
  * Registers a deferred PBR renderable builder and automatically parses glTF
@@ -588,57 +626,19 @@ async function uploadMeshes(meshDatas: GltfMeshData[], features: GltfFeature[], 
     };
 
     if (new Set(meshDatas.map((m) => m._primitive)).size < meshDatas.length) {
-        return import("./gltf-share.js").then((module) => module.share(meshDatas, buildPbrFromGltfMat, meshFeatures, ctx));
+        return import("./gltf-share.js").then((module) => module.share(meshDatas, buildPbrFromGltfMat, buildTightGltfMesh, meshFeatures, ctx));
     }
 
     return Promise.all(
         meshDatas.map(async (m, i): Promise<Mesh> => {
             const material = await buildPbrFromGltfMat(m._material);
-            const meshName = json.meshes[json.nodes[m._nodeIndex].mesh].name;
+            const meshName = json.meshes[json.nodes[m._nodeIndex].mesh].name || `gltf_mesh_${i}`;
 
             // Interleaved meshes are fully built by the dynamic module (kept out of
             // this bundle for non-interleaved scenes). The tight path below is
             // byte-identical to the non-interleaved engine.
-            let mesh: Mesh;
-            if (m._vb) {
-                mesh = (await loadInterleave()).buildInterleavedMesh(engine, m, i, material, meshName) as Mesh;
-            } else {
-                const [boundMin, boundMax] = computeAabb(m._positions!, m._worldMatrix);
-                const gpu: MeshGPU = {
-                    positionBuffer: createMappedBuffer(engine, m._positions!, BU.VERTEX),
-                    normalBuffer: createMappedBuffer(engine, m._normals!, BU.VERTEX),
-                    tangentBuffer: m._tangents ? createMappedBuffer(engine, m._tangents, BU.VERTEX) : null,
-                    uvBuffer: createMappedBuffer(engine, m._uvs!, BU.VERTEX),
-                    uv2Buffer: m._uv2s ? createMappedBuffer(engine, m._uv2s, BU.VERTEX) : null,
-                    colorBuffer: m._colors ? createMappedBuffer(engine, m._colors, BU.VERTEX) : null,
-                    indexBuffer: createMappedBuffer(engine, m._indices, BU.INDEX),
-                    indexCount: m._indexCount,
-                    indexFormat: (m._indices instanceof U32 ? "uint32" : "uint16") as GPUIndexFormat,
-                };
-
-                mesh = {
-                    name: meshName || `gltf_mesh_${i}`,
-                    material,
-                    receiveShadows: false,
-                    boundMin,
-                    boundMax,
-                    _gpu: gpu,
-                    _flatNormal: m._flatNormal,
-                } as unknown as Mesh;
-                initMeshTransform(mesh);
-
-                // Retain CPU geometry for detailed picking.
-                mesh._cpuPositions = m._positions!;
-                mesh._cpuNormals = m._normals!;
-                mesh._cpuUvs = m._uvs!;
-                mesh._cpuIndices = m._indices instanceof U32 ? m._indices : new U32(m._indices);
-                engine._dlr?.m(mesh, m._uv2s, m._tangents, m._colors, m._indices, gpu.indexFormat);
-            }
-
-            // Run all per-mesh feature hooks (skeleton, morph, …) in parallel.
-            // Each hook mutates `mesh` directly (e.g. attaches mesh.skeleton).
+            const mesh = m._vb ? (await loadInterleave()).buildInterleavedMesh(engine, m, i, material, meshName) : buildTightGltfMesh(engine, m, material, meshName);
             await Promise.all(meshFeatures.map((f) => f.applyMesh!(m, mesh, ctx)));
-
             return mesh;
         })
     );

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -1494,6 +1494,7 @@ export async function measurePage(
                 const c = document.querySelector("canvas");
                 return c?.dataset.ready === "true" || c?.dataset.error != null;
             },
+            undefined,
             { timeout: readyTimeoutMs }
         );
         notReadyReason = await page.evaluate(() => {

--- a/tests/lite/unit/bundle-scenes-ready-timeout.test.ts
+++ b/tests/lite/unit/bundle-scenes-ready-timeout.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { measurePage } from "../../../scripts/bundle-scenes-core.js";
+
+describe("bundle scene readiness timeout", () => {
+    it("passes the per-scene timeout as waitForFunction options", async () => {
+        const sentinel = new Error("stop after waitForFunction");
+        const waitForFunction = vi.fn(async () => {
+            throw sentinel;
+        });
+        const page = {
+            on: vi.fn(),
+            route: vi.fn(async () => undefined),
+            goto: vi.fn(async () => undefined),
+            waitForFunction,
+            close: vi.fn(async () => undefined),
+        };
+        const browser = {
+            newPage: vi.fn(async () => page),
+        };
+
+        await expect(measurePage(browser, 4173, "scene129", "lite/bundle-scene129.html", "/bundle/", true, 150_000)).rejects.toBe(sentinel);
+
+        expect(waitForFunction).toHaveBeenCalledWith(expect.any(Function), undefined, { timeout: 150_000 });
+    });
+});

--- a/tests/lite/unit/gltf-geometry-sharing.test.ts
+++ b/tests/lite/unit/gltf-geometry-sharing.test.ts
@@ -13,7 +13,7 @@ function align4(value: number): number {
     return (value + 3) & ~3;
 }
 
-function makeSharedMeshGlb(): ArrayBuffer {
+function makeSharedMeshGlb(mode?: number): ArrayBuffer {
     const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
     const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
     const uvs = new Float32Array([0, 0, 1, 0, 0, 1]);
@@ -41,7 +41,7 @@ function makeSharedMeshGlb(): ArrayBuffer {
         meshes: [
             {
                 name: "shared",
-                primitives: [{ attributes: { POSITION: 0, NORMAL: 1, TEXCOORD_0: 2 }, indices: 3 }],
+                primitives: [{ attributes: { POSITION: 0, NORMAL: 1, TEXCOORD_0: 2 }, indices: 3, ...(mode === undefined ? {} : { mode }) }],
             },
         ],
         buffers: [{ byteLength: binaryByteLength }],
@@ -143,5 +143,16 @@ describe("loadGltf geometry sharing", () => {
         for (const buffer of buffers) {
             expect(buffer.destroy).toHaveBeenCalledTimes(1);
         }
+    });
+
+    it("runs per-mesh feature hooks for every shared instance", async () => {
+        const { engine } = makeMockEngine();
+        const container = await loadGltf(engine, makeSharedMeshGlb(1));
+        const root = container.entities[0] as TransformNode;
+        const first = root.children[0]!.children[0] as Mesh & { _topology?: number };
+        const second = root.children[1]!.children[0] as Mesh & { _topology?: number };
+
+        expect(first._topology).toBe(2);
+        expect(second._topology).toBe(2);
     });
 });

--- a/tests/lite/unit/gltf-share.test.ts
+++ b/tests/lite/unit/gltf-share.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { BU } from "../../../packages/babylon-lite/src/engine/gpu-flags.js";
+import { U32 } from "../../../packages/babylon-lite/src/engine/typed-arrays.js";
 import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine.js";
 import type { Mat4 } from "../../../packages/babylon-lite/src/math/types.js";
 import { share } from "../../../packages/babylon-lite/src/loader-gltf/gltf-share.js";
-import type { GltfFeature, GltfLoadCtx } from "../../../packages/babylon-lite/src/loader-gltf/gltf-feature.js";
+import type { GltfLoadCtx } from "../../../packages/babylon-lite/src/loader-gltf/gltf-feature.js";
 import type { GltfMaterialData } from "../../../packages/babylon-lite/src/loader-gltf/gltf-material.js";
 import type { GltfMeshData } from "../../../packages/babylon-lite/src/loader-gltf/load-gltf.js";
 import { disposeMeshGpu } from "../../../packages/babylon-lite/src/mesh/mesh-dispose.js";
+import type { Mesh, MeshGPU } from "../../../packages/babylon-lite/src/mesh/mesh.js";
 import type { PbrMaterialProps } from "../../../packages/babylon-lite/src/material/pbr/pbr-material.js";
+import { createMappedBuffer } from "../../../packages/babylon-lite/src/resource/gpu-buffers.js";
 
 function makeEngine() {
     const createBuffer = vi.fn((descriptor: GPUBufferDescriptor) => {
@@ -44,6 +48,30 @@ function makeMeshData(nodeIndex: number, primitive: object, material: GltfMateri
     };
 }
 
+function buildTightMesh(engine: EngineContext, meshData: GltfMeshData, material: PbrMaterialProps, name: string, source?: Mesh): Mesh {
+    const gpu: MeshGPU =
+        source?._gpu ??
+        ({
+            positionBuffer: createMappedBuffer(engine, meshData._positions!, BU.VERTEX),
+            normalBuffer: createMappedBuffer(engine, meshData._normals!, BU.VERTEX),
+            uvBuffer: createMappedBuffer(engine, meshData._uvs!, BU.VERTEX),
+            indexBuffer: createMappedBuffer(engine, meshData._indices, BU.INDEX),
+            indexCount: meshData._indexCount,
+            indexFormat: "uint16",
+        } satisfies MeshGPU);
+    const mesh = {
+        name,
+        material,
+        receiveShadows: false,
+        _gpu: gpu,
+    } as Mesh;
+    mesh._cpuPositions = meshData._positions!;
+    mesh._cpuNormals = meshData._normals!;
+    mesh._cpuUvs = meshData._uvs!;
+    mesh._cpuIndices = source?._cpuIndices ?? new U32(meshData._indices);
+    return mesh;
+}
+
 describe("glTF geometry sharing scope", () => {
     it("does not retain an owner from an inactive glTF scene", async () => {
         const primitive = {};
@@ -56,7 +84,7 @@ describe("glTF geometry sharing scope", () => {
         };
         const { createBuffer, engine } = makeEngine();
         const ctx = { _engine: engine, _json: json } as unknown as GltfLoadCtx;
-        const meshes = await share([makeMeshData(0, primitive, material), makeMeshData(1, primitive, material)], async () => ({}) as PbrMaterialProps, [] as GltfFeature[], ctx);
+        const meshes = await share([makeMeshData(0, primitive, material), makeMeshData(1, primitive, material)], async () => ({}) as PbrMaterialProps, buildTightMesh, [], ctx);
 
         expect(meshes[1]!._gpu).not.toBe(meshes[0]!._gpu);
         expect(meshes[0]!._gpu._refCount).toBeUndefined();


### PR DESCRIPTION
## Summary
- route normal and repeated glTF primitives through the same tightly-packed mesh builder
- reuse the interleaved builder for shared owners instead of duplicating clone assembly in `gltf-share.ts`
- keep duplicate detection, CPU canonicalization, ref-counting, and device-loss recovery in the lazy sharing chunk
- cover per-mesh feature hooks on shared instances and correct the loader architecture documentation

Follow-up to the discussion in https://forum.babylonjs.com/t/lite-loadgltf-why-meshes-always-duplicated/63839/8 and PR #435.

## Bundle size
Shared-geometry scenes shrink while ordinary glTF loads remain within their existing ceilings:

| Scene | Delta |
|---|---:|
| 247 | -0.9 KB |
| 34, 39, 253, 266 | -0.8 KB each |
| 245 | -0.7 KB |

Common-path movement remains below 0.1 KB; every bundle-size ceiling passes.

## Validation
- `pnpm test:unit` — 1,001 passed
- `pnpm run lint` — passed
- `pnpm validate:bundle-manifest` — 217 scenes current
- `pnpm test` — all bundle ceilings passed; 433 parity tests passed, with the established Windows-local failures in Scenes 47, 104, 105, 106, and 265
- Scene 34 shared-node output visually matches its golden

