### PR TITLE
feat(texture): add loadKtx2Texture2DArray for multi-layer KTX2 containers

### DIFF
--- a/lab/public/bundle/manifest/scene104.json
+++ b/lab/public/bundle/manifest/scene104.json
@@ -4,7 +4,7 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene104-generate-mipmaps-54_-V6nt.js",
-    "scene104-gltf-feature-registry-D818-Z5Q.js",
+    "scene104-gltf-feature-registry-D5LEfzRl.js",
     "scene104-gltf-glb-parser-LgX4YXgJ.js",
     "scene104-mesh-features-Dda6QcW-.js",
     "scene104-standard-renderable-Cl849vPY.js",

--- a/lab/public/bundle/manifest/scene105.json
+++ b/lab/public/bundle/manifest/scene105.json
@@ -4,7 +4,7 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene105-generate-mipmaps-C9h2y71s.js",
-    "scene105-gltf-feature-registry-TBSY_qnQ.js",
+    "scene105-gltf-feature-registry-Dfgj3DZv.js",
     "scene105-gltf-glb-parser-D4RelBML.js",
     "scene105-mesh-features-Dda6QcW-.js",
     "scene105-standard-renderable-DZ90qPe3.js",

--- a/lab/public/bundle/manifest/scene11.json
+++ b/lab/public/bundle/manifest/scene11.json
@@ -9,7 +9,7 @@
     "scene11-gltf-ext-spec-gloss-D60sFZYX.js",
     "scene11-gltf-feature-animations-C7UZCNpY.js",
     "scene11-gltf-feature-extras-VHPteGay.js",
-    "scene11-gltf-feature-registry-DmDB9ak5.js",
+    "scene11-gltf-feature-registry-BBNieAS0.js",
     "scene11-gltf-feature-skeleton-DzqLJNf9.js",
     "scene11-gltf-glb-parser-DkzNAISh.js",
     "scene11-gltf-sampler-desc-BhDLgho4.js",

--- a/lab/public/bundle/manifest/scene112.json
+++ b/lab/public/bundle/manifest/scene112.json
@@ -1,15 +1,15 @@
 {
   "rawKB": 120,
-  "gzipKB": 49.2,
+  "gzipKB": 49.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene112-background-dds-skybox-D_JXiHwm.js",
     "scene112-background-ground-BtpYxbIK.js",
     "scene112-cubemap-skybox-material-_JaJxh4q.js",
     "scene112-generate-mipmaps-pWw2s9cL.js",
-    "scene112-gltf-ext-basisu-D0HAY2eQ.js",
+    "scene112-gltf-ext-basisu-BDn8iWQK.js",
     "scene112-gltf-ext-dielectric-C6hvXXiF.js",
-    "scene112-gltf-feature-registry-C79E6Y9l.js",
+    "scene112-gltf-feature-registry-BUmHHvej.js",
     "scene112-gltf-json-asset-jIhMyCt9.js",
     "scene112-gltf-uri-6vf9MtoR.js",
     "scene112-ibl-fragment-CeRrvT96.js",
@@ -22,5 +22,5 @@
     "scene112-wgsl-helpers-BgB2AJrF.js",
     "scene112.js"
   ],
-  "rawBytes": 122868
+  "rawBytes": 122914
 }

--- a/lab/public/bundle/manifest/scene115.json
+++ b/lab/public/bundle/manifest/scene115.json
@@ -11,7 +11,7 @@
     "scene115-gltf-color-normalize-4-WGzPL2.js",
     "scene115-gltf-feature-animations-B4dSWyOG.js",
     "scene115-gltf-feature-morph-DLWJRlR1.js",
-    "scene115-gltf-feature-registry-KRzkF8u5.js",
+    "scene115-gltf-feature-registry-CvCXXB3b.js",
     "scene115-gltf-feature-skeleton-vHn6d4rM.js",
     "scene115-gltf-json-asset-DkZ91Cxg.js",
     "scene115-mesh-features-Dda6QcW-.js",

--- a/lab/public/bundle/manifest/scene12.json
+++ b/lab/public/bundle/manifest/scene12.json
@@ -7,7 +7,7 @@
     "scene12-generate-mipmaps-BeuA_ap5.js",
     "scene12-gltf-animation-CZNCsOVr.js",
     "scene12-gltf-feature-animations-CiVyNw6v.js",
-    "scene12-gltf-feature-registry-DYJUoq1Z.js",
+    "scene12-gltf-feature-registry-Dv0yAnOr.js",
     "scene12-gltf-feature-skeleton-yTqcn85p.js",
     "scene12-gltf-glb-parser-BWKwsvg4.js",
     "scene12-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene144.json
+++ b/lab/public/bundle/manifest/scene144.json
@@ -9,7 +9,7 @@
     "scene144-gltf-ext-spec-gloss-D60sFZYX.js",
     "scene144-gltf-feature-animations-BA72qFAq.js",
     "scene144-gltf-feature-extras-VHPteGay.js",
-    "scene144-gltf-feature-registry-CHKE5KLf.js",
+    "scene144-gltf-feature-registry-4iuI9xiS.js",
     "scene144-gltf-feature-skeleton-Bb1mH-ve.js",
     "scene144-gltf-glb-parser-5J2K-QXc.js",
     "scene144-gltf-pbr-builder-ext-CfC-j6Ec.js",

--- a/lab/public/bundle/manifest/scene146.json
+++ b/lab/public/bundle/manifest/scene146.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 110.6,
-  "gzipKB": 45.7,
+  "gzipKB": 45.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene146-alpha-test-fragment-DHg1slQK.js",

--- a/lab/public/bundle/manifest/scene147.json
+++ b/lab/public/bundle/manifest/scene147.json
@@ -6,7 +6,7 @@
     "scene147-directional-light-Cwfx9Emu.js",
     "scene147-generate-mipmaps-BcrYUTQy.js",
     "scene147-gltf-feature-lights-punctual-D-p7pR9i.js",
-    "scene147-gltf-feature-registry-q9Wz_r84.js",
+    "scene147-gltf-feature-registry-C7EtwAHR.js",
     "scene147-gltf-glb-parser-Ctl3KJNN.js",
     "scene147-gltf-light-pointer-state-B7kFTRxK.js",
     "scene147-multilight-wgsl-CLgjeQ_G.js",

--- a/lab/public/bundle/manifest/scene148.json
+++ b/lab/public/bundle/manifest/scene148.json
@@ -6,7 +6,7 @@
     "scene148-directional-light-CLC0TyGx.js",
     "scene148-generate-mipmaps-DwUUAYSG.js",
     "scene148-gltf-feature-lights-punctual-BnlPhELg.js",
-    "scene148-gltf-feature-registry-OZQWtFT_.js",
+    "scene148-gltf-feature-registry-Cl_QAzqZ.js",
     "scene148-gltf-glb-parser-CFOh2GWe.js",
     "scene148-gltf-light-pointer-state-B7kFTRxK.js",
     "scene148-pbr-geometry-view-UvK3uFtV.js",

--- a/lab/public/bundle/manifest/scene149.json
+++ b/lab/public/bundle/manifest/scene149.json
@@ -9,7 +9,7 @@
     "scene149-generate-mipmaps-D8eQtFfL.js",
     "scene149-geometry-texture-output-BfeQftmX.js",
     "scene149-gltf-feature-lights-punctual-BfaFx9o3.js",
-    "scene149-gltf-feature-registry-C-enDQwF.js",
+    "scene149-gltf-feature-registry-Zr9pWz9k.js",
     "scene149-gltf-glb-parser-BufXRmlx.js",
     "scene149-gltf-light-pointer-state-B7kFTRxK.js",
     "scene149-input-block-CKEweR01.js",

--- a/lab/public/bundle/manifest/scene152.json
+++ b/lab/public/bundle/manifest/scene152.json
@@ -9,7 +9,7 @@
     "scene152-gltf-ext-spec-gloss-D60sFZYX.js",
     "scene152-gltf-feature-animations-CNTNnFt2.js",
     "scene152-gltf-feature-extras-VHPteGay.js",
-    "scene152-gltf-feature-registry-C_PAQhLo.js",
+    "scene152-gltf-feature-registry-C_iCz9Hy.js",
     "scene152-gltf-feature-skeleton-BGDYR5rN.js",
     "scene152-gltf-glb-parser-BeX6MjHH.js",
     "scene152-gltf-sampler-desc-55i7wkXO.js",

--- a/lab/public/bundle/manifest/scene157.json
+++ b/lab/public/bundle/manifest/scene157.json
@@ -7,7 +7,7 @@
     "scene157-generate-mipmaps-CQ-xfzGO.js",
     "scene157-gltf-animation-BLovhpsp.js",
     "scene157-gltf-feature-animations-Ehrd_pVw.js",
