### PR TITLE
Mark dirty-tracked properties as readonly.

### DIFF
--- a/lab/public/bundle/manifest/scene1.json
+++ b/lab/public/bundle/manifest/scene1.json
@@ -16,5 +16,5 @@
     "scene1-wgsl-helpers-BgB2AJrF.js",
     "scene1.js"
   ],
-  "rawBytes": 90530
+  "rawBytes": 90550
 }

--- a/lab/public/bundle/manifest/scene10.json
+++ b/lab/public/bundle/manifest/scene10.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 53.2,
+  "rawKB": 53.1,
   "gzipKB": 22,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene10-singlelight-hemispheric-wgsl-xIKr6fiL.js",
     "scene10.js"
   ],
-  "rawBytes": 54431
+  "rawBytes": 54382
 }

--- a/lab/public/bundle/manifest/scene100.json
+++ b/lab/public/bundle/manifest/scene100.json
@@ -6,5 +6,5 @@
     "scene100-standard-renderable-DyIqhwVt.js",
     "scene100.js"
   ],
-  "rawBytes": 52123
+  "rawBytes": 52078
 }

--- a/lab/public/bundle/manifest/scene101.json
+++ b/lab/public/bundle/manifest/scene101.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 53.9,
+  "rawKB": 53.8,
   "gzipKB": 21.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene101-standard-renderable-D4WI_kqm.js",
     "scene101.js"
   ],
-  "rawBytes": 55180
+  "rawBytes": 55135
 }

--- a/lab/public/bundle/manifest/scene102.json
+++ b/lab/public/bundle/manifest/scene102.json
@@ -6,5 +6,5 @@
     "scene102-standard-renderable-BfzwhvRR.js",
     "scene102.js"
   ],
-  "rawBytes": 60974
+  "rawBytes": 60922
 }

--- a/lab/public/bundle/manifest/scene103.json
+++ b/lab/public/bundle/manifest/scene103.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 63,
+  "rawKB": 62.9,
   "gzipKB": 25.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -8,5 +8,5 @@
     "scene103-thin-instance-gpu-BRZG8wwf.js",
     "scene103.js"
   ],
-  "rawBytes": 64476
+  "rawBytes": 64440
 }

--- a/lab/public/bundle/manifest/scene104.json
+++ b/lab/public/bundle/manifest/scene104.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 101.3,
+  "rawKB": 101.2,
   "gzipKB": 39.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,5 +11,5 @@
     "scene104-std-lightmap-fragment-BcOGvaSO.js",
     "scene104.js"
   ],
-  "rawBytes": 103720
+  "rawBytes": 103669
 }

--- a/lab/public/bundle/manifest/scene105.json
+++ b/lab/public/bundle/manifest/scene105.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 102,
+  "rawKB": 101.9,
   "gzipKB": 39.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,5 +11,5 @@
     "scene105-std-lightmap-fragment-CAyjqaXg.js",
     "scene105.js"
   ],
-  "rawBytes": 104417
+  "rawBytes": 104354
 }

--- a/lab/public/bundle/manifest/scene106.json
+++ b/lab/public/bundle/manifest/scene106.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 51.8,
+  "rawKB": 51.7,
   "gzipKB": 20.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene106-standard-renderable-BDRZY4cL.js",
     "scene106.js"
   ],
-  "rawBytes": 53039
+  "rawBytes": 52987
 }

--- a/lab/public/bundle/manifest/scene11.json
+++ b/lab/public/bundle/manifest/scene11.json
@@ -18,5 +18,5 @@
     "scene11-skeleton-fragment-D3wNNm0a.js",
     "scene11.js"
   ],
-  "rawBytes": 91229
+  "rawBytes": 91249
 }

--- a/lab/public/bundle/manifest/scene110.json
+++ b/lab/public/bundle/manifest/scene110.json
@@ -6,5 +6,5 @@
     "scene110-standard-renderable-Ci_axEDg.js",
     "scene110.js"
   ],
-  "rawBytes": 51828
+  "rawBytes": 51779
 }

--- a/lab/public/bundle/manifest/scene111.json
+++ b/lab/public/bundle/manifest/scene111.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 132.7,
+  "rawKB": 132.6,
   "gzipKB": 54.2,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
@@ -29,5 +29,5 @@
     "scene111-vertex-output-C7G5u6Y0.js",
     "scene111.js"
   ],
-  "rawBytes": 135854
+  "rawBytes": 135808
 }

--- a/lab/public/bundle/manifest/scene112.json
+++ b/lab/public/bundle/manifest/scene112.json
@@ -22,5 +22,5 @@
     "scene112-wgsl-helpers-BgB2AJrF.js",
     "scene112.js"
   ],
-  "rawBytes": 122901
+  "rawBytes": 122926
 }

--- a/lab/public/bundle/manifest/scene113.json
+++ b/lab/public/bundle/manifest/scene113.json
@@ -7,5 +7,5 @@
     "scene113-standard-renderable-DbCgwXT_.js",
     "scene113.js"
   ],
-  "rawBytes": 63716
+  "rawBytes": 63672
 }

--- a/lab/public/bundle/manifest/scene114.json
+++ b/lab/public/bundle/manifest/scene114.json
@@ -13,5 +13,5 @@
     "scene114-unlit-fragment-DWtvt7yQ.js",
     "scene114.js"
   ],
-  "rawBytes": 83458
+  "rawBytes": 83440
 }

--- a/lab/public/bundle/manifest/scene115.json
+++ b/lab/public/bundle/manifest/scene115.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 127,
-  "gzipKB": 53.4,
+  "gzipKB": 53.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene115-create-morph-targets-BxcR5t59.js",
@@ -25,5 +25,5 @@
     "scene115-standard-renderable-BXC04JFy.js",
     "scene115.js"
   ],
-  "rawBytes": 130046
+  "rawBytes": 130002
 }

--- a/lab/public/bundle/manifest/scene116.json
+++ b/lab/public/bundle/manifest/scene116.json
@@ -11,5 +11,5 @@
     "scene116-unlit-fragment-DWtvt7yQ.js",
     "scene116.js"
   ],
-  "rawBytes": 78135
+  "rawBytes": 78080
 }

--- a/lab/public/bundle/manifest/scene118.json
+++ b/lab/public/bundle/manifest/scene118.json
@@ -10,5 +10,5 @@
     "scene118-standard-renderable-CiCWOjTT.js",
     "scene118.js"
   ],
-  "rawBytes": 78853
+  "rawBytes": 78804
 }

--- a/lab/public/bundle/manifest/scene12.json
+++ b/lab/public/bundle/manifest/scene12.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 103.9,
+  "rawKB": 104,
   "gzipKB": 42.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -19,5 +19,5 @@
     "scene12-skeleton-fragment-B3HcVmlw.js",
     "scene12.js"
   ],
-  "rawBytes": 106439
+  "rawBytes": 106457
 }

--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -1,11 +1,11 @@
 {
   "rawKB": 60.3,
-  "gzipKB": 23.4,
+  "gzipKB": 23.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene127-shader-renderable-CVvVThkc.js",
     "scene127-uniform-copy-batch-5CRB0N8o.js",
     "scene127.js"
   ],
-  "rawBytes": 61759
+  "rawBytes": 61715
 }

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.3,
+  "rawKB": 60.2,
   "gzipKB": 23.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene128-uniform-copy-batch-4Fa5v6Ll.js",
     "scene128.js"
   ],
-  "rawBytes": 61728
+  "rawBytes": 61681
 }

--- a/lab/public/bundle/manifest/scene129.json
+++ b/lab/public/bundle/manifest/scene129.json
@@ -8,5 +8,5 @@
     "scene129-standard-renderable-CU0A9Dxg.js",
     "scene129.js"
   ],
-  "rawBytes": 89623
+  "rawBytes": 89570
 }

--- a/lab/public/bundle/manifest/scene13.json
+++ b/lab/public/bundle/manifest/scene13.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 84.1,
-  "gzipKB": 35,
+  "gzipKB": 35.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene13-background-ground-ZOdeTpEl.js",
@@ -14,5 +14,5 @@
     "scene13-wgsl-helpers-BgB2AJrF.js",
     "scene13.js"
   ],
-  "rawBytes": 86132
+  "rawBytes": 86152
 }

--- a/lab/public/bundle/manifest/scene14.json
+++ b/lab/public/bundle/manifest/scene14.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 88.6,
-  "gzipKB": 37.3,
+  "rawKB": 88.7,
+  "gzipKB": 37.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene14-background-dds-skybox--GK6CC4j.js",
@@ -16,5 +16,5 @@
     "scene14-wgsl-helpers-BgB2AJrF.js",
     "scene14.js"
   ],
-  "rawBytes": 90766
+  "rawBytes": 90786
 }

--- a/lab/public/bundle/manifest/scene140.json
+++ b/lab/public/bundle/manifest/scene140.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.6,
+  "rawKB": 90.5,
   "gzipKB": 42.2,
   "ignoredRawKB": 6.6,
   "runtimeChunks": [
@@ -41,5 +41,5 @@
     "scene140-vertex-output-C7G5u6Y0.js",
     "scene140.js"
   ],
-  "rawBytes": 92769
+  "rawBytes": 92712
 }

--- a/lab/public/bundle/manifest/scene141.json
+++ b/lab/public/bundle/manifest/scene141.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 122.2,
-  "gzipKB": 50.7,
+  "gzipKB": 50.8,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
     "scene141-_math-factory-DkfnO9Se.js",
@@ -26,5 +26,5 @@
     "scene141-vertex-output-C7G5u6Y0.js",
     "scene141.js"
   ],
-  "rawBytes": 125174
+  "rawBytes": 125122
 }

--- a/lab/public/bundle/manifest/scene142.json
+++ b/lab/public/bundle/manifest/scene142.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 61,
+  "rawKB": 60.9,
   "gzipKB": 23.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene142-standard-renderable-Xkd9W1L1.js",
     "scene142.js"
   ],
-  "rawBytes": 62454
+  "rawBytes": 62405
 }

--- a/lab/public/bundle/manifest/scene143.json
+++ b/lab/public/bundle/manifest/scene143.json
@@ -13,5 +13,5 @@
     "scene143-std-specular-fragment-BugkvqOj.js",
     "scene143.js"
   ],
-  "rawBytes": 72412
+  "rawBytes": 72432
 }

--- a/lab/public/bundle/manifest/scene144.json
+++ b/lab/public/bundle/manifest/scene144.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 111.8,
+  "rawKB": 111.9,
   "gzipKB": 45.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -22,5 +22,5 @@
     "scene144-texture-2d-DQo3n8D6.js",
     "scene144.js"
   ],
-  "rawBytes": 114525
+  "rawBytes": 114545
 }

--- a/lab/public/bundle/manifest/scene145.json
+++ b/lab/public/bundle/manifest/scene145.json
@@ -22,5 +22,5 @@
     "scene145-std-specular-fragment-DwjAhaXY.js",
     "scene145.js"
   ],
-  "rawBytes": 91716
+  "rawBytes": 91736
 }

--- a/lab/public/bundle/manifest/scene146.json
+++ b/lab/public/bundle/manifest/scene146.json
@@ -19,5 +19,5 @@
     "scene146-wgsl-helpers-BxdFLrVn.js",
     "scene146.js"
   ],
-  "rawBytes": 113238
+  "rawBytes": 113258
 }

--- a/lab/public/bundle/manifest/scene147.json
+++ b/lab/public/bundle/manifest/scene147.json
@@ -16,5 +16,5 @@
     "scene147-shader-composer-8GPw9fSv.js",
     "scene147.js"
   ],
-  "rawBytes": 106285
+  "rawBytes": 106305
 }

--- a/lab/public/bundle/manifest/scene148.json
+++ b/lab/public/bundle/manifest/scene148.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 109.6,
+  "rawKB": 109.7,
   "gzipKB": 43.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -16,5 +16,5 @@
     "scene148-singlelight-hemispheric-wgsl-Dl8TI5wG.js",
     "scene148.js"
   ],
-  "rawBytes": 112265
+  "rawBytes": 112285
 }

--- a/lab/public/bundle/manifest/scene149.json
+++ b/lab/public/bundle/manifest/scene149.json
@@ -22,5 +22,5 @@
     "scene149-vertex-output-C7G5u6Y0.js",
     "scene149.js"
   ],
