### PR TITLE
fix(dev): make \pnpm dev\ work

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Open **http://localhost:5174** to browse the scene gallery.
 
 | Command                    | Description                                                         |
 | -------------------------- | ------------------------------------------------------------------- |
+| `pnpm dev`                 | Alias for `pnpm dev:lab`                                            |
 | `pnpm dev:lab`             | Build bundle scenes + start the lab dev server                      |
 | `pnpm dev:playground`      | Start the Lite Playground dev server (http://localhost:5175)        |
 | `pnpm build:playground`    | Build the Lite Playground into `playground/dist`                    |

--- a/README.md
+++ b/README.md
@@ -21,17 +21,21 @@ pnpm install
 # 2. Install Playwright browsers (needed for parity & bundle-size tests)
 pnpm exec playwright install
 
-# 3. Start the dev server (builds bundle scenes, then launches Vite on port 5174)
-pnpm dev:lab
+# 3. Start the dev server (launches Vite on port 5174, scenes served from source)
+pnpm dev
 ```
 
 Open **http://localhost:5174** to browse the scene gallery.
+
+Scene and demo pages are served live from source, so this is the loop for engine work. The
+**Bundle** tab additionally needs the production bundles — build them with `pnpm dev:lab`
+(same server, preceded by a full bundle build) or with the tab's **Regenerate** button.
 
 ## Available Scripts
 
 | Command                    | Description                                                         |
 | -------------------------- | ------------------------------------------------------------------- |
-| `pnpm dev`                 | Alias for `pnpm dev:lab`                                            |
+| `pnpm dev`                 | Start the lab dev server on live source (http://localhost:5174)     |
 | `pnpm dev:lab`             | Build bundle scenes + start the lab dev server                      |
 | `pnpm dev:playground`      | Start the Lite Playground dev server (http://localhost:5175)        |
 | `pnpm build:playground`    | Build the Lite Playground into `playground/dist`                    |
@@ -133,7 +137,7 @@ rm -rf node_modules/playwright
 
 ### 404 for `/bundle/manifest.json`
 
-Run `pnpm build:bundle-scenes` (or use `pnpm dev:lab` which does this automatically).
+The dev server synthesizes this from the tracked per-scene files in `lab/public/bundle/manifest/`, so it should not 404 under `pnpm dev`. If the **bundle** pages themselves are missing or stale, run `pnpm build:bundle-scenes` (or use `pnpm dev:lab`, which does this automatically), or hit **Regenerate** in the lab's Bundle tab.
 
 ### 404 for `test-actual.png` images
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
     },
     "scripts": {
-        "dev": "pnpm --filter @babylon-lite/parity-harness dev",
+        "dev": "pnpm dev:lab",
         "dev:playground": "pnpm --filter @babylon-lite/playground dev",
         "dev:playground:watch": "pnpm --filter @babylon-lite/playground dev:watch",
         "build:playground": "pnpm --filter @babylon-lite/playground build",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
     },
     "scripts": {
-        "dev": "pnpm dev:lab",
+        "dev": "pnpm --filter @babylon-lite/lab dev",
         "dev:playground": "pnpm --filter @babylon-lite/playground dev",
         "dev:playground:watch": "pnpm --filter @babylon-lite/playground dev:watch",
         "build:playground": "pnpm --filter @babylon-lite/playground build",


### PR DESCRIPTION
## Summary

`pnpm dev` has been broken since the first commit. It filtered `@babylon-lite/parity-harness` — a package that does not exist in this workspace — so it failed immediately:

```
> pnpm --filter @babylon-lite/parity-harness dev
No projects matched the filters in "C:\Repos\Babylon-Lite-3"
```

That was the **only** reference to the name anywhere in the repo. `dev` now starts the lab Vite dev server:

```json
"dev": "pnpm --filter @babylon-lite/lab dev"
```

`dev:lab` is unchanged and remains the explicit full-prebuild variant.

## Why live source, not a prebuild

I first aliased `dev` to `dev:lab`, reasoning that starting Vite without bundles would leave a fresh clone hitting a missing `/bundle/manifest.json`. A rubber-duck review shot that down, correctly:

- **It contradicted the repo''s own docs.** The lab UI presents `pnpm dev` as the live-source command — `lab/index.html:2302`: *"Live scenes served from Vite dev server. Start with: `pnpm dev`"* — as does `docs/gl/architecture/00-lite-gl.md:1707`.
- **The rationale was obsolete.** `lab/vite.config.ts:240-267` already synthesizes `/bundle/manifest.json` from the tracked per-scene files in `lab/public/bundle/manifest/` *specifically* so a fresh checkout does not need a full build. The Bundle tab also has on-demand **Regenerate**.
- **It put a multi-minute production build in front of the most-typed command in the repo**, for bundles that are stale after the first source edit anyway.

## Validation

Verified in the fresh-clone state — the gitignored aggregate `lab/public/bundle/manifest.json` deleted:

| | |
| --- | --- |
| Vite ready | **3.2s** |
| `/` | 200 |
| `/bundle/manifest.json` | 200 — synthesized from per-scene files |
| `/lite/scene268.html` | 200 |
| `/gl/scene1.html` | 200 |

`pnpm exec prettier --check package.json README.md` passes.

README updated: `pnpm dev` is now the Getting Started step, with a note that the Bundle tab needs `dev:lab` or Regenerate, and the stale `/bundle/manifest.json` troubleshooting entry corrected.

No runtime code touched (`packages/babylon-lite/src/**` untouched), so per the repo test policy this needs no parity or bundle-size run.
