### PR TITLE
fix(bundle): make manifests reproducible and size checks byte-exact

### DIFF
--- a/lab/public/bundle/manifest/scene1.json
+++ b/lab/public/bundle/manifest/scene1.json
@@ -16,5 +16,5 @@
     "scene1-wgsl-helpers-BgB2AJrF.js",
     "scene1.js"
   ],
-  "rawBytes": 90088
+  "rawBytes": 90000
 }

--- a/lab/public/bundle/manifest/scene1.json
+++ b/lab/public/bundle/manifest/scene1.json
@@ -15,5 +15,6 @@
     "scene1-singlelight-hemispheric-wgsl-Duuwban6.js",
     "scene1-wgsl-helpers-BgB2AJrF.js",
     "scene1.js"
-  ]
+  ],
+  "rawBytes": 90088
 }

--- a/lab/public/bundle/manifest/scene10.json
+++ b/lab/public/bundle/manifest/scene10.json
@@ -7,5 +7,5 @@
     "scene10-singlelight-hemispheric-wgsl-w0cK80Wf.js",
     "scene10.js"
   ],
-  "rawBytes": 53989
+  "rawBytes": 53884
 }

--- a/lab/public/bundle/manifest/scene10.json
+++ b/lab/public/bundle/manifest/scene10.json
@@ -6,5 +6,6 @@
     "scene10-pbr-renderable-CaZVDEL5.js",
     "scene10-singlelight-hemispheric-wgsl-w0cK80Wf.js",
     "scene10.js"
-  ]
+  ],
+  "rawBytes": 53989
 }

--- a/lab/public/bundle/manifest/scene100.json
+++ b/lab/public/bundle/manifest/scene100.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene100-standard-renderable-BLTkerT6.js",
     "scene100.js"
-  ]
+  ],
+  "rawBytes": 51635
 }

--- a/lab/public/bundle/manifest/scene100.json
+++ b/lab/public/bundle/manifest/scene100.json
@@ -6,5 +6,5 @@
     "scene100-standard-renderable-BLTkerT6.js",
     "scene100.js"
   ],
-  "rawBytes": 51635
+  "rawBytes": 51515
 }

--- a/lab/public/bundle/manifest/scene101.json
+++ b/lab/public/bundle/manifest/scene101.json
@@ -6,5 +6,5 @@
     "scene101-standard-renderable-DKY3YvbU.js",
     "scene101.js"
   ],
-  "rawBytes": 54678
+  "rawBytes": 54553
 }

--- a/lab/public/bundle/manifest/scene101.json
+++ b/lab/public/bundle/manifest/scene101.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene101-standard-renderable-DKY3YvbU.js",
     "scene101.js"
-  ]
+  ],
+  "rawBytes": 54678
 }

--- a/lab/public/bundle/manifest/scene102.json
+++ b/lab/public/bundle/manifest/scene102.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene102-standard-renderable-BrfrHFTG.js",
     "scene102.js"
-  ]
+  ],
+  "rawBytes": 60589
 }

--- a/lab/public/bundle/manifest/scene102.json
+++ b/lab/public/bundle/manifest/scene102.json
@@ -6,5 +6,5 @@
     "scene102-standard-renderable-BrfrHFTG.js",
     "scene102.js"
   ],
-  "rawBytes": 60589
+  "rawBytes": 60464
 }

--- a/lab/public/bundle/manifest/scene103.json
+++ b/lab/public/bundle/manifest/scene103.json
@@ -7,5 +7,6 @@
     "scene103-thin-instance-fragment-CBn2miAC.js",
     "scene103-thin-instance-gpu-BRZG8wwf.js",
     "scene103.js"
-  ]
+  ],
+  "rawBytes": 63997
 }

--- a/lab/public/bundle/manifest/scene103.json
+++ b/lab/public/bundle/manifest/scene103.json
@@ -8,5 +8,5 @@
     "scene103-thin-instance-gpu-BRZG8wwf.js",
     "scene103.js"
   ],
-  "rawBytes": 63997
+  "rawBytes": 63892
 }

--- a/lab/public/bundle/manifest/scene104.json
+++ b/lab/public/bundle/manifest/scene104.json
@@ -11,5 +11,5 @@
     "scene104-std-lightmap-fragment-DRRzYkfc.js",
     "scene104.js"
   ],
-  "rawBytes": 103576
+  "rawBytes": 103456
 }

--- a/lab/public/bundle/manifest/scene104.json
+++ b/lab/public/bundle/manifest/scene104.json
@@ -10,5 +10,6 @@
     "scene104-standard-renderable-BchwMEGt.js",
     "scene104-std-lightmap-fragment-DRRzYkfc.js",
     "scene104.js"
-  ]
+  ],
+  "rawBytes": 103576
 }

--- a/lab/public/bundle/manifest/scene105.json
+++ b/lab/public/bundle/manifest/scene105.json
@@ -11,5 +11,5 @@
     "scene105-std-lightmap-fragment-Dgif7Vcn.js",
     "scene105.js"
   ],
-  "rawBytes": 104269
+  "rawBytes": 104138
 }

--- a/lab/public/bundle/manifest/scene105.json
+++ b/lab/public/bundle/manifest/scene105.json
@@ -10,5 +10,6 @@
     "scene105-standard-renderable-CiTdTPfJ.js",
     "scene105-std-lightmap-fragment-Dgif7Vcn.js",
     "scene105.js"
-  ]
+  ],
+  "rawBytes": 104269
 }

--- a/lab/public/bundle/manifest/scene106.json
+++ b/lab/public/bundle/manifest/scene106.json
@@ -6,5 +6,5 @@
     "scene106-standard-renderable-KmdaQ4W5.js",
     "scene106.js"
   ],
-  "rawBytes": 52671
+  "rawBytes": 52554
 }

--- a/lab/public/bundle/manifest/scene106.json
+++ b/lab/public/bundle/manifest/scene106.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene106-standard-renderable-KmdaQ4W5.js",
     "scene106.js"
-  ]
+  ],
+  "rawBytes": 52671
 }

--- a/lab/public/bundle/manifest/scene11.json
+++ b/lab/public/bundle/manifest/scene11.json
@@ -18,5 +18,5 @@
     "scene11-skeleton-fragment-DIpCBPZm.js",
     "scene11.js"
   ],
-  "rawBytes": 90960
+  "rawBytes": 90852
 }

--- a/lab/public/bundle/manifest/scene11.json
+++ b/lab/public/bundle/manifest/scene11.json
@@ -17,5 +17,6 @@
     "scene11-singlelight-hemispheric-wgsl-Cp-uE74H.js",
     "scene11-skeleton-fragment-DIpCBPZm.js",
     "scene11.js"
-  ]
+  ],
+  "rawBytes": 90960
 }

--- a/lab/public/bundle/manifest/scene110.json
+++ b/lab/public/bundle/manifest/scene110.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene110-standard-renderable-CiqM_cuQ.js",
     "scene110.js"
-  ]
+  ],
+  "rawBytes": 51647
 }

--- a/lab/public/bundle/manifest/scene110.json
+++ b/lab/public/bundle/manifest/scene110.json
@@ -6,5 +6,5 @@
     "scene110-standard-renderable-CiqM_cuQ.js",
     "scene110.js"
   ],
-  "rawBytes": 51647
+  "rawBytes": 51357
 }

--- a/lab/public/bundle/manifest/scene111.json
+++ b/lab/public/bundle/manifest/scene111.json
@@ -28,5 +28,6 @@
     "scene111-transform-block-BPVAEpAh.js",
     "scene111-vertex-output-C7G5u6Y0.js",
     "scene111.js"
-  ]
+  ],
+  "rawBytes": 135299
 }

--- a/lab/public/bundle/manifest/scene111.json
+++ b/lab/public/bundle/manifest/scene111.json
@@ -29,5 +29,5 @@
     "scene111-vertex-output-C7G5u6Y0.js",
     "scene111.js"
   ],
-  "rawBytes": 135299
+  "rawBytes": 135205
 }

--- a/lab/public/bundle/manifest/scene112.json
+++ b/lab/public/bundle/manifest/scene112.json
@@ -20,5 +20,6 @@
     "scene112-singlelight-hemispheric-wgsl-Dxp_oUoK.js",
     "scene112-wgsl-helpers-BgB2AJrF.js",
     "scene112.js"
-  ]
+  ],
+  "rawBytes": 122297
 }

--- a/lab/public/bundle/manifest/scene112.json
+++ b/lab/public/bundle/manifest/scene112.json
@@ -21,5 +21,5 @@
     "scene112-wgsl-helpers-BgB2AJrF.js",
     "scene112.js"
   ],
-  "rawBytes": 122297
+  "rawBytes": 122205
 }

--- a/lab/public/bundle/manifest/scene116.json
+++ b/lab/public/bundle/manifest/scene116.json
@@ -11,5 +11,5 @@
     "scene116-unlit-fragment-DWtvt7yQ.js",
     "scene116.js"
   ],
-  "rawBytes": 77874
+  "rawBytes": 77572
 }

--- a/lab/public/bundle/manifest/scene116.json
+++ b/lab/public/bundle/manifest/scene116.json
@@ -10,5 +10,6 @@
     "scene116-std-emissive-fragment-C813VlNk.js",
     "scene116-unlit-fragment-DWtvt7yQ.js",
     "scene116.js"
-  ]
+  ],
+  "rawBytes": 77874
 }

--- a/lab/public/bundle/manifest/scene117.json
+++ b/lab/public/bundle/manifest/scene117.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene117.js"
-  ]
+  ],
+  "rawBytes": 16684
 }

--- a/lab/public/bundle/manifest/scene118.json
+++ b/lab/public/bundle/manifest/scene118.json
@@ -9,5 +9,6 @@
     "scene118-scene-uniforms-FTYH6Ct0.js",
     "scene118-standard-renderable-DI3geU7_.js",
     "scene118.js"
-  ]
+  ],
+  "rawBytes": 78501
 }

--- a/lab/public/bundle/manifest/scene118.json
+++ b/lab/public/bundle/manifest/scene118.json
@@ -10,5 +10,5 @@
     "scene118-standard-renderable-DI3geU7_.js",
     "scene118.js"
   ],
-  "rawBytes": 78501
+  "rawBytes": 78392
 }

--- a/lab/public/bundle/manifest/scene12.json
+++ b/lab/public/bundle/manifest/scene12.json
@@ -19,5 +19,5 @@
     "scene12-skeleton-fragment-DEO1NHCq.js",
     "scene12.js"
   ],
-  "rawBytes": 106030
+  "rawBytes": 105934
 }

--- a/lab/public/bundle/manifest/scene12.json
+++ b/lab/public/bundle/manifest/scene12.json
@@ -18,5 +18,6 @@
     "scene12-singlelight-directional-wgsl-BN0OWK2-.js",
     "scene12-skeleton-fragment-DEO1NHCq.js",
     "scene12.js"
-  ]
+  ],
+  "rawBytes": 106030
 }

--- a/lab/public/bundle/manifest/scene120.json
+++ b/lab/public/bundle/manifest/scene120.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene120.js"
-  ]
+  ],
+  "rawBytes": 36657
 }

--- a/lab/public/bundle/manifest/scene120.json
+++ b/lab/public/bundle/manifest/scene120.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene120.js"
   ],
-  "rawBytes": 36657
+  "rawBytes": 36551
 }

--- a/lab/public/bundle/manifest/scene121.json
+++ b/lab/public/bundle/manifest/scene121.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene121.js"
   ],
-  "rawBytes": 36822
+  "rawBytes": 36716
 }

--- a/lab/public/bundle/manifest/scene121.json
+++ b/lab/public/bundle/manifest/scene121.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene121.js"
-  ]
+  ],
+  "rawBytes": 36822
 }

--- a/lab/public/bundle/manifest/scene122.json
+++ b/lab/public/bundle/manifest/scene122.json
@@ -6,5 +6,5 @@
     "scene122-gaussian-splatting-pipeline-sh-DvfxlmAu.js",
     "scene122.js"
   ],
-  "rawBytes": 48659
+  "rawBytes": 48557
 }

--- a/lab/public/bundle/manifest/scene122.json
+++ b/lab/public/bundle/manifest/scene122.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene122-gaussian-splatting-pipeline-sh-DvfxlmAu.js",
     "scene122.js"
-  ]
+  ],
+  "rawBytes": 48659
 }

--- a/lab/public/bundle/manifest/scene123.json
+++ b/lab/public/bundle/manifest/scene123.json
@@ -6,5 +6,5 @@
     "scene123-gaussian-splatting-pipeline-sh-DpTRf1lh.js",
     "scene123.js"
   ],
-  "rawBytes": 46178
+  "rawBytes": 46073
 }

--- a/lab/public/bundle/manifest/scene123.json
+++ b/lab/public/bundle/manifest/scene123.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene123-gaussian-splatting-pipeline-sh-DpTRf1lh.js",
     "scene123.js"
-  ]
+  ],
+  "rawBytes": 46178
 }

--- a/lab/public/bundle/manifest/scene124.json
+++ b/lab/public/bundle/manifest/scene124.json
@@ -7,5 +7,5 @@
     "scene124-splat-ply-compressed-4vnSZMqI.js",
     "scene124.js"
   ],
-  "rawBytes": 52385
+  "rawBytes": 52282
 }

--- a/lab/public/bundle/manifest/scene124.json
+++ b/lab/public/bundle/manifest/scene124.json
@@ -6,5 +6,6 @@
     "scene124-gaussian-splatting-pipeline-sh-JNl3WGvm.js",
     "scene124-splat-ply-compressed-4vnSZMqI.js",
     "scene124.js"
-  ]
+  ],
+  "rawBytes": 52385
 }

--- a/lab/public/bundle/manifest/scene125.json
+++ b/lab/public/bundle/manifest/scene125.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene125.js"
-  ]
+  ],
+  "rawBytes": 38556
 }

--- a/lab/public/bundle/manifest/scene125.json
+++ b/lab/public/bundle/manifest/scene125.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene125.js"
   ],
-  "rawBytes": 38556
+  "rawBytes": 38450
 }

--- a/lab/public/bundle/manifest/scene126.json
+++ b/lab/public/bundle/manifest/scene126.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene126.js"
   ],
-  "rawBytes": 36876
+  "rawBytes": 36770
 }

--- a/lab/public/bundle/manifest/scene126.json
+++ b/lab/public/bundle/manifest/scene126.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene126.js"
-  ]
+  ],
+  "rawBytes": 36876
 }

--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -7,5 +7,5 @@
     "scene127-uniform-copy-batch-ZVer6XpX.js",
     "scene127.js"
   ],
-  "rawBytes": 61367
+  "rawBytes": 61255
 }

--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -6,5 +6,6 @@
     "scene127-shader-renderable-C9wEDq7s.js",
     "scene127-uniform-copy-batch-ZVer6XpX.js",
     "scene127.js"
-  ]
+  ],
+  "rawBytes": 61367
 }

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -7,5 +7,5 @@
     "scene128-uniform-copy-batch-DNjEW6Ap.js",
     "scene128.js"
   ],
-  "rawBytes": 61337
+  "rawBytes": 61224
 }

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -6,5 +6,6 @@
     "scene128-shader-renderable-CPLKyvjv.js",
     "scene128-uniform-copy-batch-DNjEW6Ap.js",
     "scene128.js"
-  ]
+  ],
+  "rawBytes": 61337
 }

--- a/lab/public/bundle/manifest/scene129.json
+++ b/lab/public/bundle/manifest/scene129.json
@@ -8,5 +8,5 @@
     "scene129-standard-renderable-8fMYNFq-.js",
     "scene129.js"
   ],
-  "rawBytes": 88321
+  "rawBytes": 88219
 }

--- a/lab/public/bundle/manifest/scene129.json
+++ b/lab/public/bundle/manifest/scene129.json
@@ -7,5 +7,6 @@
     "scene129-picking-pipeline-DjTTULzW.js",
     "scene129-standard-renderable-8fMYNFq-.js",
     "scene129.js"
-  ]
+  ],
+  "rawBytes": 88321
 }

--- a/lab/public/bundle/manifest/scene13.json
+++ b/lab/public/bundle/manifest/scene13.json
@@ -14,5 +14,5 @@
     "scene13-wgsl-helpers-BgB2AJrF.js",
     "scene13.js"
   ],
-  "rawBytes": 85705
+  "rawBytes": 85613
 }

--- a/lab/public/bundle/manifest/scene13.json
+++ b/lab/public/bundle/manifest/scene13.json
@@ -13,5 +13,6 @@
     "scene13-singlelight-hemispheric-wgsl-CErkjqJ3.js",
     "scene13-wgsl-helpers-BgB2AJrF.js",
     "scene13.js"
-  ]
+  ],
+  "rawBytes": 85705
 }

--- a/lab/public/bundle/manifest/scene14.json
+++ b/lab/public/bundle/manifest/scene14.json
@@ -16,5 +16,5 @@
     "scene14-wgsl-helpers-BgB2AJrF.js",
     "scene14.js"
   ],
-  "rawBytes": 90329
+  "rawBytes": 90235
 }

--- a/lab/public/bundle/manifest/scene14.json
+++ b/lab/public/bundle/manifest/scene14.json
@@ -15,5 +15,6 @@
     "scene14-singlelight-hemispheric-wgsl-Be2dr7T9.js",
     "scene14-wgsl-helpers-BgB2AJrF.js",
     "scene14.js"
-  ]
+  ],
+  "rawBytes": 90329
 }

--- a/lab/public/bundle/manifest/scene140.json
+++ b/lab/public/bundle/manifest/scene140.json
@@ -41,5 +41,5 @@
     "scene140-vertex-output-C7G5u6Y0.js",
     "scene140.js"
   ],
-  "rawBytes": 92278
+  "rawBytes": 92187
 }

--- a/lab/public/bundle/manifest/scene140.json
+++ b/lab/public/bundle/manifest/scene140.json
@@ -40,5 +40,6 @@
     "scene140-vector-splitter-B3mnHUT-.js",
     "scene140-vertex-output-C7G5u6Y0.js",
     "scene140.js"
-  ]
+  ],
+  "rawBytes": 92278
 }

--- a/lab/public/bundle/manifest/scene141.json
+++ b/lab/public/bundle/manifest/scene141.json
@@ -26,5 +26,5 @@
     "scene141-vertex-output-C7G5u6Y0.js",
     "scene141.js"
   ],
-  "rawBytes": 124628
+  "rawBytes": 124530
 }

--- a/lab/public/bundle/manifest/scene141.json
+++ b/lab/public/bundle/manifest/scene141.json
@@ -25,5 +25,6 @@
     "scene141-transform-block-Bm9H4Yvp.js",
     "scene141-vertex-output-C7G5u6Y0.js",
     "scene141.js"
-  ]
+  ],
+  "rawBytes": 124628
 }

--- a/lab/public/bundle/manifest/scene142.json
+++ b/lab/public/bundle/manifest/scene142.json
@@ -6,5 +6,5 @@
     "scene142-standard-renderable-ZLnQhHRL.js",
     "scene142.js"
   ],
-  "rawBytes": 62072
+  "rawBytes": 61966
 }

--- a/lab/public/bundle/manifest/scene142.json
+++ b/lab/public/bundle/manifest/scene142.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene142-standard-renderable-ZLnQhHRL.js",
     "scene142.js"
-  ]
+  ],
+  "rawBytes": 62072
 }