-  "rawBytes": 109274
+  "rawBytes": 109294
 }

--- a/lab/public/bundle/manifest/scene15.json
+++ b/lab/public/bundle/manifest/scene15.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 47.9,
+  "rawKB": 47.8,
   "gzipKB": 19.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene15-standard-renderable-s8aJWbW9.js",
     "scene15.js"
   ],
-  "rawBytes": 49023
+  "rawBytes": 48974
 }

--- a/lab/public/bundle/manifest/scene150.json
+++ b/lab/public/bundle/manifest/scene150.json
@@ -6,5 +6,5 @@
     "scene150-standard-renderable-Dp-b6aUt.js",
     "scene150.js"
   ],
-  "rawBytes": 55737
+  "rawBytes": 55688
 }

--- a/lab/public/bundle/manifest/scene151.json
+++ b/lab/public/bundle/manifest/scene151.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 54.7,
+  "rawKB": 54.6,
   "gzipKB": 21.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene151-standard-renderable-BguQYttS.js",
     "scene151.js"
   ],
-  "rawBytes": 55992
+  "rawBytes": 55943
 }

--- a/lab/public/bundle/manifest/scene152.json
+++ b/lab/public/bundle/manifest/scene152.json
@@ -18,5 +18,5 @@
     "scene152-skeleton-fragment-CpAHEz2u.js",
     "scene152.js"
   ],
-  "rawBytes": 95255
+  "rawBytes": 95275
 }

--- a/lab/public/bundle/manifest/scene154.json
+++ b/lab/public/bundle/manifest/scene154.json
@@ -6,5 +6,5 @@
     "scene154-standard-renderable-CcQDuLSA.js",
     "scene154.js"
   ],
-  "rawBytes": 56166
+  "rawBytes": 56117
 }

--- a/lab/public/bundle/manifest/scene155.json
+++ b/lab/public/bundle/manifest/scene155.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 56.9,
-  "gzipKB": 22.5,
+  "rawKB": 56.8,
+  "gzipKB": 22.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene155-standard-renderable-Bdw0ZGGp.js",
     "scene155.js"
   ],
-  "rawBytes": 58226
+  "rawBytes": 58175
 }

--- a/lab/public/bundle/manifest/scene156.json
+++ b/lab/public/bundle/manifest/scene156.json
@@ -6,5 +6,5 @@
     "scene156-standard-renderable-BEaiaAAk.js",
     "scene156.js"
   ],
-  "rawBytes": 59236
+  "rawBytes": 59187
 }

--- a/lab/public/bundle/manifest/scene157.json
+++ b/lab/public/bundle/manifest/scene157.json
@@ -15,5 +15,5 @@
     "scene157-skeleton-fragment-fI62RGU2.js",
     "scene157.js"
   ],
-  "rawBytes": 98263
+  "rawBytes": 98283
 }

--- a/lab/public/bundle/manifest/scene158.json
+++ b/lab/public/bundle/manifest/scene158.json
@@ -15,5 +15,5 @@
     "scene158-skeleton-fragment-DG0TFoIM.js",
     "scene158.js"
   ],
-  "rawBytes": 98536
+  "rawBytes": 98556
 }

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -6,5 +6,5 @@
     "scene159-shader-renderable-BvJF0hyf.js",
     "scene159.js"
   ],
-  "rawBytes": 40037
+  "rawBytes": 39993
 }

--- a/lab/public/bundle/manifest/scene16.json
+++ b/lab/public/bundle/manifest/scene16.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49.9,
+  "rawKB": 49.8,
   "gzipKB": 20.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -8,5 +8,5 @@
     "scene16-thin-instance-gpu-d2Yv33aN.js",
     "scene16.js"
   ],
-  "rawBytes": 51081
+  "rawBytes": 51035
 }

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 41,
+  "rawKB": 40.9,
   "gzipKB": 16.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene160-shader-renderable-90CyR92R.js",
     "scene160.js"
   ],
-  "rawBytes": 41975
+  "rawBytes": 41927
 }

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 39.7,
+  "rawKB": 39.6,
   "gzipKB": 15.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene161-shader-renderable-xlpLRCJ-.js",
     "scene161.js"
   ],
-  "rawBytes": 40612
+  "rawBytes": 40564
 }

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -6,5 +6,5 @@
     "scene162-shader-renderable-DIRc68T5.js",
     "scene162.js"
   ],
-  "rawBytes": 40059
+  "rawBytes": 40012
 }

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -6,5 +6,5 @@
     "scene163-shader-renderable-DhpmYcK5.js",
     "scene163.js"
   ],
-  "rawBytes": 39751
+  "rawBytes": 39702
 }

--- a/lab/public/bundle/manifest/scene164.json
+++ b/lab/public/bundle/manifest/scene164.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 94.8,
-  "gzipKB": 40.2,
+  "rawKB": 94.9,
+  "gzipKB": 40.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene164-create-morph-targets-HFpNUWQ3.js",
@@ -21,5 +21,5 @@
     "scene164-skeleton-fragment-BUK5RiWS.js",
     "scene164.js"
   ],
-  "rawBytes": 97107
+  "rawBytes": 97127
 }

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 44.4,
-  "gzipKB": 17.9,
+  "rawKB": 44.3,
+  "gzipKB": 17.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene165-shader-renderable-DS-9toQQ.js",
@@ -8,5 +8,5 @@
     "scene165-thin-instance-gpu-B5cobg4p.js",
     "scene165.js"
   ],
-  "rawBytes": 45456
+  "rawBytes": 45405
 }

--- a/lab/public/bundle/manifest/scene17.json
+++ b/lab/public/bundle/manifest/scene17.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 87,
+  "rawKB": 86.9,
   "gzipKB": 36.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -14,5 +14,5 @@
     "scene17-thin-instance-gpu-BmCYehED.js",
     "scene17.js"
   ],
-  "rawBytes": 89087
+  "rawBytes": 89029
 }

--- a/lab/public/bundle/manifest/scene170.json
+++ b/lab/public/bundle/manifest/scene170.json
@@ -7,5 +7,5 @@
     "scene170-standard-renderable-CuRVZ66s.js",
     "scene170.js"
   ],
-  "rawBytes": 52857
+  "rawBytes": 52808
 }

--- a/lab/public/bundle/manifest/scene171.json
+++ b/lab/public/bundle/manifest/scene171.json
@@ -12,5 +12,5 @@
     "scene171-standard-renderable-CPqTayYc.js",
     "scene171.js"
   ],
-  "rawBytes": 97905
+  "rawBytes": 97848
 }

--- a/lab/public/bundle/manifest/scene172.json
+++ b/lab/public/bundle/manifest/scene172.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.9,
+  "rawKB": 59.8,
   "gzipKB": 23.8,
   "ignoredRawKB": 1483.8,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene172-standard-renderable-dn-Vs64N.js",
     "scene172.js"
   ],
-  "rawBytes": 61325
+  "rawBytes": 61275
 }

--- a/lab/public/bundle/manifest/scene173.json
+++ b/lab/public/bundle/manifest/scene173.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 64.8,
+  "rawKB": 64.7,
   "gzipKB": 25.3,
   "ignoredRawKB": 1483.8,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene173-standard-renderable-DmR_ooSM.js",
     "scene173.js"
   ],
-  "rawBytes": 66350
+  "rawBytes": 66300
 }

--- a/lab/public/bundle/manifest/scene174.json
+++ b/lab/public/bundle/manifest/scene174.json
@@ -12,5 +12,5 @@
     "scene174-standard-renderable-DqflF_n-.js",
     "scene174.js"
   ],
-  "rawBytes": 98540
+  "rawBytes": 98493
 }

--- a/lab/public/bundle/manifest/scene175.json
+++ b/lab/public/bundle/manifest/scene175.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 94.7,
-  "gzipKB": 39.1,
+  "gzipKB": 39,
   "ignoredRawKB": 1483.8,
   "runtimeChunks": [
     "scene175-generate-mipmaps-CCmlSqhB.js",
@@ -12,5 +12,5 @@
     "scene175-standard-renderable-ge07XCBg.js",
     "scene175.js"
   ],
-  "rawBytes": 97009
+  "rawBytes": 96952
 }

--- a/lab/public/bundle/manifest/scene176.json
+++ b/lab/public/bundle/manifest/scene176.json
@@ -18,5 +18,5 @@
     "scene176-scene-uniforms-FTYH6Ct0.js",
     "scene176.js"
   ],
-  "rawBytes": 106820
+  "rawBytes": 106764
 }

--- a/lab/public/bundle/manifest/scene177.json
+++ b/lab/public/bundle/manifest/scene177.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 70.3,
+  "rawKB": 70.2,
   "gzipKB": 28.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,5 +11,5 @@
     "scene177-scene-uniforms-FTYH6Ct0.js",
     "scene177.js"
   ],
-  "rawBytes": 71953
+  "rawBytes": 71906
 }

--- a/lab/public/bundle/manifest/scene178.json
+++ b/lab/public/bundle/manifest/scene178.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 88,
+  "rawKB": 87.9,
   "gzipKB": 36.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -15,5 +15,5 @@
     "scene178-scene-uniforms-FTYH6Ct0.js",
     "scene178.js"
   ],
-  "rawBytes": 90081
+  "rawBytes": 90023
 }

--- a/lab/public/bundle/manifest/scene179.json
+++ b/lab/public/bundle/manifest/scene179.json
@@ -9,5 +9,5 @@
     "scene179-pbr-renderable-B46ppL0E.js",
     "scene179.js"
   ],
-  "rawBytes": 75978
+  "rawBytes": 75998
 }

--- a/lab/public/bundle/manifest/scene18.json
+++ b/lab/public/bundle/manifest/scene18.json
@@ -11,5 +11,5 @@
     "scene18-std-shadow-fragment-pwyXRo4i.js",
     "scene18.js"
   ],
-  "rawBytes": 62702
+  "rawBytes": 62653
 }

--- a/lab/public/bundle/manifest/scene19.json
+++ b/lab/public/bundle/manifest/scene19.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 71,
+  "rawKB": 70.9,
   "gzipKB": 29.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -10,5 +10,5 @@
     "scene19-singlelight-hemispheric-wgsl-B2Zus5m2.js",
     "scene19.js"
   ],
-  "rawBytes": 72663
+  "rawBytes": 72634
 }

--- a/lab/public/bundle/manifest/scene2.json
+++ b/lab/public/bundle/manifest/scene2.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 47.6,
+  "rawKB": 47.5,
   "gzipKB": 19.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene2-standard-renderable-BPU8LiG6.js",
     "scene2.js"
   ],
-  "rawBytes": 48701
+  "rawBytes": 48652
 }

--- a/lab/public/bundle/manifest/scene20.json
+++ b/lab/public/bundle/manifest/scene20.json
@@ -15,5 +15,5 @@
     "scene20-wgsl-helpers-BgB2AJrF.js",
     "scene20.js"
   ],
-  "rawBytes": 80821
+  "rawBytes": 80771
 }

--- a/lab/public/bundle/manifest/scene200.json
+++ b/lab/public/bundle/manifest/scene200.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 47.7,
-  "gzipKB": 19.3,
+  "rawKB": 47.6,
+  "gzipKB": 19.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene200-standard-renderable-DM4CrBQ9.js",
     "scene200.js"
   ],
-  "rawBytes": 48836
+  "rawBytes": 48784
 }

--- a/lab/public/bundle/manifest/scene201.json
+++ b/lab/public/bundle/manifest/scene201.json
@@ -9,5 +9,5 @@
     "scene201-standard-renderable-BNIyIXML.js",
     "scene201.js"
   ],
-  "rawBytes": 50194
+  "rawBytes": 50144
 }

--- a/lab/public/bundle/manifest/scene202.json
+++ b/lab/public/bundle/manifest/scene202.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49.8,
+  "rawKB": 49.7,
   "gzipKB": 20.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -9,5 +9,5 @@
     "scene202-standard-renderable-CcaYInzj.js",
     "scene202.js"
   ],
-  "rawBytes": 50967
+  "rawBytes": 50920
 }