-    "scene157-gltf-feature-registry-DLyC5Tre.js",
+    "scene157-gltf-feature-registry-wByhDsYH.js",
     "scene157-gltf-feature-skeleton-AH5V5HHE.js",
     "scene157-gltf-glb-parser-JLqfZehj.js",
     "scene157-multilight-wgsl-BM2AsepN.js",

--- a/lab/public/bundle/manifest/scene158.json
+++ b/lab/public/bundle/manifest/scene158.json
@@ -7,7 +7,7 @@
     "scene158-generate-mipmaps-BVPXqb4h.js",
     "scene158-gltf-animation-CL3aosi_.js",
     "scene158-gltf-feature-animations-BvtlvW2t.js",
-    "scene158-gltf-feature-registry-BuQ0ALLB.js",
+    "scene158-gltf-feature-registry-9M1B1Quz.js",
     "scene158-gltf-feature-skeleton-Kj8g1SVh.js",
     "scene158-gltf-glb-parser-BXXv9nTE.js",
     "scene158-multilight-wgsl-D_3KZk-5.js",

--- a/lab/public/bundle/manifest/scene164.json
+++ b/lab/public/bundle/manifest/scene164.json
@@ -10,7 +10,7 @@
     "scene164-gltf-color-normalize-4-WGzPL2.js",
     "scene164-gltf-feature-animations-CezTXKjn.js",
     "scene164-gltf-feature-morph-7lwtFhBO.js",
-    "scene164-gltf-feature-registry-ZEqF4Q_x.js",
+    "scene164-gltf-feature-registry-4KG20V18.js",
     "scene164-gltf-feature-skeleton-Baf9dxYD.js",
     "scene164-gltf-json-asset-CJmOxkje.js",
     "scene164-morph-fragment-DlGWegG7.js",

--- a/lab/public/bundle/manifest/scene176.json
+++ b/lab/public/bundle/manifest/scene176.json
@@ -6,7 +6,7 @@
     "scene176-generate-mipmaps-Dgk2HJSe.js",
     "scene176-gltf-ext-dielectric-C6hvXXiF.js",
     "scene176-gltf-feature-extras-VHPteGay.js",
-    "scene176-gltf-feature-registry-BfqlfnST.js",
+    "scene176-gltf-feature-registry-RZT8i-Ni.js",
     "scene176-gltf-json-asset-CfnpYb9a.js",
     "scene176-ibl-fragment-CeRrvT96.js",
     "scene176-ibl-skybox-wgsl-CFIBOHHx.js",

--- a/lab/public/bundle/manifest/scene178.json
+++ b/lab/public/bundle/manifest/scene178.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene178-generate-mipmaps-DVKHAzdg.js",
     "scene178-gltf-ext-iridescence-b4LVniAM.js",
-    "scene178-gltf-feature-registry-BP7jKtW4.js",
+    "scene178-gltf-feature-registry-BhZjWRb-.js",
     "scene178-gltf-glb-parser-BrVR2m1N.js",
     "scene178-ibl-fragment-CeRrvT96.js",
     "scene178-ibl-skybox-wgsl-CFIBOHHx.js",

--- a/lab/public/bundle/manifest/scene210.json
+++ b/lab/public/bundle/manifest/scene210.json
@@ -4,7 +4,7 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene210-generate-mipmaps-Blv5VTUw.js",
-    "scene210-gltf-feature-registry-B1_0E89-.js",
+    "scene210-gltf-feature-registry-BkiVi4ND.js",
     "scene210-gltf-feature-xmp-S8Tl-XNQ.js",
     "scene210-gltf-glb-parser-DX-hcw7S.js",
     "scene210-gltf-interleave-C_9dpKt3.js",

--- a/lab/public/bundle/manifest/scene211.json
+++ b/lab/public/bundle/manifest/scene211.json
@@ -9,7 +9,7 @@
     "scene211-gltf-ext-quantization-DTtElLs7.js",
     "scene211-gltf-feature-animations-BisubEwH.js",
     "scene211-gltf-feature-meshopt-BxBnPoqa.js",
-    "scene211-gltf-feature-registry-D8BKyj_P.js",
+    "scene211-gltf-feature-registry-DNpeR3fM.js",
     "scene211-gltf-feature-skeleton-BtnE3ACq.js",
     "scene211-gltf-json-asset-T03W-2QH.js",
     "scene211-gltf-multi-buffer-CBbIh8uw.js",

--- a/lab/public/bundle/manifest/scene212.json
+++ b/lab/public/bundle/manifest/scene212.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene212-generate-mipmaps-DzxxhGEP.js",
     "scene212-gltf-ext-dielectric-C6hvXXiF.js",
-    "scene212-gltf-feature-registry-DaEETcdf.js",
+    "scene212-gltf-feature-registry-CNm12pGN.js",
     "scene212-gltf-glb-parser-DENT1Vui.js",
     "scene212-ibl-fragment-CeRrvT96.js",
     "scene212-ibl-skybox-wgsl-CFIBOHHx.js",

--- a/lab/public/bundle/manifest/scene218.json
+++ b/lab/public/bundle/manifest/scene218.json
@@ -9,7 +9,7 @@
     "scene218-gltf-ext-spec-gloss-D60sFZYX.js",
     "scene218-gltf-feature-animations-Db1JXTGV.js",
     "scene218-gltf-feature-extras-VHPteGay.js",
-    "scene218-gltf-feature-registry-wsgUivlM.js",
+    "scene218-gltf-feature-registry-DuC4qjLV.js",
     "scene218-gltf-feature-skeleton-BGy1CNCx.js",
     "scene218-gltf-glb-parser-CteHv7lF.js",
     "scene218-gltf-sampler-desc-DTA5QGlT.js",

--- a/lab/public/bundle/manifest/scene219.json
+++ b/lab/public/bundle/manifest/scene219.json
@@ -9,7 +9,7 @@
     "scene219-gltf-ext-spec-gloss-D60sFZYX.js",
     "scene219-gltf-feature-animations-D33RSsqz.js",
     "scene219-gltf-feature-extras-VHPteGay.js",
-    "scene219-gltf-feature-registry-DWmKZS6V.js",
+    "scene219-gltf-feature-registry-Bl2umlYU.js",
     "scene219-gltf-feature-skeleton-lMdcCevx.js",
     "scene219-gltf-glb-parser-DJMPJo6n.js",
     "scene219-gltf-sampler-desc-BRbZ0K5P.js",

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -7,7 +7,7 @@
     "scene240-generate-mipmaps-BfQh_jIW.js",
     "scene240-gltf-animation-P_e0TUWz.js",
     "scene240-gltf-feature-animations-C6YL7Fdf.js",
-    "scene240-gltf-feature-registry-BVHDeSgV.js",
+    "scene240-gltf-feature-registry-DH47gemp.js",
     "scene240-gltf-json-asset-BvV1yBXV.js",
     "scene240-gltf-multi-buffer-DQ-JVZha.js",
     "scene240-gltf-normals-DYhLwXNX.js",

--- a/lab/public/bundle/manifest/scene241.json
+++ b/lab/public/bundle/manifest/scene241.json
@@ -21,7 +21,7 @@
     "scene241-gltf-feature-animation-pointer-DcUorbJp.js",
     "scene241-gltf-feature-animations-3BUp5O0X.js",
     "scene241-gltf-feature-lights-punctual-DYJmo4M5.js",
-    "scene241-gltf-feature-registry-CWH1FP4d.js",
+    "scene241-gltf-feature-registry-BtyOqDfV.js",
     "scene241-gltf-json-asset-h2nlumGd.js",
     "scene241-gltf-light-pointer-state-B7kFTRxK.js",
     "scene241-gltf-pbr-builder-ext-gbDFjJEh.js",

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -10,7 +10,7 @@
     "scene242-gltf-ext-emissive-strength-CButLZnK.js",
     "scene242-gltf-feature-animation-pointer-Cx50gYCv.js",
     "scene242-gltf-feature-animations-D9KK85wv.js",
-    "scene242-gltf-feature-registry-fHkJSrop.js",
+    "scene242-gltf-feature-registry-DYpB6IFM.js",
     "scene242-gltf-json-asset-Yii58NL7.js",
     "scene242-ibl-fragment-CeRrvT96.js",
     "scene242-pbr-renderable-rdz0-k39.js",

--- a/lab/public/bundle/manifest/scene243.json
+++ b/lab/public/bundle/manifest/scene243.json
@@ -9,7 +9,7 @@
     "scene243-gltf-feature-animations-Dm9_q1zy.js",
     "scene243-gltf-feature-extras-VHPteGay.js",
     "scene243-gltf-feature-morph-BCUQi4W_.js",