--- a/lab/public/bundle/manifest/scene143.json
+++ b/lab/public/bundle/manifest/scene143.json
@@ -12,5 +12,6 @@
     "scene143-std-reflection-fragment-BMQE51J5.js",
     "scene143-std-specular-fragment-BugkvqOj.js",
     "scene143.js"
-  ]
+  ],
+  "rawBytes": 71887
 }

--- a/lab/public/bundle/manifest/scene143.json
+++ b/lab/public/bundle/manifest/scene143.json
@@ -13,5 +13,5 @@
     "scene143-std-specular-fragment-BugkvqOj.js",
     "scene143.js"
   ],
-  "rawBytes": 71887
+  "rawBytes": 71777
 }

--- a/lab/public/bundle/manifest/scene144.json
+++ b/lab/public/bundle/manifest/scene144.json
@@ -22,5 +22,5 @@
     "scene144-texture-2d-DQo3n8D6.js",
     "scene144.js"
   ],
-  "rawBytes": 114173
+  "rawBytes": 114083
 }

--- a/lab/public/bundle/manifest/scene144.json
+++ b/lab/public/bundle/manifest/scene144.json
@@ -21,5 +21,6 @@
     "scene144-skeleton-fragment-B2AL4fch.js",
     "scene144-texture-2d-DQo3n8D6.js",
     "scene144.js"
-  ]
+  ],
+  "rawBytes": 114173
 }

--- a/lab/public/bundle/manifest/scene145.json
+++ b/lab/public/bundle/manifest/scene145.json
@@ -21,5 +21,6 @@
     "scene145-std-opacity-fragment-CaZ255Iu.js",
     "scene145-std-specular-fragment-DwjAhaXY.js",
     "scene145.js"
-  ]
+  ],
+  "rawBytes": 91260
 }

--- a/lab/public/bundle/manifest/scene145.json
+++ b/lab/public/bundle/manifest/scene145.json
@@ -22,5 +22,5 @@
     "scene145-std-specular-fragment-DwjAhaXY.js",
     "scene145.js"
   ],
-  "rawBytes": 91260
+  "rawBytes": 91103
 }

--- a/lab/public/bundle/manifest/scene146.json
+++ b/lab/public/bundle/manifest/scene146.json
@@ -18,5 +18,6 @@
     "scene146-ubo-layout-CaKc5tGR.js",
     "scene146-wgsl-helpers-BxdFLrVn.js",
     "scene146.js"
-  ]
+  ],
+  "rawBytes": 112832
 }

--- a/lab/public/bundle/manifest/scene146.json
+++ b/lab/public/bundle/manifest/scene146.json
@@ -19,5 +19,5 @@
     "scene146-wgsl-helpers-BxdFLrVn.js",
     "scene146.js"
   ],
-  "rawBytes": 112832
+  "rawBytes": 112719
 }

--- a/lab/public/bundle/manifest/scene147.json
+++ b/lab/public/bundle/manifest/scene147.json
@@ -15,5 +15,6 @@
     "scene147-scene-uniforms-Ha63NnVx.js",
     "scene147-shader-composer-8GPw9fSv.js",
     "scene147.js"
-  ]
+  ],
+  "rawBytes": 106036
 }

--- a/lab/public/bundle/manifest/scene147.json
+++ b/lab/public/bundle/manifest/scene147.json
@@ -16,5 +16,5 @@
     "scene147-shader-composer-8GPw9fSv.js",
     "scene147.js"
   ],
-  "rawBytes": 106036
+  "rawBytes": 105939
 }

--- a/lab/public/bundle/manifest/scene148.json
+++ b/lab/public/bundle/manifest/scene148.json
@@ -16,5 +16,5 @@
     "scene148-singlelight-hemispheric-wgsl-Dl8TI5wG.js",
     "scene148.js"
   ],
-  "rawBytes": 112007
+  "rawBytes": 111910
 }

--- a/lab/public/bundle/manifest/scene148.json
+++ b/lab/public/bundle/manifest/scene148.json
@@ -15,5 +15,6 @@
     "scene148-shader-composer-BCkp8e9Y.js",
     "scene148-singlelight-hemispheric-wgsl-Dl8TI5wG.js",
     "scene148.js"
-  ]
+  ],
+  "rawBytes": 112007
 }

--- a/lab/public/bundle/manifest/scene149.json
+++ b/lab/public/bundle/manifest/scene149.json
@@ -21,5 +21,6 @@
     "scene149-transform-block-C8beS7Ig.js",
     "scene149-vertex-output-C7G5u6Y0.js",
     "scene149.js"
-  ]
+  ],
+  "rawBytes": 109051
 }

--- a/lab/public/bundle/manifest/scene149.json
+++ b/lab/public/bundle/manifest/scene149.json
@@ -22,5 +22,5 @@
     "scene149-vertex-output-C7G5u6Y0.js",
     "scene149.js"
   ],
-  "rawBytes": 109051
+  "rawBytes": 108961
 }

--- a/lab/public/bundle/manifest/scene15.json
+++ b/lab/public/bundle/manifest/scene15.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene15-standard-renderable-rPw2aEm-.js",
     "scene15.js"
-  ]
+  ],
+  "rawBytes": 48554
 }

--- a/lab/public/bundle/manifest/scene15.json
+++ b/lab/public/bundle/manifest/scene15.json
@@ -6,5 +6,5 @@
     "scene15-standard-renderable-rPw2aEm-.js",
     "scene15.js"
   ],
-  "rawBytes": 48554
+  "rawBytes": 48446
 }

--- a/lab/public/bundle/manifest/scene150.json
+++ b/lab/public/bundle/manifest/scene150.json
@@ -6,5 +6,5 @@
     "scene150-standard-renderable-CD3IZxs8.js",
     "scene150.js"
   ],
-  "rawBytes": 55362
+  "rawBytes": 55247
 }

--- a/lab/public/bundle/manifest/scene150.json
+++ b/lab/public/bundle/manifest/scene150.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene150-standard-renderable-CD3IZxs8.js",
     "scene150.js"
-  ]
+  ],
+  "rawBytes": 55362
 }

--- a/lab/public/bundle/manifest/scene151.json
+++ b/lab/public/bundle/manifest/scene151.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene151-standard-renderable-D1kcZ9rM.js",
     "scene151.js"
-  ]
+  ],
+  "rawBytes": 55630
 }

--- a/lab/public/bundle/manifest/scene151.json
+++ b/lab/public/bundle/manifest/scene151.json
@@ -6,5 +6,5 @@
     "scene151-standard-renderable-D1kcZ9rM.js",
     "scene151.js"
   ],
-  "rawBytes": 55630
+  "rawBytes": 55519
 }

--- a/lab/public/bundle/manifest/scene152.json
+++ b/lab/public/bundle/manifest/scene152.json
@@ -17,5 +17,6 @@
     "scene152-singlelight-hemispheric-wgsl-SwzMeRqO.js",
     "scene152-skeleton-fragment-Cy_qnGKC.js",
     "scene152.js"
-  ]
+  ],
+  "rawBytes": 94993
 }

--- a/lab/public/bundle/manifest/scene152.json
+++ b/lab/public/bundle/manifest/scene152.json
@@ -18,5 +18,5 @@
     "scene152-skeleton-fragment-Cy_qnGKC.js",
     "scene152.js"
   ],
-  "rawBytes": 94993
+  "rawBytes": 94897
 }

--- a/lab/public/bundle/manifest/scene153.json
+++ b/lab/public/bundle/manifest/scene153.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene153.js"
-  ]
+  ],
+  "rawBytes": 6982
 }

--- a/lab/public/bundle/manifest/scene154.json
+++ b/lab/public/bundle/manifest/scene154.json
@@ -6,5 +6,5 @@
     "scene154-standard-renderable-Bq2bYKMb.js",
     "scene154.js"
   ],
-  "rawBytes": 55798
+  "rawBytes": 55684
 }

--- a/lab/public/bundle/manifest/scene154.json
+++ b/lab/public/bundle/manifest/scene154.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene154-standard-renderable-Bq2bYKMb.js",
     "scene154.js"
-  ]
+  ],
+  "rawBytes": 55798
 }

--- a/lab/public/bundle/manifest/scene155.json
+++ b/lab/public/bundle/manifest/scene155.json
@@ -6,5 +6,5 @@
     "scene155-standard-renderable-BGSyq91t.js",
     "scene155.js"
   ],
-  "rawBytes": 57856
+  "rawBytes": 57740
 }

--- a/lab/public/bundle/manifest/scene155.json
+++ b/lab/public/bundle/manifest/scene155.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene155-standard-renderable-BGSyq91t.js",
     "scene155.js"
-  ]
+  ],
+  "rawBytes": 57856
 }

--- a/lab/public/bundle/manifest/scene156.json
+++ b/lab/public/bundle/manifest/scene156.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene156-standard-renderable-BAmoruQt.js",
     "scene156.js"
-  ]
+  ],
+  "rawBytes": 58885
 }

--- a/lab/public/bundle/manifest/scene156.json
+++ b/lab/public/bundle/manifest/scene156.json
@@ -6,5 +6,5 @@
     "scene156-standard-renderable-BAmoruQt.js",
     "scene156.js"
   ],
-  "rawBytes": 58885
+  "rawBytes": 58772
 }

--- a/lab/public/bundle/manifest/scene157.json
+++ b/lab/public/bundle/manifest/scene157.json
@@ -14,5 +14,6 @@
     "scene157-pbr-renderable-DIq1jqPX.js",
     "scene157-skeleton-fragment-BCka7LwS.js",
     "scene157.js"
-  ]
+  ],
+  "rawBytes": 97486
 }

--- a/lab/public/bundle/manifest/scene157.json
+++ b/lab/public/bundle/manifest/scene157.json
@@ -15,5 +15,5 @@
     "scene157-skeleton-fragment-BCka7LwS.js",
     "scene157.js"
   ],
-  "rawBytes": 97486
+  "rawBytes": 97376
 }

--- a/lab/public/bundle/manifest/scene158.json
+++ b/lab/public/bundle/manifest/scene158.json
@@ -15,5 +15,5 @@
     "scene158-skeleton-fragment-BwFUlHKl.js",
     "scene158.js"
   ],
-  "rawBytes": 97752
+  "rawBytes": 97643
 }

--- a/lab/public/bundle/manifest/scene158.json
+++ b/lab/public/bundle/manifest/scene158.json
@@ -14,5 +14,6 @@
     "scene158-pbr-renderable-DF-GCm4q.js",
     "scene158-skeleton-fragment-BwFUlHKl.js",
     "scene158.js"
-  ]
+  ],
+  "rawBytes": 97752
 }

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene159-shader-renderable-uQdpxd_b.js",
     "scene159.js"
-  ]
+  ],
+  "rawBytes": 39531
 }

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -6,5 +6,5 @@
     "scene159-shader-renderable-uQdpxd_b.js",
     "scene159.js"
   ],
-  "rawBytes": 39531
+  "rawBytes": 39422
 }

--- a/lab/public/bundle/manifest/scene16.json
+++ b/lab/public/bundle/manifest/scene16.json
@@ -7,5 +7,6 @@
     "scene16-thin-instance-fragment-CBn2miAC.js",
     "scene16-thin-instance-gpu-d2Yv33aN.js",
     "scene16.js"
-  ]
+  ],
+  "rawBytes": 50729
 }

--- a/lab/public/bundle/manifest/scene16.json
+++ b/lab/public/bundle/manifest/scene16.json
@@ -8,5 +8,5 @@
     "scene16-thin-instance-gpu-d2Yv33aN.js",
     "scene16.js"
   ],
-  "rawBytes": 50729
+  "rawBytes": 50619
 }

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -6,5 +6,5 @@
     "scene160-shader-renderable-CLtKraz9.js",
     "scene160.js"
   ],
-  "rawBytes": 41465
+  "rawBytes": 41363
 }

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene160-shader-renderable-CLtKraz9.js",
     "scene160.js"
-  ]
+  ],
+  "rawBytes": 41465
 }

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -6,5 +6,5 @@
     "scene161-shader-renderable-MmpwgoQy.js",
     "scene161.js"
   ],
-  "rawBytes": 40108
+  "rawBytes": 40000
 }

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene161-shader-renderable-MmpwgoQy.js",
     "scene161.js"
-  ]
+  ],
+  "rawBytes": 40108
 }

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene162-shader-renderable-DgumWvJ5.js",
     "scene162.js"
-  ]
+  ],
+  "rawBytes": 39547
 }

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -6,5 +6,5 @@
     "scene162-shader-renderable-DgumWvJ5.js",
     "scene162.js"
   ],
-  "rawBytes": 39547
+  "rawBytes": 39443
 }

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene163-shader-renderable-BZrqxY0b.js",
     "scene163.js"
-  ]
+  ],
+  "rawBytes": 39243
 }

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -6,5 +6,5 @@
     "scene163-shader-renderable-BZrqxY0b.js",
     "scene163.js"
   ],
-  "rawBytes": 39243
+  "rawBytes": 39139
 }

--- a/lab/public/bundle/manifest/scene164.json
+++ b/lab/public/bundle/manifest/scene164.json
@@ -21,5 +21,5 @@
     "scene164-skeleton-fragment-DG_r8HhT.js",
     "scene164.js"
   ],
-  "rawBytes": 96725
+  "rawBytes": 96621
 }

--- a/lab/public/bundle/manifest/scene164.json
+++ b/lab/public/bundle/manifest/scene164.json
@@ -20,5 +20,6 @@
     "scene164-singlelight-hemispheric-wgsl-BywgNNl_.js",
     "scene164-skeleton-fragment-DG_r8HhT.js",
     "scene164.js"
-  ]
+  ],
+  "rawBytes": 96725
 }

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -7,5 +7,6 @@
     "scene165-shader-thin-instance-BKrtjGJ6.js",
     "scene165-thin-instance-gpu-B5cobg4p.js",
     "scene165.js"
-  ]
+  ],
+  "rawBytes": 45061
 }

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -8,5 +8,5 @@
     "scene165-thin-instance-gpu-B5cobg4p.js",
     "scene165.js"
   ],
-  "rawBytes": 45061
+  "rawBytes": 44953
 }

--- a/lab/public/bundle/manifest/scene17.json
+++ b/lab/public/bundle/manifest/scene17.json
@@ -14,5 +14,5 @@
     "scene17-thin-instance-gpu-BmCYehED.js",
     "scene17.js"
   ],
-  "rawBytes": 88679
+  "rawBytes": 88592
 }

--- a/lab/public/bundle/manifest/scene17.json
+++ b/lab/public/bundle/manifest/scene17.json
@@ -13,5 +13,6 @@
     "scene17-thin-instance-fragment-CBn2miAC.js",
     "scene17-thin-instance-gpu-BmCYehED.js",
     "scene17.js"
-  ]
+  ],
+  "rawBytes": 88679
 }

--- a/lab/public/bundle/manifest/scene170.json
+++ b/lab/public/bundle/manifest/scene170.json
@@ -7,5 +7,5 @@
     "scene170-standard-renderable-DwB4suLI.js",
     "scene170.js"
   ],
-  "rawBytes": 52474
+  "rawBytes": 52353
 }

--- a/lab/public/bundle/manifest/scene170.json
+++ b/lab/public/bundle/manifest/scene170.json
@@ -6,5 +6,6 @@
     "scene170-recast-navigation-CYBQI-zY-Dry_z7x_.js",
     "scene170-standard-renderable-DwB4suLI.js",
     "scene170.js"
-  ]
+  ],
+  "rawBytes": 52474
 }

--- a/lab/public/bundle/manifest/scene171.json
+++ b/lab/public/bundle/manifest/scene171.json
@@ -11,5 +11,6 @@
     "scene171-singlelight-hemispheric-wgsl-Du7OFXSC.js",
     "scene171-standard-renderable-0yGV8y8l.js",
     "scene171.js"
-  ]
+  ],
+  "rawBytes": 97671
 }

--- a/lab/public/bundle/manifest/scene171.json
+++ b/lab/public/bundle/manifest/scene171.json
@@ -12,5 +12,5 @@
     "scene171-standard-renderable-0yGV8y8l.js",
     "scene171.js"
   ],
-  "rawBytes": 97671
+  "rawBytes": 97577
 }

--- a/lab/public/bundle/manifest/scene172.json
+++ b/lab/public/bundle/manifest/scene172.json
@@ -6,5 +6,6 @@
     "scene172-recast-navigation-CYBQI-zY-Dry_z7x_.js",
     "scene172-standard-renderable-LdAXNV9J.js",
     "scene172.js"
-  ]
+  ],
+  "rawBytes": 60941
 }

--- a/lab/public/bundle/manifest/scene172.json
+++ b/lab/public/bundle/manifest/scene172.json
@@ -7,5 +7,5 @@
     "scene172-standard-renderable-LdAXNV9J.js",
     "scene172.js"
   ],
-  "rawBytes": 60941
+  "rawBytes": 60846
 }

--- a/lab/public/bundle/manifest/scene173.json
+++ b/lab/public/bundle/manifest/scene173.json
@@ -6,5 +6,6 @@
     "scene173-recast-navigation-CYBQI-zY-Dry_z7x_.js",
     "scene173-standard-renderable-frw4RDGj.js",
     "scene173.js"
-  ]
+  ],
+  "rawBytes": 65134
 }

--- a/lab/public/bundle/manifest/scene173.json
+++ b/lab/public/bundle/manifest/scene173.json
@@ -7,5 +7,5 @@
     "scene173-standard-renderable-frw4RDGj.js",
     "scene173.js"
   ],
-  "rawBytes": 65134
+  "rawBytes": 65024
 }

--- a/lab/public/bundle/manifest/scene174.json
+++ b/lab/public/bundle/manifest/scene174.json
@@ -12,5 +12,5 @@
     "scene174-standard-renderable-z7tnf6zH.js",
     "scene174.js"
   ],
-  "rawBytes": 98312
+  "rawBytes": 98219
 }

--- a/lab/public/bundle/manifest/scene174.json
+++ b/lab/public/bundle/manifest/scene174.json
@@ -11,5 +11,6 @@
     "scene174-singlelight-hemispheric-wgsl-DRRifmYd.js",
     "scene174-standard-renderable-z7tnf6zH.js",
     "scene174.js"
-  ]
+  ],
+  "rawBytes": 98312
 }

--- a/lab/public/bundle/manifest/scene175.json
+++ b/lab/public/bundle/manifest/scene175.json
@@ -12,5 +12,5 @@
     "scene175-standard-renderable-BksrW1Ru.js",
     "scene175.js"
   ],
-  "rawBytes": 96645
+  "rawBytes": 96554
 }

--- a/lab/public/bundle/manifest/scene175.json
+++ b/lab/public/bundle/manifest/scene175.json
@@ -11,5 +11,6 @@
     "scene175-singlelight-hemispheric-wgsl-Djwg_jhe.js",
     "scene175-standard-renderable-BksrW1Ru.js",
     "scene175.js"
-  ]
+  ],
+  "rawBytes": 96645
 }

--- a/lab/public/bundle/manifest/scene176.json
+++ b/lab/public/bundle/manifest/scene176.json
@@ -17,5 +17,6 @@
     "scene176-rgbd-decode-C_UCnB7P.js",
     "scene176-scene-uniforms-FTYH6Ct0.js",
     "scene176.js"
-  ]
+  ],
+  "rawBytes": 106614
 }

--- a/lab/public/bundle/manifest/scene176.json
+++ b/lab/public/bundle/manifest/scene176.json
@@ -18,5 +18,5 @@
     "scene176-scene-uniforms-FTYH6Ct0.js",
     "scene176.js"
   ],