--- a/lab/public/bundle/manifest/scene203.json
+++ b/lab/public/bundle/manifest/scene203.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 50.1,
+  "rawKB": 50,
   "gzipKB": 20.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -9,5 +9,5 @@
     "scene203-standard-renderable-C3xBSzxG.js",
     "scene203.js"
   ],
-  "rawBytes": 51267
+  "rawBytes": 51220
 }

--- a/lab/public/bundle/manifest/scene204.json
+++ b/lab/public/bundle/manifest/scene204.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 52.3,
+  "rawKB": 52.2,
   "gzipKB": 21.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,5 +11,5 @@
     "scene204-thin-instance-gpu-DMvEkqgI.js",
     "scene204.js"
   ],
-  "rawBytes": 53518
+  "rawBytes": 53473
 }

--- a/lab/public/bundle/manifest/scene205.json
+++ b/lab/public/bundle/manifest/scene205.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62.1,
+  "rawKB": 62,
   "gzipKB": 25.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,5 +11,5 @@
     "scene205-standard-renderable-BmvrsxXJ.js",
     "scene205.js"
   ],
-  "rawBytes": 63574
+  "rawBytes": 63526
 }

--- a/lab/public/bundle/manifest/scene206.json
+++ b/lab/public/bundle/manifest/scene206.json
@@ -11,5 +11,5 @@
     "scene206-standard-renderable-IGLP4f9w.js",
     "scene206.js"
   ],
-  "rawBytes": 63922
+  "rawBytes": 63877
 }

--- a/lab/public/bundle/manifest/scene207.json
+++ b/lab/public/bundle/manifest/scene207.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 60.3,
-  "gzipKB": 24.5,
+  "rawKB": 60.2,
+  "gzipKB": 24.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene207-_mat4-storage-f64-B_0HYOAx.js",
@@ -13,5 +13,5 @@
     "scene207-std-shadow-fragment-pwyXRo4i.js",
     "scene207.js"
   ],
-  "rawBytes": 61696
+  "rawBytes": 61649
 }

--- a/lab/public/bundle/manifest/scene209.json
+++ b/lab/public/bundle/manifest/scene209.json
@@ -10,5 +10,5 @@
     "scene209-standard-renderable-D5SRe5mq.js",
     "scene209.js"
   ],
-  "rawBytes": 56263
+  "rawBytes": 56214
 }

--- a/lab/public/bundle/manifest/scene21.json
+++ b/lab/public/bundle/manifest/scene21.json
@@ -14,5 +14,5 @@
     "scene21-sheen-fragment-_mQhtdZq.js",
     "scene21.js"
   ],
-  "rawBytes": 88137
+  "rawBytes": 88157
 }

--- a/lab/public/bundle/manifest/scene210.json
+++ b/lab/public/bundle/manifest/scene210.json
@@ -7,11 +7,11 @@
     "scene210-gltf-feature-registry-BkiVi4ND.js",
     "scene210-gltf-feature-xmp-S8Tl-XNQ.js",
     "scene210-gltf-glb-parser-DX-hcw7S.js",
-    "scene210-gltf-interleave-C_9dpKt3.js",
+    "scene210-gltf-interleave-DXYIjlOJ.js",
     "scene210-gltf-normals-DYhLwXNX.js",
     "scene210-pbr-renderable-851H1-in.js",
     "scene210-singlelight-hemispheric-wgsl-9sNVHX0R.js",
     "scene210.js"
   ],
-  "rawBytes": 78975
+  "rawBytes": 78993
 }

--- a/lab/public/bundle/manifest/scene211.json
+++ b/lab/public/bundle/manifest/scene211.json
@@ -19,5 +19,5 @@
     "scene211-skeleton-fragment-KTThi-AR.js",
     "scene211.js"
   ],
-  "rawBytes": 92970
+  "rawBytes": 92988
 }

--- a/lab/public/bundle/manifest/scene212.json
+++ b/lab/public/bundle/manifest/scene212.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 104.4,
-  "gzipKB": 42.3,
+  "rawKB": 104.3,
+  "gzipKB": 42.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene212-generate-mipmaps-DzxxhGEP.js",
@@ -18,5 +18,5 @@
     "scene212-scene-uniforms-FTYH6Ct0.js",
     "scene212.js"
   ],
-  "rawBytes": 106864
+  "rawBytes": 106806
 }

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 49.1,
-  "gzipKB": 19.4,
+  "gzipKB": 19.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene213-shader-pipeline-cache-BVbK7X_V.js",
@@ -8,5 +8,5 @@
     "scene213-uniform-copy-batch-dw98bObp.js",
     "scene213.js"
   ],
-  "rawBytes": 50299
+  "rawBytes": 50249
 }

--- a/lab/public/bundle/manifest/scene214.json
+++ b/lab/public/bundle/manifest/scene214.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 69.4,
+  "rawKB": 69.3,
   "gzipKB": 27.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -10,5 +10,5 @@
     "scene214-std-shadow-fragment-DUILnYou.js",
     "scene214.js"
   ],
-  "rawBytes": 71059
+  "rawBytes": 71008
 }

--- a/lab/public/bundle/manifest/scene215.json
+++ b/lab/public/bundle/manifest/scene215.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 80.9,
+  "rawKB": 80.8,
   "gzipKB": 32.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -12,5 +12,5 @@
     "scene215-singlelight-directional-wgsl-BpRi11tU.js",
     "scene215.js"
   ],
-  "rawBytes": 82812
+  "rawBytes": 82763
 }

--- a/lab/public/bundle/manifest/scene216.json
+++ b/lab/public/bundle/manifest/scene216.json
@@ -8,5 +8,5 @@
     "scene216-singlelight-hemispheric-wgsl-D6t-GAaw.js",
     "scene216.js"
   ],
-  "rawBytes": 55624
+  "rawBytes": 55575
 }

--- a/lab/public/bundle/manifest/scene217.json
+++ b/lab/public/bundle/manifest/scene217.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 78.4,
+  "rawKB": 78.3,
   "gzipKB": 31.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -9,5 +9,5 @@
     "scene217-standard-renderable-BsszhK6j.js",
     "scene217.js"
   ],
-  "rawBytes": 80258
+  "rawBytes": 80207
 }

--- a/lab/public/bundle/manifest/scene218.json
+++ b/lab/public/bundle/manifest/scene218.json
@@ -17,5 +17,5 @@
     "scene218-singlelight-hemispheric-wgsl-C0jht4qY.js",
     "scene218.js"
   ],
-  "rawBytes": 96849
+  "rawBytes": 96869
 }

--- a/lab/public/bundle/manifest/scene219.json
+++ b/lab/public/bundle/manifest/scene219.json
@@ -19,5 +19,5 @@
     "scene219-thin-instance-gpu-CCiryIV4.js",
     "scene219.js"
   ],
-  "rawBytes": 99998
+  "rawBytes": 100023
 }

--- a/lab/public/bundle/manifest/scene22.json
+++ b/lab/public/bundle/manifest/scene22.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 98.4,
+  "rawKB": 98.3,
   "gzipKB": 39.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -17,5 +17,5 @@
     "scene22-standard-renderable-wBGGANmr.js",
     "scene22.js"
   ],
-  "rawBytes": 100715
+  "rawBytes": 100669
 }

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -9,5 +9,5 @@
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221.js"
   ],
-  "rawBytes": 102007
+  "rawBytes": 101955
 }

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 112.6,
+  "rawKB": 112.5,
   "gzipKB": 42.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -12,5 +12,5 @@
     "scene222-uniform-copy-batch-DrEP8HMR.js",
     "scene222.js"
   ],
-  "rawBytes": 115278
+  "rawBytes": 115235
 }

--- a/lab/public/bundle/manifest/scene223.json
+++ b/lab/public/bundle/manifest/scene223.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 66.7,
+  "rawKB": 66.6,
   "gzipKB": 25.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene223-swapchain-overlay-ilhN4El_.js",
     "scene223.js"
   ],
-  "rawBytes": 68255
+  "rawBytes": 68210
 }

--- a/lab/public/bundle/manifest/scene224.json
+++ b/lab/public/bundle/manifest/scene224.json
@@ -7,5 +7,5 @@
     "scene224-swapchain-overlay-ilhN4El_.js",
     "scene224.js"
   ],
-  "rawBytes": 82157
+  "rawBytes": 82116
 }

--- a/lab/public/bundle/manifest/scene225.json
+++ b/lab/public/bundle/manifest/scene225.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 58.6,
+  "rawKB": 58.5,
   "gzipKB": 23.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene225-standard-renderable-Cr5JfdXs.js",
     "scene225.js"
   ],
-  "rawBytes": 59963
+  "rawBytes": 59915
 }

--- a/lab/public/bundle/manifest/scene227.json
+++ b/lab/public/bundle/manifest/scene227.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 48.8,
+  "rawKB": 48.7,
   "gzipKB": 19.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene227-standard-renderable-B4Yx2Gcb.js",
     "scene227.js"
   ],
-  "rawBytes": 49930
+  "rawBytes": 49881
 }

--- a/lab/public/bundle/manifest/scene228.json
+++ b/lab/public/bundle/manifest/scene228.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 50.8,
+  "rawKB": 50.7,
   "gzipKB": 20.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene228-standard-renderable-BLdwheuI.js",
     "scene228.js"
   ],
-  "rawBytes": 51985
+  "rawBytes": 51936
 }

--- a/lab/public/bundle/manifest/scene229.json
+++ b/lab/public/bundle/manifest/scene229.json
@@ -11,5 +11,5 @@
     "scene229-unlit-fragment-DWtvt7yQ.js",
     "scene229.js"
   ],
-  "rawBytes": 69908
+  "rawBytes": 69928
 }

--- a/lab/public/bundle/manifest/scene23.json
+++ b/lab/public/bundle/manifest/scene23.json
@@ -14,5 +14,5 @@
     "scene23-wgsl-helpers-BgB2AJrF.js",
     "scene23.js"
   ],
-  "rawBytes": 80625
+  "rawBytes": 80583
 }

--- a/lab/public/bundle/manifest/scene231.json
+++ b/lab/public/bundle/manifest/scene231.json
@@ -7,5 +7,5 @@
     "scene231-std-skeleton-fragment-BIMTVdV3.js",
     "scene231.js"
   ],
-  "rawBytes": 55236
+  "rawBytes": 55218
 }

--- a/lab/public/bundle/manifest/scene24.json
+++ b/lab/public/bundle/manifest/scene24.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.3,
+  "rawKB": 59.4,
   "gzipKB": 24.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -15,5 +15,5 @@
     "scene24-std-specular-fragment-DhCYMq1P.js",
     "scene24.js"
   ],
-  "rawBytes": 60757
+  "rawBytes": 60775
 }

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -17,5 +17,5 @@
     "scene240-scene-uniforms-FTYH6Ct0.js",
     "scene240.js"
   ],
-  "rawBytes": 93502
+  "rawBytes": 93522
 }

--- a/lab/public/bundle/manifest/scene241.json
+++ b/lab/public/bundle/manifest/scene241.json
@@ -45,5 +45,5 @@
     "scene241-visibility-CKB7eGDU.js",
     "scene241.js"
   ],
-  "rawBytes": 165945
+  "rawBytes": 165965
 }

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -19,5 +19,5 @@
     "scene242-visibility-ZqejguTC.js",
     "scene242.js"
   ],
-  "rawBytes": 99915
+  "rawBytes": 99935
 }

--- a/lab/public/bundle/manifest/scene243.json
+++ b/lab/public/bundle/manifest/scene243.json
@@ -21,5 +21,5 @@
     "scene243-texture-2d-DQo3n8D6.js",
     "scene243.js"
   ],
-  "rawBytes": 100036
+  "rawBytes": 100056
 }

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -28,5 +28,5 @@
     "scene244-visibility-BcAL-WaI.js",
     "scene244.js"
   ],
-  "rawBytes": 137015
+  "rawBytes": 137035
 }

--- a/lab/public/bundle/manifest/scene245.json
+++ b/lab/public/bundle/manifest/scene245.json
@@ -10,10 +10,10 @@
     "scene245-gltf-feature-animations-DnWT-O_8.js",
     "scene245-gltf-feature-registry-DbxNNkFg.js",
     "scene245-gltf-feature-skeleton-DWhCgmVK.js",
