### PR TITLE
Move quat-euler conversions to math/ and export from the top-level barrel

### DIFF
--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -5,12 +5,12 @@
   "runtimeChunks": [
     "scene222-gpu-pool-CHlSfwGp.js",
     "scene222-scene-uniforms-Ha63NnVx.js",
-    "scene222-shader-pipeline-cache-Dyic7m9D.js",
-    "scene222-shader-renderable-Ba4uQuXa.js",
-    "scene222-standard-renderable-BQS0k0qP.js",
+    "scene222-shader-pipeline-cache-CRfxG7iY.js",
+    "scene222-shader-renderable-BtDJhdXD.js",
+    "scene222-standard-renderable-C9AUaG7J.js",
     "scene222-swapchain-overlay-ilhN4El_.js",
-    "scene222-uniform-copy-batch-CCq6WmBY.js",
+    "scene222-uniform-copy-batch-DrEP8HMR.js",
     "scene222.js"
   ],
-  "rawBytes": 115217
+  "rawBytes": 115249
 }

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -408,6 +408,7 @@ export type { DecomposedTransform } from "./math/mat4-decompose.js";
 export type { Vec2, Vec3, Vec3Tuple, Vec4, Color3, Color4, Mat4, Quat } from "./math/types.js";
 export type { Aabb } from "./math/aabb.js";
 export { computeAabb } from "./math/aabb.js";
+export { eulerToQuat, quatToEulerXYZ } from "./math/quat-euler.js";
 export type { GltfMetadata, LiteMetadata } from "./metadata.js";
 
 // ─── Color ───────────────────────────────────────────────────────────

--- a/packages/babylon-lite/src/math/quat-euler.ts
+++ b/packages/babylon-lite/src/math/quat-euler.ts
@@ -1,0 +1,19 @@
+/** Euler XYZ → quaternion (intrinsic XYZ order). */
+export function eulerToQuat(rx: number, ry: number, rz: number): [number, number, number, number] {
+    const cx = Math.cos(rx * 0.5),
+        sx_ = Math.sin(rx * 0.5);
+    const cy = Math.cos(ry * 0.5),
+        sy_ = Math.sin(ry * 0.5);
+    const cz = Math.cos(rz * 0.5),
+        sz_ = Math.sin(rz * 0.5);
+    return [sx_ * cy * cz + cx * sy_ * sz_, cx * sy_ * cz - sx_ * cy * sz_, cx * cy * sz_ + sx_ * sy_ * cz, cx * cy * cz - sx_ * sy_ * sz_];
+}
+
+/** Quaternion → Euler XYZ (inverse of eulerToQuat). */
+export function quatToEulerXYZ(qx: number, qy: number, qz: number, qw: number): [number, number, number] {
+    const sinY = 2 * (qx * qz + qw * qy);
+    const ry = Math.asin(Math.max(-1, Math.min(1, sinY)));
+    const rx = Math.atan2(-(2 * (qy * qz - qw * qx)), 1 - 2 * (qx * qx + qy * qy));
+    const rz = Math.atan2(-(2 * (qx * qy - qw * qz)), 1 - 2 * (qy * qy + qz * qz));
+    return [rx, ry, rz];
+}

--- a/packages/babylon-lite/src/mesh/GaussianSplatting/gaussian-splatting-mesh.ts
+++ b/packages/babylon-lite/src/mesh/GaussianSplatting/gaussian-splatting-mesh.ts
@@ -17,7 +17,8 @@ import type { Mat4 } from "../../math/types.js";
 import { ObservableVec3 } from "../../math/observable-vec3.js";
 import { ObservableQuat } from "../../math/observable-quat.js";
 import { createWorldMatrixState, attachWorldMatrixState, composeTrsLocalMatrix } from "../../scene/world-matrix-state.js";