-  "rawBytes": 106614
+  "rawBytes": 106526
 }

--- a/lab/public/bundle/manifest/scene177.json
+++ b/lab/public/bundle/manifest/scene177.json
@@ -10,5 +10,6 @@
     "scene177-rgbd-decode-DgyvGBcz.js",
     "scene177-scene-uniforms-FTYH6Ct0.js",
     "scene177.js"
-  ]
+  ],
+  "rawBytes": 71586
 }

--- a/lab/public/bundle/manifest/scene177.json
+++ b/lab/public/bundle/manifest/scene177.json
@@ -11,5 +11,5 @@
     "scene177-scene-uniforms-FTYH6Ct0.js",
     "scene177.js"
   ],
-  "rawBytes": 71586
+  "rawBytes": 71478
 }

--- a/lab/public/bundle/manifest/scene178.json
+++ b/lab/public/bundle/manifest/scene178.json
@@ -14,5 +14,6 @@
     "scene178-rgbd-decode-DrDqC6lT.js",
     "scene178-scene-uniforms-FTYH6Ct0.js",
     "scene178.js"
-  ]
+  ],
+  "rawBytes": 89875
 }

--- a/lab/public/bundle/manifest/scene178.json
+++ b/lab/public/bundle/manifest/scene178.json
@@ -15,5 +15,5 @@
     "scene178-scene-uniforms-FTYH6Ct0.js",
     "scene178.js"
   ],
-  "rawBytes": 89875
+  "rawBytes": 89779
 }

--- a/lab/public/bundle/manifest/scene179.json
+++ b/lab/public/bundle/manifest/scene179.json
@@ -8,5 +8,6 @@
     "scene179-gltf-json-asset-CRvHeVKI.js",
     "scene179-pbr-renderable-MYLQScDZ.js",
     "scene179.js"
-  ]
+  ],
+  "rawBytes": 75423
 }

--- a/lab/public/bundle/manifest/scene179.json
+++ b/lab/public/bundle/manifest/scene179.json
@@ -9,5 +9,5 @@
     "scene179-pbr-renderable-MYLQScDZ.js",
     "scene179.js"
   ],
-  "rawBytes": 75423
+  "rawBytes": 75521
 }

--- a/lab/public/bundle/manifest/scene18.json
+++ b/lab/public/bundle/manifest/scene18.json
@@ -10,5 +10,6 @@
     "scene18-standard-renderable-Dd4PqSw3.js",
     "scene18-std-shadow-fragment-pwyXRo4i.js",
     "scene18.js"
-  ]
+  ],
+  "rawBytes": 62229
 }

--- a/lab/public/bundle/manifest/scene18.json
+++ b/lab/public/bundle/manifest/scene18.json
@@ -11,5 +11,5 @@
     "scene18-std-shadow-fragment-pwyXRo4i.js",
     "scene18.js"
   ],
-  "rawBytes": 62229
+  "rawBytes": 62099
 }

--- a/lab/public/bundle/manifest/scene180.json
+++ b/lab/public/bundle/manifest/scene180.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene180-text-shaper-Cie-Mnk-.js",
     "scene180.js"
-  ]
+  ],
+  "rawBytes": 27995
 }

--- a/lab/public/bundle/manifest/scene181.json
+++ b/lab/public/bundle/manifest/scene181.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene181-text-shaper-Cie-Mnk-.js",
     "scene181.js"
-  ]
+  ],
+  "rawBytes": 44508
 }

--- a/lab/public/bundle/manifest/scene181.json
+++ b/lab/public/bundle/manifest/scene181.json
@@ -6,5 +6,5 @@
     "scene181-text-shaper-Cie-Mnk-.js",
     "scene181.js"
   ],
-  "rawBytes": 44508
+  "rawBytes": 44386
 }

--- a/lab/public/bundle/manifest/scene19.json
+++ b/lab/public/bundle/manifest/scene19.json
@@ -9,5 +9,6 @@
     "scene19-rgbd-decode-Bhk0icKs.js",
     "scene19-singlelight-hemispheric-wgsl-CWifOPl1.js",
     "scene19.js"
-  ]
+  ],
+  "rawBytes": 72172
 }

--- a/lab/public/bundle/manifest/scene19.json
+++ b/lab/public/bundle/manifest/scene19.json
@@ -10,5 +10,5 @@
     "scene19-singlelight-hemispheric-wgsl-CWifOPl1.js",
     "scene19.js"
   ],
-  "rawBytes": 72172
+  "rawBytes": 72063
 }

--- a/lab/public/bundle/manifest/scene2.json
+++ b/lab/public/bundle/manifest/scene2.json
@@ -6,5 +6,5 @@
     "scene2-standard-renderable-ClWbKmS9.js",
     "scene2.js"
   ],
-  "rawBytes": 48213
+  "rawBytes": 48107
 }

--- a/lab/public/bundle/manifest/scene2.json
+++ b/lab/public/bundle/manifest/scene2.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene2-standard-renderable-ClWbKmS9.js",
     "scene2.js"
-  ]
+  ],
+  "rawBytes": 48213
 }

--- a/lab/public/bundle/manifest/scene20.json
+++ b/lab/public/bundle/manifest/scene20.json
@@ -15,5 +15,5 @@
     "scene20-wgsl-helpers-BgB2AJrF.js",
     "scene20.js"
   ],
-  "rawBytes": 80185
+  "rawBytes": 80085
 }

--- a/lab/public/bundle/manifest/scene20.json
+++ b/lab/public/bundle/manifest/scene20.json
@@ -14,5 +14,6 @@
     "scene20-singlelight-hemispheric-wgsl-TLZaCFzg.js",
     "scene20-wgsl-helpers-BgB2AJrF.js",
     "scene20.js"
-  ]
+  ],
+  "rawBytes": 80185
 }

--- a/lab/public/bundle/manifest/scene200.json
+++ b/lab/public/bundle/manifest/scene200.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene200-standard-renderable-BMQsAcMO.js",
     "scene200.js"
-  ]
+  ],
+  "rawBytes": 48455
 }

--- a/lab/public/bundle/manifest/scene200.json
+++ b/lab/public/bundle/manifest/scene200.json
@@ -6,5 +6,5 @@
     "scene200-standard-renderable-BMQsAcMO.js",
     "scene200.js"
   ],
-  "rawBytes": 48455
+  "rawBytes": 48349
 }

--- a/lab/public/bundle/manifest/scene201.json
+++ b/lab/public/bundle/manifest/scene201.json
@@ -9,5 +9,5 @@
     "scene201-standard-renderable-CZ_RoX6C.js",
     "scene201.js"
   ],
-  "rawBytes": 49815
+  "rawBytes": 49704
 }

--- a/lab/public/bundle/manifest/scene201.json
+++ b/lab/public/bundle/manifest/scene201.json
@@ -8,5 +8,6 @@
     "scene201-pack-mat4-with-offset-BS-Lz8k7.js",
     "scene201-standard-renderable-CZ_RoX6C.js",
     "scene201.js"
-  ]
+  ],
+  "rawBytes": 49815
 }

--- a/lab/public/bundle/manifest/scene202.json
+++ b/lab/public/bundle/manifest/scene202.json
@@ -8,5 +8,6 @@
     "scene202-pack-mat4-with-offset-BS-Lz8k7.js",
     "scene202-standard-renderable-BKzhy1-Q.js",
     "scene202.js"
-  ]
+  ],
+  "rawBytes": 50583
 }

--- a/lab/public/bundle/manifest/scene202.json
+++ b/lab/public/bundle/manifest/scene202.json
@@ -9,5 +9,5 @@
     "scene202-standard-renderable-BKzhy1-Q.js",
     "scene202.js"
   ],
-  "rawBytes": 50583
+  "rawBytes": 50470
 }

--- a/lab/public/bundle/manifest/scene203.json
+++ b/lab/public/bundle/manifest/scene203.json
@@ -9,5 +9,5 @@
     "scene203-standard-renderable-y266HOp7.js",
     "scene203.js"
   ],
-  "rawBytes": 50884
+  "rawBytes": 50780
 }

--- a/lab/public/bundle/manifest/scene203.json
+++ b/lab/public/bundle/manifest/scene203.json
@@ -8,5 +8,6 @@
     "scene203-pack-mat4-with-offset-BS-Lz8k7.js",
     "scene203-standard-renderable-y266HOp7.js",
     "scene203.js"
-  ]
+  ],
+  "rawBytes": 50884
 }

--- a/lab/public/bundle/manifest/scene204.json
+++ b/lab/public/bundle/manifest/scene204.json
@@ -10,5 +10,6 @@
     "scene204-thin-instance-fragment-CBn2miAC.js",
     "scene204-thin-instance-gpu-DMvEkqgI.js",
     "scene204.js"
-  ]
+  ],
+  "rawBytes": 53154
 }

--- a/lab/public/bundle/manifest/scene204.json
+++ b/lab/public/bundle/manifest/scene204.json
@@ -11,5 +11,5 @@
     "scene204-thin-instance-gpu-DMvEkqgI.js",
     "scene204.js"
   ],
-  "rawBytes": 53154
+  "rawBytes": 53036
 }

--- a/lab/public/bundle/manifest/scene205.json
+++ b/lab/public/bundle/manifest/scene205.json
@@ -11,5 +11,5 @@
     "scene205-standard-renderable-sjJionX5.js",
     "scene205.js"
   ],
-  "rawBytes": 63198
+  "rawBytes": 63096
 }

--- a/lab/public/bundle/manifest/scene205.json
+++ b/lab/public/bundle/manifest/scene205.json
@@ -10,5 +10,6 @@
     "scene205-scene-uniforms-FTYH6Ct0.js",
     "scene205-standard-renderable-sjJionX5.js",
     "scene205.js"
-  ]
+  ],
+  "rawBytes": 63198
 }

--- a/lab/public/bundle/manifest/scene206.json
+++ b/lab/public/bundle/manifest/scene206.json
@@ -11,5 +11,5 @@
     "scene206-standard-renderable-DVuWCcsG.js",
     "scene206.js"
   ],
-  "rawBytes": 63556
+  "rawBytes": 63445
 }

--- a/lab/public/bundle/manifest/scene206.json
+++ b/lab/public/bundle/manifest/scene206.json
@@ -10,5 +10,6 @@
     "scene206-scene-uniforms-FTYH6Ct0.js",
     "scene206-standard-renderable-DVuWCcsG.js",
     "scene206.js"
-  ]
+  ],
+  "rawBytes": 63556
 }

--- a/lab/public/bundle/manifest/scene207.json
+++ b/lab/public/bundle/manifest/scene207.json
@@ -12,5 +12,6 @@
     "scene207-standard-renderable-Crg42H3b.js",
     "scene207-std-shadow-fragment-pwyXRo4i.js",
     "scene207.js"
-  ]
+  ],
+  "rawBytes": 61196
 }

--- a/lab/public/bundle/manifest/scene207.json
+++ b/lab/public/bundle/manifest/scene207.json
@@ -13,5 +13,5 @@
     "scene207-std-shadow-fragment-pwyXRo4i.js",
     "scene207.js"
   ],
-  "rawBytes": 61196
+  "rawBytes": 61102
 }

--- a/lab/public/bundle/manifest/scene209.json
+++ b/lab/public/bundle/manifest/scene209.json
@@ -9,5 +9,6 @@
     "scene209-pack-mat4-with-offset-BS-Lz8k7.js",
     "scene209-standard-renderable-xpp8iiFV.js",
     "scene209.js"
-  ]
+  ],
+  "rawBytes": 55794
 }

--- a/lab/public/bundle/manifest/scene209.json
+++ b/lab/public/bundle/manifest/scene209.json
@@ -10,5 +10,5 @@
     "scene209-standard-renderable-xpp8iiFV.js",
     "scene209.js"
   ],
-  "rawBytes": 55794
+  "rawBytes": 55671
 }

--- a/lab/public/bundle/manifest/scene21.json
+++ b/lab/public/bundle/manifest/scene21.json
@@ -13,5 +13,6 @@
     "scene21-scene-uniforms-FTYH6Ct0.js",
     "scene21-sheen-fragment-C2VjeVge.js",
     "scene21.js"
-  ]
+  ],
+  "rawBytes": 87707
 }

--- a/lab/public/bundle/manifest/scene21.json
+++ b/lab/public/bundle/manifest/scene21.json
@@ -14,5 +14,5 @@
     "scene21-sheen-fragment-C2VjeVge.js",
     "scene21.js"
   ],
-  "rawBytes": 87707
+  "rawBytes": 87610
 }

--- a/lab/public/bundle/manifest/scene210.json
+++ b/lab/public/bundle/manifest/scene210.json
@@ -12,5 +12,6 @@
     "scene210-pbr-renderable-2TFv9lTV.js",
     "scene210-singlelight-hemispheric-wgsl-B1ByCXeR.js",
     "scene210.js"
-  ]
+  ],
+  "rawBytes": 78711
 }

--- a/lab/public/bundle/manifest/scene210.json
+++ b/lab/public/bundle/manifest/scene210.json
@@ -13,5 +13,5 @@
     "scene210-singlelight-hemispheric-wgsl-B1ByCXeR.js",
     "scene210.js"
   ],
-  "rawBytes": 78711
+  "rawBytes": 78620
 }

--- a/lab/public/bundle/manifest/scene211.json
+++ b/lab/public/bundle/manifest/scene211.json
@@ -19,5 +19,5 @@
     "scene211-skeleton-fragment-BkCAiLip.js",
     "scene211.js"
   ],
-  "rawBytes": 92703
+  "rawBytes": 92605
 }

--- a/lab/public/bundle/manifest/scene211.json
+++ b/lab/public/bundle/manifest/scene211.json
@@ -18,5 +18,6 @@
     "scene211-singlelight-hemispheric-wgsl-BR9VDf4z.js",
     "scene211-skeleton-fragment-BkCAiLip.js",
     "scene211.js"
-  ]
+  ],
+  "rawBytes": 92703
 }

--- a/lab/public/bundle/manifest/scene212.json
+++ b/lab/public/bundle/manifest/scene212.json
@@ -18,5 +18,5 @@
     "scene212-scene-uniforms-FTYH6Ct0.js",
     "scene212.js"
   ],
-  "rawBytes": 106648
+  "rawBytes": 106560
 }

--- a/lab/public/bundle/manifest/scene212.json
+++ b/lab/public/bundle/manifest/scene212.json
@@ -17,5 +17,6 @@
     "scene212-rgbd-decode-XDHh5Xrg.js",
     "scene212-scene-uniforms-FTYH6Ct0.js",
     "scene212.js"
-  ]
+  ],
+  "rawBytes": 106648
 }

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -8,5 +8,5 @@
     "scene213-uniform-copy-batch-dw98bObp.js",
     "scene213.js"
   ],
-  "rawBytes": 49911
+  "rawBytes": 49809
 }

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -7,5 +7,6 @@
     "scene213-shader-renderable-CRW09kCW.js",
     "scene213-uniform-copy-batch-dw98bObp.js",
     "scene213.js"
-  ]
+  ],
+  "rawBytes": 49911
 }

--- a/lab/public/bundle/manifest/scene214.json
+++ b/lab/public/bundle/manifest/scene214.json
@@ -9,5 +9,6 @@
     "scene214-standard-renderable-CpHx5Kv7.js",
     "scene214-std-shadow-fragment-DBsVFNMn.js",
     "scene214.js"
-  ]
+  ],
+  "rawBytes": 70330
 }

--- a/lab/public/bundle/manifest/scene214.json
+++ b/lab/public/bundle/manifest/scene214.json
@@ -10,5 +10,5 @@
     "scene214-std-shadow-fragment-DBsVFNMn.js",
     "scene214.js"
   ],
-  "rawBytes": 70330
+  "rawBytes": 70354
 }

--- a/lab/public/bundle/manifest/scene215.json
+++ b/lab/public/bundle/manifest/scene215.json
@@ -11,5 +11,6 @@
     "scene215-shadow-task-CPnE-PjD.js",
     "scene215-singlelight-directional-wgsl-DzV54v_g.js",
     "scene215.js"
-  ]
+  ],
+  "rawBytes": 82127
 }

--- a/lab/public/bundle/manifest/scene215.json
+++ b/lab/public/bundle/manifest/scene215.json
@@ -12,5 +12,5 @@
     "scene215-singlelight-directional-wgsl-DzV54v_g.js",
     "scene215.js"
   ],
-  "rawBytes": 82127
+  "rawBytes": 82154
 }

--- a/lab/public/bundle/manifest/scene216.json
+++ b/lab/public/bundle/manifest/scene216.json
@@ -8,5 +8,5 @@
     "scene216-singlelight-hemispheric-wgsl-BXqEjdZQ.js",
     "scene216.js"
   ],
-  "rawBytes": 55293
+  "rawBytes": 55190
 }

--- a/lab/public/bundle/manifest/scene216.json
+++ b/lab/public/bundle/manifest/scene216.json
@@ -7,5 +7,6 @@
     "scene216-pbr-renderable-CQsuWQID.js",
     "scene216-singlelight-hemispheric-wgsl-BXqEjdZQ.js",
     "scene216.js"
-  ]
+  ],
+  "rawBytes": 55293
 }

--- a/lab/public/bundle/manifest/scene217.json
+++ b/lab/public/bundle/manifest/scene217.json
@@ -9,5 +9,5 @@
     "scene217-standard-renderable-Bk-03qbL.js",
     "scene217.js"
   ],
-  "rawBytes": 79915
+  "rawBytes": 79809
 }

--- a/lab/public/bundle/manifest/scene217.json
+++ b/lab/public/bundle/manifest/scene217.json
@@ -8,5 +8,6 @@
     "scene217-shader-composer-CRnzWPZ6.js",
     "scene217-standard-renderable-Bk-03qbL.js",
     "scene217.js"
-  ]
+  ],
+  "rawBytes": 79915
 }

--- a/lab/public/bundle/manifest/scene218.json
+++ b/lab/public/bundle/manifest/scene218.json
@@ -16,5 +16,6 @@
     "scene218-pbr-renderable-DKk3VIVl.js",
     "scene218-singlelight-hemispheric-wgsl-C-rWpDqQ.js",
     "scene218.js"
-  ]
+  ],
+  "rawBytes": 96577
 }

--- a/lab/public/bundle/manifest/scene218.json
+++ b/lab/public/bundle/manifest/scene218.json
@@ -17,5 +17,5 @@
     "scene218-singlelight-hemispheric-wgsl-C-rWpDqQ.js",
     "scene218.js"
   ],
-  "rawBytes": 96577
+  "rawBytes": 96482
 }

--- a/lab/public/bundle/manifest/scene219.json
+++ b/lab/public/bundle/manifest/scene219.json
@@ -18,5 +18,6 @@
     "scene219-thin-instance-fragment-CBn2miAC.js",
     "scene219-thin-instance-gpu-Boul_gpr.js",
     "scene219.js"
-  ]
+  ],
+  "rawBytes": 99724
 }

--- a/lab/public/bundle/manifest/scene219.json
+++ b/lab/public/bundle/manifest/scene219.json
@@ -19,5 +19,5 @@
     "scene219-thin-instance-gpu-Boul_gpr.js",
     "scene219.js"
   ],
-  "rawBytes": 99724
+  "rawBytes": 99626
 }

--- a/lab/public/bundle/manifest/scene22.json
+++ b/lab/public/bundle/manifest/scene22.json
@@ -16,5 +16,6 @@
     "scene22-shadow-task-Yvrdp5XB.js",
     "scene22-standard-renderable--Wd3wjFx.js",
     "scene22.js"