-    "scene243-gltf-feature-registry-DnVeqHO-.js",
+    "scene243-gltf-feature-registry-DCC1xo3U.js",
     "scene243-gltf-json-asset-CpMCrBLi.js",
     "scene243-gltf-pbr-builder-ext-Dcy7_zeN.js",
     "scene243-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -12,7 +12,7 @@
     "scene244-gltf-ext-uv-transform-YGWG8v_J.js",
     "scene244-gltf-feature-animation-pointer-bwuK5QO-.js",
     "scene244-gltf-feature-animations-6j36Wz9a.js",
-    "scene244-gltf-feature-registry-CRkXu9sN.js",
+    "scene244-gltf-feature-registry-CUrZPEgR.js",
     "scene244-gltf-json-asset-Dz1M9M4x.js",
     "scene244-gltf-pbr-builder-ext-Cs5PHlG2.js",
     "scene244-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene245.json
+++ b/lab/public/bundle/manifest/scene245.json
@@ -8,7 +8,7 @@
     "scene245-generate-mipmaps-BiirLBBd.js",
     "scene245-gltf-animation-B2ts7voU.js",
     "scene245-gltf-feature-animations-DnWT-O_8.js",
-    "scene245-gltf-feature-registry-DkguMoOM.js",
+    "scene245-gltf-feature-registry-DbxNNkFg.js",
     "scene245-gltf-feature-skeleton-DWhCgmVK.js",
     "scene245-gltf-interleave-KM-jw4Ig.js",
     "scene245-gltf-json-asset-9bYm1ZAX.js",

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -8,7 +8,7 @@
     "scene246-generate-mipmaps-BdMtDSMF.js",
     "scene246-gltf-animation-NnQVJBYD.js",
     "scene246-gltf-feature-animations-DWJWoTT5.js",
-    "scene246-gltf-feature-registry-CFKHRmuD.js",
+    "scene246-gltf-feature-registry-C2pLItIL.js",
     "scene246-gltf-feature-skeleton-xpb4slfP.js",
     "scene246-gltf-interleave-Cx5yld1W.js",
     "scene246-gltf-json-asset-Dl53bm1i.js",

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -6,7 +6,7 @@
     "scene247-generate-mipmaps-Ca5oZGgo.js",
     "scene247-gltf-feature-extras-VHPteGay.js",
     "scene247-gltf-feature-gpu-instancing-ZadykV65.js",
-    "scene247-gltf-feature-registry-rCHgkNyp.js",
+    "scene247-gltf-feature-registry-D3_NJiXs.js",
     "scene247-gltf-json-asset-aprJZkKh.js",
     "scene247-gltf-multi-buffer-BzFIY2Yd.js",
     "scene247-gltf-share-DF9ijqo2.js",

--- a/lab/public/bundle/manifest/scene251.json
+++ b/lab/public/bundle/manifest/scene251.json
@@ -7,7 +7,7 @@
     "scene251-generate-mipmaps-v13WAvu6.js",
     "scene251-gltf-animation-B3flhwjw.js",
     "scene251-gltf-feature-animations-DCF81c6Z.js",
-    "scene251-gltf-feature-registry-D3ZFBmyU.js",
+    "scene251-gltf-feature-registry-CfSjBJGo.js",
     "scene251-gltf-feature-skeleton--AOJPJ-6.js",
     "scene251-gltf-glb-parser-BxMi87nG.js",
     "scene251-multilight-wgsl-BTjKzv_v.js",

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -24,7 +24,7 @@
     "scene253-gltf-feature-extras-VHPteGay.js",
     "scene253-gltf-feature-lights-punctual-BSyMjUBf.js",
     "scene253-gltf-feature-morph-OgvZWqfo.js",
-    "scene253-gltf-feature-registry-DJstZU0m.js",
+    "scene253-gltf-feature-registry-CJQ06uHs.js",
     "scene253-gltf-feature-skeleton-4sXidr_V.js",
     "scene253-gltf-json-asset-CBZJXM3t.js",
     "scene253-gltf-light-pointer-state-B7kFTRxK.js",

--- a/lab/public/bundle/manifest/scene254.json
+++ b/lab/public/bundle/manifest/scene254.json
@@ -6,7 +6,7 @@
     "scene254-generate-mipmaps-CO7DFb3U.js",
     "scene254-gltf-animation-WU-R3ods.js",
     "scene254-gltf-feature-animations-BWpXxloW.js",
-    "scene254-gltf-feature-registry-DIt8QDcb.js",
+    "scene254-gltf-feature-registry-7V1NK9NE.js",
     "scene254-gltf-json-asset-CuuycPiY.js",
     "scene254-gltf-sampler-denorm-BzFzUiaO.js",
     "scene254-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -8,7 +8,7 @@
     "scene255-generate-mipmaps-CwS-SesP.js",
     "scene255-gltf-animation-BdNI7eQz.js",
     "scene255-gltf-feature-animations-DWGTy8Ey.js",
-    "scene255-gltf-feature-registry-CqH-leyy.js",
+    "scene255-gltf-feature-registry-DAaHsIWR.js",
     "scene255-gltf-feature-skeleton-DXWdHHtm.js",
     "scene255-gltf-json-asset-BJyr96Ic.js",
     "scene255-gltf-normals-DYhLwXNX.js",

