### PR TITLE
feat(compat): add texture load observable

### DIFF
--- a/packages/babylon-lite-compat/src/misc/observable.ts
+++ b/packages/babylon-lite-compat/src/misc/observable.ts
@@ -10,9 +10,20 @@ export type ObserverCallback<T> = (eventData: T) => void;
 
 export class Observable<T> {
     private _observers: ObserverCallback<T>[] = [];
+    private _hasNotified = false;
+    private _lastNotifiedValue: T | undefined;
+
+    public constructor(
+        private _onObserverAdded?: (observer: ObserverCallback<T>) => void,
+        public notifyIfTriggered = false
+    ) {}
 
     public add(callback: ObserverCallback<T>): ObserverCallback<T> {
         this._observers.push(callback);
+        this._onObserverAdded?.(callback);
+        if (this._hasNotified && this.notifyIfTriggered && this._lastNotifiedValue !== undefined) {
+            callback(this._lastNotifiedValue);
+        }
         return callback;
     }
 
@@ -21,8 +32,7 @@ export class Observable<T> {
             this.removeCallback(wrapper);
             callback(eventData);
         };
-        this._observers.push(wrapper);
-        return wrapper;
+        return this.add(wrapper);
     }
 
     public remove(callback: ObserverCallback<T> | null | undefined): boolean {
@@ -39,6 +49,10 @@ export class Observable<T> {
     }
 
     public notifyObservers(eventData?: T): void {
+        if (this.notifyIfTriggered) {
+            this._hasNotified = true;
+            this._lastNotifiedValue = eventData;
+        }
         // Iterate a copy so observers can add/remove during notification.
         for (const observer of this._observers.slice()) {
             observer(eventData as T);
@@ -51,5 +65,12 @@ export class Observable<T> {
 
     public clear(): void {
         this._observers = [];
+        this._onObserverAdded = undefined;
+        this.cleanLastNotifiedState();
+    }
+
+    public cleanLastNotifiedState(): void {
+        this._hasNotified = false;
+        this._lastNotifiedValue = undefined;
     }
 }

--- a/packages/babylon-lite-compat/src/textures/textures.ts
+++ b/packages/babylon-lite-compat/src/textures/textures.ts
@@ -89,6 +89,7 @@ export abstract class BaseTexture {
 
 export class Texture extends BaseTexture {
     private readonly _ready: Promise<void>;
+    private _onLoadObservable: Observable<Texture> | undefined;
     /** Babylon.js sampling-mode constants (numeric parity). */
     public static readonly NEAREST_SAMPLINGMODE = 1;
     public static readonly BILINEAR_SAMPLINGMODE = 2;
@@ -160,6 +161,7 @@ export class Texture extends BaseTexture {
 
         this._ready = loadCompatTexture(engine, url, loadOpts).then((tex) => {
             this._lite = tex;
+            this._notifyLoadObservable();
             if (onLoad) {
                 onLoad();
             }
@@ -199,6 +201,25 @@ export class Texture extends BaseTexture {
 
     public override whenReadyAsync(): Promise<void> {
         return this._ready;
+    }
+
+    /** Babylon.js `Texture.onLoadObservable`, allocated only when code subscribes. */
+    public get onLoadObservable(): Observable<Texture> {
+        let observable = this._onLoadObservable;
+        if (!observable) {
+            observable = new Observable<Texture>(undefined, true);
+            this._onLoadObservable = observable;
+            if (this.isReady()) {
+                observable.notifyObservers(this);
+            }
+        }
+        return observable;
+    }
+
+    private _notifyLoadObservable(): void {
+        if (this._onLoadObservable) {
+            this._onLoadObservable.notifyObservers(this);
+        }
     }
 
     /** Babylon.js `BaseTexture.isReady()` — true once the GPU handle has resolved. */

--- a/packages/babylon-lite-compat/tests/misc.test.ts
+++ b/packages/babylon-lite-compat/tests/misc.test.ts
@@ -42,6 +42,59 @@ describe("Observable", () => {
         obs.notifyObservers();
         expect(cb).toHaveBeenCalledTimes(1);
     });
+
+    it("replays the last notification to late subscribers when notifyIfTriggered is enabled", () => {
+        const obs = new Observable<number>(undefined, true);
+        const seen: number[] = [];
+
+        obs.notifyObservers(3);
+        obs.add((n) => seen.push(n));
+        obs.notifyObservers(5);
+
+        expect(seen).toEqual([3, 5]);
+    });
+
+    it("does not replay to late subscribers by default", () => {
+        const obs = new Observable<number>();
+        const seen: number[] = [];
+
+        obs.notifyObservers(3);
+        obs.add((n) => seen.push(n));
+
+        expect(seen).toEqual([]);
+    });
+
+    it("replays addOnce late subscribers once when notifyIfTriggered is enabled", () => {
+        const obs = new Observable<number>(undefined, true);
+        const seen: number[] = [];
+
+        obs.notifyObservers(3);
+        obs.addOnce((n) => seen.push(n));
+        obs.notifyObservers(5);
+
+        expect(seen).toEqual([3]);
+    });
+
+    it("does not replay an undefined last notification, matching Babylon.js", () => {
+        const obs = new Observable<void>(undefined, true);
+        const cb = vi.fn();
+
+        obs.notifyObservers();
+        obs.add(cb);
+
+        expect(cb).not.toHaveBeenCalled();
+    });
+
+    it("clears the last notified state", () => {
+        const obs = new Observable<number>(undefined, true);
+        const seen: number[] = [];
+
+        obs.notifyObservers(3);
+        obs.cleanLastNotifiedState();
+        obs.add((n) => seen.push(n));
+
+        expect(seen).toEqual([]);
+    });
 });
 
 describe("Tools", () => {

--- a/packages/babylon-lite-compat/tests/textures.test.ts
+++ b/packages/babylon-lite-compat/tests/textures.test.ts
@@ -1,6 +1,49 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { resolveKtxUrl, CubeTexture, HDRCubeTexture } from "../src/textures/textures";
+const liteMocks = vi.hoisted(() => ({
+    loadTexture2D: vi.fn(),
+    loadBasisTexture2D: vi.fn(),
+    loadKtxTexture2D: vi.fn(),
+    createTexture2DFromPixels: vi.fn(),
+    updateTexture2DFromPixels: vi.fn(),
+    createTexture3DFromPixels: vi.fn(),
+    createDynamicTexture: vi.fn(),
+    updateDynamicTexture: vi.fn(),
+}));
+
+vi.mock("babylon-lite", () => liteMocks);
+
+import { resolveKtxUrl, CubeTexture, HDRCubeTexture, Texture } from "../src/textures/textures";
+
+type Deferred<T> = {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+function engineWrapper(): { _lite: object } {
+    return { _lite: {} };
+}
+
+function textureHandle(): unknown {
+    return { id: "texture" };
+}
+
+beforeEach(() => {
+    for (const mock of Object.values(liteMocks)) {
+        mock.mockReset();
+    }
+});
 
 /**
  * `resolveKtxUrl` recognises a pre-resolved compressed `.ktx` URL (the single
@@ -26,6 +69,91 @@ describe("resolveKtxUrl", () => {
         expect(resolveKtxUrl("https://h/UVgrid.png")).toBeNull();
         expect(resolveKtxUrl("https://h/UVgrid.ktx")).toBeNull(); // no recognised format suffix
         expect(resolveKtxUrl("https://h/model.basis")).toBeNull();
+    });
+});
+
+describe("Texture onLoadObservable", () => {
+    it("does not allocate the observable when nobody subscribes", async () => {
+        const load = deferred<unknown>();
+        liteMocks.loadTexture2D.mockReturnValueOnce(load.promise);
+
+        const tex = new Texture("https://h/albedo.png", engineWrapper());
+        expect((tex as unknown as { _onLoadObservable?: unknown })._onLoadObservable).toBeUndefined();
+
+        load.resolve(textureHandle());
+        await tex.whenReadyAsync();
+
+        expect(tex.isReady()).toBe(true);
+        expect((tex as unknown as { _onLoadObservable?: unknown })._onLoadObservable).toBeUndefined();
+    });
+
+    it("fires once with the constructor onLoad callback and whenReadyAsync", async () => {
+        const load = deferred<unknown>();
+        liteMocks.loadTexture2D.mockReturnValueOnce(load.promise);
+        let onLoadCalls = 0;
+        let observerCalls = 0;
+        const events: string[] = [];
+
+        const tex = new Texture("https://h/albedo.png", engineWrapper(), undefined, undefined, undefined, () => {
+            events.push("onLoad");
+            onLoadCalls++;
+        });
+        tex.onLoadObservable.add((observed) => {
+            events.push("observable");
+            observerCalls++;
+            expect(observed).toBe(tex);
+        });
+
+        load.resolve(textureHandle());
+        await tex.whenReadyAsync();
+
+        expect(tex.isReady()).toBe(true);
+        expect(onLoadCalls).toBe(1);
+        expect(observerCalls).toBe(1);
+        expect(events).toEqual(["observable", "onLoad"]);
+    });
+
+    it("fires immediately for subscribers attached after the texture is ready", async () => {
+        const load = deferred<unknown>();
+        liteMocks.loadTexture2D.mockReturnValueOnce(load.promise);
+        const tex = new Texture("https://h/albedo.png", engineWrapper());
+
+        load.resolve(textureHandle());
+        await tex.whenReadyAsync();
+
+        let addCalls = 0;
+        let addOnceCalls = 0;
+        tex.onLoadObservable.add((observed) => {
+            addCalls++;
+            expect(observed).toBe(tex);
+        });
+        tex.onLoadObservable.addOnce((observed) => {
+            addOnceCalls++;
+            expect(observed).toBe(tex);
+        });
+
+        expect(addCalls).toBe(1);
+        expect(addOnceCalls).toBe(1);
+    });
+
+    it("does not double-fire when a constructor onLoad callback subscribes", async () => {
+        const load = deferred<unknown>();
+        liteMocks.loadTexture2D.mockReturnValueOnce(load.promise);
+        let observerCalls = 0;
+        const state: { tex?: Texture } = {};
+
+        const tex = new Texture("https://h/albedo.png", engineWrapper(), undefined, undefined, undefined, () => {
+            state.tex!.onLoadObservable.add((observed) => {
+                observerCalls++;
+                expect(observed).toBe(state.tex);
+            });
+        });
+        state.tex = tex;
+
+        load.resolve(textureHandle());
+        await tex.whenReadyAsync();
+
+        expect(observerCalls).toBe(1);
     });
 });
 


### PR DESCRIPTION
Fixes #479

## Summary
- Added `Texture.onLoadObservable` parity for compat `Texture`.
- Moved the late-subscriber replay primitive into the base compat `Observable` as a Babylon.js-style `notifyIfTriggered` constructor option instead of keeping a texture-local subclass.
- `Texture.onLoadObservable` remains lazily allocated via a getter; if first touched after readiness, it primes the observable so late subscribers replay correctly. Readiness notification runs once before the constructor `onLoad` callback and composes with `whenReadyAsync()` without double-firing.

## Validation
- `pnpm lint:fix` — passed
- `pnpm lint` — passed
- `pnpm test:unit` — passed on rerun (first run hit known flaky `tests/lite/unit/racer-vehicle.test.ts` timeout)
- `pnpm exec vitest run --project compat` — passed (34 files, 339 tests)

Parity was not run because this PR only changes `packages/babylon-lite-compat/**`, not `packages/babylon-lite/src/**`.