-  ]
+  ],
+  "rawBytes": 100138
 }

--- a/lab/public/bundle/manifest/scene22.json
+++ b/lab/public/bundle/manifest/scene22.json
@@ -17,5 +17,5 @@
     "scene22-standard-renderable--Wd3wjFx.js",
     "scene22.js"
   ],
-  "rawBytes": 100138
+  "rawBytes": 100043
 }

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -9,5 +9,5 @@
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221.js"
   ],
-  "rawBytes": 101253
+  "rawBytes": 101149
 }

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -8,5 +8,6 @@
     "scene221-standard-renderable-DGvyOygd.js",
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221.js"
-  ]
+  ],
+  "rawBytes": 101253
 }

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -12,5 +12,5 @@
     "scene222-uniform-copy-batch-B53Ok7jL.js",
     "scene222.js"
   ],
-  "rawBytes": 114462
+  "rawBytes": 114338
 }

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -11,5 +11,6 @@
     "scene222-swapchain-overlay-ilhN4El_.js",
     "scene222-uniform-copy-batch-B53Ok7jL.js",
     "scene222.js"
-  ]
+  ],
+  "rawBytes": 114462
 }

--- a/lab/public/bundle/manifest/scene223.json
+++ b/lab/public/bundle/manifest/scene223.json
@@ -7,5 +7,5 @@
     "scene223-swapchain-overlay-ilhN4El_.js",
     "scene223.js"
   ],
-  "rawBytes": 66888
+  "rawBytes": 66590
 }

--- a/lab/public/bundle/manifest/scene223.json
+++ b/lab/public/bundle/manifest/scene223.json
@@ -6,5 +6,6 @@
     "scene223-standard-renderable-e49zYoBk.js",
     "scene223-swapchain-overlay-ilhN4El_.js",
     "scene223.js"
-  ]
+  ],
+  "rawBytes": 66888
 }

--- a/lab/public/bundle/manifest/scene224.json
+++ b/lab/public/bundle/manifest/scene224.json
@@ -6,5 +6,6 @@
     "scene224-standard-renderable-De6I5af8.js",
     "scene224-swapchain-overlay-ilhN4El_.js",
     "scene224.js"
-  ]
+  ],
+  "rawBytes": 81435
 }

--- a/lab/public/bundle/manifest/scene224.json
+++ b/lab/public/bundle/manifest/scene224.json
@@ -7,5 +7,5 @@
     "scene224-swapchain-overlay-ilhN4El_.js",
     "scene224.js"
   ],
-  "rawBytes": 81435
+  "rawBytes": 81327
 }

--- a/lab/public/bundle/manifest/scene225.json
+++ b/lab/public/bundle/manifest/scene225.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene225-standard-renderable-B884z2HX.js",
     "scene225.js"
-  ]
+  ],
+  "rawBytes": 59574
 }

--- a/lab/public/bundle/manifest/scene225.json
+++ b/lab/public/bundle/manifest/scene225.json
@@ -6,5 +6,5 @@
     "scene225-standard-renderable-B884z2HX.js",
     "scene225.js"
   ],
-  "rawBytes": 59574
+  "rawBytes": 59469
 }

--- a/lab/public/bundle/manifest/scene227.json
+++ b/lab/public/bundle/manifest/scene227.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene227-standard-renderable-CerX-0_4.js",
     "scene227.js"
-  ]
+  ],
+  "rawBytes": 49542
 }

--- a/lab/public/bundle/manifest/scene227.json
+++ b/lab/public/bundle/manifest/scene227.json
@@ -6,5 +6,5 @@
     "scene227-standard-renderable-CerX-0_4.js",
     "scene227.js"
   ],
-  "rawBytes": 49542
+  "rawBytes": 49446
 }

--- a/lab/public/bundle/manifest/scene228.json
+++ b/lab/public/bundle/manifest/scene228.json
@@ -6,5 +6,5 @@
     "scene228-standard-renderable-Dn1qrVk0.js",
     "scene228.js"
   ],
-  "rawBytes": 51481
+  "rawBytes": 51365
 }

--- a/lab/public/bundle/manifest/scene228.json
+++ b/lab/public/bundle/manifest/scene228.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene228-standard-renderable-Dn1qrVk0.js",
     "scene228.js"
-  ]
+  ],
+  "rawBytes": 51481
 }

--- a/lab/public/bundle/manifest/scene229.json
+++ b/lab/public/bundle/manifest/scene229.json
@@ -10,5 +10,6 @@
     "scene229-pbr-renderable-BnFxgdwz.js",
     "scene229-unlit-fragment-DWtvt7yQ.js",
     "scene229.js"
-  ]
+  ],
+  "rawBytes": 69536
 }

--- a/lab/public/bundle/manifest/scene229.json
+++ b/lab/public/bundle/manifest/scene229.json
@@ -11,5 +11,5 @@
     "scene229-unlit-fragment-DWtvt7yQ.js",
     "scene229.js"
   ],
-  "rawBytes": 69536
+  "rawBytes": 69447
 }

--- a/lab/public/bundle/manifest/scene23.json
+++ b/lab/public/bundle/manifest/scene23.json
@@ -14,5 +14,5 @@
     "scene23-wgsl-helpers-BgB2AJrF.js",
     "scene23.js"
   ],
-  "rawBytes": 80148
+  "rawBytes": 80044
 }

--- a/lab/public/bundle/manifest/scene23.json
+++ b/lab/public/bundle/manifest/scene23.json
@@ -13,5 +13,6 @@
     "scene23-scene-uniforms-FTYH6Ct0.js",
     "scene23-wgsl-helpers-BgB2AJrF.js",
     "scene23.js"
-  ]
+  ],
+  "rawBytes": 80148
 }

--- a/lab/public/bundle/manifest/scene231.json
+++ b/lab/public/bundle/manifest/scene231.json
@@ -6,5 +6,6 @@
     "scene231-standard-renderable-DfUkAO7_.js",
     "scene231-std-skeleton-fragment-BIMTVdV3.js",
     "scene231.js"
-  ]
+  ],
+  "rawBytes": 54747
 }

--- a/lab/public/bundle/manifest/scene231.json
+++ b/lab/public/bundle/manifest/scene231.json
@@ -7,5 +7,5 @@
     "scene231-std-skeleton-fragment-BIMTVdV3.js",
     "scene231.js"
   ],
-  "rawBytes": 54747
+  "rawBytes": 54643
 }

--- a/lab/public/bundle/manifest/scene24.json
+++ b/lab/public/bundle/manifest/scene24.json
@@ -14,5 +14,6 @@
     "scene24-std-opacity-fragment-BWB8M-CF.js",
     "scene24-std-specular-fragment-DhCYMq1P.js",
     "scene24.js"
-  ]
+  ],
+  "rawBytes": 60298
 }

--- a/lab/public/bundle/manifest/scene24.json
+++ b/lab/public/bundle/manifest/scene24.json
@@ -15,5 +15,5 @@
     "scene24-std-specular-fragment-DhCYMq1P.js",
     "scene24.js"
   ],
-  "rawBytes": 60298
+  "rawBytes": 60156
 }

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -17,5 +17,5 @@
     "scene240-scene-uniforms-FTYH6Ct0.js",
     "scene240.js"
   ],
-  "rawBytes": 93205
+  "rawBytes": 93104
 }

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -16,5 +16,6 @@
     "scene240-rgbd-decode-CuZL2LZR.js",
     "scene240-scene-uniforms-FTYH6Ct0.js",
     "scene240.js"
-  ]
+  ],
+  "rawBytes": 93205
 }

--- a/lab/public/bundle/manifest/scene241.json
+++ b/lab/public/bundle/manifest/scene241.json
@@ -44,5 +44,6 @@
     "scene241-uv-transform-fragment-B8ijWmAK.js",
     "scene241-visibility-CqAUQo5a.js",
     "scene241.js"
-  ]
+  ],
+  "rawBytes": 165646
 }

--- a/lab/public/bundle/manifest/scene241.json
+++ b/lab/public/bundle/manifest/scene241.json
@@ -45,5 +45,5 @@
     "scene241-visibility-CqAUQo5a.js",
     "scene241.js"
   ],
-  "rawBytes": 165646
+  "rawBytes": 165537
 }

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -19,5 +19,5 @@
     "scene242-visibility-CCvf681l.js",
     "scene242.js"
   ],
-  "rawBytes": 99609
+  "rawBytes": 99506
 }

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -18,5 +18,6 @@
     "scene242-scene-uniforms-FTYH6Ct0.js",
     "scene242-visibility-CCvf681l.js",
     "scene242.js"
-  ]
+  ],
+  "rawBytes": 99609
 }

--- a/lab/public/bundle/manifest/scene243.json
+++ b/lab/public/bundle/manifest/scene243.json
@@ -20,5 +20,6 @@
     "scene243-scene-uniforms-FTYH6Ct0.js",
     "scene243-texture-2d-DQo3n8D6.js",
     "scene243.js"
-  ]
+  ],
+  "rawBytes": 99736
 }

--- a/lab/public/bundle/manifest/scene243.json
+++ b/lab/public/bundle/manifest/scene243.json
@@ -21,5 +21,5 @@
     "scene243-texture-2d-DQo3n8D6.js",
     "scene243.js"
   ],
-  "rawBytes": 99736
+  "rawBytes": 99639
 }

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -27,5 +27,6 @@
     "scene244-uv-transform-fragment-B8ijWmAK.js",
     "scene244-visibility-D2SiVGFF.js",
     "scene244.js"
-  ]
+  ],
+  "rawBytes": 136722
 }

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -28,5 +28,5 @@
     "scene244-visibility-D2SiVGFF.js",
     "scene244.js"
   ],
-  "rawBytes": 136722
+  "rawBytes": 136622
 }

--- a/lab/public/bundle/manifest/scene245.json
+++ b/lab/public/bundle/manifest/scene245.json
@@ -22,5 +22,6 @@
     "scene245-scene-uniforms-FTYH6Ct0.js",
     "scene245-skeleton-fragment-DX-M_RZR.js",
     "scene245.js"
-  ]
+  ],
+  "rawBytes": 104334
 }

--- a/lab/public/bundle/manifest/scene245.json
+++ b/lab/public/bundle/manifest/scene245.json
@@ -23,5 +23,5 @@
     "scene245-skeleton-fragment-DX-M_RZR.js",
     "scene245.js"
   ],
-  "rawBytes": 104334
+  "rawBytes": 104231
 }

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -21,5 +21,6 @@
     "scene246-scene-uniforms-FTYH6Ct0.js",
     "scene246-skeleton-fragment-I9To07Fx.js",
     "scene246.js"
-  ]
+  ],
+  "rawBytes": 101922
 }

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -22,5 +22,5 @@
     "scene246-skeleton-fragment-I9To07Fx.js",
     "scene246.js"
   ],
-  "rawBytes": 101922
+  "rawBytes": 101814
 }

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -18,5 +18,5 @@
     "scene247-thin-instance-gpu-BoNgOgQp.js",
     "scene247.js"
   ],
-  "rawBytes": 88119
+  "rawBytes": 88021
 }

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -17,5 +17,6 @@
     "scene247-thin-instance-fragment-CBn2miAC.js",
     "scene247-thin-instance-gpu-BoNgOgQp.js",
     "scene247.js"
-  ]
+  ],
+  "rawBytes": 88119
 }

--- a/lab/public/bundle/manifest/scene248.json
+++ b/lab/public/bundle/manifest/scene248.json
@@ -11,5 +11,6 @@
     "scene248-rgbd-decode-C6qoiNS2.js",
     "scene248-scene-uniforms-FTYH6Ct0.js",
     "scene248.js"
-  ]
+  ],
+  "rawBytes": 78767
 }

--- a/lab/public/bundle/manifest/scene248.json
+++ b/lab/public/bundle/manifest/scene248.json
@@ -12,5 +12,5 @@
     "scene248-scene-uniforms-FTYH6Ct0.js",
     "scene248.js"
   ],
-  "rawBytes": 78767
+  "rawBytes": 78669
 }

--- a/lab/public/bundle/manifest/scene249.json
+++ b/lab/public/bundle/manifest/scene249.json
@@ -14,5 +14,5 @@
     "scene249-scene-uniforms-FTYH6Ct0.js",
     "scene249.js"
   ],
-  "rawBytes": 80386
+  "rawBytes": 80286
 }

--- a/lab/public/bundle/manifest/scene249.json
+++ b/lab/public/bundle/manifest/scene249.json
@@ -13,5 +13,6 @@
     "scene249-rgbd-decode-aJFzOIzF.js",
     "scene249-scene-uniforms-FTYH6Ct0.js",
     "scene249.js"
-  ]
+  ],
+  "rawBytes": 80386
 }

--- a/lab/public/bundle/manifest/scene25.json
+++ b/lab/public/bundle/manifest/scene25.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene25-standard-renderable-DF8rZDaA.js",
     "scene25.js"
-  ]
+  ],
+  "rawBytes": 52734
 }

--- a/lab/public/bundle/manifest/scene25.json
+++ b/lab/public/bundle/manifest/scene25.json
@@ -6,5 +6,5 @@
     "scene25-standard-renderable-DF8rZDaA.js",
     "scene25.js"
   ],
-  "rawBytes": 52734
+  "rawBytes": 52600
 }

--- a/lab/public/bundle/manifest/scene251.json
+++ b/lab/public/bundle/manifest/scene251.json
@@ -15,5 +15,5 @@
     "scene251-skeleton-fragment-BJx0LLQ2.js",
     "scene251.js"
   ],
-  "rawBytes": 91809
+  "rawBytes": 91714
 }

--- a/lab/public/bundle/manifest/scene251.json
+++ b/lab/public/bundle/manifest/scene251.json
@@ -14,5 +14,6 @@
     "scene251-pbr-renderable-CyI-H6RG.js",
     "scene251-skeleton-fragment-BJx0LLQ2.js",
     "scene251.js"
-  ]
+  ],
+  "rawBytes": 91809
 }

--- a/lab/public/bundle/manifest/scene252.json
+++ b/lab/public/bundle/manifest/scene252.json
@@ -7,5 +7,5 @@
     "scene252-standard-renderable-C0_ZZEGh.js",
     "scene252.js"
   ],
-  "rawBytes": 50192
+  "rawBytes": 50083
 }

--- a/lab/public/bundle/manifest/scene252.json
+++ b/lab/public/bundle/manifest/scene252.json
@@ -6,5 +6,6 @@
     "scene252-morph-fragment-core-COF7FjhN.js",
     "scene252-standard-renderable-C0_ZZEGh.js",
     "scene252.js"
-  ]
+  ],
+  "rawBytes": 50192
 }

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -52,5 +52,5 @@
     "scene253-visibility-DzpaYEgE.js",
     "scene253.js"
   ],
-  "rawBytes": 157494
+  "rawBytes": 157395
 }

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -51,5 +51,6 @@
     "scene253-uv-transform-fragment-B8ijWmAK.js",
     "scene253-visibility-DzpaYEgE.js",
     "scene253.js"
-  ]
+  ],
+  "rawBytes": 157494
 }

--- a/lab/public/bundle/manifest/scene254.json
+++ b/lab/public/bundle/manifest/scene254.json
@@ -15,5 +15,6 @@
     "scene254-scene-uniforms-FTYH6Ct0.js",
     "scene254-singlelight-hemispheric-wgsl-DIgy99yY.js",
     "scene254.js"
-  ]
+  ],
+  "rawBytes": 94693
 }

--- a/lab/public/bundle/manifest/scene254.json
+++ b/lab/public/bundle/manifest/scene254.json
@@ -16,5 +16,5 @@
     "scene254-singlelight-hemispheric-wgsl-DIgy99yY.js",
     "scene254.js"
   ],
-  "rawBytes": 94693
+  "rawBytes": 94605
 }

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -18,5 +18,6 @@
     "scene255-scene-uniforms-FTYH6Ct0.js",
     "scene255-skeleton-fragment-Bt_lOxko.js",
     "scene255.js"
-  ]
+  ],
+  "rawBytes": 96453
 }

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -19,5 +19,5 @@
     "scene255-skeleton-fragment-Bt_lOxko.js",
     "scene255.js"
   ],
-  "rawBytes": 96453
+  "rawBytes": 96361
 }

--- a/lab/public/bundle/manifest/scene257.json
+++ b/lab/public/bundle/manifest/scene257.json
@@ -14,5 +14,6 @@
     "scene257-rgbd-decode-C4X6l6Ro.js",
     "scene257-scene-uniforms-FTYH6Ct0.js",
     "scene257.js"
-  ]
+  ],
+  "rawBytes": 82051
 }

--- a/lab/public/bundle/manifest/scene257.json
+++ b/lab/public/bundle/manifest/scene257.json
@@ -15,5 +15,5 @@
     "scene257-scene-uniforms-FTYH6Ct0.js",
     "scene257.js"
   ],
-  "rawBytes": 82051
+  "rawBytes": 81951
 }

--- a/lab/public/bundle/manifest/scene258.json
+++ b/lab/public/bundle/manifest/scene258.json
@@ -16,5 +16,5 @@
     "scene258-scene-uniforms-FTYH6Ct0.js",
     "scene258.js"
   ],
-  "rawBytes": 84948
+  "rawBytes": 84852
 }

--- a/lab/public/bundle/manifest/scene258.json
+++ b/lab/public/bundle/manifest/scene258.json
@@ -15,5 +15,6 @@
     "scene258-rgbd-decode-BPg8jfWX.js",
     "scene258-scene-uniforms-FTYH6Ct0.js",
     "scene258.js"
-  ]
+  ],
+  "rawBytes": 84948
 }

--- a/lab/public/bundle/manifest/scene259.json
+++ b/lab/public/bundle/manifest/scene259.json
@@ -14,5 +14,5 @@
     "scene259-scene-uniforms-FTYH6Ct0.js",
     "scene259.js"
   ],
-  "rawBytes": 78958
+  "rawBytes": 78858
 }

--- a/lab/public/bundle/manifest/scene259.json
+++ b/lab/public/bundle/manifest/scene259.json
@@ -13,5 +13,6 @@
     "scene259-rgbd-decode-CkmHf8hT.js",
     "scene259-scene-uniforms-FTYH6Ct0.js",
     "scene259.js"
-  ]
+  ],
+  "rawBytes": 78958
 }

--- a/lab/public/bundle/manifest/scene26.json
+++ b/lab/public/bundle/manifest/scene26.json
@@ -13,5 +13,6 @@
     "scene26-singlelight-point-wgsl-DZzE_4y0.js",
     "scene26-subsurface-fragment-C_EahV0e.js",
     "scene26.js"
-  ]
+  ],
+  "rawBytes": 91924
 }

--- a/lab/public/bundle/manifest/scene26.json
+++ b/lab/public/bundle/manifest/scene26.json
@@ -14,5 +14,5 @@
     "scene26-subsurface-fragment-C_EahV0e.js",
     "scene26.js"
   ],
-  "rawBytes": 91924
+  "rawBytes": 91828
 }

--- a/lab/public/bundle/manifest/scene260.json
+++ b/lab/public/bundle/manifest/scene260.json
@@ -14,5 +14,6 @@
     "scene260-rgbd-decode-BHKCP5vu.js",
     "scene260-scene-uniforms-FTYH6Ct0.js",
     "scene260.js"
-  ]
+  ],
+  "rawBytes": 82019
 }