--- a/lab/public/bundle/manifest/scene257.json
+++ b/lab/public/bundle/manifest/scene257.json
@@ -1,12 +1,12 @@
 {
   "rawKB": 80.4,
-  "gzipKB": 33.4,
+  "gzipKB": 33.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene257-flat-normal-wgsl-Cm9mM4tC.js",
     "scene257-generate-mipmaps-CgL0cUr7.js",
     "scene257-gltf-feature-primitive-B2T0cWKj.js",
-    "scene257-gltf-feature-registry-BgGOfB4w.js",
+    "scene257-gltf-feature-registry-2G2AF-4i.js",
     "scene257-gltf-json-asset-BowOnmOI.js",
     "scene257-gltf-normals-DYhLwXNX.js",
     "scene257-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene260.json
+++ b/lab/public/bundle/manifest/scene260.json
@@ -6,7 +6,7 @@
     "scene260-flat-normal-wgsl-Cm9mM4tC.js",
     "scene260-generate-mipmaps-BnwWStsP.js",
     "scene260-gltf-feature-primitive-DIf9OO5C.js",
-    "scene260-gltf-feature-registry-CzaYBuKP.js",
+    "scene260-gltf-feature-registry-D1Y6hkeG.js",
     "scene260-gltf-json-asset-yi5RiuZK.js",
     "scene260-gltf-normals-DYhLwXNX.js",
     "scene260-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene265.json
+++ b/lab/public/bundle/manifest/scene265.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene265-generate-mipmaps-JrMA50q2.js",
     "scene265-gltf-ext-lights-image-based-BsjHiLEV.js",
-    "scene265-gltf-feature-registry-B8GwFaWb.js",
+    "scene265-gltf-feature-registry-YFo9A1Bs.js",
     "scene265-gltf-json-asset-vKqzvk0U.js",
     "scene265-gltf-uri-6vf9MtoR.js",
     "scene265-ibl-cubemap-upload-DubDFVEU.js",

--- a/lab/public/bundle/manifest/scene266.json
+++ b/lab/public/bundle/manifest/scene266.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene266-generate-mipmaps-VcAE7FCP.js",
     "scene266-gltf-feature-primitive-BcZmWV7D.js",
-    "scene266-gltf-feature-registry-DFXI6Gsu.js",
+    "scene266-gltf-feature-registry-CdTL8BE3.js",
     "scene266-gltf-glb-parser-D-h9Fgu9.js",
     "scene266-gltf-share-D0T73tB6.js",
     "scene266-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene269.json
+++ b/lab/public/bundle/manifest/scene269.json
@@ -7,7 +7,7 @@
     "scene269-flat-normal-wgsl-Cm9mM4tC.js",
     "scene269-generate-mipmaps-JhPCdeKZ.js",
     "scene269-gltf-feature-primitive-B9_QCtUK.js",
-    "scene269-gltf-feature-registry-B_KFpvtS.js",
+    "scene269-gltf-feature-registry-BxWrH-LK.js",
     "scene269-gltf-json-asset-CGkzVmki.js",
     "scene269-gltf-normals-DYhLwXNX.js",
     "scene269-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene27.json
+++ b/lab/public/bundle/manifest/scene27.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene27-generate-mipmaps-BYzB1g85.js",
     "scene27-gltf-ext-dielectric-C6hvXXiF.js",
-    "scene27-gltf-feature-registry-BFNL1GNd.js",
+    "scene27-gltf-feature-registry-CwlwfjXL.js",
     "scene27-gltf-feature-variants-iIAQmf6C.js",
     "scene27-gltf-glb-parser-DJVUqR7n.js",
     "scene27-gltf-pbr-builder-ext-ws3zROCS.js",

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -6,7 +6,7 @@
     "scene28-clearcoat-fragment-BaJYbmIz.js",
     "scene28-generate-mipmaps--RTi66vr.js",
     "scene28-gltf-ext-clearcoat-BgaLgSgD.js",
-    "scene28-gltf-feature-registry-Dz4QoNyA.js",
+    "scene28-gltf-feature-registry-Bqjc4FAJ.js",
     "scene28-gltf-json-asset-B8WAjZ11.js",
     "scene28-ibl-fragment-CeRrvT96.js",
     "scene28-pbr-renderable-D7w8mm0i.js",

--- a/lab/public/bundle/manifest/scene29.json
+++ b/lab/public/bundle/manifest/scene29.json
@@ -6,7 +6,7 @@
     "scene29-generate-mipmaps-C0ljVA3A.js",
     "scene29-gltf-ext-sheen-Dv23b_3T.js",
     "scene29-gltf-ext-uv-transform-tUSEOqA7.js",
-    "scene29-gltf-feature-registry-DU31v5cg.js",
+    "scene29-gltf-feature-registry-Dk-cseKm.js",
     "scene29-gltf-json-asset-JowKGjPS.js",
     "scene29-gltf-pbr-builder-ext-0Tgp6igg.js",
     "scene29-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -8,7 +8,7 @@
     "scene30-gltf-ext-dielectric-C6hvXXiF.js",
     "scene30-gltf-ext-uv-transform-DQN5DAiE.js",
     "scene30-gltf-feature-draco-BSbw1ZBU.js",
-    "scene30-gltf-feature-registry-C-NCQd38.js",
+    "scene30-gltf-feature-registry-DYpbJQM5.js",
     "scene30-gltf-glb-parser-CPRfMQrD.js",
     "scene30-gltf-pbr-builder-ext-CqZZdTfz.js",
     "scene30-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene31.json
+++ b/lab/public/bundle/manifest/scene31.json
@@ -6,7 +6,7 @@
     "scene31-emissive-fragment-hx1-6YeZ.js",
     "scene31-generate-mipmaps-B8GEe_zm.js",
     "scene31-gltf-ext-emissive-strength-CButLZnK.js",
-    "scene31-gltf-feature-registry-GeHw6YeP.js",
+    "scene31-gltf-feature-registry-jSFo6afa.js",
     "scene31-gltf-glb-parser-DzBScCtC.js",
     "scene31-ibl-fragment-CeRrvT96.js",
     "scene31-pbr-renderable-CtyGiH2i.js",

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene32-generate-mipmaps-Cr6tLrFA.js",
     "scene32-gltf-ext-unlit-1vUYfF7v.js",
-    "scene32-gltf-feature-registry-C5iqJKc8.js",
+    "scene32-gltf-feature-registry-DSwxv2YD.js",
     "scene32-gltf-glb-parser-Cr0xOgAx.js",
     "scene32-ibl-fragment-CeRrvT96.js",
     "scene32-pbr-renderable-teit2HN6.js",

--- a/lab/public/bundle/manifest/scene33.json
+++ b/lab/public/bundle/manifest/scene33.json
@@ -6,7 +6,7 @@
     "scene33-generate-mipmaps-ysS4vyzD.js",
     "scene33-gltf-ext-dielectric-C6hvXXiF.js",
     "scene33-gltf-feature-lights-punctual-DgRdWmlT.js",
-    "scene33-gltf-feature-registry-DldvuHV6.js",
+    "scene33-gltf-feature-registry-vKy4Pqar.js",
     "scene33-gltf-glb-parser-D4DERHwD.js",
     "scene33-gltf-light-pointer-state-B7kFTRxK.js",
     "scene33-gltf-sampler-desc-D-67mIj3.js",

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -8,7 +8,7 @@
     "scene34-gltf-ext-node-visibility-DMN6N0YJ.js",
     "scene34-gltf-feature-animation-pointer-BExjAhc7.js",
     "scene34-gltf-feature-animations-WgygAm3k.js",
-    "scene34-gltf-feature-registry-CUDB9pbK.js",
+    "scene34-gltf-feature-registry-Z-VX40TD.js",
     "scene34-gltf-glb-parser-Cq9dWVnL.js",
     "scene34-gltf-sampler-denorm-CTv2yBPK.js",
     "scene34-gltf-share-CD7RSpVC.js",

--- a/lab/public/bundle/manifest/scene35.json
+++ b/lab/public/bundle/manifest/scene35.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene35-generate-mipmaps-CeOT21or.js",
     "scene35-gltf-feature-gpu-instancing-B76GsBxq.js",
-    "scene35-gltf-feature-registry-CseqGSCe.js",
+    "scene35-gltf-feature-registry-BOGDyOow.js",
     "scene35-gltf-glb-parser-CK3Suivb.js",
     "scene35-ibl-fragment-CeRrvT96.js",
     "scene35-pbr-renderable-DCyQ3W1B.js",

--- a/lab/public/bundle/manifest/scene37.json
+++ b/lab/public/bundle/manifest/scene37.json
@@ -8,7 +8,7 @@
     "scene37-gltf-ext-dielectric-C6hvXXiF.js",
     "scene37-gltf-ext-sheen-Dv23b_3T.js",
     "scene37-gltf-ext-uv-transform-hVTzf5Q9.js",
-    "scene37-gltf-feature-registry-CRlAP2Jl.js",
+    "scene37-gltf-feature-registry-DGZl_rEa.js",
     "scene37-gltf-glb-parser-BvLkUAFg.js",
     "scene37-gltf-pbr-builder-ext-DBkuxTnO.js",
     "scene37-ibl-fragment-CeRrvT96.js",
@@ -22,5 +22,5 @@
     "scene37-uv-transform-fragment-B8ijWmAK.js",
     "scene37.js"
   ],
-  "rawBytes": 99678
+  "rawBytes": 99683
 }

--- a/lab/public/bundle/manifest/scene39.json
+++ b/lab/public/bundle/manifest/scene39.json
@@ -12,7 +12,7 @@
     "scene39-gltf-feature-animation-pointer-DLP6qwQK.js",
     "scene39-gltf-feature-animations-CxATJO7n.js",
     "scene39-gltf-feature-lights-punctual-qLLf1x1o.js",
-    "scene39-gltf-feature-registry-CBsfxaxD.js",
+    "scene39-gltf-feature-registry-BVRSbBPT.js",
     "scene39-gltf-json-asset-PF5DAnha.js",
     "scene39-gltf-light-pointer-state-B7kFTRxK.js",
     "scene39-gltf-pbr-builder-ext-DyaMnJed.js",

--- a/lab/public/bundle/manifest/scene41.json
+++ b/lab/public/bundle/manifest/scene41.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene41-generate-mipmaps-CwF4YsJB.js",
     "scene41-gltf-ext-spec-gloss-D60sFZYX.js",
-    "scene41-gltf-feature-registry-CBrpdekJ.js",
+    "scene41-gltf-feature-registry-jIA-kZXd.js",
     "scene41-gltf-glb-parser-B45AG9UF.js",
     "scene41-gltf-sampler-desc-BaZGySA_.js",
     "scene41-mesh-features-Dda6QcW-.js",

--- a/lab/public/bundle/manifest/scene47.json
+++ b/lab/public/bundle/manifest/scene47.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene47-generate-mipmaps-CbVkRtUN.js",
     "scene47-gltf-ext-spec-gloss-D60sFZYX.js",
-    "scene47-gltf-feature-registry-CqTCSApA.js",
+    "scene47-gltf-feature-registry-Bu1DTbHU.js",
     "scene47-gltf-glb-parser-Dy8gRD43.js",
     "scene47-gltf-sampler-desc-CkHYNGuu.js",
     "scene47-mesh-features-Dda6QcW-.js",

--- a/lab/public/bundle/manifest/scene5.json
+++ b/lab/public/bundle/manifest/scene5.json
@@ -10,7 +10,7 @@
     "scene5-gltf-color-normalize-4-WGzPL2.js",
     "scene5-gltf-feature-animations-5XaxivPx.js",
     "scene5-gltf-feature-morph-BNcyLEaQ.js",
-    "scene5-gltf-feature-registry-CrLoFraL.js",
+    "scene5-gltf-feature-registry-D8HRJeVR.js",
     "scene5-gltf-feature-skeleton-BcZBHJWQ.js",
     "scene5-gltf-json-asset-PrBgaXiL.js",
     "scene5-morph-fragment-dAMPL0JQ.js",

--- a/lab/public/bundle/manifest/scene7.json
+++ b/lab/public/bundle/manifest/scene7.json
@@ -10,7 +10,7 @@
     "scene7-gltf-animation-CBEXoXjt.js",
     "scene7-gltf-feature-animations-DBjQPXJn.js",
     "scene7-gltf-feature-extras-VHPteGay.js",
-    "scene7-gltf-feature-registry-Cmn6kW40.js",
+    "scene7-gltf-feature-registry-DscNVoLY.js",
     "scene7-gltf-feature-skeleton-C4mxkxAa.js",
     "scene7-gltf-json-asset-DboJkkGT.js",
     "scene7-ibl-fragment-CeRrvT96.js",

