### PR TITLE
feat(compat): add quaternion toRotationMatrix

### DIFF
--- a/docs/lite/architecture/00-overview.md
+++ b/docs/lite/architecture/00-overview.md
@@ -886,6 +886,7 @@ Indices `[col*4+row]` — matches WGSL `mat4x4<f32>` storage.
 | `mat4Invert(m)`                                | `→ Mat4 \| null` | Full 4x4 inverse via cofactors                |
 | `mat4Compose(tx,ty,tz, qx,qy,qz,qw, sx,sy,sz)` | `→ Mat4`         | TRS composition                               |
 | `mat4FromQuat(qx,qy,qz,qw)`                    | `→ Mat4`         | Quaternion to rotation matrix                 |
+| `mat4FromQuatInto(out, qx,qy,qz,qw)`           | `→ out`          | Zero-allocation quaternion to rotation matrix |
 
 **LookAtLH formula** (matches Babylon.js `Matrix.LookAtLHToRef`):
 

--- a/docs/lite/architecture/21-core-math.md
+++ b/docs/lite/architecture/21-core-math.md
@@ -122,6 +122,9 @@ export function mat4Translation(x: number, y: number, z: number): Mat4;
 /** Create a rotation matrix from a quaternion. */
 export function mat4FromQuat(qx: number, qy: number, qz: number, qw: number): Mat4;
 
+/** Write a rotation matrix from a quaternion into an existing matrix buffer. */
+export function mat4FromQuatInto<T extends Float32Array | Float64Array>(out: T, qx: number, qy: number, qz: number, qw: number): T;
+
 /** Compose TRS (translation * rotation * scale) into a single Mat4. */
 export function mat4Compose(tx: number, ty: number, tz: number, qx: number, qy: number, qz: number, qw: number, sx: number, sy: number, sz: number): Mat4;
 
@@ -311,6 +314,9 @@ out = identity with out[12]=x, out[13]=y, out[14]=z
 
 ### mat4FromQuat(qx, qy, qz, qw)
 