--- a/lab/public/bundle/manifest/scene260.json
+++ b/lab/public/bundle/manifest/scene260.json
@@ -15,5 +15,5 @@
     "scene260-scene-uniforms-FTYH6Ct0.js",
     "scene260.js"
   ],
-  "rawBytes": 82019
+  "rawBytes": 81921
 }

--- a/lab/public/bundle/manifest/scene261.json
+++ b/lab/public/bundle/manifest/scene261.json
@@ -6,5 +6,5 @@
     "scene261-standard-renderable-BzpNfwuA.js",
     "scene261.js"
   ],
-  "rawBytes": 55193
+  "rawBytes": 55070
 }

--- a/lab/public/bundle/manifest/scene261.json
+++ b/lab/public/bundle/manifest/scene261.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene261-standard-renderable-BzpNfwuA.js",
     "scene261.js"
-  ]
+  ],
+  "rawBytes": 55193
 }

--- a/lab/public/bundle/manifest/scene262.json
+++ b/lab/public/bundle/manifest/scene262.json
@@ -21,5 +21,6 @@
     "scene262-update-position-block-Bd7HeafP.js",
     "scene262-vec3-ref-BQ9hm9R5.js",
     "scene262.js"
-  ]
+  ],
+  "rawBytes": 43115
 }

--- a/lab/public/bundle/manifest/scene262.json
+++ b/lab/public/bundle/manifest/scene262.json
@@ -22,5 +22,5 @@
     "scene262-vec3-ref-BQ9hm9R5.js",
     "scene262.js"
   ],
-  "rawBytes": 43115
+  "rawBytes": 43019
 }

--- a/lab/public/bundle/manifest/scene263.json
+++ b/lab/public/bundle/manifest/scene263.json
@@ -22,5 +22,5 @@
     "scene263-vec3-ref-BQ9hm9R5.js",
     "scene263.js"
   ],
-  "rawBytes": 44360
+  "rawBytes": 44260
 }

--- a/lab/public/bundle/manifest/scene263.json
+++ b/lab/public/bundle/manifest/scene263.json
@@ -21,5 +21,6 @@
     "scene263-update-position-block-Db3NyC5r.js",
     "scene263-vec3-ref-BQ9hm9R5.js",
     "scene263.js"
-  ]
+  ],
+  "rawBytes": 44360
 }

--- a/lab/public/bundle/manifest/scene264.json
+++ b/lab/public/bundle/manifest/scene264.json
@@ -25,5 +25,5 @@
     "scene264-vec3-ref-BQ9hm9R5.js",
     "scene264.js"
   ],
-  "rawBytes": 41357
+  "rawBytes": 41261
 }

--- a/lab/public/bundle/manifest/scene264.json
+++ b/lab/public/bundle/manifest/scene264.json
@@ -24,5 +24,6 @@
     "scene264-update-size-block-BidWI-OX.js",
     "scene264-vec3-ref-BQ9hm9R5.js",
     "scene264.js"
-  ]
+  ],
+  "rawBytes": 41357
 }

--- a/lab/public/bundle/manifest/scene265.json
+++ b/lab/public/bundle/manifest/scene265.json
@@ -12,5 +12,6 @@
     "scene265-ibl-fragment-CeRrvT96.js",
     "scene265-pbr-renderable-eU1iFJht.js",
     "scene265.js"
-  ]
+  ],
+  "rawBytes": 81795
 }

--- a/lab/public/bundle/manifest/scene265.json
+++ b/lab/public/bundle/manifest/scene265.json
@@ -13,5 +13,5 @@
     "scene265-pbr-renderable-eU1iFJht.js",
     "scene265.js"
   ],
-  "rawBytes": 81795
+  "rawBytes": 81697
 }

--- a/lab/public/bundle/manifest/scene266.json
+++ b/lab/public/bundle/manifest/scene266.json
@@ -13,5 +13,6 @@
     "scene266-rgbd-decode-BlUmJD6L.js",
     "scene266-scene-uniforms-FTYH6Ct0.js",
     "scene266.js"
-  ]
+  ],
+  "rawBytes": 81942
 }

--- a/lab/public/bundle/manifest/scene266.json
+++ b/lab/public/bundle/manifest/scene266.json
@@ -14,5 +14,5 @@
     "scene266-scene-uniforms-FTYH6Ct0.js",
     "scene266.js"
   ],
-  "rawBytes": 81942
+  "rawBytes": 81844
 }

--- a/lab/public/bundle/manifest/scene267.json
+++ b/lab/public/bundle/manifest/scene267.json
@@ -6,5 +6,5 @@
     "scene267-standard-renderable-CyQv56qq.js",
     "scene267.js"
   ],
-  "rawBytes": 43812
+  "rawBytes": 43697
 }

--- a/lab/public/bundle/manifest/scene267.json
+++ b/lab/public/bundle/manifest/scene267.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene267-standard-renderable-CyQv56qq.js",
     "scene267.js"
-  ]
+  ],
+  "rawBytes": 43812
 }

--- a/lab/public/bundle/manifest/scene268.json
+++ b/lab/public/bundle/manifest/scene268.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene268-standard-renderable-BaQyCxGB.js",
     "scene268.js"
-  ]
+  ],
+  "rawBytes": 46992
 }

--- a/lab/public/bundle/manifest/scene268.json
+++ b/lab/public/bundle/manifest/scene268.json
@@ -6,5 +6,5 @@
     "scene268-standard-renderable-BaQyCxGB.js",
     "scene268.js"
   ],
-  "rawBytes": 46992
+  "rawBytes": 46898
 }

--- a/lab/public/bundle/manifest/scene27.json
+++ b/lab/public/bundle/manifest/scene27.json
@@ -15,5 +15,6 @@
     "scene27-singlelight-hemispheric-wgsl-BMMbUYIK.js",
     "scene27-texture-2d-DQo3n8D6.js",
     "scene27.js"
-  ]
+  ],
+  "rawBytes": 84539
 }

--- a/lab/public/bundle/manifest/scene27.json
+++ b/lab/public/bundle/manifest/scene27.json
@@ -16,5 +16,5 @@
     "scene27-texture-2d-DQo3n8D6.js",
     "scene27.js"
   ],
-  "rawBytes": 84539
+  "rawBytes": 84441
 }

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -14,5 +14,5 @@
     "scene28-scene-uniforms-FTYH6Ct0.js",
     "scene28.js"
   ],
-  "rawBytes": 88784
+  "rawBytes": 88687
 }

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -13,5 +13,6 @@
     "scene28-rgbd-decode-DNHi-djf.js",
     "scene28-scene-uniforms-FTYH6Ct0.js",
     "scene28.js"
-  ]
+  ],
+  "rawBytes": 88784
 }

--- a/lab/public/bundle/manifest/scene29.json
+++ b/lab/public/bundle/manifest/scene29.json
@@ -18,5 +18,6 @@
     "scene29-texture-2d-DQo3n8D6.js",
     "scene29-uv-transform-fragment-B8ijWmAK.js",
     "scene29.js"
-  ]
+  ],
+  "rawBytes": 92503
 }

--- a/lab/public/bundle/manifest/scene29.json
+++ b/lab/public/bundle/manifest/scene29.json
@@ -19,5 +19,5 @@
     "scene29-uv-transform-fragment-B8ijWmAK.js",
     "scene29.js"
   ],
-  "rawBytes": 92503
+  "rawBytes": 92407
 }

--- a/lab/public/bundle/manifest/scene3.json
+++ b/lab/public/bundle/manifest/scene3.json
@@ -10,5 +10,5 @@
     "scene3-wgsl-fog-m3PkjS7i.js",
     "scene3.js"
   ],
-  "rawBytes": 56146
+  "rawBytes": 56042
 }

--- a/lab/public/bundle/manifest/scene3.json
+++ b/lab/public/bundle/manifest/scene3.json
@@ -9,5 +9,6 @@
     "scene3-std-fog-wgsl-CUdIP7-q.js",
     "scene3-wgsl-fog-m3PkjS7i.js",
     "scene3.js"
-  ]
+  ],
+  "rawBytes": 56146
 }

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -21,5 +21,6 @@
     "scene30-texture-2d-DQo3n8D6.js",
     "scene30-uv-transform-fragment-B8ijWmAK.js",
     "scene30.js"
-  ]
+  ],
+  "rawBytes": 106205
 }

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -22,5 +22,5 @@
     "scene30-uv-transform-fragment-B8ijWmAK.js",
     "scene30.js"
   ],
-  "rawBytes": 106205
+  "rawBytes": 106103
 }

--- a/lab/public/bundle/manifest/scene31.json
+++ b/lab/public/bundle/manifest/scene31.json
@@ -14,5 +14,5 @@
     "scene31-scene-uniforms-FTYH6Ct0.js",
     "scene31.js"
   ],
-  "rawBytes": 82013
+  "rawBytes": 81919
 }

--- a/lab/public/bundle/manifest/scene31.json
+++ b/lab/public/bundle/manifest/scene31.json
@@ -13,5 +13,6 @@
     "scene31-rgbd-decode-CT6Q-rdi.js",
     "scene31-scene-uniforms-FTYH6Ct0.js",
     "scene31.js"
-  ]
+  ],
+  "rawBytes": 82013
 }

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -13,5 +13,6 @@
     "scene32-scene-uniforms-FTYH6Ct0.js",
     "scene32-unlit-fragment-DWtvt7yQ.js",
     "scene32.js"
-  ]
+  ],
+  "rawBytes": 81842
 }

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -14,5 +14,5 @@
     "scene32-unlit-fragment-DWtvt7yQ.js",
     "scene32.js"
   ],
-  "rawBytes": 81842
+  "rawBytes": 81748
 }

--- a/lab/public/bundle/manifest/scene33.json
+++ b/lab/public/bundle/manifest/scene33.json
@@ -21,5 +21,5 @@
     "scene33-scene-uniforms-FTYH6Ct0.js",
     "scene33.js"
   ],
-  "rawBytes": 106052
+  "rawBytes": 105955
 }

--- a/lab/public/bundle/manifest/scene33.json
+++ b/lab/public/bundle/manifest/scene33.json
@@ -20,5 +20,6 @@
     "scene33-rgbd-decode-CBCiayil.js",
     "scene33-scene-uniforms-FTYH6Ct0.js",
     "scene33.js"
-  ]
+  ],
+  "rawBytes": 106052
 }

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -18,5 +18,6 @@
     "scene34-scene-uniforms-FTYH6Ct0.js",
     "scene34-visibility-DXbo0bsF.js",
     "scene34.js"
-  ]
+  ],
+  "rawBytes": 100292
 }

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -19,5 +19,5 @@
     "scene34-visibility-DXbo0bsF.js",
     "scene34.js"
   ],
-  "rawBytes": 100292
+  "rawBytes": 100196
 }

--- a/lab/public/bundle/manifest/scene35.json
+++ b/lab/public/bundle/manifest/scene35.json
@@ -15,5 +15,5 @@
     "scene35-thin-instance-gpu-akqUuIbn.js",
     "scene35.js"
   ],
-  "rawBytes": 85883
+  "rawBytes": 85791
 }

--- a/lab/public/bundle/manifest/scene35.json
+++ b/lab/public/bundle/manifest/scene35.json
@@ -14,5 +14,6 @@
     "scene35-thin-instance-fragment-CBn2miAC.js",
     "scene35-thin-instance-gpu-akqUuIbn.js",
     "scene35.js"
-  ]
+  ],
+  "rawBytes": 85883
 }

--- a/lab/public/bundle/manifest/scene36.json
+++ b/lab/public/bundle/manifest/scene36.json
@@ -6,5 +6,6 @@
     "scene36-standard-renderable-5voU6dC5.js",
     "scene36-std-emissive-fragment-DthzsVUc.js",
     "scene36.js"
-  ]
+  ],
+  "rawBytes": 52715
 }

--- a/lab/public/bundle/manifest/scene36.json
+++ b/lab/public/bundle/manifest/scene36.json
@@ -7,5 +7,5 @@
     "scene36-std-emissive-fragment-DthzsVUc.js",
     "scene36.js"
   ],
-  "rawBytes": 52715
+  "rawBytes": 52601
 }

--- a/lab/public/bundle/manifest/scene37.json
+++ b/lab/public/bundle/manifest/scene37.json
@@ -22,5 +22,5 @@
     "scene37-uv-transform-fragment-B8ijWmAK.js",
     "scene37.js"
   ],
-  "rawBytes": 99357
+  "rawBytes": 99258
 }

--- a/lab/public/bundle/manifest/scene37.json
+++ b/lab/public/bundle/manifest/scene37.json
@@ -21,5 +21,6 @@
     "scene37-texture-2d-DQo3n8D6.js",
     "scene37-uv-transform-fragment-B8ijWmAK.js",
     "scene37.js"
-  ]
+  ],
+  "rawBytes": 99357
 }

--- a/lab/public/bundle/manifest/scene38.json
+++ b/lab/public/bundle/manifest/scene38.json
@@ -6,5 +6,5 @@
     "scene38-standard-renderable-D08EiPDr.js",
     "scene38.js"
   ],
-  "rawBytes": 62743
+  "rawBytes": 62652
 }

--- a/lab/public/bundle/manifest/scene38.json
+++ b/lab/public/bundle/manifest/scene38.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene38-standard-renderable-D08EiPDr.js",
     "scene38.js"
-  ]
+  ],
+  "rawBytes": 62743
 }

--- a/lab/public/bundle/manifest/scene39.json
+++ b/lab/public/bundle/manifest/scene39.json
@@ -30,5 +30,6 @@
     "scene39-uv-transform-fragment-B8ijWmAK.js",
     "scene39-visibility-C8-zL1dC.js",
     "scene39.js"
-  ]
+  ],
+  "rawBytes": 112357
 }

--- a/lab/public/bundle/manifest/scene39.json
+++ b/lab/public/bundle/manifest/scene39.json
@@ -31,5 +31,5 @@
     "scene39-visibility-C8-zL1dC.js",
     "scene39.js"
   ],
-  "rawBytes": 112357
+  "rawBytes": 112254
 }

--- a/lab/public/bundle/manifest/scene4.json
+++ b/lab/public/bundle/manifest/scene4.json
@@ -12,5 +12,5 @@
     "scene4-std-shadow-fragment-pwyXRo4i.js",
     "scene4.js"
   ],
-  "rawBytes": 74487
+  "rawBytes": 74382
 }

--- a/lab/public/bundle/manifest/scene4.json
+++ b/lab/public/bundle/manifest/scene4.json
@@ -11,5 +11,6 @@
     "scene4-standard-renderable-DXLBxL1A.js",
     "scene4-std-shadow-fragment-pwyXRo4i.js",
     "scene4.js"
-  ]
+  ],
+  "rawBytes": 74487
 }

--- a/lab/public/bundle/manifest/scene40.json
+++ b/lab/public/bundle/manifest/scene40.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene40-standard-renderable-reN-BJcF.js",
     "scene40.js"
-  ]
+  ],
+  "rawBytes": 50907
 }

--- a/lab/public/bundle/manifest/scene40.json
+++ b/lab/public/bundle/manifest/scene40.json
@@ -6,5 +6,5 @@
     "scene40-standard-renderable-reN-BJcF.js",
     "scene40.js"
   ],
-  "rawBytes": 50907
+  "rawBytes": 50789
 }

--- a/lab/public/bundle/manifest/scene41.json
+++ b/lab/public/bundle/manifest/scene41.json
@@ -12,5 +12,6 @@
     "scene41-point-light-CvySeHAG.js",
     "scene41-standard-renderable-AIXG2apz.js",
     "scene41.js"
-  ]
+  ],
+  "rawBytes": 94546
 }

--- a/lab/public/bundle/manifest/scene41.json
+++ b/lab/public/bundle/manifest/scene41.json
@@ -13,5 +13,5 @@
     "scene41-standard-renderable-AIXG2apz.js",
     "scene41.js"
   ],
-  "rawBytes": 94546
+  "rawBytes": 94459
 }

--- a/lab/public/bundle/manifest/scene42.json
+++ b/lab/public/bundle/manifest/scene42.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene42-standard-renderable-Ez0za1eb.js",
     "scene42.js"
-  ]
+  ],
+  "rawBytes": 52543
 }

--- a/lab/public/bundle/manifest/scene42.json
+++ b/lab/public/bundle/manifest/scene42.json
@@ -6,5 +6,5 @@
     "scene42-standard-renderable-Ez0za1eb.js",
     "scene42.js"
   ],
-  "rawBytes": 52543
+  "rawBytes": 52409
 }

--- a/lab/public/bundle/manifest/scene43.json
+++ b/lab/public/bundle/manifest/scene43.json
@@ -8,5 +8,5 @@
     "scene43-thin-instance-gpu-BBn8oq97.js",
     "scene43.js"
   ],
-  "rawBytes": 60209
+  "rawBytes": 60093
 }

--- a/lab/public/bundle/manifest/scene43.json
+++ b/lab/public/bundle/manifest/scene43.json
@@ -7,5 +7,6 @@
     "scene43-thin-instance-fragment-CBn2miAC.js",
     "scene43-thin-instance-gpu-BBn8oq97.js",
     "scene43.js"
-  ]
+  ],
+  "rawBytes": 60209
 }

--- a/lab/public/bundle/manifest/scene44.json
+++ b/lab/public/bundle/manifest/scene44.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene44-standard-renderable-Bwr3ul9c.js",
     "scene44.js"
-  ]
+  ],
+  "rawBytes": 51386
 }

--- a/lab/public/bundle/manifest/scene44.json
+++ b/lab/public/bundle/manifest/scene44.json
@@ -6,5 +6,5 @@
     "scene44-standard-renderable-Bwr3ul9c.js",
     "scene44.js"
   ],
-  "rawBytes": 51386
+  "rawBytes": 51267
 }

--- a/lab/public/bundle/manifest/scene45.json
+++ b/lab/public/bundle/manifest/scene45.json
@@ -6,5 +6,5 @@
     "scene45-standard-renderable-BLPcE0F5.js",
     "scene45.js"
   ],
-  "rawBytes": 52701
+  "rawBytes": 52576
 }

--- a/lab/public/bundle/manifest/scene45.json
+++ b/lab/public/bundle/manifest/scene45.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene45-standard-renderable-BLPcE0F5.js",
     "scene45.js"
-  ]
+  ],
+  "rawBytes": 52701
 }

--- a/lab/public/bundle/manifest/scene46.json
+++ b/lab/public/bundle/manifest/scene46.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene46-standard-renderable-UBs2tsoM.js",
     "scene46.js"
-  ]
+  ],
+  "rawBytes": 55737
 }

--- a/lab/public/bundle/manifest/scene46.json
+++ b/lab/public/bundle/manifest/scene46.json
@@ -6,5 +6,5 @@
     "scene46-standard-renderable-UBs2tsoM.js",
     "scene46.js"
   ],
-  "rawBytes": 55737
+  "rawBytes": 55604
 }

--- a/lab/public/bundle/manifest/scene47.json
+++ b/lab/public/bundle/manifest/scene47.json
@@ -11,5 +11,6 @@
     "scene47-mesh-features-Dda6QcW-.js",
     "scene47-standard-renderable-B1PqGVBa.js",
     "scene47.js"
-  ]
+  ],
+  "rawBytes": 93449
 }

--- a/lab/public/bundle/manifest/scene47.json
+++ b/lab/public/bundle/manifest/scene47.json
@@ -12,5 +12,5 @@
     "scene47-standard-renderable-B1PqGVBa.js",
     "scene47.js"
   ],
