### PR TITLE
Export enableStandardSkeleton, enableStandardUvOffset, enableStandardVertexColors.

### DIFF
--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -223,6 +223,8 @@ export { setKtx2DecoderUrl, loadKtx2Texture2D } from "./texture/ktx2-loader.js";
 // ─── Materials ───────────────────────────────────────────────────────
 export { createStandardMaterial } from "./material/standard/create-standard-material.js";
 export { createStandardNoColorMaterialView } from "./material/standard/no-color-view.js";
+export { enableStandardSkeleton, enableStandardUvOffset } from "./material/standard/enable-standard-mesh-features.js";
+export { enableStandardVertexColors } from "./material/standard/enable-standard-vertex-colors.js";
 export { createPbrMaterial } from "./material/pbr/pbr-material.js";
 export {
     createShaderMaterial,


### PR DESCRIPTION
Export `enableStandardSkeleton`, `enableStandardUvOffset`, `enableStandardVertexColors` that are added in 9541329937c1acda58cd19b7f707c09c52ddfd4a.