-import { eulerToQuat, createEulerProxy } from "../../scene/scene-node.js";
+import { createEulerProxy } from "../../scene/scene-node.js";
+import { eulerToQuat } from "../../math/quat-euler.js";
 import { buildSplatGeometry, type SplatGeometry, type ParsedSplat } from "../../loader-splat/splat-data.js";
 
 /** Names of the four WGSL slots a `GsShaderFragment` may inject into the

--- a/packages/babylon-lite/src/mesh/mesh.ts
+++ b/packages/babylon-lite/src/mesh/mesh.ts
@@ -11,7 +11,8 @@ import { ObservableQuat } from "../math/observable-quat.js";
 import type { ThinInstanceData } from "./thin-instance.js";
 import { createWorldMatrixState, attachWorldMatrixState, composeTrsLocalMatrix } from "../scene/world-matrix-state.js";
 import type { SceneNode } from "../scene/scene-node.js";
-import { eulerToQuat, createEulerProxy } from "../scene/scene-node.js";
+import { createEulerProxy } from "../scene/scene-node.js";
+import { eulerToQuat } from "../math/quat-euler.js";
 
 // ─── Mesh GPU Geometry ───────────────────────────────────────────────
 

--- a/packages/babylon-lite/src/scene/scene-node.ts
+++ b/packages/babylon-lite/src/scene/scene-node.ts
@@ -9,6 +9,7 @@ import type { IWorldMatrixProvider } from "./parentable.js";
 import { ObservableVec3 } from "../math/observable-vec3.js";
 import { ObservableQuat } from "../math/observable-quat.js";
 import { createWorldMatrixState, attachWorldMatrixState, composeTrsLocalMatrix } from "./world-matrix-state.js";
+import { eulerToQuat, quatToEulerXYZ } from "../math/quat-euler.js";
 
 // ─── EulerProxy ──────────────────────────────────────────────────────
 
@@ -45,28 +46,6 @@ export interface SceneNode {
     visible?: boolean;
     /** User metadata. glTF loads populate `metadata.gltf.extras` when source extras exist. */
     metadata?: LiteMetadata;
-}
-
-// ─── Math helpers ─────────────────────────────────────────────────────
-
-/** Euler XYZ → quaternion (intrinsic XYZ order). */
-export function eulerToQuat(rx: number, ry: number, rz: number): [number, number, number, number] {
-    const cx = Math.cos(rx * 0.5),
-        sx_ = Math.sin(rx * 0.5);
-    const cy = Math.cos(ry * 0.5),
-        sy_ = Math.sin(ry * 0.5);
-    const cz = Math.cos(rz * 0.5),
-        sz_ = Math.sin(rz * 0.5);
-    return [sx_ * cy * cz + cx * sy_ * sz_, cx * sy_ * cz - sx_ * cy * sz_, cx * cy * sz_ + sx_ * sy_ * cz, cx * cy * cz - sx_ * sy_ * sz_];
-}
-
-/** Quaternion → Euler XYZ (inverse of eulerToQuat). */
-export function quatToEulerXYZ(qx: number, qy: number, qz: number, qw: number): [number, number, number] {
-    const sinY = 2 * (qx * qz + qw * qy);
-    const ry = Math.asin(Math.max(-1, Math.min(1, sinY)));
-    const rx = Math.atan2(-(2 * (qy * qz - qw * qx)), 1 - 2 * (qx * qx + qy * qy));
-    const rz = Math.atan2(-(2 * (qx * qy - qw * qz)), 1 - 2 * (qy * qy + qz * qz));
-    return [rx, ry, rz];
 }
 
 /** Create a live bidirectional EulerProxy backed by the given ObservableQuat.


### PR DESCRIPTION
These conversions are used in multiple places and are generally useful for babylon users who utilize Euler coordinates in their code.

- Moved eulerToQuat and quatToEulerXYZ to `math/quat-euler.js`
- Updated existing imports.
- Added an export for both to the root `index.js` barrel.