-  "rawBytes": 93449
+  "rawBytes": 93349
 }

--- a/lab/public/bundle/manifest/scene48.json
+++ b/lab/public/bundle/manifest/scene48.json
@@ -6,5 +6,5 @@
     "scene48-standard-renderable-B5JH9i1c.js",
     "scene48.js"
   ],
-  "rawBytes": 55546
+  "rawBytes": 55415
 }

--- a/lab/public/bundle/manifest/scene48.json
+++ b/lab/public/bundle/manifest/scene48.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene48-standard-renderable-B5JH9i1c.js",
     "scene48.js"
-  ]
+  ],
+  "rawBytes": 55546
 }

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -8,5 +8,5 @@
     "scene49-swapchain-overlay-ilhN4El_.js",
     "scene49.js"
   ],
-  "rawBytes": 91992
+  "rawBytes": 91893
 }

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -7,5 +7,6 @@
     "scene49-standard-renderable-DNKfQv4C.js",
     "scene49-swapchain-overlay-ilhN4El_.js",
     "scene49.js"
-  ]
+  ],
+  "rawBytes": 91992
 }

--- a/lab/public/bundle/manifest/scene5.json
+++ b/lab/public/bundle/manifest/scene5.json
@@ -20,5 +20,5 @@
     "scene5-skeleton-fragment-BjBWmkNL.js",
     "scene5.js"
   ],
-  "rawBytes": 94178
+  "rawBytes": 94066
 }

--- a/lab/public/bundle/manifest/scene5.json
+++ b/lab/public/bundle/manifest/scene5.json
@@ -19,5 +19,6 @@
     "scene5-singlelight-hemispheric-wgsl-CMZ8qc16.js",
     "scene5-skeleton-fragment-BjBWmkNL.js",
     "scene5.js"
-  ]
+  ],
+  "rawBytes": 94178
 }

--- a/lab/public/bundle/manifest/scene50.json
+++ b/lab/public/bundle/manifest/scene50.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene50.js"
-  ]
+  ],
+  "rawBytes": 15915
 }

--- a/lab/public/bundle/manifest/scene51.json
+++ b/lab/public/bundle/manifest/scene51.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene51.js"
-  ]
+  ],
+  "rawBytes": 16340
 }

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -6,5 +6,5 @@
     "scene52-standard-renderable-BFLmSxXa.js",
     "scene52.js"
   ],
-  "rawBytes": 58684
+  "rawBytes": 58566
 }

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene52-standard-renderable-BFLmSxXa.js",
     "scene52.js"
-  ]
+  ],
+  "rawBytes": 58684
 }

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -6,5 +6,5 @@
     "scene53-standard-renderable-DaD1sbsL.js",
     "scene53.js"
   ],
-  "rawBytes": 58334
+  "rawBytes": 58227
 }

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene53-standard-renderable-DaD1sbsL.js",
     "scene53.js"
-  ]
+  ],
+  "rawBytes": 58334
 }

--- a/lab/public/bundle/manifest/scene54.json
+++ b/lab/public/bundle/manifest/scene54.json
@@ -7,5 +7,6 @@
     "scene54-scene-uniforms-FTYH6Ct0.js",
     "scene54-standard-renderable-CVXf7MEA.js",
     "scene54.js"
-  ]
+  ],
+  "rawBytes": 61057
 }

--- a/lab/public/bundle/manifest/scene54.json
+++ b/lab/public/bundle/manifest/scene54.json
@@ -8,5 +8,5 @@
     "scene54-standard-renderable-CVXf7MEA.js",
     "scene54.js"
   ],
-  "rawBytes": 61057
+  "rawBytes": 60960
 }

--- a/lab/public/bundle/manifest/scene55.json
+++ b/lab/public/bundle/manifest/scene55.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene55-billboard-renderable-DleldkEk.js",
     "scene55.js"
-  ]
+  ],
+  "rawBytes": 32140
 }

--- a/lab/public/bundle/manifest/scene55.json
+++ b/lab/public/bundle/manifest/scene55.json
@@ -6,5 +6,5 @@
     "scene55-billboard-renderable-DleldkEk.js",
     "scene55.js"
   ],
-  "rawBytes": 32140
+  "rawBytes": 31954
 }

--- a/lab/public/bundle/manifest/scene56.json
+++ b/lab/public/bundle/manifest/scene56.json
@@ -8,5 +8,5 @@
     "scene56-standard-renderable-CGoDechb.js",
     "scene56.js"
   ],
-  "rawBytes": 61268
+  "rawBytes": 61171
 }

--- a/lab/public/bundle/manifest/scene56.json
+++ b/lab/public/bundle/manifest/scene56.json
@@ -7,5 +7,6 @@
     "scene56-scene-uniforms-FTYH6Ct0.js",
     "scene56-standard-renderable-CGoDechb.js",
     "scene56.js"
-  ]
+  ],
+  "rawBytes": 61268
 }

--- a/lab/public/bundle/manifest/scene57.json
+++ b/lab/public/bundle/manifest/scene57.json
@@ -7,5 +7,6 @@
     "scene57-scene-uniforms-FTYH6Ct0.js",
     "scene57-standard-renderable-B5xr-iqQ.js",
     "scene57.js"
-  ]
+  ],
+  "rawBytes": 61159
 }

--- a/lab/public/bundle/manifest/scene57.json
+++ b/lab/public/bundle/manifest/scene57.json
@@ -8,5 +8,5 @@
     "scene57-standard-renderable-B5xr-iqQ.js",
     "scene57.js"
   ],
-  "rawBytes": 61159
+  "rawBytes": 61049
 }

--- a/lab/public/bundle/manifest/scene58.json
+++ b/lab/public/bundle/manifest/scene58.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene58.js"
-  ]
+  ],
+  "rawBytes": 18664
 }

--- a/lab/public/bundle/manifest/scene59.json
+++ b/lab/public/bundle/manifest/scene59.json
@@ -7,5 +7,6 @@
     "scene59-scene-uniforms-FTYH6Ct0.js",
     "scene59-standard-renderable-DRR3Pz6o.js",
     "scene59.js"
-  ]
+  ],
+  "rawBytes": 63768
 }

--- a/lab/public/bundle/manifest/scene59.json
+++ b/lab/public/bundle/manifest/scene59.json
@@ -8,5 +8,5 @@
     "scene59-standard-renderable-DRR3Pz6o.js",
     "scene59.js"
   ],
-  "rawBytes": 63768
+  "rawBytes": 63650
 }

--- a/lab/public/bundle/manifest/scene6.json
+++ b/lab/public/bundle/manifest/scene6.json
@@ -13,5 +13,5 @@
     "scene6-wgsl-helpers-BgB2AJrF.js",
     "scene6.js"
   ],
-  "rawBytes": 74224
+  "rawBytes": 74105
 }

--- a/lab/public/bundle/manifest/scene6.json
+++ b/lab/public/bundle/manifest/scene6.json
@@ -12,5 +12,6 @@
     "scene6-scene-uniforms-FTYH6Ct0.js",
     "scene6-wgsl-helpers-BgB2AJrF.js",
     "scene6.js"
-  ]
+  ],
+  "rawBytes": 74224
 }

--- a/lab/public/bundle/manifest/scene60.json
+++ b/lab/public/bundle/manifest/scene60.json
@@ -12,5 +12,5 @@
     "scene60-vertex-output-C7G5u6Y0.js",
     "scene60.js"
   ],
-  "rawBytes": 55429
+  "rawBytes": 55329
 }

--- a/lab/public/bundle/manifest/scene60.json
+++ b/lab/public/bundle/manifest/scene60.json
@@ -11,5 +11,6 @@
     "scene60-transform-block-Cok05vIU.js",
     "scene60-vertex-output-C7G5u6Y0.js",
     "scene60.js"
-  ]
+  ],
+  "rawBytes": 55429
 }

--- a/lab/public/bundle/manifest/scene61.json
+++ b/lab/public/bundle/manifest/scene61.json
@@ -13,5 +13,6 @@
     "scene61-transform-block-Bn0rX0Dn.js",
     "scene61-vertex-output-C7G5u6Y0.js",
     "scene61.js"
-  ]
+  ],
+  "rawBytes": 54328
 }

--- a/lab/public/bundle/manifest/scene61.json
+++ b/lab/public/bundle/manifest/scene61.json
@@ -14,5 +14,5 @@
     "scene61-vertex-output-C7G5u6Y0.js",
     "scene61.js"
   ],
-  "rawBytes": 54328
+  "rawBytes": 54221
 }

--- a/lab/public/bundle/manifest/scene62.json
+++ b/lab/public/bundle/manifest/scene62.json
@@ -14,5 +14,5 @@
     "scene62-vertex-output-C7G5u6Y0.js",
     "scene62.js"
   ],
-  "rawBytes": 60039
+  "rawBytes": 59936
 }

--- a/lab/public/bundle/manifest/scene62.json
+++ b/lab/public/bundle/manifest/scene62.json
@@ -13,5 +13,6 @@
     "scene62-transform-block-joLLcrsq.js",
     "scene62-vertex-output-C7G5u6Y0.js",
     "scene62.js"
-  ]
+  ],
+  "rawBytes": 60039
 }

--- a/lab/public/bundle/manifest/scene63.json
+++ b/lab/public/bundle/manifest/scene63.json
@@ -12,5 +12,6 @@
     "scene63-transform-block-DCRg5SH0.js",
     "scene63-vertex-output-C7G5u6Y0.js",
     "scene63.js"
-  ]
+  ],
+  "rawBytes": 58716
 }

--- a/lab/public/bundle/manifest/scene63.json
+++ b/lab/public/bundle/manifest/scene63.json
@@ -13,5 +13,5 @@
     "scene63-vertex-output-C7G5u6Y0.js",
     "scene63.js"
   ],
-  "rawBytes": 58716
+  "rawBytes": 58606
 }

--- a/lab/public/bundle/manifest/scene64.json
+++ b/lab/public/bundle/manifest/scene64.json
@@ -13,5 +13,5 @@
     "scene64-vertex-output-C7G5u6Y0.js",
     "scene64.js"
   ],
-  "rawBytes": 56646
+  "rawBytes": 56544
 }

--- a/lab/public/bundle/manifest/scene64.json
+++ b/lab/public/bundle/manifest/scene64.json
@@ -12,5 +12,6 @@
     "scene64-transform-block-DdGmVCAg.js",
     "scene64-vertex-output-C7G5u6Y0.js",
     "scene64.js"
-  ]
+  ],
+  "rawBytes": 56646
 }

--- a/lab/public/bundle/manifest/scene65.json
+++ b/lab/public/bundle/manifest/scene65.json
@@ -17,5 +17,6 @@
     "scene65-transform-block-BaCdcvKO.js",
     "scene65-vertex-output-C7G5u6Y0.js",
     "scene65.js"
-  ]
+  ],
+  "rawBytes": 74947
 }

--- a/lab/public/bundle/manifest/scene65.json
+++ b/lab/public/bundle/manifest/scene65.json
@@ -18,5 +18,5 @@
     "scene65-vertex-output-C7G5u6Y0.js",
     "scene65.js"
   ],
-  "rawBytes": 74947
+  "rawBytes": 74843
 }

--- a/lab/public/bundle/manifest/scene66.json
+++ b/lab/public/bundle/manifest/scene66.json
@@ -41,5 +41,5 @@
     "scene66-vertex-output-C7G5u6Y0.js",
     "scene66.js"
   ],
-  "rawBytes": 89604
+  "rawBytes": 89499
 }

--- a/lab/public/bundle/manifest/scene66.json
+++ b/lab/public/bundle/manifest/scene66.json
@@ -40,5 +40,6 @@
     "scene66-vector-splitter-CQIcUojE.js",
     "scene66-vertex-output-C7G5u6Y0.js",
     "scene66.js"
-  ]
+  ],
+  "rawBytes": 89604
 }

--- a/lab/public/bundle/manifest/scene67.json
+++ b/lab/public/bundle/manifest/scene67.json
@@ -17,5 +17,5 @@
     "scene67-vertex-output-C7G5u6Y0.js",
     "scene67.js"
   ],
-  "rawBytes": 76576
+  "rawBytes": 76466
 }

--- a/lab/public/bundle/manifest/scene67.json
+++ b/lab/public/bundle/manifest/scene67.json
@@ -16,5 +16,6 @@
     "scene67-transform-block-B0Xv3i1T.js",
     "scene67-vertex-output-C7G5u6Y0.js",
     "scene67.js"
-  ]
+  ],
+  "rawBytes": 76576
 }

--- a/lab/public/bundle/manifest/scene68.json
+++ b/lab/public/bundle/manifest/scene68.json
@@ -17,5 +17,5 @@
     "scene68-vertex-output-C7G5u6Y0.js",
     "scene68.js"
   ],
-  "rawBytes": 91449
+  "rawBytes": 91335
 }

--- a/lab/public/bundle/manifest/scene68.json
+++ b/lab/public/bundle/manifest/scene68.json
@@ -16,5 +16,6 @@
     "scene68-transform-block-DB_xSvh7.js",
     "scene68-vertex-output-C7G5u6Y0.js",
     "scene68.js"
-  ]
+  ],
+  "rawBytes": 91449
 }

--- a/lab/public/bundle/manifest/scene69.json
+++ b/lab/public/bundle/manifest/scene69.json
@@ -18,5 +18,5 @@
     "scene69-vertex-output-C7G5u6Y0.js",
     "scene69.js"
   ],
-  "rawBytes": 90894
+  "rawBytes": 90782
 }

--- a/lab/public/bundle/manifest/scene69.json
+++ b/lab/public/bundle/manifest/scene69.json
@@ -17,5 +17,6 @@
     "scene69-transform-block-CLdLAGMF.js",
     "scene69-vertex-output-C7G5u6Y0.js",
     "scene69.js"
-  ]
+  ],
+  "rawBytes": 90894
 }

--- a/lab/public/bundle/manifest/scene7.json
+++ b/lab/public/bundle/manifest/scene7.json
@@ -23,5 +23,5 @@
     "scene7-wgsl-helpers-BgB2AJrF.js",
     "scene7.js"
   ],
-  "rawBytes": 107874
+  "rawBytes": 107780
 }

--- a/lab/public/bundle/manifest/scene7.json
+++ b/lab/public/bundle/manifest/scene7.json
@@ -22,5 +22,6 @@
     "scene7-skybox.vertex-Ban7q6IM-D1KSfOUq.js",
     "scene7-wgsl-helpers-BgB2AJrF.js",
     "scene7.js"
-  ]
+  ],
+  "rawBytes": 107874
 }

--- a/lab/public/bundle/manifest/scene70.json
+++ b/lab/public/bundle/manifest/scene70.json
@@ -18,5 +18,6 @@
     "scene70-transform-block-CQATYNMr.js",
     "scene70-vertex-output-C7G5u6Y0.js",
     "scene70.js"
-  ]
+  ],
+  "rawBytes": 91195
 }

--- a/lab/public/bundle/manifest/scene70.json
+++ b/lab/public/bundle/manifest/scene70.json
@@ -19,5 +19,5 @@
     "scene70-vertex-output-C7G5u6Y0.js",
     "scene70.js"
   ],
-  "rawBytes": 91195
+  "rawBytes": 91088
 }

--- a/lab/public/bundle/manifest/scene71.json
+++ b/lab/public/bundle/manifest/scene71.json
@@ -18,5 +18,5 @@
     "scene71-vertex-output-C7G5u6Y0.js",
     "scene71.js"
   ],
-  "rawBytes": 91067
+  "rawBytes": 90959
 }

--- a/lab/public/bundle/manifest/scene71.json
+++ b/lab/public/bundle/manifest/scene71.json
@@ -17,5 +17,6 @@
     "scene71-transform-block-DCJBpYz6.js",
     "scene71-vertex-output-C7G5u6Y0.js",
     "scene71.js"
-  ]
+  ],
+  "rawBytes": 91067
 }

--- a/lab/public/bundle/manifest/scene72.json
+++ b/lab/public/bundle/manifest/scene72.json
@@ -31,5 +31,6 @@
     "scene72-vector-merger-YcC3xFyg.js",
     "scene72-vertex-output-C7G5u6Y0.js",
     "scene72.js"
-  ]
+  ],
+  "rawBytes": 109262
 }

--- a/lab/public/bundle/manifest/scene72.json
+++ b/lab/public/bundle/manifest/scene72.json
@@ -32,5 +32,5 @@
     "scene72-vertex-output-C7G5u6Y0.js",
     "scene72.js"
   ],
-  "rawBytes": 109262
+  "rawBytes": 109160
 }

--- a/lab/public/bundle/manifest/scene73.json
+++ b/lab/public/bundle/manifest/scene73.json
@@ -27,5 +27,5 @@
     "scene73-vertex-output-C7G5u6Y0.js",
     "scene73.js"
   ],
-  "rawBytes": 144875
+  "rawBytes": 144782
 }

--- a/lab/public/bundle/manifest/scene73.json
+++ b/lab/public/bundle/manifest/scene73.json
@@ -26,5 +26,6 @@
     "scene73-transform-block-DxObegvg.js",
     "scene73-vertex-output-C7G5u6Y0.js",
     "scene73.js"
-  ]
+  ],
+  "rawBytes": 144875
 }

--- a/lab/public/bundle/manifest/scene74.json
+++ b/lab/public/bundle/manifest/scene74.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene74.js"
-  ]
+  ],
+  "rawBytes": 8767
 }

--- a/lab/public/bundle/manifest/scene75.json
+++ b/lab/public/bundle/manifest/scene75.json
@@ -5,5 +5,6 @@
   "runtimeChunks": [
     "scene75-standard-renderable-ZwLPKP0u.js",
     "scene75.js"
-  ]
+  ],
+  "rawBytes": 50733
 }

--- a/lab/public/bundle/manifest/scene75.json
+++ b/lab/public/bundle/manifest/scene75.json
@@ -6,5 +6,5 @@
     "scene75-standard-renderable-ZwLPKP0u.js",
     "scene75.js"
   ],
-  "rawBytes": 50733
+  "rawBytes": 50634
 }

--- a/lab/public/bundle/manifest/scene76.json
+++ b/lab/public/bundle/manifest/scene76.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene76.js"
-  ]
+  ],
+  "rawBytes": 9636
 }

--- a/lab/public/bundle/manifest/scene77.json
+++ b/lab/public/bundle/manifest/scene77.json
@@ -21,5 +21,5 @@
     "scene77-vertex-output-C7G5u6Y0.js",
     "scene77.js"
   ],
-  "rawBytes": 59228
+  "rawBytes": 59123
 }

--- a/lab/public/bundle/manifest/scene77.json
+++ b/lab/public/bundle/manifest/scene77.json
@@ -20,5 +20,6 @@
     "scene77-vector-splitter-BsUvwv5L.js",
     "scene77-vertex-output-C7G5u6Y0.js",
     "scene77.js"
-  ]
+  ],
+  "rawBytes": 59228
 }

--- a/lab/public/bundle/manifest/scene78.json
+++ b/lab/public/bundle/manifest/scene78.json
@@ -28,5 +28,6 @@
     "scene78-vector-splitter-C6WU4fje.js",
     "scene78-vertex-output-C7G5u6Y0.js",
     "scene78.js"
-  ]
+  ],
+  "rawBytes": 57579
 }

--- a/lab/public/bundle/manifest/scene78.json
+++ b/lab/public/bundle/manifest/scene78.json
@@ -29,5 +29,5 @@
     "scene78-vertex-output-C7G5u6Y0.js",
     "scene78.js"
   ],