-    "scene245-gltf-interleave-KM-jw4Ig.js",
+    "scene245-gltf-interleave-1k4znsGs.js",
     "scene245-gltf-json-asset-9bYm1ZAX.js",
     "scene245-gltf-normals-DYhLwXNX.js",
-    "scene245-gltf-share-CeStaSTa.js",
+    "scene245-gltf-share-B3sSVG5H.js",
     "scene245-gltf-strided-attribute-CGKc0Sx6.js",
     "scene245-ibl-fragment-CeRrvT96.js",
     "scene245-pbr-renderable-BvxWmN-2.js",
@@ -23,5 +23,5 @@
     "scene245-skeleton-fragment-BgkBRi8w.js",
     "scene245.js"
   ],
-  "rawBytes": 104636
+  "rawBytes": 104654
 }

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -10,7 +10,7 @@
     "scene246-gltf-feature-animations-DWJWoTT5.js",
     "scene246-gltf-feature-registry-C2pLItIL.js",
     "scene246-gltf-feature-skeleton-xpb4slfP.js",
-    "scene246-gltf-interleave-Cx5yld1W.js",
+    "scene246-gltf-interleave-B7rLz0yY.js",
     "scene246-gltf-json-asset-Dl53bm1i.js",
     "scene246-gltf-multi-buffer-BlwDrcuy.js",
     "scene246-gltf-normals-DYhLwXNX.js",
@@ -22,5 +22,5 @@
     "scene246-skeleton-fragment-DWUcGtvv.js",
     "scene246.js"
   ],
-  "rawBytes": 102213
+  "rawBytes": 102231
 }

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 86.3,
+  "rawKB": 86.4,
   "gzipKB": 36.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -9,7 +9,7 @@
     "scene247-gltf-feature-registry-D3_NJiXs.js",
     "scene247-gltf-json-asset-aprJZkKh.js",
     "scene247-gltf-multi-buffer-BzFIY2Yd.js",
-    "scene247-gltf-share-DF9ijqo2.js",
+    "scene247-gltf-share-bZfqjrG_.js",
     "scene247-ibl-fragment-CeRrvT96.js",
     "scene247-pbr-renderable-B5AzE9wU.js",
     "scene247-rgbd-decode-BGfzKZhs.js",
@@ -18,5 +18,5 @@
     "scene247-thin-instance-gpu-DJosAWKP.js",
     "scene247.js"
   ],
-  "rawBytes": 88411
+  "rawBytes": 88431
 }

--- a/lab/public/bundle/manifest/scene248.json
+++ b/lab/public/bundle/manifest/scene248.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 77.3,
-  "gzipKB": 32.2,
+  "gzipKB": 32.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene248-generate-mipmaps-CQnzwwcC.js",
@@ -12,5 +12,5 @@
     "scene248-scene-uniforms-FTYH6Ct0.js",
     "scene248.js"
   ],
-  "rawBytes": 79168
+  "rawBytes": 79188
 }

--- a/lab/public/bundle/manifest/scene249.json
+++ b/lab/public/bundle/manifest/scene249.json
@@ -14,5 +14,5 @@
     "scene249-scene-uniforms-FTYH6Ct0.js",
     "scene249.js"
   ],
-  "rawBytes": 80787
+  "rawBytes": 80807
 }

--- a/lab/public/bundle/manifest/scene25.json
+++ b/lab/public/bundle/manifest/scene25.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 52,
+  "rawKB": 51.9,
   "gzipKB": 20.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene25-standard-renderable-DXEXI8AF.js",
     "scene25.js"
   ],
-  "rawBytes": 53205
+  "rawBytes": 53154
 }

--- a/lab/public/bundle/manifest/scene251.json
+++ b/lab/public/bundle/manifest/scene251.json
@@ -15,5 +15,5 @@
     "scene251-skeleton-fragment-DgMYwmmW.js",
     "scene251.js"
   ],
-  "rawBytes": 92070
+  "rawBytes": 92090
 }

--- a/lab/public/bundle/manifest/scene252.json
+++ b/lab/public/bundle/manifest/scene252.json
@@ -1,11 +1,11 @@
 {
-  "rawKB": 49.5,
-  "gzipKB": 20.1,
+  "rawKB": 49.4,
+  "gzipKB": 20,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene252-morph-fragment-core-DxZU-4QX.js",
     "scene252-standard-renderable-D8h8Bqs7.js",
     "scene252.js"
   ],
-  "rawBytes": 50677
+  "rawBytes": 50628
 }

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -30,7 +30,7 @@
     "scene253-gltf-light-pointer-state-B7kFTRxK.js",
     "scene253-gltf-pbr-builder-ext-DZSY-53Y.js",
     "scene253-gltf-sampler-desc-CJ9AGAsX.js",
-    "scene253-gltf-share-ib1sbZka.js",
+    "scene253-gltf-share-QP9HiaTT.js",
     "scene253-ibl-fragment-CeRrvT96.js",
     "scene253-iridescence-fragment-ChMtYpez.js",
     "scene253-light-base-ClJ8rhI7.js",
@@ -52,5 +52,5 @@
     "scene253-visibility-BVgAow7R.js",
     "scene253.js"
   ],
-  "rawBytes": 157809
+  "rawBytes": 157829
 }

--- a/lab/public/bundle/manifest/scene254.json
+++ b/lab/public/bundle/manifest/scene254.json
@@ -16,5 +16,5 @@
     "scene254-singlelight-hemispheric-wgsl-CqFh488F.js",
     "scene254.js"
   ],
-  "rawBytes": 95005
+  "rawBytes": 95025
 }

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -19,5 +19,5 @@
     "scene255-skeleton-fragment-CUdJz97F.js",
     "scene255.js"
   ],
-  "rawBytes": 96752
+  "rawBytes": 96772
 }

--- a/lab/public/bundle/manifest/scene257.json
+++ b/lab/public/bundle/manifest/scene257.json
@@ -15,5 +15,5 @@
     "scene257-scene-uniforms-FTYH6Ct0.js",
     "scene257.js"
   ],
-  "rawBytes": 82292
+  "rawBytes": 82312
 }

--- a/lab/public/bundle/manifest/scene258.json
+++ b/lab/public/bundle/manifest/scene258.json
@@ -1,11 +1,11 @@
 {
-  "rawKB": 83.3,
+  "rawKB": 83.4,
   "gzipKB": 35.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene258-flat-normal-wgsl-Cm9mM4tC.js",
     "scene258-generate-mipmaps-DLp_Ml6Z.js",
-    "scene258-gltf-interleave-lHttiyyP.js",
+    "scene258-gltf-interleave-DP2Wm1fM.js",
     "scene258-gltf-json-asset-B3VWshNY.js",
     "scene258-gltf-normals-DYhLwXNX.js",
     "scene258-gltf-uv-denorm-BTmmiHmh.js",
@@ -16,5 +16,5 @@
     "scene258-scene-uniforms-FTYH6Ct0.js",
     "scene258.js"
   ],
-  "rawBytes": 85338
+  "rawBytes": 85356
 }

--- a/lab/public/bundle/manifest/scene259.json
+++ b/lab/public/bundle/manifest/scene259.json
@@ -14,5 +14,5 @@
     "scene259-scene-uniforms-FTYH6Ct0.js",
     "scene259.js"
   ],
-  "rawBytes": 79361
+  "rawBytes": 79381
 }

--- a/lab/public/bundle/manifest/scene26.json
+++ b/lab/public/bundle/manifest/scene26.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.1,
+  "rawKB": 90,
   "gzipKB": 37,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -14,5 +14,5 @@
     "scene26-subsurface-fragment-PWl6-_mP.js",
     "scene26.js"
   ],
-  "rawBytes": 92249
+  "rawBytes": 92209
 }

--- a/lab/public/bundle/manifest/scene260.json
+++ b/lab/public/bundle/manifest/scene260.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 80.3,
+  "rawKB": 80.4,
   "gzipKB": 33.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -15,5 +15,5 @@
     "scene260-scene-uniforms-FTYH6Ct0.js",
     "scene260.js"
   ],
-  "rawBytes": 82260
+  "rawBytes": 82280
 }

--- a/lab/public/bundle/manifest/scene261.json
+++ b/lab/public/bundle/manifest/scene261.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 54.3,
+  "rawKB": 54.2,
   "gzipKB": 21.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene261-standard-renderable-BDD27p3e.js",
     "scene261.js"
   ],
-  "rawBytes": 55584
+  "rawBytes": 55535
 }

--- a/lab/public/bundle/manifest/scene265.json
+++ b/lab/public/bundle/manifest/scene265.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 80.4,
-  "gzipKB": 33.8,
+  "gzipKB": 33.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene265-generate-mipmaps-JrMA50q2.js",
@@ -14,5 +14,5 @@
     "scene265-pbr-renderable-4zo7fs0w.js",
     "scene265.js"
   ],
-  "rawBytes": 82286
+  "rawBytes": 82306
 }

--- a/lab/public/bundle/manifest/scene266.json
+++ b/lab/public/bundle/manifest/scene266.json
@@ -7,12 +7,12 @@
     "scene266-gltf-feature-primitive-BcZmWV7D.js",
     "scene266-gltf-feature-registry-CdTL8BE3.js",
     "scene266-gltf-glb-parser-D-h9Fgu9.js",
-    "scene266-gltf-share-D0T73tB6.js",
+    "scene266-gltf-share-ZS_-nUmT.js",
     "scene266-ibl-fragment-CeRrvT96.js",
     "scene266-pbr-renderable-BqakVPZZ.js",
     "scene266-rgbd-decode-BlUmJD6L.js",
     "scene266-scene-uniforms-FTYH6Ct0.js",
     "scene266.js"
   ],
-  "rawBytes": 82205
+  "rawBytes": 82225
 }

--- a/lab/public/bundle/manifest/scene267.json
+++ b/lab/public/bundle/manifest/scene267.json
@@ -6,5 +6,5 @@
     "scene267-standard-renderable-BDPNqQcL.js",
     "scene267.js"
   ],
-  "rawBytes": 44298
+  "rawBytes": 44316
 }

--- a/lab/public/bundle/manifest/scene268.json
+++ b/lab/public/bundle/manifest/scene268.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 46.3,
+  "rawKB": 46.2,
   "gzipKB": 18.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene268-standard-renderable-BEBAGFCB.js",
     "scene268.js"
   ],
-  "rawBytes": 47382
+  "rawBytes": 47336
 }

--- a/lab/public/bundle/manifest/scene269.json
+++ b/lab/public/bundle/manifest/scene269.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 89.1,
-  "rawBytes": 91193,
+  "rawKB": 89,
+  "rawBytes": 91135,
   "gzipKB": 37.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene27.json
+++ b/lab/public/bundle/manifest/scene27.json
@@ -16,5 +16,5 @@
     "scene27-texture-2d-DQo3n8D6.js",
     "scene27.js"
   ],
-  "rawBytes": 84805
+  "rawBytes": 84825
 }

--- a/lab/public/bundle/manifest/scene270.json
+++ b/lab/public/bundle/manifest/scene270.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 51.2,
-  "rawBytes": 52478,
+  "rawBytes": 52420,
   "gzipKB": 20.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene271.json
+++ b/lab/public/bundle/manifest/scene271.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 70.2,
-  "rawBytes": 71923,
+  "rawBytes": 71870,
   "gzipKB": 27.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene272.json
+++ b/lab/public/bundle/manifest/scene272.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 55.2,
-  "rawBytes": 56516,
+  "rawBytes": 56475,
   "gzipKB": 21.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene273.json
+++ b/lab/public/bundle/manifest/scene273.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 80.9,
-  "rawBytes": 82840,
+  "rawBytes": 82794,
   "gzipKB": 33.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene274.json
+++ b/lab/public/bundle/manifest/scene274.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 43.4,
-  "rawBytes": 44487,
+  "rawBytes": 44443,
   "gzipKB": 17.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -14,5 +14,5 @@
     "scene28-scene-uniforms-FTYH6Ct0.js",
     "scene28.js"
   ],
-  "rawBytes": 89081
+  "rawBytes": 89101
 }

