### PR TITLE
fix(compat): report engine startup rejections

### DIFF
--- a/packages/babylon-lite-compat/src/engine/engine.ts
+++ b/packages/babylon-lite-compat/src/engine/engine.ts
@@ -37,6 +37,7 @@ import {
 import type { EngineContext, EngineOptions, RenderCanvas } from "babylon-lite";
 
 import { LiteCompatError, unsupported } from "../error.js";
+import { Logger } from "../misc/misc-utils.js";
 import { Observable } from "../misc/observable.js";
 import type { Scene } from "../scene/scene.js";
 
@@ -82,6 +83,9 @@ export abstract class AbstractEngine {
 
     /** Babylon.js `engine.onResizeObservable` — fires after `resize()` / `setSize()`. */
     public readonly onResizeObservable = new Observable<AbstractEngine>();
+
+    /** Optional startup failure hook; left undefined unless an app opts in. */
+    public onStartupError: ((error: unknown) => void) | undefined;
 
     /** @internal Babylon.js hardware-scaling level. Babylon Lite manages device-pixel-ratio itself; stored for parity. */
     private _hardwareScalingLevel = 1;
@@ -279,23 +283,27 @@ export abstract class AbstractEngine {
         for (const scene of this._scenes) {
             onBeforeRender(scene._lite, () => callback());
         }
-        void this._start().then(() => {
-            // Scene-less render loops (e.g. the `SpriteRenderer` 2D path) have no
-            // scene before-render hook to drive the callback. Run them on a
-            // `requestAnimationFrame` loop so per-frame work (e.g. sprite-sheet
-            // animation that mutates `cellIndex` each tick) actually advances.
-            // Babylon Lite's own render loop draws the registered sprite renderer;
-            // we just need to push the updated sprite data before each frame.
-            if (this._scenes.length === 0 && this._rafId === null && typeof requestAnimationFrame === "function") {
-                const tick = (): void => {
-                    for (const cb of this._loopCallbacks) {
-                        cb();
-                    }
+        void this._start()
+            .then(() => {
+                // Scene-less render loops (e.g. the `SpriteRenderer` 2D path) have no
+                // scene before-render hook to drive the callback. Run them on a
+                // `requestAnimationFrame` loop so per-frame work (e.g. sprite-sheet
+                // animation that mutates `cellIndex` each tick) actually advances.
+                // Babylon Lite's own render loop draws the registered sprite renderer;
+                // we just need to push the updated sprite data before each frame.
+                if (this._scenes.length === 0 && this._rafId === null && typeof requestAnimationFrame === "function") {
+                    const tick = (): void => {
+                        for (const cb of this._loopCallbacks) {
+                            cb();
+                        }
+                        this._rafId = requestAnimationFrame(tick);
+                    };
                     this._rafId = requestAnimationFrame(tick);
-                };
-                this._rafId = requestAnimationFrame(tick);
-            }
-        });
+                }
+            })
+            .catch((error: unknown) => {
+                this._reportStartupError(error);
+            });
     }
 
     public stopRenderLoop(): void {
@@ -405,6 +413,22 @@ export abstract class AbstractEngine {
         if (!this._initialized) {
             throw new LiteCompatError(`${this.constructor.name}.${api}`, "Call `await engine.initAsync()` before using the engine.");
         }
+    }
+
+    private _reportStartupError(error: unknown): void {
+        Logger.Error(`${this.constructor.name}.runRenderLoop startup failed: ${this._formatStartupError(error)}`);
+        try {
+            this.onStartupError?.(error);
+        } catch (hookError) {
+            Logger.Error(`${this.constructor.name}.onStartupError callback failed: ${this._formatStartupError(hookError)}`);
+        }
+    }
+
+    private _formatStartupError(error: unknown): string {
+        if (error instanceof Error) {
+            return error.message ? `${error.name}: ${error.message}` : error.name;
+        }
+        return String(error);
     }
 }
 

--- a/packages/babylon-lite-compat/tests/engine-startup.test.ts
+++ b/packages/babylon-lite-compat/tests/engine-startup.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const lite = vi.hoisted(() => ({
+    createEngine: vi.fn(),
+    startEngine: vi.fn(),
+    stopEngine: vi.fn(),
+    resizeEngine: vi.fn(),
+    setEngineSize: vi.fn(),
+    disposeEngine: vi.fn(),
+    registerScene: vi.fn(),
+    registerSceneWithShadowSupport: vi.fn(),
+    onBeforeRender: vi.fn(),
+    createNullEngine: vi.fn(),
+    stepScene: vi.fn(),
+    VERSION: "test-version",
+}));
+
+vi.mock("babylon-lite", () => lite);
+
+import { WebGPUEngine } from "../src/engine/engine";
+import { Logger } from "../src/misc/misc-utils";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+});
+
+describe("engine startup error reporting", () => {
+    it("reports registerScene rejections through Logger.Error and the optional startup hook", async () => {
+        const startupError = new Error("registerScene failed");
+        lite.registerScene.mockRejectedValueOnce(startupError);
+
+        const loggerError = vi.spyOn(Logger, "Error").mockImplementation(() => {});
+        const engine = new WebGPUEngine({ width: 1, height: 1 } as never);
+        (engine as unknown as { _initialized: boolean; _lite: unknown })._initialized = true;
+        (engine as unknown as { _initialized: boolean; _lite: unknown })._lite = {};
+
+        const scene = {
+            _lite: {},
+            _buildShadowGenerators: vi.fn(),
+            _parseNodeMaterials: vi.fn().mockResolvedValue(undefined),
+            _awaitPendingTextures: vi.fn().mockResolvedValue(undefined),
+            _bakeGroundUvs: vi.fn(),
+            _flushPendingAdds: vi.fn(),
+            _buildMorphTargets: vi.fn(),
+            _loadPendingEnvironment: vi.fn().mockResolvedValue(undefined),
+            _hasShadows: vi.fn(() => false),
+        };
+        (engine as unknown as { _scenes: unknown[] })._scenes.push(scene);
+
+        const reported = new Promise<unknown>((resolve) => {
+            engine.onStartupError = resolve;
+        });
+
+        engine.runRenderLoop(() => {});
+
+        await expect(reported).resolves.toBe(startupError);
+        expect(lite.registerScene).toHaveBeenCalledWith(scene._lite);
+        expect(loggerError).toHaveBeenCalledTimes(1);
+        expect(loggerError.mock.calls[0]?.[0]).toContain("WebGPUEngine.runRenderLoop startup failed");
+        expect(loggerError.mock.calls[0]?.[0]).toContain("Error: registerScene failed");
+    });
+});


### PR DESCRIPTION
Fixes #470

## Summary
- Added a catch on the compat `runRenderLoop()` startup chain so `_start()` rejections are attributed through `Logger.Error` instead of becoming bare unhandled rejections.
- Added `engine.onStartupError` as a plain optional callback for apps that want to observe startup failures without paying for an always-allocated observable.
- Added a compat regression test that makes `registerScene` reject and asserts both `Logger.Error` and the optional hook receive the failure.

## Validation
- `pnpm lint:fix` — passed
- `pnpm lint` — passed
- `pnpm exec vitest run --project compat packages/babylon-lite-compat/tests/engine-startup.test.ts` — passed (1/1)
- `pnpm exec vitest run --project compat` — passed (331/331)
- `pnpm test:unit` — run three times; failures were timeouts in known/pre-existing flaky tests (`tests/lite/unit/audit/no-direct-mat4-writes.test.ts`, `tests/lite/unit/racer-vehicle.test.ts`) plus one load-related timeout in `bundle-content-no-f64` that passed on targeted retry. Targeted retry passed `no-direct-mat4-writes` and `bundle-content-no-f64`; `racer-vehicle` remains the known pre-existing failure.

No `packages/babylon-lite/src/**` files were modified, so parity/bundle-scene validation was not required.