-  "rawBytes": 57579
+  "rawBytes": 57474
 }

--- a/lab/public/bundle/manifest/scene79.json
+++ b/lab/public/bundle/manifest/scene79.json
@@ -23,5 +23,5 @@
     "scene79-wave-block-BSzEr0oO.js",
     "scene79.js"
   ],
-  "rawBytes": 60773
+  "rawBytes": 60666
 }

--- a/lab/public/bundle/manifest/scene79.json
+++ b/lab/public/bundle/manifest/scene79.json
@@ -22,5 +22,6 @@
     "scene79-vertex-output-C7G5u6Y0.js",
     "scene79-wave-block-BSzEr0oO.js",
     "scene79.js"
-  ]
+  ],
+  "rawBytes": 60773
 }

--- a/lab/public/bundle/manifest/scene8.json
+++ b/lab/public/bundle/manifest/scene8.json
@@ -11,5 +11,5 @@
     "scene8-singlelight-point-wgsl-2QlXbmIF.js",
     "scene8.js"
   ],
-  "rawBytes": 76348
+  "rawBytes": 76244
 }

--- a/lab/public/bundle/manifest/scene8.json
+++ b/lab/public/bundle/manifest/scene8.json
@@ -10,5 +10,6 @@
     "scene8-scene-uniforms-FTYH6Ct0.js",
     "scene8-singlelight-point-wgsl-2QlXbmIF.js",
     "scene8.js"
-  ]
+  ],
+  "rawBytes": 76348
 }

--- a/lab/public/bundle/manifest/scene80.json
+++ b/lab/public/bundle/manifest/scene80.json
@@ -20,5 +20,5 @@
     "scene80-vertex-output-C7G5u6Y0.js",
     "scene80.js"
   ],
-  "rawBytes": 60451
+  "rawBytes": 60346
 }

--- a/lab/public/bundle/manifest/scene80.json
+++ b/lab/public/bundle/manifest/scene80.json
@@ -19,5 +19,6 @@
     "scene80-vector-splitter-BK_eLmNK.js",
     "scene80-vertex-output-C7G5u6Y0.js",
     "scene80.js"
-  ]
+  ],
+  "rawBytes": 60451
 }

--- a/lab/public/bundle/manifest/scene81.json
+++ b/lab/public/bundle/manifest/scene81.json
@@ -20,5 +20,5 @@
     "scene81-vertex-output-C7G5u6Y0.js",
     "scene81.js"
   ],
-  "rawBytes": 66549
+  "rawBytes": 66442
 }

--- a/lab/public/bundle/manifest/scene81.json
+++ b/lab/public/bundle/manifest/scene81.json
@@ -19,5 +19,6 @@
     "scene81-triplanar-block-BsmOH9oT.js",
     "scene81-vertex-output-C7G5u6Y0.js",
     "scene81.js"
-  ]
+  ],
+  "rawBytes": 66549
 }

--- a/lab/public/bundle/manifest/scene82.json
+++ b/lab/public/bundle/manifest/scene82.json
@@ -24,5 +24,5 @@
     "scene82-worley-noise-3d-block-DvnzjY-o.js",
     "scene82.js"
   ],
-  "rawBytes": 66301
+  "rawBytes": 66192
 }

--- a/lab/public/bundle/manifest/scene82.json
+++ b/lab/public/bundle/manifest/scene82.json
@@ -23,5 +23,6 @@
     "scene82-voronoi-noise-block-qKswGW4q.js",
     "scene82-worley-noise-3d-block-DvnzjY-o.js",
     "scene82.js"
-  ]
+  ],
+  "rawBytes": 66301
 }

--- a/lab/public/bundle/manifest/scene83.json
+++ b/lab/public/bundle/manifest/scene83.json
@@ -28,5 +28,5 @@
     "scene83-vertex-output-C7G5u6Y0.js",
     "scene83.js"
   ],
-  "rawBytes": 70380
+  "rawBytes": 70270
 }

--- a/lab/public/bundle/manifest/scene83.json
+++ b/lab/public/bundle/manifest/scene83.json
@@ -27,5 +27,6 @@
     "scene83-vector-splitter-D3gcJxEP.js",
     "scene83-vertex-output-C7G5u6Y0.js",
     "scene83.js"
-  ]
+  ],
+  "rawBytes": 70380
 }

--- a/lab/public/bundle/manifest/scene84.json
+++ b/lab/public/bundle/manifest/scene84.json
@@ -23,5 +23,6 @@
     "scene84-vector-splitter-BB8dPQl7.js",
     "scene84-vertex-output-C7G5u6Y0.js",
     "scene84.js"
-  ]
+  ],
+  "rawBytes": 84540
 }

--- a/lab/public/bundle/manifest/scene84.json
+++ b/lab/public/bundle/manifest/scene84.json
@@ -24,5 +24,5 @@
     "scene84-vertex-output-C7G5u6Y0.js",
     "scene84.js"
   ],
-  "rawBytes": 84540
+  "rawBytes": 84436
 }

--- a/lab/public/bundle/manifest/scene85.json
+++ b/lab/public/bundle/manifest/scene85.json
@@ -20,5 +20,5 @@
     "scene85-vertex-output-C7G5u6Y0.js",
     "scene85.js"
   ],
-  "rawBytes": 60169
+  "rawBytes": 60065
 }

--- a/lab/public/bundle/manifest/scene85.json
+++ b/lab/public/bundle/manifest/scene85.json
@@ -19,5 +19,6 @@
     "scene85-vector-merger-YcC3xFyg.js",
     "scene85-vertex-output-C7G5u6Y0.js",
     "scene85.js"
-  ]
+  ],
+  "rawBytes": 60169
 }

--- a/lab/public/bundle/manifest/scene86.json
+++ b/lab/public/bundle/manifest/scene86.json
@@ -23,5 +23,5 @@
     "scene86-vertex-output-C7G5u6Y0.js",
     "scene86.js"
   ],
-  "rawBytes": 59423
+  "rawBytes": 59318
 }

--- a/lab/public/bundle/manifest/scene86.json
+++ b/lab/public/bundle/manifest/scene86.json
@@ -22,5 +22,6 @@
     "scene86-vector-splitter-4zfDJ-Vd.js",
     "scene86-vertex-output-C7G5u6Y0.js",
     "scene86.js"
-  ]
+  ],
+  "rawBytes": 59423
 }

--- a/lab/public/bundle/manifest/scene87.json
+++ b/lab/public/bundle/manifest/scene87.json
@@ -19,5 +19,5 @@
     "scene87-vertex-output-C7G5u6Y0.js",
     "scene87.js"
   ],
-  "rawBytes": 94265
+  "rawBytes": 94152
 }

--- a/lab/public/bundle/manifest/scene87.json
+++ b/lab/public/bundle/manifest/scene87.json
@@ -18,5 +18,6 @@
     "scene87-transform-block-gyGmS88H.js",
     "scene87-vertex-output-C7G5u6Y0.js",
     "scene87.js"
-  ]
+  ],
+  "rawBytes": 94265
 }

--- a/lab/public/bundle/manifest/scene88.json
+++ b/lab/public/bundle/manifest/scene88.json
@@ -23,5 +23,6 @@
     "scene88-vector-splitter-BYJt88EE.js",
     "scene88-vertex-output-C7G5u6Y0.js",
     "scene88.js"
-  ]
+  ],
+  "rawBytes": 60036
 }

--- a/lab/public/bundle/manifest/scene88.json
+++ b/lab/public/bundle/manifest/scene88.json
@@ -24,5 +24,5 @@
     "scene88-vertex-output-C7G5u6Y0.js",
     "scene88.js"
   ],
-  "rawBytes": 60036
+  "rawBytes": 59918
 }

--- a/lab/public/bundle/manifest/scene89.json
+++ b/lab/public/bundle/manifest/scene89.json
@@ -24,5 +24,5 @@
     "scene89-vertex-output-C7G5u6Y0.js",
     "scene89.js"
   ],
-  "rawBytes": 59455
+  "rawBytes": 59345
 }

--- a/lab/public/bundle/manifest/scene89.json
+++ b/lab/public/bundle/manifest/scene89.json
@@ -23,5 +23,6 @@
     "scene89-vector-splitter-CyI5Xucv.js",
     "scene89-vertex-output-C7G5u6Y0.js",
     "scene89.js"
-  ]
+  ],
+  "rawBytes": 59455
 }

--- a/lab/public/bundle/manifest/scene9.json
+++ b/lab/public/bundle/manifest/scene9.json
@@ -13,5 +13,5 @@
     "scene9-std-specular-fragment-lgpgl8DR.js",
     "scene9.js"
   ],
-  "rawBytes": 61460
+  "rawBytes": 61362
 }

--- a/lab/public/bundle/manifest/scene9.json
+++ b/lab/public/bundle/manifest/scene9.json
@@ -12,5 +12,6 @@
     "scene9-std-reflection-fragment-Cb2Nq9Do.js",
     "scene9-std-specular-fragment-lgpgl8DR.js",
     "scene9.js"
-  ]
+  ],
+  "rawBytes": 61460
 }

--- a/lab/public/bundle/manifest/scene90.json
+++ b/lab/public/bundle/manifest/scene90.json
@@ -7,5 +7,5 @@
     "scene90-standard-renderable-BFcsrzjv.js",
     "scene90.js"
   ],
-  "rawBytes": 60274
+  "rawBytes": 60162
 }

--- a/lab/public/bundle/manifest/scene90.json
+++ b/lab/public/bundle/manifest/scene90.json
@@ -6,5 +6,6 @@
     "scene90-generate-mipmaps-SRXClq-S.js",
     "scene90-standard-renderable-BFcsrzjv.js",
     "scene90.js"
-  ]
+  ],
+  "rawBytes": 60274
 }

--- a/lab/public/bundle/manifest/scene91.json
+++ b/lab/public/bundle/manifest/scene91.json
@@ -8,5 +8,5 @@
     "scene91-standard-renderable-DAnTrD2S.js",
     "scene91.js"
   ],
-  "rawBytes": 58870
+  "rawBytes": 58754
 }

--- a/lab/public/bundle/manifest/scene91.json
+++ b/lab/public/bundle/manifest/scene91.json
@@ -7,5 +7,6 @@
     "scene91-manifold-DtI3BJoR-BxUkvd-s.js",
     "scene91-standard-renderable-DAnTrD2S.js",
     "scene91.js"
-  ]
+  ],
+  "rawBytes": 58870
 }

--- a/lab/public/bundle/manifest/scene92.json
+++ b/lab/public/bundle/manifest/scene92.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene92.js"
-  ]
+  ],
+  "rawBytes": 18800
 }

--- a/lab/public/bundle/manifest/scene93.json
+++ b/lab/public/bundle/manifest/scene93.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene93.js"
-  ]
+  ],
+  "rawBytes": 19876
 }

--- a/lab/public/bundle/manifest/scene94.json
+++ b/lab/public/bundle/manifest/scene94.json
@@ -6,5 +6,6 @@
     "scene94-billboard-renderable-DP7M1jjd.js",
     "scene94-standard-renderable-CH2iJ5Rr.js",
     "scene94.js"
-  ]
+  ],
+  "rawBytes": 64917
 }

--- a/lab/public/bundle/manifest/scene94.json
+++ b/lab/public/bundle/manifest/scene94.json
@@ -7,5 +7,5 @@
     "scene94-standard-renderable-CH2iJ5Rr.js",
     "scene94.js"
   ],
-  "rawBytes": 64917
+  "rawBytes": 64819
 }

--- a/lab/public/bundle/manifest/scene95.json
+++ b/lab/public/bundle/manifest/scene95.json
@@ -6,5 +6,6 @@
     "scene95-billboard-renderable-DnOPYCf_.js",
     "scene95-standard-renderable-CfHhNfDX.js",
     "scene95.js"
-  ]
+  ],
+  "rawBytes": 65975
 }

--- a/lab/public/bundle/manifest/scene95.json
+++ b/lab/public/bundle/manifest/scene95.json
@@ -7,5 +7,5 @@
     "scene95-standard-renderable-CfHhNfDX.js",
     "scene95.js"
   ],
-  "rawBytes": 65975
+  "rawBytes": 65869
 }

--- a/lab/public/bundle/manifest/scene96.json
+++ b/lab/public/bundle/manifest/scene96.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene96.js"
-  ]
+  ],
+  "rawBytes": 16095
 }

--- a/lab/public/bundle/manifest/scene97.json
+++ b/lab/public/bundle/manifest/scene97.json
@@ -4,5 +4,6 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene97.js"
-  ]
+  ],
+  "rawBytes": 16077
 }

--- a/lab/public/bundle/manifest/scene98.json
+++ b/lab/public/bundle/manifest/scene98.json
@@ -8,5 +8,5 @@
     "scene98-standard-renderable-BttSxNjd.js",
     "scene98.js"
   ],
-  "rawBytes": 61343
+  "rawBytes": 61235
 }

--- a/lab/public/bundle/manifest/scene98.json
+++ b/lab/public/bundle/manifest/scene98.json
@@ -7,5 +7,6 @@
     "scene98-scene-uniforms-FTYH6Ct0.js",
     "scene98-standard-renderable-BttSxNjd.js",
     "scene98.js"
-  ]
+  ],
+  "rawBytes": 61343
 }

--- a/lab/public/bundle/manifest/scene99.json
+++ b/lab/public/bundle/manifest/scene99.json
@@ -17,5 +17,5 @@
     "scene99-types-BVAXdTdf.js",
     "scene99.js"
   ],
-  "rawBytes": 94249
+  "rawBytes": 94147
 }

--- a/lab/public/bundle/manifest/scene99.json
+++ b/lab/public/bundle/manifest/scene99.json
@@ -16,5 +16,6 @@
     "scene99-skeleton-fragment-5aZqnpxb.js",
     "scene99-types-BVAXdTdf.js",
     "scene99.js"
-  ]
+  ],
+  "rawBytes": 94249
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "build:lab-site": "tsx scripts/build-lab-site.ts",
         "build:pages-site": "tsx scripts/build-pages-site.ts",
         "build:bundle-scenes": "pnpm build:lib && tsx scripts/build-bundle-scenes.ts",
-        "build:bundle-manifest:device": "tsx scripts/build-bundle-scenes.ts --software --scenes scene113,scene114,scene115",
+        "build:bundle-manifest:device": "pnpm build:lib && tsx scripts/build-bundle-scenes.ts --software --scenes scene113,scene114,scene115",
         "build:bundle-scenes:gl": "tsx scripts/build-bundle-scenes-gl.ts",
         "build:bundle-demos": "tsx scripts/build-bundle-demos.ts",
         "build:bundle-demo": "tsx scripts/build-bundle-demo.ts",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "build:lab-site": "tsx scripts/build-lab-site.ts",
         "build:pages-site": "tsx scripts/build-pages-site.ts",
         "build:bundle-scenes": "pnpm build:lib && tsx scripts/build-bundle-scenes.ts",
+        "build:bundle-manifest:device": "tsx scripts/build-bundle-scenes.ts --software --scenes scene113,scene114,scene115",
         "build:bundle-scenes:gl": "tsx scripts/build-bundle-scenes-gl.ts",
         "build:bundle-demos": "tsx scripts/build-bundle-demos.ts",
         "build:bundle-demo": "tsx scripts/build-bundle-demo.ts",

--- a/scene-config.json
+++ b/scene-config.json
@@ -1169,6 +1169,7 @@
         "name": "Scene 113 — Picking Precision",
         "maxMad": 0.3,
         "maxRawKB": 68,
+        "deviceDependentChunks": true,
         "description": "Visual picking validation: one detailed sphere pick places a tiny surface marker at the picked point and a small oriented box along the picked normal.",
         "tags": ["std", "procedural", "picking"],
         "skipPerf": true
@@ -1179,6 +1180,7 @@
         "name": "Scene 114 — Morph/Skeleton Picking",
         "maxMad": 0.1,
         "maxRawKB": 86,
+        "deviceDependentChunks": true,
         "skipBundleSize": true,
         "description": "Visual picking validation on morphed and skinned geometry: GPU and detailed picks drive marker positions from the deformed rendered surface.",
         "tags": ["pbr", "procedural", "morph", "skeleton", "picking"],
@@ -1190,6 +1192,7 @@
         "name": "Scene 115 — Alien Picking Frame 100",
         "maxMad": 0.01,
         "maxRawKB": 127.6,
+        "deviceDependentChunks": true,
         "description": "Precise picking validation on the animated Alien glTF at frame 100: BJS and Lite CPU PickInfo values drive a surface sphere and normal marker.",
         "tags": ["pbr", "gltf", "anim", "skeleton", "picking"],
         "skipPerf": true

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -990,9 +990,11 @@ export function measurementBrowserArgs(): string[] {
     return ["--force-color-profile=srgb", "--enable-unsafe-webgpu", ...swiftShaderArgs];
 }
 