--- a/lab/public/bundle/manifest/scene29.json
+++ b/lab/public/bundle/manifest/scene29.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.6,
+  "rawKB": 90.7,
   "gzipKB": 37.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -19,5 +19,5 @@
     "scene29-uv-transform-fragment-B8ijWmAK.js",
     "scene29.js"
   ],
-  "rawBytes": 92810
+  "rawBytes": 92830
 }

--- a/lab/public/bundle/manifest/scene3.json
+++ b/lab/public/bundle/manifest/scene3.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 55.2,
+  "rawKB": 55.1,
   "gzipKB": 22.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -10,5 +10,5 @@
     "scene3-wgsl-fog-m3PkjS7i.js",
     "scene3.js"
   ],
-  "rawBytes": 56515
+  "rawBytes": 56468
 }

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -22,5 +22,5 @@
     "scene30-uv-transform-fragment-B8ijWmAK.js",
     "scene30.js"
   ],
-  "rawBytes": 106499
+  "rawBytes": 106519
 }

--- a/lab/public/bundle/manifest/scene31.json
+++ b/lab/public/bundle/manifest/scene31.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 80.4,
-  "gzipKB": 33.3,
+  "gzipKB": 33.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene31-emissive-fragment-hx1-6YeZ.js",
@@ -14,5 +14,5 @@
     "scene31-scene-uniforms-FTYH6Ct0.js",
     "scene31.js"
   ],
-  "rawBytes": 82324
+  "rawBytes": 82344
 }

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 80.2,
-  "gzipKB": 33.3,
+  "rawKB": 80.3,
+  "gzipKB": 33.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene32-generate-mipmaps-Cr6tLrFA.js",
@@ -14,5 +14,5 @@
     "scene32-unlit-fragment-DWtvt7yQ.js",
     "scene32.js"
   ],
-  "rawBytes": 82153
+  "rawBytes": 82178
 }

--- a/lab/public/bundle/manifest/scene33.json
+++ b/lab/public/bundle/manifest/scene33.json
@@ -21,5 +21,5 @@
     "scene33-scene-uniforms-FTYH6Ct0.js",
     "scene33.js"
   ],
-  "rawBytes": 106346
+  "rawBytes": 106366
 }

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 98.2,
+  "rawKB": 98.3,
   "gzipKB": 41,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,7 +11,7 @@
     "scene34-gltf-feature-registry-Z-VX40TD.js",
     "scene34-gltf-glb-parser-Cq9dWVnL.js",
     "scene34-gltf-sampler-denorm-CTv2yBPK.js",
-    "scene34-gltf-share-CD7RSpVC.js",
+    "scene34-gltf-share-Dc_F4AR-.js",
     "scene34-ibl-fragment-CeRrvT96.js",
     "scene34-pbr-renderable-COIBkoBS.js",
     "scene34-rgbd-decode-EQ-YQ9oq.js",
@@ -19,5 +19,5 @@
     "scene34-visibility-CRkrFthj.js",
     "scene34.js"
   ],
-  "rawBytes": 100599
+  "rawBytes": 100619
 }

--- a/lab/public/bundle/manifest/scene35.json
+++ b/lab/public/bundle/manifest/scene35.json
@@ -15,5 +15,5 @@
     "scene35-thin-instance-gpu-C0sF7s2H.js",
     "scene35.js"
   ],
-  "rawBytes": 86189
+  "rawBytes": 86209
 }

--- a/lab/public/bundle/manifest/scene36.json
+++ b/lab/public/bundle/manifest/scene36.json
@@ -7,5 +7,5 @@
     "scene36-std-emissive-fragment-DthzsVUc.js",
     "scene36.js"
   ],
-  "rawBytes": 53070
+  "rawBytes": 53017
 }

--- a/lab/public/bundle/manifest/scene37.json
+++ b/lab/public/bundle/manifest/scene37.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 97.3,
-  "gzipKB": 40.2,
+  "rawKB": 97.4,
+  "gzipKB": 40.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene37-generate-mipmaps-DaBvcePx.js",
@@ -22,5 +22,5 @@
     "scene37-uv-transform-fragment-B8ijWmAK.js",
     "scene37.js"
   ],
-  "rawBytes": 99670
+  "rawBytes": 99690
 }

--- a/lab/public/bundle/manifest/scene38.json
+++ b/lab/public/bundle/manifest/scene38.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 61.8,
+  "rawKB": 61.7,
   "gzipKB": 24.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene38-standard-renderable-Dh_oMFSC.js",
     "scene38.js"
   ],
-  "rawBytes": 63257
+  "rawBytes": 63209
 }

--- a/lab/public/bundle/manifest/scene39.json
+++ b/lab/public/bundle/manifest/scene39.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 110,
-  "gzipKB": 47,
+  "gzipKB": 47.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene39-alpha-test-fragment-DDFTge21.js",
@@ -17,7 +17,7 @@
     "scene39-gltf-light-pointer-state-B7kFTRxK.js",
     "scene39-gltf-pbr-builder-ext-DyaMnJed.js",
     "scene39-gltf-sampler-desc-DY59huRr.js",
-    "scene39-gltf-share-CdeJsh_e.js",
+    "scene39-gltf-share-B0MKpCsU.js",
     "scene39-ibl-fragment-CeRrvT96.js",
     "scene39-light-base-DJIAgtv-.js",
     "scene39-light-matrix-CBTBdGsb.js",
@@ -31,5 +31,5 @@
     "scene39-visibility-D_WcxQMp.js",
     "scene39.js"
   ],
-  "rawBytes": 112664
+  "rawBytes": 112689
 }

--- a/lab/public/bundle/manifest/scene4.json
+++ b/lab/public/bundle/manifest/scene4.json
@@ -12,5 +12,5 @@
     "scene4-std-shadow-fragment-pwyXRo4i.js",
     "scene4.js"
   ],
-  "rawBytes": 75093
+  "rawBytes": 75047
 }

--- a/lab/public/bundle/manifest/scene40.json
+++ b/lab/public/bundle/manifest/scene40.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 50.2,
-  "gzipKB": 20.3,
+  "rawKB": 50.1,
+  "gzipKB": 20.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene40-standard-renderable-D7_myor6.js",
     "scene40.js"
   ],
-  "rawBytes": 51380
+  "rawBytes": 51331
 }

--- a/lab/public/bundle/manifest/scene41.json
+++ b/lab/public/bundle/manifest/scene41.json
@@ -13,5 +13,5 @@
     "scene41-standard-renderable-D52DjuE5.js",
     "scene41.js"
   ],
-  "rawBytes": 94870
+  "rawBytes": 94810
 }

--- a/lab/public/bundle/manifest/scene42.json
+++ b/lab/public/bundle/manifest/scene42.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 51.9,
+  "rawKB": 51.8,
   "gzipKB": 20.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene42-standard-renderable-CTATVaLu.js",
     "scene42.js"
   ],
-  "rawBytes": 53124
+  "rawBytes": 53076
 }

--- a/lab/public/bundle/manifest/scene43.json
+++ b/lab/public/bundle/manifest/scene43.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.3,
+  "rawKB": 59.2,
   "gzipKB": 23.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -8,5 +8,5 @@
     "scene43-thin-instance-gpu-BBn8oq97.js",
     "scene43.js"
   ],
-  "rawBytes": 60697
+  "rawBytes": 60625
 }

--- a/lab/public/bundle/manifest/scene44.json
+++ b/lab/public/bundle/manifest/scene44.json
@@ -6,5 +6,5 @@
     "scene44-standard-renderable-D7O_trHZ.js",
     "scene44.js"
   ],
-  "rawBytes": 51757
+  "rawBytes": 51708
 }

--- a/lab/public/bundle/manifest/scene45.json
+++ b/lab/public/bundle/manifest/scene45.json
@@ -6,5 +6,5 @@
     "scene45-standard-renderable-B6Nd9Dzc.js",
     "scene45.js"
   ],
-  "rawBytes": 53061
+  "rawBytes": 53012
 }

--- a/lab/public/bundle/manifest/scene46.json
+++ b/lab/public/bundle/manifest/scene46.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 54.8,
+  "rawKB": 54.7,
   "gzipKB": 21.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene46-standard-renderable-pSfqo6O9.js",
     "scene46.js"
   ],
-  "rawBytes": 56104
+  "rawBytes": 56055
 }

--- a/lab/public/bundle/manifest/scene47.json
+++ b/lab/public/bundle/manifest/scene47.json
@@ -12,5 +12,5 @@
     "scene47-standard-renderable-CLVbHJlI.js",
     "scene47.js"
   ],
-  "rawBytes": 93622
+  "rawBytes": 93580
 }

--- a/lab/public/bundle/manifest/scene48.json
+++ b/lab/public/bundle/manifest/scene48.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 54.6,
+  "rawKB": 54.5,
   "gzipKB": 21.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene48-standard-renderable-DmbKr-oj.js",
     "scene48.js"
   ],
-  "rawBytes": 55906
+  "rawBytes": 55857
 }

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.7,
+  "rawKB": 90.6,
   "gzipKB": 34.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -8,5 +8,5 @@
     "scene49-swapchain-overlay-ilhN4El_.js",
     "scene49.js"
   ],
-  "rawBytes": 92847
+  "rawBytes": 92798
 }

--- a/lab/public/bundle/manifest/scene5.json
+++ b/lab/public/bundle/manifest/scene5.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 92.2,
-  "gzipKB": 39.2,
+  "rawKB": 92.3,
+  "gzipKB": 39.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene5-create-morph-targets-CxWjyKmd.js",
@@ -20,5 +20,5 @@
     "scene5-skeleton-fragment-DGh13Gsr.js",
     "scene5.js"
   ],
-  "rawBytes": 94450
+  "rawBytes": 94470
 }

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -6,5 +6,5 @@
     "scene52-standard-renderable-B93G7FTA.js",
     "scene52.js"
   ],
-  "rawBytes": 59219
+  "rawBytes": 59170
 }

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -6,5 +6,5 @@
     "scene53-standard-renderable-B8GrpWDK.js",
     "scene53.js"
   ],
-  "rawBytes": 59296
+  "rawBytes": 59247
 }

--- a/lab/public/bundle/manifest/scene54.json
+++ b/lab/public/bundle/manifest/scene54.json
@@ -8,5 +8,5 @@
     "scene54-standard-renderable-vGBAQ-9A.js",
     "scene54.js"
   ],
-  "rawBytes": 61439
+  "rawBytes": 61392
 }

--- a/lab/public/bundle/manifest/scene56.json
+++ b/lab/public/bundle/manifest/scene56.json
@@ -8,5 +8,5 @@
     "scene56-standard-renderable-Dm9mFrnO.js",
     "scene56.js"
   ],
-  "rawBytes": 61641
+  "rawBytes": 61601
 }

--- a/lab/public/bundle/manifest/scene57.json
+++ b/lab/public/bundle/manifest/scene57.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 60.6,
-  "gzipKB": 24.9,
+  "gzipKB": 24.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene57-billboard-renderable-BmngFr2T.js",
@@ -8,5 +8,5 @@
     "scene57-standard-renderable-B61xdak7.js",
     "scene57.js"
   ],
-  "rawBytes": 62048
+  "rawBytes": 62008
 }

--- a/lab/public/bundle/manifest/scene59.json
+++ b/lab/public/bundle/manifest/scene59.json
@@ -8,5 +8,5 @@
     "scene59-standard-renderable-Bal23tGp.js",
     "scene59.js"
   ],
-  "rawBytes": 64141
+  "rawBytes": 64089
 }

--- a/lab/public/bundle/manifest/scene6.json
+++ b/lab/public/bundle/manifest/scene6.json
@@ -13,5 +13,5 @@
     "scene6-wgsl-helpers-BgB2AJrF.js",
     "scene6.js"
   ],
-  "rawBytes": 74687
+  "rawBytes": 74645
 }

--- a/lab/public/bundle/manifest/scene60.json
+++ b/lab/public/bundle/manifest/scene60.json
@@ -12,5 +12,5 @@
     "scene60-vertex-output-C7G5u6Y0.js",
     "scene60.js"
   ],
-  "rawBytes": 55923
+  "rawBytes": 55875
 }

--- a/lab/public/bundle/manifest/scene61.json
+++ b/lab/public/bundle/manifest/scene61.json
@@ -14,5 +14,5 @@
     "scene61-vertex-output-C7G5u6Y0.js",
     "scene61.js"
   ],