--- a/lab/public/bundle/manifest/scene73.json
+++ b/lab/public/bundle/manifest/scene73.json
@@ -10,7 +10,7 @@
     "scene73-fragment-output-CfRmfbPv.js",
     "scene73-generate-mipmaps-CJGADMtK.js",
     "scene73-gltf-ext-clearcoat-BgaLgSgD.js",
-    "scene73-gltf-feature-registry-D3CxZLlj.js",
+    "scene73-gltf-feature-registry-w2-cMOQ5.js",
     "scene73-gltf-glb-parser-CzK8F7CW.js",
     "scene73-ibl-fragment-CeRrvT96.js",
     "scene73-input-block-CDf7C7a2.js",

--- a/lab/public/bundle/manifest/scene99.json
+++ b/lab/public/bundle/manifest/scene99.json
@@ -8,7 +8,7 @@
     "scene99-generate-mipmaps-DK0i16m1.js",
     "scene99-gltf-animation-CThXkIZ6.js",
     "scene99-gltf-feature-animations-C4bJDmAU.js",
-    "scene99-gltf-feature-registry-pGUJvkIg.js",
+    "scene99-gltf-feature-registry-B_z4-r8M.js",
     "scene99-gltf-feature-skeleton-CdNN_36B.js",
     "scene99-gltf-glb-parser-Bz7upPhi.js",
     "scene99-multilight-wgsl-CZoyLoRC.js",

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -226,6 +226,8 @@ export {
     uploadImageToArrayLayer,
     loadImageToArrayLayer,
     createTexture2DArrayFromUrls,
+    uploadKtx2Texture2DArray,
+    loadKtx2Texture2DArray,
 } from "./texture/texture-array.js";
 export type { Texture2DArray, TextureArrayOptions, ArrayLayerUploadOptions, TextureArrayFromUrlsOptions } from "./texture/texture-array.js";
 export { createDynamicTexture, updateDynamicTexture } from "./texture/dynamic-texture.js";

--- a/packages/babylon-lite/src/texture/ktx2-loader.ts
+++ b/packages/babylon-lite/src/texture/ktx2-loader.ts
@@ -22,13 +22,17 @@ interface Ktx2DecoderCaps {
     etc1: boolean;
 }
 