-/** `--software` on the command line, or `BUNDLE_SOFTWARE_RENDER=1`. */
+/** `--software` on the command line, or `BUNDLE_SOFTWARE_RENDER=1`. Only an explicit
+ *  truthy value counts, so `BUNDLE_SOFTWARE_RENDER=0` disables it as one would expect. */
 function softwareRenderRequested(): boolean {
-    return process.argv.includes("--software") || !!process.env.BUNDLE_SOFTWARE_RENDER;
+    const env = process.env.BUNDLE_SOFTWARE_RENDER;
+    return process.argv.includes("--software") || env === "1" || env === "true";
 }
 
 /** Why some scenes' committed manifest is authored under the software renderer only.
@@ -1242,6 +1244,10 @@ export async function buildBundleScenes(): Promise<void> {
         }
     }
     reportCeilingHeadroom(scenesToBuild, manifest);
+    if (process.exitCode) {
+        console.error(`✘ Bundle scenes built to ${outDir}, but a ceiling was exceeded (total ${elapsed(t0)})`);
+        return;
+    }
     console.log(`✓ Bundle scenes + manifest built to ${outDir} (total ${elapsed(t0)})`);
 }
 

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -203,11 +203,24 @@ export const LITE_BUNDLE_TARGET = "esnext";
 interface SceneConfigEntry {
     id: number;
     tags?: string[];
+    /** Raw bundle-size ceiling in KB. Absent for scenes that opt out of the check. */
+    maxRawKB?: number;
+    /** Scene opts out of bundle-size ceiling enforcement (mirrors bundle-size.spec.ts). */
+    skipBundleSize?: boolean;
+    /** This scene's runtime dynamic-imports branch on device capability, so its measured
+     *  chunk set differs between a developer's GPU and CI's software renderer. A local
+     *  build measures it but does not overwrite its committed manifest entry; only CI's
+     *  measurement is authoritative. See `DEVICE_DEPENDENT_NOTE`. */
+    deviceDependentChunks?: boolean;
 }
 
 interface BundleManifestEntry {
     rawKB: number;
     gzipKB: number;
+    /** Exact runtime-fetched byte count. `rawKB` is this rounded to 0.1 KB for display, which
+     *  hides sub-50-byte drift — including a ceiling overflow on a zero-headroom scene. Tools
+     *  comparing sizes (`validate:bundle-manifest`, the build's ceiling check) use this. */
+    rawBytes?: number;
     ignoredRawKB?: number;
     bjsRawKB?: number;
     bjsGzipKB?: number;
@@ -965,12 +978,54 @@ export async function buildLiteSceneBundleInfo(scene: string, sourceRoot: string
     rmSync(sceneOutDir, { recursive: true, force: true });
 }
 
+/** Chromium flags for the measurement browser. SwiftShader under CI, or locally when the
+ *  `--software` flag is passed; otherwise the real GPU (SwiftShader is far slower, and
+ *  several heavy scenes never reach `dataset.ready` under it on Windows).
+ *  See `DEVICE_DEPENDENT_NOTE`. */
 export function measurementBrowserArgs(): string[] {
-    const swiftShaderArgs = process.env.CI
-        ? ["--enable-features=Vulkan", "--use-vulkan=swiftshader", "--use-angle=swiftshader", "--disable-vulkan-fallback-to-gl-for-testing", "--ignore-gpu-blocklist"]
-        : [];
+    const swiftShaderArgs =
+        process.env.CI || softwareRenderRequested()
+            ? ["--enable-features=Vulkan", "--use-vulkan=swiftshader", "--use-angle=swiftshader", "--disable-vulkan-fallback-to-gl-for-testing", "--ignore-gpu-blocklist"]
+            : [];
     return ["--force-color-profile=srgb", "--enable-unsafe-webgpu", ...swiftShaderArgs];
 }
+
+/** `--software` on the command line, or `BUNDLE_SOFTWARE_RENDER=1`. */
+function softwareRenderRequested(): boolean {
+    return process.argv.includes("--software") || !!process.env.BUNDLE_SOFTWARE_RENDER;
+}
+
+/** Why some scenes' committed manifest is authored under the software renderer only.
+ *
+ *  CI measures under SwiftShader; a developer machine measures on its real GPU. A few
+ *  runtime paths branch on device capability and dynamic-import different chunks as a
+ *  result — scenes 113/114/115 resolve detailed picking to `picking-detailed-pipeline` on
+ *  a real GPU and to `picking-pipeline` under SwiftShader. Their measured chunk set (and
+ *  size) therefore depends on the machine, so a locally regenerated manifest could never
+ *  match what CI rebuilds, and `validate:bundle-manifest` failed on PRs that had not
+ *  touched those scenes at all — three times before this was diagnosed.
+ *
+ *  Forcing SwiftShader for the whole build was tried and rejected: on Windows the heavy
+ *  IBL scenes never reach `dataset.ready` under it. Restricting the run to the flagged
+ *  scenes is the canonical way to regenerate them:
+ *
+ *      pnpm build:bundle-manifest:device
+ *
+ *  That command needs a working SwiftShader WebGPU stack — reliable on the Linux CI image,
+ *  flaky-to-unusable on Windows, where these scenes also time out. So on Windows those
+ *  three entries are effectively CI-authored: leave them as committed.
+ *
+ *  Outside such a run, a local build measures these scenes (so the ceiling check and the
+ *  generated aggregate manifest see real local numbers) but leaves their TRACKED per-scene
+ *  file untouched, because only a software-renderer measurement is comparable to CI's. */
+const DEVICE_DEPENDENT_NOTE = "device-dependent chunk set — tracked manifest left untouched (regenerate with: pnpm build:bundle-manifest:device)";
+
+/** A scene with less than this much room under its ceiling is reported after a build: at
+ *  that margin the next shared-path change lands on it, and finding that out from CI costs
+ *  ~35 minutes. */
+const TIGHT_HEADROOM_BYTES = 256;
+/** Cap the tight-headroom list so a build's output stays readable; the rest are counted. */
+const TIGHT_HEADROOM_LIST_LIMIT = 10;
 
 export async function buildBundleScenes(): Promise<void> {
     const t0 = performance.now();
@@ -1186,7 +1241,55 @@ export async function buildBundleScenes(): Promise<void> {
             console.log(line);
         }
     }
+    reportCeilingHeadroom(scenesToBuild, manifest);
     console.log(`✓ Bundle scenes + manifest built to ${outDir} (total ${elapsed(t0)})`);
+}
+
+/**
+ * Report each measured scene against its `scene-config.json` ceiling, in BYTES.
+ *
+ * `rawKB` is rounded to 0.1 KB, so a scene sitting exactly at its ceiling can overflow by
+ * a few bytes while both the printed size and the committed manifest still read the same
+ * value — the overflow then only surfaces in CI's bundle-size job, ~35 minutes later.
+ * Comparing exact bytes here surfaces it immediately, and listing the tightest scenes makes
+ * a zero-margin scene visible *before* it is the thing that breaks someone else's PR.
+ */
+function reportCeilingHeadroom(scenes: readonly string[], manifest: Record<string, BundleManifestEntry>): void {
+    const over: string[] = [];
+    const tight: { scene: string; headroom: number; ceilingKB: number }[] = [];
+
+    for (const scene of scenes) {
+        const measured = manifest[scene]?.rawBytes;
+        const config = sceneConfigByName.get(scene);
+        const ceilingKB = config?.maxRawKB;
+        // Honour the same opt-out as the ceiling test in bundle-size.spec.ts.
+        if (measured == null || ceilingKB == null || config?.skipBundleSize) {
+            continue;
+        }
+        const ceilingBytes = ceilingKB * 1024;
+        // Compare before rounding: a ceiling like 92.2 KB is 94412.8 bytes, so 94413 bytes is
+        // over by 0.2 — which `Math.round` would turn into `-0` and wave through.
+        if (measured > ceilingBytes) {
+            over.push(`  ${scene}: ${(measured / 1024).toFixed(3)} KB exceeds ceiling ${ceilingKB} KB by ${Math.ceil(measured - ceilingBytes)} bytes`);
+        } else {
+            const headroom = Math.floor(ceilingBytes - measured);
+            if (headroom < TIGHT_HEADROOM_BYTES) {
+                tight.push({ scene, headroom, ceilingKB });
+            }
+        }
+    }
+
+    if (tight.length > 0) {
+        tight.sort((a, b) => a.headroom - b.headroom);
+        const shown = tight.slice(0, TIGHT_HEADROOM_LIST_LIMIT).map((t) => `  ${t.scene}: ${t.headroom} B below its ${t.ceilingKB} KB ceiling`);
+        const more = tight.length > shown.length ? `\n  … and ${tight.length - shown.length} more under ${TIGHT_HEADROOM_BYTES} B` : "";
+        console.log(`\n⚠ ${tight.length} scene(s) with little headroom — a shared-path change may push them over:\n${shown.join("\n")}${more}`);
+    }
+    if (over.length > 0) {
+        console.error(`\n✘ Bundle-size ceiling exceeded (exact bytes; scene-config.json maxRawKB):\n${over.join("\n")}`);
+        console.error(`\nRaising a ceiling requires explicit user approval — see GUIDANCE.md.`);
+        process.exitCode = 1;
+    }
 }
 
 /**
@@ -1239,7 +1342,7 @@ async function measureLiteSceneWithRetry(
     browser: any,
     port: number,
     scene: string
-): Promise<{ rawKB: number; gzipKB: number; ignoredRawKB: number; chunks: string[] }> {
+): Promise<{ rawKB: number; rawBytes: number; gzipKB: number; ignoredRawKB: number; chunks: string[] }> {
     let lastError: unknown;
     for (let attempt = 1; attempt <= LITE_MEASURE_ATTEMPTS; attempt++) {
         try {
@@ -1277,14 +1380,27 @@ async function measureLiveSizes(liteScenes: readonly string[], bjsScenes: readon
         const browser = await chromium.launch({ channel: "chrome", headless: true, args: measurementBrowserArgs() });
         console.log(`Browser launched in ${elapsed(tBrowser)}`);
 
+        // A scene whose chunk set depends on the GPU keeps its TRACKED file when measured on a
+        // real GPU: only a software-renderer measurement is comparable to CI's. The measurement
+        // is still recorded in memory, so the ceiling check and the generated aggregate manifest
+        // reflect what this machine actually loads.
+        const trackedWriteSuppressed = (scene: string): boolean =>
+            !!sceneConfigByName.get(scene)?.deviceDependentChunks && !process.env.CI && !softwareRenderRequested();
+
         // Measure Lite scenes (write after each), retrying transient failures.
         for (const scene of liteScenes) {
             const tPage = performance.now();
-            const { rawKB, gzipKB, ignoredRawKB, chunks } = await measureLiteSceneWithRetry(browser, port, scene);
-            manifest[scene] = { ...manifest[scene], rawKB, gzipKB, ignoredRawKB, runtimeChunks: chunks };
-            flushScene(scene);
+            const { rawKB, rawBytes, gzipKB, ignoredRawKB, chunks } = await measureLiteSceneWithRetry(browser, port, scene);
+            manifest[scene] = { ...manifest[scene], rawKB, rawBytes, gzipKB, ignoredRawKB, runtimeChunks: chunks };
+            const suppressed = trackedWriteSuppressed(scene);
+            if (suppressed) {
+                writeAggregateBundleManifest(manifest);
+            } else {
+                flushScene(scene);
+            }
             const ignored = ignoredRawKB > 0 ? `, ignored ${ignoredRawKB} KB raw ${IGNORED_BUNDLE_MODULE_PATTERN}` : "";
-            console.log(`  measured ${scene}: ${rawKB} KB raw, ${gzipKB} KB gzip${ignored} (${elapsed(tPage)})`);
+            const note = suppressed ? ` — ${DEVICE_DEPENDENT_NOTE}` : "";
+            console.log(`  measured ${scene}: ${rawKB} KB raw, ${gzipKB} KB gzip${ignored} (${elapsed(tPage)})${note}`);
         }
 
         // Measure BJS scenes — skip if sizes already cached in manifest
@@ -1461,7 +1577,7 @@ export async function measurePage(
     bundlePath: string,
     requireReady = false,
     readyTimeoutMs = READY_TIMEOUT_MS_DEFAULT
-): Promise<{ rawKB: number; gzipKB: number; ignoredRawKB: number; chunks: string[] }> {
+): Promise<{ rawKB: number; rawBytes: number; gzipKB: number; ignoredRawKB: number; chunks: string[] }> {
     const page = await browser.newPage();
     const jsPayloads: RuntimeJsPayload[] = [];
     const chunkFiles: string[] = [];
@@ -1538,6 +1654,7 @@ export async function measurePage(
     await page.close();
     return {
         rawKB: bytesToRoundedKB(rawBytes),
+        rawBytes,
         gzipKB: bytesToRoundedKB(summary.gzipBytes),
         ignoredRawKB,
         chunks: Array.from(new Set(chunkFiles)).sort(),

--- a/scripts/validate-bundle-manifest.ts
+++ b/scripts/validate-bundle-manifest.ts
@@ -11,8 +11,10 @@
  * This script is meant to run in CI AFTER `pnpm build:bundle-scenes`, which
  * overwrites the working-tree per-scene files with freshly measured sizes. It
  * compares those freshly built files against the versions committed at `git
- * HEAD`. Sizes are rounded to whole KB before comparison (matching the PR delta
- * comment), so sub-KB gzip jitter does not cause spurious failures.
+ * HEAD`. Raw size is compared exactly, in bytes (`rawBytes`), because `rawKB` is
+ * rounded to 0.1 KB and hides sub-50-byte drift. gzip stays rounded to whole KB:
+ * its output varies with the zlib build, so an exact check would fail spuriously
+ * across environments.
  *
  * It also compares each scene's `runtimeChunks` set. Chunk filenames carry a
  * content hash, so they change whenever a PR alters code that actually lands in
@@ -33,6 +35,7 @@ const LEGACY_MANIFEST_REL_PATH = "lab/public/bundle/manifest.json";
 
 interface ManifestEntry {
     rawKB?: number;
+    rawBytes?: number;
     gzipKB?: number;
     runtimeChunks?: string[];
 }
@@ -41,6 +44,29 @@ type Manifest = Record<string, ManifestEntry>;
 
 function roundToWholeKB(kb: number | undefined): number {
     return Math.round(kb ?? 0);
+}
+
+/** Compare raw size as exactly as both sides allow.
+ *
+ *  `rawBytes` is exact and deterministic (a sum of fetched file lengths), so when both
+ *  sides carry it they are compared byte-for-byte: `rawKB` alone is rounded to 0.1 KB and
+ *  hides sub-50-byte drift, which is precisely how a stale manifest slipped through on a
+ *  zero-headroom scene. Entries committed before `rawBytes` existed fall back to the old
+ *  whole-KB comparison rather than failing spuriously.
+ *
+ *  gzip is deliberately NOT compared exactly: its output varies with the zlib build, so an
+ *  exact check would fail across environments. It stays rounded to whole KB. */
+function diffRawSize(committed: ManifestEntry, built: ManifestEntry): string | null {
+    if (committed.rawBytes != null && built.rawBytes != null) {
+        if (committed.rawBytes !== built.rawBytes) {
+            const delta = built.rawBytes - committed.rawBytes;
+            return `committed raw=${committed.rawBytes}B → rebuilt raw=${built.rawBytes}B (${delta > 0 ? "+" : ""}${delta} bytes)`;
+        }
+        return null;
+    }
+    const committedRaw = roundToWholeKB(committed.rawKB);
+    const builtRaw = roundToWholeKB(built.rawKB);
+    return committedRaw === builtRaw ? null : `committed raw=${committedRaw}KB → rebuilt raw=${builtRaw}KB`;
 }
 
 /** Compare two chunk lists as order-independent sets. Returns null when equal. */
@@ -167,13 +193,15 @@ function main(): void {
             continue;
         }
 
-        const builtRaw = roundToWholeKB(builtEntry.rawKB);
-        const committedRaw = roundToWholeKB(committedEntry.rawKB);
+        const rawDiff = diffRawSize(committedEntry, builtEntry);
+        if (rawDiff !== null) {
+            mismatches.push(`  ${key}: ${rawDiff}`);
+        }
+
         const builtGzip = roundToWholeKB(builtEntry.gzipKB);
         const committedGzip = roundToWholeKB(committedEntry.gzipKB);
-
-        if (builtRaw !== committedRaw || builtGzip !== committedGzip) {
-            mismatches.push(`  ${key}: committed raw=${committedRaw}KB gzip=${committedGzip}KB → rebuilt raw=${builtRaw}KB gzip=${builtGzip}KB`);
+        if (builtGzip !== committedGzip) {
+            mismatches.push(`  ${key}: committed gzip=${committedGzip}KB → rebuilt gzip=${builtGzip}KB`);
         }
 
         const chunkDiff = diffRuntimeChunks(committedEntry.runtimeChunks, builtEntry.runtimeChunks);
@@ -186,8 +214,16 @@ function main(): void {
         console.error(
             `Bundle manifest validation FAILED: per-scene manifest under ${MANIFEST_DIR_REL_PATH}/ is stale.\n` +
                 `This PR changes per-scene bundle output but did not commit the updated manifest files.\n` +
-                `Run 'pnpm build:bundle-scenes' locally and commit the regenerated ${MANIFEST_DIR_REL_PATH}/<scene>.json files.\n\n` +
-                `Differences (committed vs rebuilt; sizes rounded to whole KB):\n` +
+                `Run 'pnpm build:bundle-scenes' locally and commit the regenerated ${MANIFEST_DIR_REL_PATH}/<scene>.json files.\n` +
+                `\n` +
+                `If the differing scenes are flagged 'deviceDependentChunks' in scene-config.json (113/114/115), a\n` +
+                `plain local build deliberately leaves them alone: their chunk set depends on the GPU, so only a\n` +
+                `software-renderer measurement matches CI. Regenerate those with:\n` +
+                `    pnpm build:bundle-manifest:device\n` +
+                `(that needs a working SwiftShader WebGPU stack — fine on Linux/CI, unreliable on Windows. If it\n` +
+                `cannot run, restore those files to their committed values: they are CI-authored.)\n` +
+                `\n` +
+                `Differences (committed vs rebuilt; raw compared exactly in bytes, gzip rounded to whole KB):\n` +
                 mismatches.join("\n")
         );
         process.exit(1);


### PR DESCRIPTION
Two tooling fixes for CI failures that repeatedly hit PRs which had **not touched the scenes involved**. No runtime code changes (`packages/babylon-lite/src/**` untouched).

## 1. Manifests that could never match CI

Scenes 113/114/115 failed `validate:bundle-manifest` **three times** on unrelated PRs (#449, #453, and #454's merge).

**Root cause, established empirically:** `measurementBrowserArgs()` enables SwiftShader only when `CI` is set — so CI measures in software and a developer machine measures on its real GPU. Those scenes call `enableDetailedPicking`, and `gpu-picker.ts:302` dynamic-imports `picking-detailed-pipeline` vs `picking-pipeline` through a device-capability branch (`needsAdvancedPipeline ||= … || !!mesh._gpu._vbLayout?._p`).

Verified on a single commit:

| Renderer | Chunk |
| --- | --- |
| Real GPU (local default) | `picking-detailed-pipeline` |
| `CI=1` locally → SwiftShader | `picking-pipeline` — matches CI and master exactly |

**Rejected:** forcing SwiftShader for the whole build. On Windows the heavy IBL scenes never reach `dataset.ready` under it (scene1: 3×50s attempts, verified), and even the light ones are unreliable.

**Shipped:** `deviceDependentChunks` in `scene-config.json` for those three. A local build still *measures* them — the in-memory manifest, the generated aggregate, and the ceiling check all see real local numbers — but leaves their **tracked** file untouched, because only a software-renderer measurement is comparable to CI's.

`pnpm build:bundle-manifest:device` regenerates them via a new `--software` flag. That needs a working SwiftShader WebGPU stack: fine on Linux/CI, unreliable on Windows. The validator failure message now says exactly that, instead of recommending `pnpm build:bundle-scenes` — which deliberately does not touch those files and so could never have helped.

## 2. Rounding that hid a ceiling overflow

`rawKB` is rounded to 0.1 KB. Scenes 43 and 103 sat at *exactly* their ceiling, so a 10-byte increase from a shared-path change overflowed while the manifest and a local check both still read the same number. Only CI caught it, ~35 minutes later.

- Manifest entries gain exact **`rawBytes`** (215 regenerated); `rawKB` stays for display.
- `validate-bundle-manifest.ts` compares raw size **exactly in bytes** when both sides have `rawBytes`, falling back to whole-KB for older entries. gzip stays rounded on purpose — its output varies with the zlib build, so an exact check would flake.
- `build:bundle-scenes` now **fails (exit 1)** on a ceiling overflow, in exact bytes, and lists the tightest scenes under 256 bytes of headroom:

```
⚠ 1 scene(s) with little headroom — a shared-path change may push them over:
  scene43: 2 B below its 58.8 KB ceiling
```

That is the scene that caused this, now visible in 15s instead of 35 minutes.

## Review fixes

A rubber-duck pass caught four issues in the first draft, all fixed here:

1. Device-dependent measurements were **discarded** rather than just withheld from the tracked file, leaving the aggregate manifest and headroom check reading stale CI data. Now only `writePerSceneManifest` is skipped.
2. The validator told you to run a command that would not help — hence the new `build:bundle-manifest:device` and the corrected message.
3. `Math.round(ceiling - measured)` turned a sub-1-byte overflow into `-0` and waved it through (e.g. a 92.2 KB ceiling is 94412.8 bytes; 94413 passed). Now compared before rounding.
4. The new hard gate ignored `skipBundleSize`, newly failing a scene that explicitly opts out (scene114). Now honoured, matching `bundle-size.spec.ts`.

## Validation

- `pnpm run lint` clean.
- Full `pnpm build:bundle-scenes`: 215 manifests updated with `rawBytes`, 113/114/115 left byte-identical, no ceiling exceeded, headroom report correct.
- Suppression, `skipBundleSize` and headroom verified together on a mixed subset.
