### PR TITLE
fix(sprite): make Sprite2D flipX/flipY absolute instead of a UV toggle

### DIFF
--- a/lab/public/bundle/manifest/scene117.json
+++ b/lab/public/bundle/manifest/scene117.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 16.3,
+  "rawKB": 16.4,
   "gzipKB": 7.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene117.js"
   ],
-  "rawBytes": 16684
+  "rawBytes": 16760
 }

--- a/lab/public/bundle/manifest/scene50.json
+++ b/lab/public/bundle/manifest/scene50.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 15.5,
-  "gzipKB": 6.8,
+  "rawKB": 15.6,
+  "gzipKB": 6.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene50.js"
   ],
-  "rawBytes": 15915
+  "rawBytes": 15965
 }

--- a/lab/public/bundle/manifest/scene51.json
+++ b/lab/public/bundle/manifest/scene51.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene51.js"
   ],
-  "rawBytes": 16340
+  "rawBytes": 16390
 }

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 57.2,
-  "gzipKB": 23,
+  "rawKB": 57.3,
+  "gzipKB": 23.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene52-standard-renderable-BFLmSxXa.js",
     "scene52.js"
   ],
-  "rawBytes": 58566
+  "rawBytes": 58626
 }

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -6,5 +6,5 @@
     "scene53-standard-renderable-DaD1sbsL.js",
     "scene53.js"
   ],
-  "rawBytes": 58227
+  "rawBytes": 58309
 }

--- a/lab/public/bundle/manifest/scene58.json
+++ b/lab/public/bundle/manifest/scene58.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 18.2,
+  "rawKB": 18.3,
   "gzipKB": 7.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene58.js"
   ],
-  "rawBytes": 18664
+  "rawBytes": 18714
 }

--- a/lab/public/bundle/manifest/scene92.json
+++ b/lab/public/bundle/manifest/scene92.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene92.js"
   ],
-  "rawBytes": 18800
+  "rawBytes": 18850
 }

--- a/lab/public/bundle/manifest/scene93.json
+++ b/lab/public/bundle/manifest/scene93.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 19.4,
+  "rawKB": 19.5,
   "gzipKB": 8.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene93.js"
   ],
-  "rawBytes": 19876
+  "rawBytes": 19926
 }

--- a/lab/public/bundle/manifest/scene96.json
+++ b/lab/public/bundle/manifest/scene96.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 15.7,
+  "rawKB": 15.8,
   "gzipKB": 6.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene96.js"
   ],
-  "rawBytes": 16095
+  "rawBytes": 16145
 }

--- a/lab/public/bundle/manifest/scene97.json
+++ b/lab/public/bundle/manifest/scene97.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene97.js"
   ],
-  "rawBytes": 16077
+  "rawBytes": 16127
 }