-  "rawBytes": 54815
+  "rawBytes": 54768
 }

--- a/lab/public/bundle/manifest/scene62.json
+++ b/lab/public/bundle/manifest/scene62.json
@@ -14,5 +14,5 @@
     "scene62-vertex-output-C7G5u6Y0.js",
     "scene62.js"
   ],
-  "rawBytes": 60534
+  "rawBytes": 60493
 }

--- a/lab/public/bundle/manifest/scene63.json
+++ b/lab/public/bundle/manifest/scene63.json
@@ -13,5 +13,5 @@
     "scene63-vertex-output-C7G5u6Y0.js",
     "scene63.js"
   ],
-  "rawBytes": 59201
+  "rawBytes": 59158
 }

--- a/lab/public/bundle/manifest/scene64.json
+++ b/lab/public/bundle/manifest/scene64.json
@@ -13,5 +13,5 @@
     "scene64-vertex-output-C7G5u6Y0.js",
     "scene64.js"
   ],
-  "rawBytes": 57132
+  "rawBytes": 57089
 }

--- a/lab/public/bundle/manifest/scene65.json
+++ b/lab/public/bundle/manifest/scene65.json
@@ -18,5 +18,5 @@
     "scene65-vertex-output-C7G5u6Y0.js",
     "scene65.js"
   ],
-  "rawBytes": 75518
+  "rawBytes": 75464
 }

--- a/lab/public/bundle/manifest/scene66.json
+++ b/lab/public/bundle/manifest/scene66.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 88,
+  "rawKB": 87.9,
   "gzipKB": 40.9,
   "ignoredRawKB": 5.5,
   "runtimeChunks": [
@@ -41,5 +41,5 @@
     "scene66-vertex-output-C7G5u6Y0.js",
     "scene66.js"
   ],
-  "rawBytes": 90084
+  "rawBytes": 90027
 }

--- a/lab/public/bundle/manifest/scene67.json
+++ b/lab/public/bundle/manifest/scene67.json
@@ -17,5 +17,5 @@
     "scene67-vertex-output-C7G5u6Y0.js",
     "scene67.js"
   ],
-  "rawBytes": 77111
+  "rawBytes": 77061
 }

--- a/lab/public/bundle/manifest/scene68.json
+++ b/lab/public/bundle/manifest/scene68.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 89.8,
-  "gzipKB": 35.7,
+  "gzipKB": 35.6,
   "ignoredRawKB": 11.4,
   "runtimeChunks": [
     "scene68-_math-factory-BeBEFbRS.js",
@@ -17,5 +17,5 @@
     "scene68-vertex-output-C7G5u6Y0.js",
     "scene68.js"
   ],
-  "rawBytes": 91988
+  "rawBytes": 91939
 }

--- a/lab/public/bundle/manifest/scene69.json
+++ b/lab/public/bundle/manifest/scene69.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.3,
+  "rawKB": 89.2,
   "gzipKB": 35.9,
   "ignoredRawKB": 13.3,
   "runtimeChunks": [
@@ -18,5 +18,5 @@
     "scene69-vertex-output-C7G5u6Y0.js",
     "scene69.js"
   ],
-  "rawBytes": 91433
+  "rawBytes": 91384
 }

--- a/lab/public/bundle/manifest/scene7.json
+++ b/lab/public/bundle/manifest/scene7.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 105.6,
+  "rawKB": 105.7,
   "gzipKB": 45,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -23,5 +23,5 @@
     "scene7-wgsl-helpers-BgB2AJrF.js",
     "scene7.js"
   ],
-  "rawBytes": 108175
+  "rawBytes": 108195
 }

--- a/lab/public/bundle/manifest/scene70.json
+++ b/lab/public/bundle/manifest/scene70.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.6,
+  "rawKB": 89.5,
   "gzipKB": 36.5,
   "ignoredRawKB": 14.9,
   "runtimeChunks": [
@@ -19,5 +19,5 @@
     "scene70-vertex-output-C7G5u6Y0.js",
     "scene70.js"
   ],
-  "rawBytes": 91742
+  "rawBytes": 91693
 }

--- a/lab/public/bundle/manifest/scene71.json
+++ b/lab/public/bundle/manifest/scene71.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 89.5,
+  "rawKB": 89.4,
   "gzipKB": 35.9,
   "ignoredRawKB": 12.9,
   "runtimeChunks": [
@@ -18,5 +18,5 @@
     "scene71-vertex-output-C7G5u6Y0.js",
     "scene71.js"
   ],
-  "rawBytes": 91607
+  "rawBytes": 91556
 }

--- a/lab/public/bundle/manifest/scene72.json
+++ b/lab/public/bundle/manifest/scene72.json
@@ -32,5 +32,5 @@
     "scene72-vertex-output-C7G5u6Y0.js",
     "scene72.js"
   ],
-  "rawBytes": 109908
+  "rawBytes": 109864
 }

--- a/lab/public/bundle/manifest/scene73.json
+++ b/lab/public/bundle/manifest/scene73.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 141.8,
-  "gzipKB": 57.7,
+  "gzipKB": 57.8,
   "ignoredRawKB": 3.3,
   "runtimeChunks": [
     "scene73-_math-factory-C7IfuSt9.js",
@@ -27,5 +27,5 @@
     "scene73-vertex-output-C7G5u6Y0.js",
     "scene73.js"
   ],
-  "rawBytes": 145215
+  "rawBytes": 145230
 }

--- a/lab/public/bundle/manifest/scene75.json
+++ b/lab/public/bundle/manifest/scene75.json
@@ -6,5 +6,5 @@
     "scene75-standard-renderable-CUCYhRZj.js",
     "scene75.js"
   ],
-  "rawBytes": 51229
+  "rawBytes": 51180
 }

--- a/lab/public/bundle/manifest/scene77.json
+++ b/lab/public/bundle/manifest/scene77.json
@@ -21,5 +21,5 @@
     "scene77-vertex-output-C7G5u6Y0.js",
     "scene77.js"
   ],
-  "rawBytes": 59717
+  "rawBytes": 59671
 }

--- a/lab/public/bundle/manifest/scene78.json
+++ b/lab/public/bundle/manifest/scene78.json
@@ -29,5 +29,5 @@
     "scene78-vertex-output-C7G5u6Y0.js",
     "scene78.js"
   ],
-  "rawBytes": 58067
+  "rawBytes": 58014
 }

--- a/lab/public/bundle/manifest/scene79.json
+++ b/lab/public/bundle/manifest/scene79.json
@@ -23,5 +23,5 @@
     "scene79-wave-block-BSzEr0oO.js",
     "scene79.js"
   ],
-  "rawBytes": 61260
+  "rawBytes": 61209
 }

--- a/lab/public/bundle/manifest/scene8.json
+++ b/lab/public/bundle/manifest/scene8.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 74.9,
+  "rawKB": 74.8,
   "gzipKB": 30.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,5 +11,5 @@
     "scene8-singlelight-point-wgsl-DwaRtc_Q.js",
     "scene8.js"
   ],
-  "rawBytes": 76694
+  "rawBytes": 76639
 }

--- a/lab/public/bundle/manifest/scene80.json
+++ b/lab/public/bundle/manifest/scene80.json
@@ -20,5 +20,5 @@
     "scene80-vertex-output-C7G5u6Y0.js",
     "scene80.js"
   ],
-  "rawBytes": 60927
+  "rawBytes": 60884
 }

--- a/lab/public/bundle/manifest/scene81.json
+++ b/lab/public/bundle/manifest/scene81.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 65.5,
+  "rawKB": 65.4,
   "gzipKB": 29.4,
   "ignoredRawKB": 7,
   "runtimeChunks": [
@@ -20,5 +20,5 @@
     "scene81-vertex-output-C7G5u6Y0.js",
     "scene81.js"
   ],
-  "rawBytes": 67030
+  "rawBytes": 66984
 }

--- a/lab/public/bundle/manifest/scene82.json
+++ b/lab/public/bundle/manifest/scene82.json
@@ -24,5 +24,5 @@
     "scene82-worley-noise-3d-block-DvnzjY-o.js",
     "scene82.js"
   ],
-  "rawBytes": 66787
+  "rawBytes": 66742
 }

--- a/lab/public/bundle/manifest/scene83.json
+++ b/lab/public/bundle/manifest/scene83.json
@@ -28,5 +28,5 @@
     "scene83-vertex-output-C7G5u6Y0.js",
     "scene83.js"
   ],
-  "rawBytes": 70859
+  "rawBytes": 70815
 }

--- a/lab/public/bundle/manifest/scene84.json
+++ b/lab/public/bundle/manifest/scene84.json
@@ -24,5 +24,5 @@
     "scene84-vertex-output-C7G5u6Y0.js",
     "scene84.js"
   ],
-  "rawBytes": 85017
+  "rawBytes": 84966
 }

--- a/lab/public/bundle/manifest/scene85.json
+++ b/lab/public/bundle/manifest/scene85.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 59.2,
-  "gzipKB": 26.1,
+  "gzipKB": 26,
   "ignoredRawKB": 6.5,
   "runtimeChunks": [
     "scene85-_math-factory-MA2pmMp6.js",
@@ -20,5 +20,5 @@
     "scene85-vertex-output-C7G5u6Y0.js",
     "scene85.js"
   ],
-  "rawBytes": 60656
+  "rawBytes": 60604
 }

--- a/lab/public/bundle/manifest/scene86.json
+++ b/lab/public/bundle/manifest/scene86.json
@@ -23,5 +23,5 @@
     "scene86-vertex-output-C7G5u6Y0.js",
     "scene86.js"
   ],
-  "rawBytes": 59911
+  "rawBytes": 59927
 }

--- a/lab/public/bundle/manifest/scene87.json
+++ b/lab/public/bundle/manifest/scene87.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92.6,
+  "rawKB": 92.5,
   "gzipKB": 37.4,
   "ignoredRawKB": 12,
   "runtimeChunks": [
@@ -19,5 +19,5 @@
     "scene87-vertex-output-C7G5u6Y0.js",
     "scene87.js"
   ],
-  "rawBytes": 94792
+  "rawBytes": 94748
 }

--- a/lab/public/bundle/manifest/scene88.json
+++ b/lab/public/bundle/manifest/scene88.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.1,
+  "rawKB": 59,
   "gzipKB": 26.5,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
@@ -24,5 +24,5 @@
     "scene88-vertex-output-C7G5u6Y0.js",
     "scene88.js"
   ],
-  "rawBytes": 60523
+  "rawBytes": 60461
 }

--- a/lab/public/bundle/manifest/scene89.json
+++ b/lab/public/bundle/manifest/scene89.json
@@ -24,5 +24,5 @@
     "scene89-vertex-output-C7G5u6Y0.js",
     "scene89.js"
   ],
-  "rawBytes": 59950
+  "rawBytes": 59898
 }

--- a/lab/public/bundle/manifest/scene9.json
+++ b/lab/public/bundle/manifest/scene9.json
@@ -13,5 +13,5 @@
     "scene9-std-specular-fragment-lgpgl8DR.js",
     "scene9.js"
   ],
-  "rawBytes": 61939
+  "rawBytes": 61959
 }

--- a/lab/public/bundle/manifest/scene90.json
+++ b/lab/public/bundle/manifest/scene90.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.3,
+  "rawKB": 59.2,
   "gzipKB": 23.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene90-standard-renderable-CdRf9hlg.js",
     "scene90.js"
   ],
-  "rawBytes": 60679
+  "rawBytes": 60627
 }

--- a/lab/public/bundle/manifest/scene91.json
+++ b/lab/public/bundle/manifest/scene91.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 57.8,
-  "rawBytes": 59232,
+  "rawBytes": 59186,
   "gzipKB": 23.4,
   "ignoredRawKB": 1451.1,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene94.json
+++ b/lab/public/bundle/manifest/scene94.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 63.8,
+  "rawKB": 63.7,
   "gzipKB": 25.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene94-standard-renderable-CRuUFWr4.js",
     "scene94.js"
   ],
-  "rawBytes": 65288
+  "rawBytes": 65243
 }