-interface Ktx2DecodedMip {
+/** @internal One decoded mip level of one array layer, as reported by the KTX2 decoder. */
+export interface Ktx2DecodedMip {
     width: number;
     height: number;
     data: Uint8Array;
+    /** Array layer this entry belongs to. Only reported by decoders with 2D-array support. */
+    layerIndex?: number;
 }
 
-interface Ktx2DecodedData {
+/** @internal Validated output of the KTX2 decoder. */
+export interface Ktx2DecodedData {
     width: number;
     height: number;
     transcodedFormat: number;
@@ -36,6 +40,9 @@ interface Ktx2DecodedData {
     hasAlpha: boolean;
     transcoderName: string;
     errors?: string;
+    /** For an array texture, `mipmaps` holds `layerCount` consecutive entries per mip level, ordered by
+     *  layer. Only reported by decoders with 2D-array support; absent (undefined) on older decoders. */
+    layerCount?: number;
     mipmaps: Ktx2DecodedMip[];
 }
 
@@ -137,7 +144,9 @@ function loadKtx2Decoder(): Promise<Ktx2Decoder> {
     return _ktx2DecoderPromise;
 }
 
-function srgbFormat(format: GPUTextureFormat): GPUTextureFormat {
+/** @internal Map a linear GPU format to its sRGB twin (identity when there is none). Shared with
+ *  texture-array.ts so the KTX2 array path resolves formats exactly like the 2D path. */
+export function srgbFormat(format: GPUTextureFormat): GPUTextureFormat {
     switch (format) {
         case "rgba8unorm":
             return "rgba8unorm-srgb";
@@ -188,7 +197,8 @@ function srgbFormat(format: GPUTextureFormat): GPUTextureFormat {
     }
 }
 
-function uncompressedInfo(glFormat: number): { format: GPUTextureFormat; bytesPerPixel: number } | null {
+/** @internal Map an uncompressed transcode target (a GL internal format) to its WebGPU format + stride. */
+export function uncompressedInfo(glFormat: number): { format: GPUTextureFormat; bytesPerPixel: number } | null {
     switch (glFormat) {
         case GL_RGBA8:
             return { format: "rgba8unorm", bytesPerPixel: 4 };
@@ -216,7 +226,8 @@ function validateDecoded(decoded: Ktx2DecodedData): Ktx2DecodedMip[] {
     return decoded.mipmaps;
 }
 
-function makeSampler(engine: EngineContext, mipCount: number): GPUSampler {
+/** @internal Sampler shared by every codec-decoded KTX2 texture, 2D or array. */
+export function makeSampler(engine: EngineContext, mipCount: number): GPUSampler {
     return getOrCreateSampler(engine, {
         addressModeU: "repeat",
         addressModeV: "repeat",
@@ -281,14 +292,23 @@ function uploadUncompressed(engine: EngineContext, mips: Ktx2DecodedMip[], info:
     return tex2d;
 }
 
+/** @internal Load the decoder and transcode `buffer` with the device's compression caps. The seam other
+ *  texture modules build on (mirrors Babylon.js `KhronosTextureContainer2._decodeAsync`) so they never touch
+ *  the decoder script glue themselves. Transcodes to the best GPU-supported compressed format (or RGBA8 on
+ *  devices without one): the compressed path uploads a few times less data than uncompressed RGBA8 and keeps
+ *  the texture compressed in VRAM. */
+export async function decodeKtx2Async(engine: EngineContext, buffer: ArrayBuffer): Promise<Ktx2DecodedData> {
+    const decoder = await loadKtx2Decoder();
+    const decoded = await decoder.decode(new U8(buffer), deviceKtx2Caps(engine));
+    validateDecoded(decoded);
+    return decoded;
+}
+
 /** Decode a KTX2 texture with the current WebGPU compression caps and upload the
  *  decoder-provided full mip chain directly to a Texture2D. */
 export async function uploadKtx2Texture2D(engine: EngineContext, buffer: ArrayBuffer, sRGB: boolean): Promise<Texture2D> {
-    const decoder = await loadKtx2Decoder();
-    // Transcode to the best GPU-supported compressed format (or RGBA8 on devices without one). The compressed
-    // path below uploads a few times less data than uncompressed RGBA8 and keeps the texture compressed in VRAM.
-    const decoded = await decoder.decode(new U8(buffer), deviceKtx2Caps(engine));
-    const mips = validateDecoded(decoded);
+    const decoded = await decodeKtx2Async(engine, buffer);
+    const mips = decoded.mipmaps;
 
     const compressed = getCompressedFormat(decoded.transcodedFormat);
     if (compressed) {

--- a/packages/babylon-lite/src/texture/texture-array.ts
+++ b/packages/babylon-lite/src/texture/texture-array.ts
@@ -8,6 +8,8 @@
  * application create an array and fill individual layers from any WebGPU
  * external-image source — `ImageBitmap`, `ImageData`, a canvas, or a video —
  * without the "draw to an offscreen canvas and read back raw bytes" dance.
+ * {@link loadKtx2Texture2DArray} covers the other shape: every layer already
+ * packed into one GPU-compressed `.ktx2` container.
  *
  * The whole feature is a set of free functions with zero module-level side
  * effects, so an app that never touches texture arrays strips it entirely, and
@@ -49,6 +51,10 @@
 import { TU } from "../engine/gpu-flags.js";
 import { acquireTexture, getOrCreateSampler } from "../resource/gpu-pool.js";
 import { generateMipmaps, recordMipmaps } from "./generate-mipmaps.js";
+import { decodeKtx2Async, makeSampler, srgbFormat, uncompressedInfo } from "./ktx2-loader.js";
+import type { Ktx2DecodedData, Ktx2DecodedMip } from "./ktx2-loader.js";
+import { getCompressedFormat } from "./compressed-formats.js";
+import type { CompressedFormatInfo } from "./compressed-formats.js";
 import { mipLevelCount } from "./mip-count.js";
 import type { Texture2D } from "./texture-2d.js";
 import type { EngineContext } from "../engine/engine.js";
@@ -322,4 +328,168 @@ export function updateTexture2DArrayFromPixels(engine: EngineContext, tex: Textu
         }
         engine._device.queue.submit([encoder.finish()]);
     }
+}
+
+// ─── KTX2 (Basis Universal) array containers ─────────────────────────
+//
+// A single .ktx2 file can carry all N layers (`layerCount` > 1), which is the
+// compressed, one-request counterpart to `createTexture2DArrayFromUrls()`. The
+// decoder glue lives in ktx2-loader.ts; this module only reshapes its output and
+// drives the GPU uploads — the same split Babylon.js uses between
+// `KhronosTextureContainer2._decodeAsync` and `rawTexture2DArray.functions`.
+
+/** Group the decoder's flat mipmap list into `[level][layer]`. The decoder emits `layerCount` consecutive
+ *  entries per level, ordered by layer, so the grouping is a straight reshape — but `layerIndex` is verified
+ *  rather than assumed so a decoder change cannot silently scramble the layers. */
+function groupArrayMips(decoded: Ktx2DecodedData): { layers: number; levels: Ktx2DecodedMip[][] } {
+    const mips = decoded.mipmaps;
+    const layers = decoded.layerCount;
+    if (layers === undefined) {
+        throw new Error("KTX2: the decoder does not report layerCount; a decoder with 2D array support is required (see setKtx2DecoderUrl)");
+    }
+    if (layers < 1 || mips.length % layers !== 0) {
+        throw new Error(`KTX2: decoder produced ${mips.length} mips, which is not a whole number of ${layers}-layer levels`);
+    }
+
+    const levels: Ktx2DecodedMip[][] = [];
+    for (let i = 0; i < mips.length; i += layers) {
+        const level = mips.slice(i, i + layers);
+        for (let layer = 0; layer < layers; layer++) {
+            const mip = level[layer]!;
+            if (mip.layerIndex !== layer) {
+                throw new Error(`KTX2: expected layer ${layer} at mip index ${i + layer} but the decoder reported layer ${mip.layerIndex}`);
+            }
+            if (mip.width !== level[0]!.width || mip.height !== level[0]!.height) {
+                throw new Error(`KTX2: layers of one mip level must share a size (level ${levels.length}, layer ${layer})`);
+            }
+        }
+        levels.push(level);
+    }
+    return { layers, levels };
+}
+
+function createKtx2ArrayTexture(engine: EngineContext, width: number, height: number, layers: number, levelCount: number, format: GPUTextureFormat, sRGB: boolean): Texture2DArray {
+    const texture = engine._device.createTexture({
+        size: { width, height, depthOrArrayLayers: layers },
+        dimension: "2d",
+        format: sRGB ? srgbFormat(format) : format,
+        mipLevelCount: levelCount,
+        usage: TU.TEXTURE_BINDING | TU.COPY_DST,
+    });
+    // The mip chain comes from the container, so no RENDER_ATTACHMENT / blit pass is needed here (unlike
+    // createTexture2DArray, which regenerates mips after an external-image copy).
+    const tex: Texture2DArray = { texture, view: texture.createView({ dimension: "2d-array" }), sampler: makeSampler(engine, levelCount), width, height, layers, invertY: true };
+    acquireTexture(tex);
+    return tex;
+}
+
+function uploadCompressedKtx2Array(engine: EngineContext, decoded: Ktx2DecodedData, format: CompressedFormatInfo, sRGB: boolean): Texture2DArray {
+    if (!engine._device.features.has(format.feature as GPUFeatureName)) {
+        throw new Error(`KTX2: device does not support ${format.feature}`);
+    }
+    const { layers, levels } = groupArrayMips(decoded);
+    const width = levels[0]![0]!.width;
+    const height = levels[0]![0]!.height;
+    const tex = createKtx2ArrayTexture(engine, width, height, layers, levels.length, format.gpuFormat, sRGB);
+
+    for (let level = 0; level < levels.length; level++) {
+        const blocksPerRow = Math.ceil(levels[level]![0]!.width / format.blockW);
+        const rowBytes = blocksPerRow * format.blockBytes;
+        // Copy extent must be the block-padded (physical) size; tail mips smaller than one block are copied
+        // as a single full block (see ktx-loader.ts).
+        const copyW = blocksPerRow * format.blockW;
+        const copyH = Math.ceil(levels[level]![0]!.height / format.blockH) * format.blockH;
+        for (let layer = 0; layer < layers; layer++) {
+            const mip = levels[level]![layer]!;
+            engine._device.queue.writeTexture(
+                { texture: tex.texture, mipLevel: level, origin: { x: 0, y: 0, z: layer } },
+                mip.data as Uint8Array<ArrayBuffer>,
+                { bytesPerRow: rowBytes },
+                { width: copyW, height: copyH, depthOrArrayLayers: 1 }
+            );
+        }
+    }
+    return tex;
+}
+
+function uploadUncompressedKtx2Array(engine: EngineContext, decoded: Ktx2DecodedData, info: { format: GPUTextureFormat; bytesPerPixel: number }, sRGB: boolean): Texture2DArray {
+    const bytesPerPixel = info.bytesPerPixel;
+    const { layers, levels } = groupArrayMips(decoded);
+    const width = levels[0]![0]!.width;
+    const height = levels[0]![0]!.height;
+    const tex = createKtx2ArrayTexture(engine, width, height, layers, levels.length, info.format, sRGB);
+
+    for (let level = 0; level < levels.length; level++) {
+        const levelWidth = levels[level]![0]!.width;
+        const levelHeight = levels[level]![0]!.height;
+        for (let layer = 0; layer < layers; layer++) {
+            const mip = levels[level]![layer]!;
+            const expected = levelWidth * levelHeight * bytesPerPixel;
+            if (mip.data.length !== expected) {
+                throw new Error(`KTX2: uncompressed mip ${level} layer ${layer} has ${mip.data.length} bytes, expected ${expected}`);
+            }
+            engine._device.queue.writeTexture(
+                { texture: tex.texture, mipLevel: level, origin: { x: 0, y: 0, z: layer } },
+                mip.data as Uint8Array<ArrayBuffer>,
+                { bytesPerRow: levelWidth * bytesPerPixel },
+                { width: levelWidth, height: levelHeight, depthOrArrayLayers: 1 }
+            );
+        }
+    }
+    return tex;
+}
+
+/**
+ * Decode an in-memory multi-layer KTX2 container and upload every layer of its mip chain to a
+ * `Texture2DArray`. The buffer counterpart to {@link loadKtx2Texture2DArray} — use it when the bytes are
+ * already in hand (an ArrayBuffer from a zip, an XHR, or a glTF binary chunk).
+ *
+ * @param engine - Engine context.
+ * @param buffer - Raw `.ktx2` file bytes with `layerCount` \>= 1.
+ * @param sRGB - Select the `*-srgb` GPU format. Default false.
+ */
+export async function uploadKtx2Texture2DArray(engine: EngineContext, buffer: ArrayBuffer, sRGB = false): Promise<Texture2DArray> {
+    // Unlike Babylon.js core (which must transcode arrays to RGBA because its engine cannot upload compressed
+    // array layers), WebGPU's writeTexture takes compressed layers directly via origin.z, so the array is kept
+    // in a GPU-compressed format whenever the device supports one.
+    const decoded = await decodeKtx2Async(engine, buffer);
+
+    const compressed = getCompressedFormat(decoded.transcodedFormat);
+    if (compressed) {
+        return uploadCompressedKtx2Array(engine, decoded, compressed, sRGB);
+    }
+
+    const uncompressed = uncompressedInfo(decoded.transcodedFormat);
+    if (uncompressed) {
+        return uploadUncompressedKtx2Array(engine, decoded, uncompressed, sRGB);
+    }
+
+    throw new Error(`KTX2: unsupported transcoded format 0x${decoded.transcodedFormat.toString(16)}`);
+}
+
+/**
+ * Fetch and decode a KTX2 file holding array layers (`layerCount` \>= 1) into a `Texture2DArray` —
+ * the single-file, single-request counterpart to {@link createTexture2DArrayFromUrls}, which needs one image
+ * per layer. A single-layer container is accepted and yields a one-layer array.
+ *
+ * The array is transcoded to the device's best GPU-compressed format (BC7/ETC2/ASTC) and stays compressed in
+ * VRAM, and the container's authored mip chain is uploaded as-is rather than regenerated.
+ *
+ * Like every codec-decoded texture the data is uploaded unflipped with `invertY = true` (GUIDANCE §8 path 2),
+ * unlike `createTexture2DArrayFromUrls` which flips on upload. No built-in material samples an array, so
+ * honour that flag in your own WGSL (`v = 1 - v`).
+ *
+ * Requires a KTX2 decoder with 2D array support (configure self-hosting via `setKtx2DecoderUrl`).
+ *
+ * @param engine - Engine context.
+ * @param url - URL of a `.ktx2` file whose layers become the array's layers, in order.
+ * @param sRGB - Select the `*-srgb` GPU format. Default false, matching `loadKtx2Texture2D`.
+ * @returns A promise resolving to the populated `Texture2DArray`.
+ */
+export async function loadKtx2Texture2DArray(engine: EngineContext, url: string, sRGB = false): Promise<Texture2DArray> {
+    const resp = await fetch(url);
+    if (!resp.ok) {
+        throw new Error(`KTX2 fetch failed: ${resp.status} for ${url}`);
+    }
+    return uploadKtx2Texture2DArray(engine, await resp.arrayBuffer(), sRGB);
 }

--- a/tests/lite/unit/ktx2-texture-array.test.ts
+++ b/tests/lite/unit/ktx2-texture-array.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { loadKtx2Texture2DArray, uploadKtx2Texture2DArray } from "../../../packages/babylon-lite/src/texture/texture-array";
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+
+interface WriteCall {
+    dst: GPUTexelCopyTextureInfo;
+    data: ArrayBufferView;
+    layout: GPUTexelCopyBufferLayout;
+    size: GPUExtent3DStrict;
+}
+
+interface Captured {
+    createDesc?: GPUTextureDescriptor;
+    viewDesc?: GPUTextureViewDescriptor;
+    writes: WriteCall[];
+}
+
+function makeEngine(cap: Captured, features: string[] = []): EngineContext {
+    const device = {
+        features: { has: (f: string) => features.includes(f) },
+        createTexture: (desc: GPUTextureDescriptor) => {
+            cap.createDesc = desc;
+            return {
+                mipLevelCount: desc.mipLevelCount ?? 1,
+                createView: (v?: GPUTextureViewDescriptor) => ((cap.viewDesc = v), { _kind: "view" }),
+                destroy: () => undefined,
+            } as unknown as GPUTexture;
+        },
+        createSampler: () => ({ _kind: "sampler" }) as unknown as GPUSampler,
+        queue: {
+            writeTexture: (dst: GPUTexelCopyTextureInfo, data: ArrayBufferView, layout: GPUTexelCopyBufferLayout, size: GPUExtent3DStrict) => {
+                cap.writes.push({ dst, data, layout, size });
+            },
+        },
+    };
+    return { _device: device as unknown as GPUDevice } as unknown as EngineContext;
+}
+
+const GL_RGBA8 = 0x8058;
+const GL_BC7 = 0x8e8c;
+
+interface FakeMip {
+    width: number;
+    height: number;
+    data: Uint8Array;
+    layerIndex?: number;
+}
+
+/** Builds a decoder result: `levels` mip levels, each holding `layers` entries tagged with their layer index. */
+function fakeDecoded(options: { width: number; layers: number; levels: number; format: number; bytesPerPixel?: number; layerCount?: number | undefined; blockBytes?: number }) {
+    const mipmaps: FakeMip[] = [];
+    for (let level = 0; level < options.levels; level++) {
+        const size = Math.max(options.width >> level, 1);
+        for (let layer = 0; layer < options.layers; layer++) {
+            const byteLength = options.blockBytes ? Math.ceil(size / 4) * Math.ceil(size / 4) * options.blockBytes : size * size * (options.bytesPerPixel ?? 4);
+            mipmaps.push({ width: size, height: size, data: new Uint8Array(byteLength).fill(level * 16 + layer + 1), layerIndex: layer });
+        }
+    }
+    return {
+        width: options.width,
+        height: options.width,
+        transcodedFormat: options.format,
+        isInGammaSpace: false,
+        hasAlpha: true,
+        transcoderName: "fake",
+        layerCount: "layerCount" in options ? options.layerCount : options.layers,
+        mipmaps,
+    };
+}
+
+let decodeResult: unknown = null;
+
+beforeEach(() => {
+    // Stand in for the CDN decoder script that loadKtx2Decoder() injects.
+    (globalThis as unknown as { KTX2DECODER?: unknown }).KTX2DECODER = {
+        MSCTranscoder: { UseFromWorkerThread: true },
+        WASMMemoryManager: { LoadBinariesFromCurrentThread: false },
+        KTX2Decoder: class {
+            public async decode() {
+                return decodeResult;
+            }
+        },
+    };
+});
+
+afterEach(() => {
+    delete (globalThis as unknown as { KTX2DECODER?: unknown }).KTX2DECODER;
+    vi.unstubAllGlobals();
+});
+
+describe("uploadKtx2Texture2DArray", () => {
+    it("creates a layered texture with a 2d-array view and the container's mip chain", async () => {
+        decodeResult = fakeDecoded({ width: 4, layers: 3, levels: 3, format: GL_RGBA8 });
+        const cap: Captured = { writes: [] };
+
+        const tex = await uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8));
+
+        expect(cap.createDesc?.dimension).toBe("2d");
+        expect(cap.createDesc?.size).toEqual({ width: 4, height: 4, depthOrArrayLayers: 3 });
+        expect(cap.createDesc?.format).toBe("rgba8unorm");
+        expect(cap.createDesc?.mipLevelCount).toBe(3);
+        // The mip chain is authored, so no render-attachment/blit pass is needed.
+        expect((cap.createDesc?.usage ?? 0) & GPUTextureUsage.RENDER_ATTACHMENT).toBe(0);
+        expect(cap.viewDesc).toEqual({ dimension: "2d-array" });
+        expect(tex.layers).toBe(3);
+        expect(tex.width).toBe(4);
+        // Codec-decoded data is uploaded unflipped, so the material must flip V (GUIDANCE §8 path 2).
+        expect(tex.invertY).toBe(true);
+    });
+
+    it("writes each layer of each level to its own origin.z", async () => {
+        decodeResult = fakeDecoded({ width: 2, layers: 2, levels: 2, format: GL_RGBA8 });
+        const cap: Captured = { writes: [] };
+
+        await uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8));
+
+        expect(cap.writes).toHaveLength(4);
+        expect(cap.writes.map((w) => [w.dst.mipLevel, (w.dst.origin as { z: number }).z])).toEqual([
+            [0, 0],
+            [0, 1],
+            [1, 0],
+            [1, 1],
+        ]);
+        expect(cap.writes[0]!.size).toEqual({ width: 2, height: 2, depthOrArrayLayers: 1 });
+        expect(cap.writes[0]!.layout).toEqual({ bytesPerRow: 8 });
+        expect(cap.writes[2]!.size).toEqual({ width: 1, height: 1, depthOrArrayLayers: 1 });
+        // Each write must carry its own layer's bytes.
+        expect((cap.writes[0]!.data as Uint8Array)[0]).toBe(1);
+        expect((cap.writes[1]!.data as Uint8Array)[0]).toBe(2);
+        expect((cap.writes[2]!.data as Uint8Array)[0]).toBe(17);
+    });
+
+    it("keeps a compressed array compressed and block-pads the copy extent", async () => {
+        decodeResult = fakeDecoded({ width: 8, layers: 2, levels: 3, format: GL_BC7, blockBytes: 16 });
+        const cap: Captured = { writes: [] };
+
+        const tex = await uploadKtx2Texture2DArray(makeEngine(cap, ["texture-compression-bc"]), new ArrayBuffer(8));
+
+        expect(cap.createDesc?.format).toBe("bc7-rgba-unorm");
+        expect(tex.layers).toBe(2);
+        expect(cap.writes).toHaveLength(6);
+        // 8x8 -> 2x2 blocks of 16 bytes.
+        expect(cap.writes[0]!.layout).toEqual({ bytesPerRow: 32 });
+        expect(cap.writes[0]!.size).toEqual({ width: 8, height: 8, depthOrArrayLayers: 1 });
+        // 2x2 tail mip is padded up to one full 4x4 block.
+        expect(cap.writes[4]!.size).toEqual({ width: 4, height: 4, depthOrArrayLayers: 1 });
+    });
+
+    it("selects the sRGB format when requested", async () => {
+        decodeResult = fakeDecoded({ width: 2, layers: 2, levels: 1, format: GL_RGBA8 });
+        const cap: Captured = { writes: [] };
+
+        await uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8), true);
+
+        expect(cap.createDesc?.format).toBe("rgba8unorm-srgb");
+    });
+
+    it("handles a single-layer file", async () => {
+        decodeResult = fakeDecoded({ width: 2, layers: 1, levels: 2, format: GL_RGBA8 });
+        const cap: Captured = { writes: [] };
+
+        const tex = await uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8));
+
+        expect(tex.layers).toBe(1);
+        expect(cap.writes).toHaveLength(2);
+    });
+
+    it("rejects a decoder that does not report layerCount", async () => {
+        decodeResult = fakeDecoded({ width: 2, layers: 1, levels: 1, format: GL_RGBA8, layerCount: undefined });
+        const cap: Captured = { writes: [] };
+
+        await expect(uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8))).rejects.toThrow(/does not report layerCount/);
+    });
+
+    it("rejects when the decoder scrambles the layer order", async () => {
+        const decoded = fakeDecoded({ width: 2, layers: 2, levels: 1, format: GL_RGBA8 });
+        decoded.mipmaps[1]!.layerIndex = 0;
+        decodeResult = decoded;
+        const cap: Captured = { writes: [] };
+
+        await expect(uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8))).rejects.toThrow(/expected layer 1 at mip index 1/);
+    });
+
+    it("rejects when the mip count is not a whole number of levels", async () => {
+        const decoded = fakeDecoded({ width: 2, layers: 2, levels: 1, format: GL_RGBA8 });
+        decoded.mipmaps.push({ width: 1, height: 1, data: new Uint8Array(4), layerIndex: 0 });
+        decodeResult = decoded;
+        const cap: Captured = { writes: [] };
+
+        await expect(uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8))).rejects.toThrow(/whole number of 2-layer levels/);
+    });
+
+    it("rejects when the device lacks the compressed format feature", async () => {
+        decodeResult = fakeDecoded({ width: 4, layers: 2, levels: 1, format: GL_BC7, blockBytes: 16 });
+        const cap: Captured = { writes: [] };
+
+        await expect(uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8))).rejects.toThrow(/does not support texture-compression-bc/);
+    });
+
+    it("rejects an uncompressed layer whose size does not match its dimensions", async () => {
+        const decoded = fakeDecoded({ width: 2, layers: 2, levels: 1, format: GL_RGBA8 });
+        decoded.mipmaps[1]!.data = new Uint8Array(4);
+        decodeResult = decoded;
+        const cap: Captured = { writes: [] };
+
+        await expect(uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8))).rejects.toThrow(/layer 1 has 4 bytes, expected 16/);
+    });
+
+    it("surfaces decoder errors", async () => {
+        decodeResult = { ...fakeDecoded({ width: 2, layers: 1, levels: 1, format: GL_RGBA8 }), errors: "boom" };
+        const cap: Captured = { writes: [] };
+
+        await expect(uploadKtx2Texture2DArray(makeEngine(cap), new ArrayBuffer(8))).rejects.toThrow(/boom/);
+    });
+});
+
+describe("loadKtx2Texture2DArray", () => {
+    it("fetches the url and uploads the result", async () => {
+        decodeResult = fakeDecoded({ width: 2, layers: 2, levels: 1, format: GL_RGBA8 });
+        const cap: Captured = { writes: [] };
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => ({ ok: true, status: 200, arrayBuffer: async () => new ArrayBuffer(8) }))
+        );
+
+        const tex = await loadKtx2Texture2DArray(makeEngine(cap), "array.ktx2");
+
+        expect(tex.layers).toBe(2);
+        expect(cap.writes).toHaveLength(2);
+    });
+
+    it("rejects on a failed fetch", async () => {
+        const cap: Captured = { writes: [] };
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => ({ ok: false, status: 404 }))
+        );
+
+        await expect(loadKtx2Texture2DArray(makeEngine(cap), "missing.ktx2")).rejects.toThrow(/KTX2 fetch failed: 404/);
+    });
+});