+`mat4FromQuatInto(out, qx, qy, qz, qw)` writes the same 16 values into an
+existing matrix buffer and returns `out`.
+
 ```
 xx=qx*qx  yy=qy*qy  zz=qz*qz
 xy=qx*qy  xz=qx*qz  yz=qy*qz
@@ -359,6 +365,7 @@ result[15] = 1
 | `mat4PerspectiveLH(fov,ar,n,f)` | `BABYLON.Matrix.PerspectiveFovLH(fov,ar,n,f)`        |
 | `mat4Invert(m)`                 | `m.invert()` / `BABYLON.Matrix.Invert(m)`            |
 | `mat4FromQuat(qx,qy,qz,qw)`     | `BABYLON.Matrix.FromQuaternion(q)`                   |
+| `mat4FromQuatInto(out,...)`     | `BABYLON.Matrix.FromQuaternionToRef(q,out)`          |
 | `mat4Compose(t,r,s)`            | `BABYLON.Matrix.Compose(scale,rotation,translation)` |
 | Column-major layout             | Column-major layout (same)                           |
 | Left-handed                     | Left-handed (same)                                   |
@@ -383,6 +390,7 @@ result[15] = 1
 | `mat4Invert returns null for singular` | Zero matrix → null                                      |
 | `mat4FromQuat identity`                | Quat (0,0,0,1) → identity matrix                        |
 | `mat4FromQuat 90° around Y`            | Verify correct rotation                                 |
+| `mat4FromQuatInto`                     | Writes into existing storage with no replacement         |
 | `mat4Compose T×R×S`                    | Compare with manual multiply of separate matrices       |
 | `normalizeVec3 zero`                   | Returns (0,0,0) for zero vector                         |
 | `crossVec3 X×Y=Z`                      | (1,0,0) × (0,1,0) = (0,0,1)                             |

--- a/packages/babylon-lite-compat/src/math/quaternion.ts
+++ b/packages/babylon-lite-compat/src/math/quaternion.ts
@@ -5,7 +5,7 @@
  * Babylon Lite `{ x, y, z, w }` quaternion shape used on transform nodes.
  */
 
-import { quatFromRotationMatrix } from "babylon-lite";
+import { mat4FromQuatInto, quatFromRotationMatrix } from "babylon-lite";
 import type { Mat4 } from "babylon-lite";
 
 import { Vector3 } from "./vector.js";
@@ -75,6 +75,15 @@ export class Quaternion {
         this.z = q.z;
         this.w = q.w;
         return this;
+    }
+
+    /**
+     * Babylon.js `Quaternion.toRotationMatrix` — write this quaternion's rotation
+     * into `result`.
+     */
+    public toRotationMatrix<T extends Matrix>(result: T): T {
+        mat4FromQuatInto(result.m, this.x, this.y, this.z, this.w);
+        return result;
     }
 
     public clone(): Quaternion {

--- a/packages/babylon-lite-compat/tests/math.test.ts
+++ b/packages/babylon-lite-compat/tests/math.test.ts
@@ -258,6 +258,39 @@ describe("Quaternion", () => {
         expect(back.w * sign).toBeCloseTo(src.w, 5);
     });
 
+    it("writes a Babylon.js-convention rotation matrix and resets translation", () => {
+        const q = Quaternion.RotationAxis(new Vector3(0, 0, 1), Math.PI / 2);
+        const result = Matrix.Translation(7, 8, 9);
+        const storage = result.m;
+        const returned = q.toRotationMatrix(result);
+
+        expect(returned).toBe(result);
+        expect(result.m).toBe(storage);
+        expect(result.m[0]).toBeCloseTo(0, 6);
+        expect(result.m[1]).toBeCloseTo(1, 6);
+        expect(result.m[4]).toBeCloseTo(-1, 6);
+        expect(result.m[5]).toBeCloseTo(0, 6);
+        expect(result.m[10]).toBeCloseTo(1, 6);
+        expect(result.m[12]).toBe(0);
+        expect(result.m[13]).toBe(0);
+        expect(result.m[14]).toBe(0);
+        expect(result.m[15]).toBe(1);
+    });
+
+    it("round-trips through toRotationMatrix and fromRotationMatrix", () => {
+        const src = Quaternion.RotationYawPitchRoll(-0.7, 0.2, 1.4).normalize();
+        const rotMat = new Matrix();
+        src.toRotationMatrix(rotMat);
+
+        const back = new Quaternion().fromRotationMatrix(rotMat);
+        const dot = back.x * src.x + back.y * src.y + back.z * src.z + back.w * src.w;
+        const sign = dot < 0 ? -1 : 1;
+        expect(back.x * sign).toBeCloseTo(src.x, 5);
+        expect(back.y * sign).toBeCloseTo(src.y, 5);
+        expect(back.z * sign).toBeCloseTo(src.z, 5);
+        expect(back.w * sign).toBeCloseTo(src.w, 5);
+    });
+
     it("updates in place via fromRotationMatrix and FromRotationMatrixToRef", () => {
         const src = Quaternion.RotationYawPitchRoll(-0.2, 0.9, 0.3).normalize();
         const rotMat = Matrix.Compose(new Vector3(1, 1, 1), src, new Vector3());

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -393,7 +393,7 @@ export { mat4Invert } from "./math/mat4-invert.js";
 export { mat4Multiply } from "./math/mat4-multiply.js";
 export { mat4LookAtLH } from "./math/mat4-look-at-lh.js";
 export { mat4PerspectiveLH } from "./math/mat4-perspective-lh.js";
-export { mat4FromQuat } from "./math/mat4-from-quat.js";
+export { mat4FromQuat, mat4FromQuatInto } from "./math/mat4-from-quat.js";
 export { quatFromRotationMatrix } from "./math/quat-from-rotation-matrix.js";
 export { quatFromLookDirectionRH } from "./math/quat-from-look-direction-rh.js";
 export { mat4Decompose } from "./math/mat4-decompose.js";

--- a/packages/babylon-lite/src/math/index.ts
+++ b/packages/babylon-lite/src/math/index.ts
@@ -42,7 +42,7 @@ export { mat4OrthoOffCenterLHToRef } from "./mat4-ortho-lh-to-ref.js";
 export { mat4Invert } from "./mat4-invert.js";
 export { mat4Scale } from "./mat4-scale.js";
 export { mat4Translation } from "./mat4-translation.js";
-export { mat4FromQuat } from "./mat4-from-quat.js";
+export { mat4FromQuat, mat4FromQuatInto } from "./mat4-from-quat.js";
 export { mat4Compose } from "./mat4-compose.js";
 export { mat4ComposeInto } from "./mat4-compose-into.js";
 export { mat4MultiplyInto } from "./mat4-multiply-into.js";

--- a/packages/babylon-lite/src/math/mat4-from-quat.ts
+++ b/packages/babylon-lite/src/math/mat4-from-quat.ts
@@ -2,6 +2,12 @@ import { F32 } from "../engine/typed-arrays.js";
 import type { Mat4 } from "./types.js";
 import { mat4ComposeInto } from "./mat4-compose-into.js";
 
+/** Write a rotation matrix from a quaternion into an existing matrix buffer. */
+export function mat4FromQuatInto<T extends Float32Array | Float64Array>(out: T, qx: number, qy: number, qz: number, qw: number): T {
+    mat4ComposeInto(out, 0, 0, 0, 0, qx, qy, qz, qw, 1, 1, 1);
+    return out;
+}
+
 /** Create a rotation matrix from a quaternion. */
 export function mat4FromQuat(qx: number, qy: number, qz: number, qw: number): Mat4 {
     const out = new F32(16);

--- a/packages/babylon-lite/src/math/mat4.ts
+++ b/packages/babylon-lite/src/math/mat4.ts
@@ -7,7 +7,7 @@ export { mat4OrthoOffCenterLHToRef } from "./mat4-ortho-lh-to-ref.js";
 export { mat4Invert } from "./mat4-invert.js";
 export { mat4Scale } from "./mat4-scale.js";
 export { mat4Translation } from "./mat4-translation.js";
-export { mat4FromQuat } from "./mat4-from-quat.js";
+export { mat4FromQuat, mat4FromQuatInto } from "./mat4-from-quat.js";
 export { mat4Compose } from "./mat4-compose.js";
 export { mat4ComposeInto } from "./mat4-compose-into.js";
 export { mat4MultiplyInto } from "./mat4-multiply-into.js";

--- a/tests/lite/unit/mat4-transform.test.ts
+++ b/tests/lite/unit/mat4-transform.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { transformCoordinatesToRef, transformNormalToRef, mat4GetTranslationToRef } from "../../../packages/babylon-lite/src/math/mat4-transform";
 import { mat4Identity } from "../../../packages/babylon-lite/src/math/mat4-identity";
 import { mat4Translation } from "../../../packages/babylon-lite/src/math/mat4-translation";
+import { mat4FromQuatInto } from "../../../packages/babylon-lite/src/math/mat4-from-quat";
 import type { Mat4, Vec3 } from "../../../packages/babylon-lite/src/math/types";
 
 /** Build a Mat4 from 16 column-major numbers (test-only). */
@@ -64,5 +65,20 @@ describe("mat4 vec transforms", () => {
         const out: Vec3 = { x: 0, y: 0, z: 0 };
         mat4GetTranslationToRef(mat4Translation(4, -5, 6), out);
         expect(out).toEqual({ x: 4, y: -5, z: 6 });
+    });
+
+    it("mat4FromQuatInto writes into existing storage and resets translation", () => {
+        const out = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 7, 8, 9, 1]);
+        const returned = mat4FromQuatInto(out, 0, 0, Math.sin(Math.PI / 4), Math.cos(Math.PI / 4));
+
+        expect(returned).toBe(out);
+        expect(out[0]).toBeCloseTo(0, 6);
+        expect(out[1]).toBeCloseTo(1, 6);
+        expect(out[4]).toBeCloseTo(-1, 6);
+        expect(out[5]).toBeCloseTo(0, 6);
+        expect(out[12]).toBe(0);
+        expect(out[13]).toBe(0);
+        expect(out[14]).toBe(0);
+        expect(out[15]).toBe(1);
     });
 });


### PR DESCRIPTION
Fixes #481

## Summary
- Added compat `Quaternion.toRotationMatrix(result)`.
- Added root-exported Lite `mat4FromQuatInto(out, qx, qy, qz, qw)` so compat can write directly into the supplied `Matrix.m` without allocating an intermediate matrix.
- Added regression coverage for returned out-param/subtype, storage reuse, Babylon.js row-vector layout, translation reset, and `toRotationMatrix` -> `fromRotationMatrix` round-trip.

## Implementation choice
I used a focused zero-allocation core helper instead of importing `mat4ComposeInto` directly from compat. Compat still imports only from the `babylon-lite` root entry point; `mat4ComposeInto` remains an internal implementation detail. Because the final PR touches `packages/babylon-lite/src/**`, I regenerated and committed the per-scene bundle manifests.

## Matrix convention verified
Verified against Babylon.js `Quaternion.toRotationMatrix` / `Matrix.FromQuaternionToRef` via `C:\Repos\Babylon.js\packages\dev\core\src\Maths\math.vector.ts` (which re-exports `math.vector.pure.ts`): it writes Babylon's row-vector 4x4 layout (`m[1] = +sin`, `m[4] = -sin` for +Z 90°), resets `m[12..14]` to `0`, sets `m[15]` to `1`, and returns the supplied matrix.

## Validation
- `pnpm lint:fix` — passed
- `pnpm lint` — passed
- `pnpm test:unit` — passed (156 files, 1167 tests)
- `pnpm exec vitest run --project compat` — passed (37 files, 356 tests)
- `pnpm build:bundle-scenes` — passed; committed regenerated per-scene manifests
- `pnpm validate:bundle-manifest` — passed (223 scenes checked)