--- a/lab/public/bundle/manifest/scene95.json
+++ b/lab/public/bundle/manifest/scene95.json
@@ -7,5 +7,5 @@
     "scene95-standard-renderable-Dm9EzkUk.js",
     "scene95.js"
   ],
-  "rawBytes": 66360
+  "rawBytes": 66311
 }

--- a/lab/public/bundle/manifest/scene98.json
+++ b/lab/public/bundle/manifest/scene98.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.3,
+  "rawKB": 60.2,
   "gzipKB": 24.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -8,5 +8,5 @@
     "scene98-standard-renderable-aPXwOKJJ.js",
     "scene98.js"
   ],
-  "rawBytes": 61713
+  "rawBytes": 61670
 }

--- a/lab/public/bundle/manifest/scene99.json
+++ b/lab/public/bundle/manifest/scene99.json
@@ -17,5 +17,5 @@
     "scene99-types-BVAXdTdf.js",
     "scene99.js"
   ],
-  "rawBytes": 94604
+  "rawBytes": 94624
 }

--- a/packages/babylon-lite/src/camera/free-camera.ts
+++ b/packages/babylon-lite/src/camera/free-camera.ts
@@ -16,8 +16,8 @@ import { allocateMat4 } from "../math/_matrix-allocator.js";
  *  Push-based dirty tracking: position and target use ObservableVec3,
  *  _yaw/_pitch use Object.defineProperty. */
 export interface FreeCamera extends Camera, IWorldMatrixProvider, IParentable {
-    position: ObservableVec3;
-    target: ObservableVec3;
+    readonly position: ObservableVec3;
+    readonly target: ObservableVec3;
     /** Movement speed. Default 2.0 (matches BJS). */
     speed: number;
     /** Mouse rotation sensitivity (higher = less sensitive). Default 2000 (matches BJS). */

--- a/packages/babylon-lite/src/light/directional-light.ts
+++ b/packages/babylon-lite/src/light/directional-light.ts
@@ -10,8 +10,8 @@ import { allocateMat4 } from "../math/_matrix-allocator.js";
 
 export interface DirectionalLight extends LightBase {
     readonly lightType: "directional";
-    direction: ObservableVec3;
-    position: ObservableVec3;
+    readonly direction: ObservableVec3;
+    readonly position: ObservableVec3;
     diffuse: [number, number, number];
     specular: [number, number, number];
     intensity: number;

--- a/packages/babylon-lite/src/light/hemispheric.ts
+++ b/packages/babylon-lite/src/light/hemispheric.ts
@@ -10,7 +10,7 @@ import { allocateMat4 } from "../math/_matrix-allocator.js";
 
 export interface HemisphericLight extends LightBase {
     readonly lightType: "hemispheric";
-    direction: ObservableVec3;
+    readonly direction: ObservableVec3;
     intensity: number;
     diffuseColor: [number, number, number];
     specularColor: [number, number, number];

--- a/packages/babylon-lite/src/light/point-light.ts
+++ b/packages/babylon-lite/src/light/point-light.ts
@@ -11,7 +11,7 @@ import { allocateMat4 } from "../math/_matrix-allocator.js";
 
 export interface PointLight extends LightBase {
     readonly lightType: "point";
-    position: ObservableVec3;
+    readonly position: ObservableVec3;
     diffuse: [number, number, number];
     specular: [number, number, number];
     intensity: number;

--- a/packages/babylon-lite/src/light/spot-light.ts
+++ b/packages/babylon-lite/src/light/spot-light.ts
@@ -11,8 +11,8 @@ import { allocateMat4 } from "../math/_matrix-allocator.js";
 
 export interface SpotLight extends LightBase {
     readonly lightType: "spot";
-    position: ObservableVec3;
-    direction: ObservableVec3;
+    readonly position: ObservableVec3;
+    readonly direction: ObservableVec3;
     /** Full cone angle in radians. */
     angle: number;
     /** Falloff exponent — higher = sharper spotlight. */

--- a/packages/babylon-lite/src/loader-babylon/load-babylon.ts
+++ b/packages/babylon-lite/src/loader-babylon/load-babylon.ts
@@ -413,22 +413,15 @@ export async function loadBabylon(engine: EngineContext, url: string, opts: Load
                         mat = createStandardMaterial();
                     }
 
-                    const mesh = {
-                        name: md.name + (subMeshes.length > 1 ? `_sub${sub.materialIndex}` : ""),
-                        id: md.id,
-                        material: mat,
-                        receiveShadows: false,
-                        _gpu: gpu,
-                    } as unknown as Mesh;
-
-                    mesh._cpuPositions = positions;
-                    mesh._cpuNormals = normals;
-                    mesh._cpuUvs = uvs;
-                    mesh._cpuIndices = subIndices;
-
                     // Each mesh carries its own TRS from the node.
-                    initMeshTransform(
-                        mesh,
+                    const mesh = initMeshTransform(
+                        {
+                            name: md.name + (subMeshes.length > 1 ? `_sub${sub.materialIndex}` : ""),
+                            id: md.id,
+                            material: mat,
+                            receiveShadows: false,
+                            _gpu: gpu,
+                        },
                         md.position?.[0] ?? 0,
                         md.position?.[1] ?? 0,
                         md.position?.[2] ?? 0,
@@ -439,6 +432,11 @@ export async function loadBabylon(engine: EngineContext, url: string, opts: Load
                         md.scaling?.[1] ?? 1,
                         md.scaling?.[2] ?? 1
                     );
+
+                    mesh._cpuPositions = positions;
+                    mesh._cpuNormals = normals;
+                    mesh._cpuUvs = uvs;
+                    mesh._cpuIndices = subIndices;
 
                     allMeshes.push(mesh as unknown as Mesh);
                     if (!meshesByNodeId.has(md.id)) {

--- a/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
@@ -355,7 +355,7 @@ export function buildInterleavedMesh(engine: EngineContext, m: GltfMeshData, ind
     // AABB: fold strided positions straight from the slice; tight positions normally.
     const [boundMin, boundMax] = m._vb!._p ? computeAabbStrided(m._vb!._p, m._worldMatrix) : computeAabb(m._positions!, m._worldMatrix);
 
-    const mesh = {
+    const mesh = initMeshTransform({
         name: name || `gltf_mesh_${index}`,
         material,
         receiveShadows: false,
@@ -363,8 +363,7 @@ export function buildInterleavedMesh(engine: EngineContext, m: GltfMeshData, ind
         boundMax,
         _gpu: gpu,
         _flatNormal: m._flatNormal,
-    } as unknown as Mesh;
-    initMeshTransform(mesh);
+    });
 
     // Lazy CPU geometry: the de-strided tight copy is built only on first read.
     installLazyCpu(mesh, m);

--- a/packages/babylon-lite/src/loader-gltf/load-gltf.ts
+++ b/packages/babylon-lite/src/loader-gltf/load-gltf.ts
@@ -108,7 +108,7 @@ function buildTightGltfMesh(engine: EngineContext, meshData: GltfMeshData, mater
               indexFormat: (uint32 ? "uint32" : "uint16") as GPUIndexFormat,
           } satisfies MeshGPU);
 
-    const mesh = {
+    const mesh = initMeshTransform({
         name,
         material,
         receiveShadows: false,
@@ -116,8 +116,7 @@ function buildTightGltfMesh(engine: EngineContext, meshData: GltfMeshData, mater
         boundMax,
         _gpu: gpu,
         _flatNormal: meshData._flatNormal,
-    } as unknown as Mesh;
-    initMeshTransform(mesh);
+    });
     mesh._cpuPositions = meshData._positions!;
     mesh._cpuNormals = meshData._normals!;
     mesh._cpuUvs = meshData._uvs!;

--- a/packages/babylon-lite/src/mesh/mesh-factories.ts
+++ b/packages/babylon-lite/src/mesh/mesh-factories.ts
@@ -122,15 +122,14 @@ export function createMeshFromData(
     colors?: Float32Array
 ): Mesh {
     const [min, max] = computeAabb(positions);
-    const mesh = {
+    const mesh = initMeshTransform({
         name,
-        material: null as unknown,
+        material: null as unknown as Mesh["material"],
         receiveShadows: false,
         boundMin: isFinite(min[0]) ? min : undefined,
         boundMax: isFinite(max[0]) ? max : undefined,
         _gpu: uploadMeshToGPU(engine, positions, normals, indices, uvs, uvs2, tangents, colors),
-    } as unknown as Mesh;
-    initMeshTransform(mesh);
+    });
 
     // Retain CPU geometry for detailed picking (ray-triangle intersection)
     mesh._cpuPositions = positions;

--- a/packages/babylon-lite/src/mesh/mesh.ts
+++ b/packages/babylon-lite/src/mesh/mesh.ts
@@ -170,20 +170,20 @@ export interface Mesh extends SceneNode {
     _cpuIndexFormat?: GPUIndexFormat;
 }
 
-type MutableMesh = { -readonly [P in keyof Mesh]: Mesh[P] };
-
 /** Wire ObservableVec3/ObservableQuat TRS and children onto a partially-built mesh object.
  *  Used by all mesh creation paths (factories, loaders). */
-export function initMeshTransform(mesh: Mesh, px = 0, py = 0, pz = 0, rx = 0, ry = 0, rz = 0, sx = 1, sy = 1, sz = 1): void {
+export function initMeshTransform(partialMesh: Partial<Mesh> & { _flatNormal?: boolean }, px = 0, py = 0, pz = 0, rx = 0, ry = 0, rz = 0, sx = 1, sy = 1, sz = 1): Mesh {
     const wm = createWorldMatrixState(() => composeTrsLocalMatrix(mesh.position, mesh.rotationQuaternion, mesh.scaling));
     const onWmDirty = () => wm.markLocalDirty();
 
     const [iqx, iqy, iqz, iqw] = eulerToQuat(rx, ry, rz);
     const rq = new ObservableQuat(iqx, iqy, iqz, iqw, onWmDirty);
-    (mesh as MutableMesh).rotationQuaternion = rq;
-    (mesh as MutableMesh).rotation = createEulerProxy(rq);
-    (mesh as MutableMesh).position = new ObservableVec3(px, py, pz, onWmDirty);
-    (mesh as MutableMesh).scaling = new ObservableVec3(sx, sy, sz, onWmDirty);
+    const rotationQuaternion = rq;
+    const rotation = createEulerProxy(rq);
+    const position = new ObservableVec3(px, py, pz, onWmDirty);
+    const scaling = new ObservableVec3(sx, sy, sz, onWmDirty);
+
+    const mesh = { ...partialMesh, position, rotationQuaternion, rotation, scaling } as Mesh;
 
     if (!(mesh as unknown as Record<string, unknown>).children) {
         (mesh as unknown as Record<string, unknown>).children = [];
@@ -214,6 +214,7 @@ export function initMeshTransform(mesh: Mesh, px = 0, py = 0, pz = 0, rx = 0, ry
         enumerable: false,
     });
     attachWorldMatrixState(mesh, wm);
+    return mesh;
 }
 
 // ─── GPU Geometry Upload ─────────────────────────────────────────────

--- a/packages/babylon-lite/src/mesh/mesh.ts
+++ b/packages/babylon-lite/src/mesh/mesh.ts
@@ -170,6 +170,8 @@ export interface Mesh extends SceneNode {
     _cpuIndexFormat?: GPUIndexFormat;
 }
 
+type MutableMesh = { -readonly [P in keyof Mesh]: Mesh[P] };
+
 /** Wire ObservableVec3/ObservableQuat TRS and children onto a partially-built mesh object.
  *  Used by all mesh creation paths (factories, loaders). */
 export function initMeshTransform(mesh: Mesh, px = 0, py = 0, pz = 0, rx = 0, ry = 0, rz = 0, sx = 1, sy = 1, sz = 1): void {
@@ -178,10 +180,10 @@ export function initMeshTransform(mesh: Mesh, px = 0, py = 0, pz = 0, rx = 0, ry
 
     const [iqx, iqy, iqz, iqw] = eulerToQuat(rx, ry, rz);
     const rq = new ObservableQuat(iqx, iqy, iqz, iqw, onWmDirty);
-    mesh.rotationQuaternion = rq;
-    mesh.rotation = createEulerProxy(rq);
-    mesh.position = new ObservableVec3(px, py, pz, onWmDirty);
-    mesh.scaling = new ObservableVec3(sx, sy, sz, onWmDirty);
+    (mesh as MutableMesh).rotationQuaternion = rq;
+    (mesh as MutableMesh).rotation = createEulerProxy(rq);
+    (mesh as MutableMesh).position = new ObservableVec3(px, py, pz, onWmDirty);
+    (mesh as MutableMesh).scaling = new ObservableVec3(sx, sy, sz, onWmDirty);
 
     if (!(mesh as unknown as Record<string, unknown>).children) {
         (mesh as unknown as Record<string, unknown>).children = [];

--- a/packages/babylon-lite/src/scene/scene-node.ts
+++ b/packages/babylon-lite/src/scene/scene-node.ts
@@ -28,12 +28,12 @@ export interface EulerProxy {
 export interface SceneNode {
     name: string;
     children: SceneNode[];
-    position: ObservableVec3;
+    readonly position: ObservableVec3;
     /** Quaternion rotation — source of truth for the local matrix. */
-    rotationQuaternion: ObservableQuat;
+    readonly rotationQuaternion: ObservableQuat;
     /** Euler XYZ bidirectional proxy — reads decompose current quat; writes update quat atomically. */
-    rotation: EulerProxy;
-    scaling: ObservableVec3;
+    readonly rotation: EulerProxy;
+    readonly scaling: ObservableVec3;
     parent: IWorldMatrixProvider | null;
     readonly worldMatrix: Mat4;
     readonly worldMatrixVersion: number;

--- a/packages/babylon-lite/src/scene/scene-node.ts
+++ b/packages/babylon-lite/src/scene/scene-node.ts
@@ -136,15 +136,18 @@ function createSceneNodeCore(name: string, matrix: Mat4 | null, px = 0, py = 0, 
         }
     };
 
+    const position = new ObservableVec3(px, py, pz, onWmDirty);
     const rq = new ObservableQuat(qx, qy, qz, qw, onWmDirty);
+    const rotation = createEulerProxy(rq);
+    const scaling = new ObservableVec3(sx, sy, sz, onWmDirty);
 
     const node: SceneNode = {
         name,
         children: [],
-        position: new ObservableVec3(px, py, pz, onWmDirty),
+        position,
         rotationQuaternion: rq,
-        rotation: createEulerProxy(rq),
-        scaling: new ObservableVec3(sx, sy, sz, onWmDirty),
+        rotation,
+        scaling,
         get parent() {
             return wm.parent;
         },

--- a/packages/babylon-lite/src/scene/transform-node.ts
+++ b/packages/babylon-lite/src/scene/transform-node.ts
@@ -68,15 +68,26 @@ function cloneMeshNode(mesh: Mesh): Mesh {
     if (mesh._disposed) {
         throw Error(`Mesh "${mesh.name}" cannot be cloned: it was disposed when it left its last scene.`);
     }
-    const meshClone = {
-        ...mesh,
-        name: mesh.name + "_clone",
-        children: [],
-        // Share the SAME `_gpu` object (not a copy) — the wrapper's identity is the ref-count
-        // key in resource/ref-count.ts, so both meshes must point at the exact same instance
-        // for `disposeMeshGpu` to know they're co-owners of the underlying GPUBuffers.
-        _gpu: mesh._gpu,
-    } as unknown as Mesh;
+    const meshClone = initMeshTransform(
+        {
+            ...mesh,
+            name: mesh.name + "_clone",
+            children: [],
+            // Share the SAME `_gpu` object (not a copy) — the wrapper's identity is the ref-count
+            // key in resource/ref-count.ts, so both meshes must point at the exact same instance
+            // for `disposeMeshGpu` to know they're co-owners of the underlying GPUBuffers.
+            _gpu: mesh._gpu,
+        },
+        mesh.position.x,
+        mesh.position.y,
+        mesh.position.z,
+        0,
+        0,
+        0,
+        mesh.scaling.x,
+        mesh.scaling.y,
+        mesh.scaling.z
+    );
     // `skeleton`/`vat`/`morphTargets`/`thinInstances` are already shared by reference via the `...mesh`
     // spread above. Register the extra ownership for all shared GPU resources so `disposeMeshGpu`
     // only destroys their buffers once the LAST owning mesh (source or clone) releases them —
@@ -86,7 +97,6 @@ function cloneMeshNode(mesh: Mesh): Mesh {
             retain(r);
         }
     }
-    initMeshTransform(meshClone, mesh.position.x, mesh.position.y, mesh.position.z, 0, 0, 0, mesh.scaling.x, mesh.scaling.y, mesh.scaling.z);
     // Copy the source rotation as a QUATERNION — the Euler round-trip (mesh.rotation.x/y/z) is lossy
     // near gimbal lock and would skew the clone. set() marks the world matrix dirty so it recomputes.
     const rq = mesh.rotationQuaternion;

--- a/tests/lite/unit/hierarchy-instance-pool.test.ts
+++ b/tests/lite/unit/hierarchy-instance-pool.test.ts
@@ -16,13 +16,12 @@ import { mat4Translation } from "../../../packages/babylon-lite/src/math/mat4-tr
 import type { Mat4 } from "../../../packages/babylon-lite/src/math/types";
 
 function makeMesh(name: string): Mesh {
-    const mesh = {
+    const mesh = initMeshTransform({
         name,
-        material: {},
+        material: {} as Mesh["material"],
         receiveShadows: false,
-        _gpu: {},
-    } as unknown as Mesh;
-    initMeshTransform(mesh);
+        _gpu: {} as Mesh["_gpu"],
+    });
     return mesh;
 }
 

--- a/tests/lite/unit/mesh-attribute-range-update.test.ts
+++ b/tests/lite/unit/mesh-attribute-range-update.test.ts
@@ -16,7 +16,7 @@ function fixture() {
     };
     const writeBuffer = vi.fn();
     const engine = { _device: { queue: { writeBuffer } } } as unknown as EngineContext;
-    const mesh = {
+    const mesh = initMeshTransform({
         _gpu: {
             positionBuffer: buffers.position,
             normalBuffer: buffers.normal,
@@ -24,9 +24,8 @@ function fixture() {
             uvBuffer: buffers.uv,
             uv2Buffer: buffers.uv2,
             tangentBuffer: buffers.tangent,
-        },
-    } as unknown as Mesh;
-    initMeshTransform(mesh);
+        } as Mesh["_gpu"],
+    });
     return { buffers, writeBuffer, engine, mesh };
 }
 

--- a/tests/lite/unit/shader-uniform-range-update.test.ts
+++ b/tests/lite/unit/shader-uniform-range-update.test.ts
@@ -5,7 +5,6 @@ import type { RenderTargetSignature } from "../../../packages/babylon-lite/src/e
 import { createShaderMaterial, setShaderFloat, setShaderUniform } from "../../../packages/babylon-lite/src/material/shader/shader-material";
 import { buildShaderMaterialRenderables } from "../../../packages/babylon-lite/src/material/shader/shader-renderable";
 import { enableShaderUniformRangeUpdates } from "../../../packages/babylon-lite/src/material/shader/shader-uniform-range";
-import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
 import { initMeshTransform } from "../../../packages/babylon-lite/src/mesh/mesh";
 import type { UniformCopyBatch } from "../../../packages/babylon-lite/src/render/uniform-copy-batch";
 import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
@@ -57,7 +56,7 @@ function fixture(getUniformBatch?: () => UniformCopyBatch, enabled = true) {
             { name: "tint", type: "vec3<f32>" },
         ],
     });
-    const mesh = {
+    const mesh = initMeshTransform({
         name: "range",
         children: [],
         material,
@@ -70,8 +69,7 @@ function fixture(getUniformBatch?: () => UniformCopyBatch, enabled = true) {
             indexCount: 3,
             indexFormat: "uint32",
         },
-    } as unknown as Mesh;
-    initMeshTransform(mesh);
+    });
     const scene = {
         surface: { engine },
         camera: null,

--- a/tests/lite/unit/shadow-caster-dirty.test.ts
+++ b/tests/lite/unit/shadow-caster-dirty.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Camera } from "../../../packages/babylon-lite/src/camera/camera";
 import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
 import type { Mat4 } from "../../../packages/babylon-lite/src/math/types";
-import type { Mesh, MeshGPU } from "../../../packages/babylon-lite/src/mesh/mesh";
+import type { MeshGPU } from "../../../packages/babylon-lite/src/mesh/mesh";
 import { initMeshTransform } from "../../../packages/babylon-lite/src/mesh/mesh";
 import { updateMeshGeometry } from "../../../packages/babylon-lite/src/mesh/mesh-factories";
 import { setThinInstanceColor, setThinInstanceDrawCount, setThinInstanceMatrix, type ThinInstanceData } from "../../../packages/babylon-lite/src/mesh/thin-instance";
@@ -58,7 +58,7 @@ describe("shadow caster dirty tracking", () => {
             hasTangent: false,
             hasColor: false,
         } satisfies MeshGPU;
-        const mesh = {
+        const mesh = initMeshTransform({
             name: "caster",
             children: [],
             _gpu: gpu,
@@ -66,8 +66,7 @@ describe("shadow caster dirty tracking", () => {
             _cpuNormals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
             _cpuIndices: new Uint32Array([0, 1, 2]),
             thinInstances: makeThinInstances(),
-        } as unknown as Mesh;
-        initMeshTransform(mesh);
+        });
         const execute = vi.fn(() => 1);
         const task = { record: vi.fn(), execute, dispose: vi.fn() } as unknown as PcfTaskState["_task"];
         const camera = {
@@ -112,15 +111,14 @@ describe("shadow caster dirty tracking", () => {
         expect(renderPcfShadowMap(engine, shadowGenerator, state, computeLightMatrix)).toBe(1);
         expect(renderPcfShadowMap(engine, shadowGenerator, state, computeLightMatrix)).toBe(0);
 
-        const unrelated = {
+        const unrelated = initMeshTransform({
             name: "unrelated",
             children: [],
             _gpu: { ...gpu },
             _cpuPositions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
             _cpuNormals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
             _cpuIndices: new Uint32Array([0, 1, 2]),
-        } as unknown as Mesh;
-        initMeshTransform(unrelated);
+        });
         updateMeshGeometry(engine, unrelated, new Float32Array([0, 0, 0, 2, 0, 0, 0, 2, 0]), new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), new Uint32Array([0, 2, 1]));
         expect(renderPcfShadowMap(engine, shadowGenerator, state, computeLightMatrix)).toBe(0);
 

--- a/tests/lite/unit/storage-buffer-lifecycle.test.ts
+++ b/tests/lite/unit/storage-buffer-lifecycle.test.ts
@@ -4,7 +4,6 @@ import type { EngineContext } from "../../../packages/babylon-lite/src/engine/en
 import { disposeEngine } from "../../../packages/babylon-lite/src/engine/engine.js";
 import { createShaderMaterial, setShaderStorageBuffer } from "../../../packages/babylon-lite/src/material/shader/shader-material.js";
 import { buildShaderMaterialRenderables } from "../../../packages/babylon-lite/src/material/shader/shader-renderable.js";
-import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh.js";
 import { initMeshTransform } from "../../../packages/babylon-lite/src/mesh/mesh.js";
 import { _getStorageBufferHandle, createStorageBuffer, disposeStorageBuffer } from "../../../packages/babylon-lite/src/resource/storage-buffer.js";
 import { updateStorageBuffer } from "../../../packages/babylon-lite/src/resource/storage-buffer.js";
@@ -84,7 +83,7 @@ function makeRenderableFixture() {
         attributes: ["position"],
         storageBuffers: [{ name: "cells", type: "array<f32>" }],
     });
-    const mesh = {
+    const mesh = initMeshTransform({
         name: "storage",
         children: [],
         material,
@@ -97,8 +96,7 @@ function makeRenderableFixture() {
             indexCount: 3,
             indexFormat: "uint32",
         },
-    } as unknown as Mesh;
-    initMeshTransform(mesh);
+    });
     const scene = {
         surface: { engine },
         camera: null,


### PR DESCRIPTION
Prevent accidental overwrite of ObservableVec3, ObservableQuat, and EulerProxy.
BREAKING CHANGE: Instead of replacing these proxy objects, they should be mutated.