### PR DESCRIPTION
Answers the [forum request](https://forum.babylonjs.com/t/populate-2d-texture-array-from-image-asset/35140/12) for loading a 2D texture array from a **single** `.ktx2` file — the compressed, one-request counterpart to the `createTexture2DArrayFromUrls` added earlier in that thread.

```ts
const atlas = await loadKtx2Texture2DArray(engine, "icons-array.ktx2");
// atlas.layers === 5, full authored mip chain, still BC7/ETC2/ASTC in VRAM
```

## What's here

| Export | Purpose |
| --- | --- |
| `loadKtx2Texture2DArray(engine, url, sRGB?)` | Fetch + decode a multi-layer container into a `Texture2DArray` |
| `uploadKtx2Texture2DArray(engine, buffer, sRGB?)` | Same, when the bytes are already in hand (zip, XHR, glTF binary chunk) |

Both live in `texture/texture-array.ts` next to the existing array helpers.

## Design

The decoder glue stays in `ktx2-loader.ts`, which gains an internal `decodeKtx2Async` seam (load decoder → transcode with the device's compression caps → validate) plus `@internal` exports of the `srgbFormat` / `uncompressedInfo` / `makeSampler` helpers it already had. `texture-array.ts` consumes those and owns array texture creation and the GPU uploads.

That mirrors the split Babylon.js core uses between `KhronosTextureContainer2._decodeAsync` and `rawTexture2DArray.functions`, and keeps `ktx2-loader.ts` free of any `Texture2DArray` import, so there's no cycle.

**Unlike BJS core, layers stay compressed.** Core must `forceRGBA` on arrays because its WebGL engine has no `compressedTexImage3D` for `TEXTURE_2D_ARRAY`. WebGPU's `writeTexture` takes compressed layers directly via `origin.z`, so BC7/ETC2/ASTC survive into VRAM here.

**Orientation** follows GUIDANCE §8 path 2 — uploaded unflipped with `invertY = true`, matching `loadKtx2Texture2D` (and unlike `createTexture2DArrayFromUrls`, which flips on upload). No built-in material samples an array, so consumers honour the flag in their own WGSL.

**Layer ordering is verified, not assumed.** The decoder emits `layerCount` consecutive entries per mip level; `groupArrayMips` checks each entry's reported `layerIndex` and per-level size rather than trusting the stride, so a future decoder change can't silently scramble layers.

### Known duplication

The transcode-target dispatch (`getCompressedFormat` → `uncompressedInfo` → throw) and the device-feature check are mirrored between `uploadKtx2Texture2D` and `uploadKtx2Texture2DArray` — about 17 lines. An earlier revision hoisted them into a shared `decodeKtx2Async` that returned a resolved-format object; that was reverted for the bundle-size reason below. Happy to dedupe with a callback-shaped helper if reviewers would rather have that.

## Bundle size

Worth calling out because it drove the design. `scene112` (glTF `KHR_texture_basisu`) already ships `srgbFormat` / `uncompressedInfo` / `makeSampler`, so **sharing** them across the seam costs it **54 B**. The earlier version that instead handed a resolved-format object across the seam cost the same scene **260 B** — every KTX2 consumer paying for an array feature they don't use — because the object's property names appear in both producer and consumers and aren't manglable.

**No scene ceilings changed.** All manifests regenerated per GUIDANCE §158.

`scene115` needed a targeted fix. It is flagged `deviceDependentChunks`, and this change alters the shared `gltf-feature-registry` chunk it loads, so CI reported its manifest stale. `pnpm build:bundle-manifest:device` cannot author it here — SwiftShader will not run these GPU-picking scenes on Windows — but a plain local build still *measures* the scene on the real GPU and records it in the untracked aggregate manifest, which isolates exactly what changed:

- `gltf-feature-registry` hash `KRzkF8u5` → `CvCXXB3b` — a build artifact, identical to what CI computed, and the only delta this PR causes.
- `picking-pipeline` → `picking-detailed-pipeline` — the genuinely device-dependent difference (my GPU takes the detailed path), which is why the scene carries the flag.

Only the first is committed; the CI-authored picking chunk and the recorded sizes are left untouched. `pnpm validate:bundle-manifest` now reports up to date across all 223 scenes. `scene113`/`114` were checked the same way and show only the device-dependent picking swap, so they are unchanged.

## Upstream dependency

Needs a KTX2 decoder with 2D-array support: BabylonJS/Babylon.js#18740 (merge `59b8301502`), which added the decoder's array loop (`layerIndex` / `layerCount`) and uncompressed RGBSDA support. It has been live on `cdn.babylonjs.com/babylon.ktx2Decoder.js` since 2026-07-28. Self-hosters can point at their own build via `setKtx2DecoderUrl`. If an older decoder is in play, `groupArrayMips` throws a message pointing at `setKtx2DecoderUrl` rather than producing a scrambled texture.

## Validation

- **In-browser against the live CDN decoder and a remote asset** ([`material-icons-msdf-array.ktx2`](https://raw.githubusercontent.com/axeljaeger/msdf-icon-flag/main/public/icons/material-icons-msdf-array.ktx2) — vkFormat 37, 256×256, 5 layers, 9 levels): all 5 MSDF icons render upright, `mipLevelCount` 9, `invertY` true, 5 draw calls, empty WebGPU validation error scope. The harness was temporary and is not part of this PR (GUIDANCE §0b).
- 13 new unit tests in `tests/lite/unit/ktx2-texture-array.test.ts` covering the reshape, `writeTexture` call sequence, block-padded copy extents for compressed layers, uncompressed stride validation, and every error path.
- `pnpm run lint` clean (eslint + 6 tsc projects).
- `pnpm build:bundle-scenes` — all ceilings pass.
- `pnpm test:parity` — 449 passed, 1 failed (`scene265` environment, MAD 0.78). Pre-existing and reproduces on a clean `master`. The three character-controller scenes that also used to fail now pass, thanks to the MAD thresholds fixed in #497.

## Not covered

No UASTC/ETC1S **array** `.ktx2` asset appears to exist publicly, so the compressed-array upload path is spec-correct and unit-tested but not runtime-verified. The uncompressed path is verified end-to-end above.