--- a/packages/babylon-lite/src/sprite/sprite-2d.ts
+++ b/packages/babylon-lite/src/sprite/sprite-2d.ts
@@ -166,7 +166,14 @@ export interface Sprite2DProps {
     frame?: number;
     rotation?: number;
     color?: [number, number, number, number];
+    /**
+     * Absolute horizontal orientation, not a toggle: `true` mirrors the sprite, `false`
+     * restores it, and omitting the flag preserves whatever orientation the sprite already
+     * has (including across a `frame` change). Re-sending the same value every frame is a
+     * no-op.
+     */
     flipX?: boolean;
+    /** Absolute vertical orientation. See {@link Sprite2DProps.flipX}. */
     flipY?: boolean;
     visible?: boolean;
     /** Reserved for clip animation. Accepted but unused today. */
@@ -309,8 +316,9 @@ function setSprite2DCount(layer: Sprite2DLayer, count: number): void {
  *
  * Resolution rules (per field): `props` value if given, else (on add) the default, else `prev`.
  * `frame` is a higher-level intent: when supplied it stomps the four UV slots from the atlas
- * (then `flipX`/`flipY` swap them). It does **not** by itself imply a size change — `sizePx`
- * remains independent — but on add, a missing `sizePx` falls back to `frame.sourceSizePx`.
+ * (the sprite's current `flipX`/`flipY` orientation is then re-applied on top). It does **not**
+ * by itself imply a size change — `sizePx` remains independent — but on add, a missing `sizePx`
+ * falls back to `frame.sourceSizePx`.
  *
  * **Visibility model (the part that needs explaining):**
  *   - `_savedSize[slot]` always stores the sprite's *true* size (unaffected by visibility).
@@ -363,7 +371,10 @@ function writeInstance(layer: Sprite2DLayer, slotIndex: number, props: Partial<S
     }
 
     // ── UVs (frame stomps; else preserved; else default [0,0,1,1] on add) ───────────────
-    // flipX/flipY apply on top, by swapping the U/V endpoints.
+    // flipX/flipY are absolute orientation flags, not toggles: they are resolved against
+    // the flip already baked into the endpoints, so re-sending the same value every frame
+    // is idempotent. Omitting them preserves the current orientation (so a frame change
+    // keeps the existing flip, matching `setSprite2DFrameIndex` and the billboard path).
     let uMin: number;
     let vMin: number;
     let uMax: number;
@@ -384,15 +395,29 @@ function writeInstance(layer: Sprite2DLayer, slotIndex: number, props: Partial<S
         uMax = prev![6]!;
         vMax = prev![7]!;
     }
-    if (props.flipX === true) {
-        const t = uMin;
+    // Flip currently baked into the (possibly preserved) UV endpoints.
+    const currentFlipX = uMin > uMax;
+    const currentFlipY = vMin > vMax;
+    // Flip carried over from the previous instance (used when the flag is omitted,
+    // so a frame change keeps the existing flip).
+    const prevFlipX = !isAdd && prev![4]! > prev![6]!;
+    const prevFlipY = !isAdd && prev![5]! > prev![7]!;
+    // Resolve the desired flip. The explicit `=== true` test (rather than a
+    // `boolean !== flag` XOR) keeps both operands genuine booleans so terser's
+    // `booleans_as_integers` pass cannot turn the flag into a number and break the
+    // strict comparison (a boolean is never `!==`-equal to the integer 0/1 it maps
+    // a flag onto).
+    const wantsFlipX = props.flipX !== undefined ? props.flipX === true : prevFlipX;
+    const wantsFlipY = props.flipY !== undefined ? props.flipY === true : prevFlipY;
+    if (currentFlipX !== wantsFlipX) {
+        const previousMinU = uMin;
         uMin = uMax;
-        uMax = t;
+        uMax = previousMinU;
     }
-    if (props.flipY === true) {
-        const t = vMin;
+    if (currentFlipY !== wantsFlipY) {
+        const previousMinV = vMin;
         vMin = vMax;
-        vMax = t;
+        vMax = previousMinV;
     }
 
     // ── Rotation ────────────────────────────────────────────────────────────────────────

--- a/tests/lite/unit/sprite-2d.test.ts
+++ b/tests/lite/unit/sprite-2d.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import type { SpriteAtlas } from "../../../packages/babylon-lite/src/sprite/shared/sprite-atlas";
+import { addSprite2DIndex, createSprite2DLayer, setSprite2DFrameIndex, updateSprite2DIndex } from "../../../packages/babylon-lite/src/sprite/sprite-2d";
+import type { Sprite2DLayer } from "../../../packages/babylon-lite/src/sprite/sprite-2d";
+import type { Texture2D } from "../../../packages/babylon-lite/src/texture/texture-2d";
+
+function makeMockAtlas(): SpriteAtlas {
+    const texture = {
+        texture: {} as GPUTexture,
+        view: {} as GPUTextureView,
+        sampler: {} as GPUSampler,
+        width: 128,
+        height: 128,
+    } satisfies Texture2D;
+
+    return {
+        texture,
+        textureSizePx: [128, 128],
+        frames: [
+            { uvMin: [0, 0], uvMax: [0.25, 0.25], sourceSizePx: [32, 32], pivot: [0.5, 0.5] },
+            { uvMin: [0.25, 0], uvMax: [0.5, 0.25], sourceSizePx: [32, 32], pivot: [0.5, 0.5] },
+        ],
+        premultipliedAlpha: false,
+    };
+}
+
+/** `[uMin, vMin, uMax, vMax]` for slot 0. */
+function uvs(layer: Sprite2DLayer): number[] {
+    return Array.from(layer._instanceData.slice(4, 8));
+}
+
+describe("Sprite2D flipX/flipY", () => {
+    it("treats flipX as absolute state, so re-sending it every frame is idempotent", () => {
+        const layer = createSprite2DLayer(makeMockAtlas(), { capacity: 1 });
+        const i = addSprite2DIndex(layer, { positionPx: [0, 0], sizePx: [32, 32], frame: 0 });
+
+        // A game re-sends the current facing every tick alongside a moving position and
+        // no `frame`. Every one of these must leave the sprite mirrored, not toggle it.
+        for (let tick = 0; tick < 4; tick++) {
+            updateSprite2DIndex(layer, i, { positionPx: [tick, 0], flipX: true });
+            expect(uvs(layer)).toEqual([0.25, 0, 0, 0.25]);
+        }
+    });
+
+    it("clears the flip when flipX is false, with or without a frame in the same patch", () => {
+        const layer = createSprite2DLayer(makeMockAtlas(), { capacity: 1 });
+        const i = addSprite2DIndex(layer, { positionPx: [0, 0], sizePx: [32, 32], frame: 0, flipX: true });
+        expect(uvs(layer)).toEqual([0.25, 0, 0, 0.25]);
+
+        updateSprite2DIndex(layer, i, { positionPx: [1, 0], flipX: false });
+        expect(uvs(layer)).toEqual([0, 0, 0.25, 0.25]);
+
+        updateSprite2DIndex(layer, i, { flipX: true });
+        expect(uvs(layer)).toEqual([0.25, 0, 0, 0.25]);
+
+        updateSprite2DIndex(layer, i, { frame: 0, flipX: false });
+        expect(uvs(layer)).toEqual([0, 0, 0.25, 0.25]);
+    });
+
+    it("preserves the flip across a frame change that omits the flag", () => {
+        const layer = createSprite2DLayer(makeMockAtlas(), { capacity: 1 });
+        const i = addSprite2DIndex(layer, { positionPx: [0, 0], sizePx: [32, 32], frame: 0, flipX: true });
+
+        // Same guarantee the animation path already gives via setSprite2DFrameIndex.
+        updateSprite2DIndex(layer, i, { frame: 1 });
+        expect(uvs(layer)).toEqual([0.5, 0, 0.25, 0.25]);
+
+        setSprite2DFrameIndex(layer, i, 0);
+        expect(uvs(layer)).toEqual([0.25, 0, 0, 0.25]);
+    });
+
+    it("applies the same absolute semantics to flipY", () => {
+        const layer = createSprite2DLayer(makeMockAtlas(), { capacity: 1 });
+        const i = addSprite2DIndex(layer, { positionPx: [0, 0], sizePx: [32, 32], frame: 0 });
+
+        updateSprite2DIndex(layer, i, { flipY: true });
+        updateSprite2DIndex(layer, i, { flipY: true });
+        expect(uvs(layer)).toEqual([0, 0.25, 0.25, 0]);
+
+        updateSprite2DIndex(layer, i, { flipY: false });
+        expect(uvs(layer)).toEqual([0, 0, 0.25, 0.25]);
+    });
+
+    it("leaves both axes untouched when neither flag is supplied", () => {
+        const layer = createSprite2DLayer(makeMockAtlas(), { capacity: 1 });
+        const i = addSprite2DIndex(layer, { positionPx: [0, 0], sizePx: [32, 32], frame: 0, flipX: true, flipY: true });
+
+        updateSprite2DIndex(layer, i, { positionPx: [9, 9] });
+
+        expect(uvs(layer)).toEqual([0.25, 0.25, 0, 0]);
+    });
+});


### PR DESCRIPTION
## Problem

`updateSprite2DIndex(layer, i, { flipX: true })` is **not idempotent**. When the patch carries no `frame`, `writeInstance` seeds `uMin`/`uMax` from the slot's previous — already oriented — UVs, then swaps them unconditionally:

```ts
} else {
    uMin = prev![4]!;   // already reflects the current flip
    uMax = prev![6]!;
}
if (props.flipX === true) {
    const t = uMin;     // unconditional swap, not an absolute set
    uMin = uMax;
    uMax = t;
}
```

A game writes its character's facing once per frame, which is the normal pattern. Doing so alternated the sprite between mirrored and unmirrored **every frame**, rendering a 60 Hz strobe that reads on screen as the character facing both directions at once. It showed up here as a sword attack appearing to swing on both sides simultaneously.

Two related symptoms fall out of the same line:

- `flipX: false` could never un-flip a flipped sprite — it is a no-op, because the swap only runs on `true`.
- A `{ frame }`-only patch silently **cleared** the flip, disagreeing with `setSprite2DFrameIndex`, which preserves it.

Minimal repro, no GPU needed:

```
PATCH WITHOUT `frame`:
  after add                   flipped=false
  update #1 {flipX:true}      flipped=true
  update #2 {flipX:true}      flipped=false   <-- toggles
  update #3 {flipX:true}      flipped=true
  update   {flipX:false}      flipped=false   <-- only by luck; false is a no-op
```

`flipX`/`flipY` are typed as plain `boolean`s with no documentation suggesting a toggle, and **every other field** in `writeInstance` (position, size, colour, rotation, z, visible) is an absolute set with a previous-value fallback. The toggle was neither documented nor intended.

## Fix

Resolve the desired orientation against the flip already baked into the endpoints and swap only on mismatch.

This is not a new invention — `billboard-sprite.ts` **already does exactly this** (`currentFlipX` / `prevFlipX` / `wantsFlipX`). The 2D path was the outlier, so this change makes the two sprite paths consistent, and carries over the billboard comment explaining why `=== true` is used rather than an XOR (terser's `booleans_as_integers` pass can otherwise turn the flag into a number and break the strict compare).

Resulting contract, now shared by both paths:

- `flipX: true` is idempotent when re-sent every frame
- `flipX: false` un-flips
- omitting the flag preserves the current orientation, including across a frame change

The doc comments on `Sprite2DProps.flipX/flipY` and on `writeInstance` were updated to state this.

## Behaviour change

A `{ frame }`-only patch now **keeps** the sprite's flip instead of clearing it. This aligns `updateSprite2DIndex` with `setSprite2DFrameIndex` and the billboard path. The public type signature is unchanged, and the previous behaviour was internally inconsistent, so this is filed as a fix rather than a breaking change — happy to relabel if you read it differently.

## Tests

New `tests/lite/unit/sprite-2d.test.ts` (5 tests). **4 of the 5 fail without the source change** — verified by stashing the fix and re-running:

- flipX re-sent every tick is idempotent
- flipX false clears the flip, with and without a frame in the same patch
- flip is preserved across a frame change that omits the flag
- flipY has the same absolute semantics
- omitting both flags leaves both axes untouched

## Verification

| Gate | Result |
|---|---|
| `test:unit` | 1118 passed. 3 failures in `compare-utils` / `shadow-tracking-bundle-isolation` are pre-existing on master — confirmed by re-running with the change stashed |
| `lint` (eslint + 6 tsc projects) | clean |
| `prettier` | touched files clean |
| `build:bundle-scenes` | passed, no ceiling exceeded |
| Sprite parity (10 scenes: 50, 51, 52, 53, 58, 92, 93, 96, 97, 117) | all pass, MAD 0.000–0.078 |
| `test:parity` (full) | 432 passed, 7 failed — the **same 7 fail on master** with the change stashed, and none of them reference the sprite API at all (8, 75, 104, 105, 106, 211, 265) |

## Bundle size

The 10 sprite scene manifests are regenerated and included: **+50 to +76 bytes** each. No ceiling was modified and none is exceeded.

Worth flagging: **scene117 now sits only 33 B below its 16.4 KB ceiling.** It passes, but it has almost no headroom left, so the next sprite change will likely need that ceiling raised.
