### PR TITLE
ci: fail Playwright parity runs fast on first error

### DIFF
--- a/config/playwright.parity-cloud.config.ts
+++ b/config/playwright.parity-cloud.config.ts
@@ -48,6 +48,9 @@ export default defineConfig({
     timeout: 120_000,
     retries: 1,
     workers: ciWorkers ?? (useBrowserStack ? 1 : 2),
+    // On CI, bail on the first failing test (after its retries) to save time;
+    // locally we keep running so devs see every failure in one pass.
+    maxFailures: isCI ? 1 : undefined,
     fullyParallel: true,
     outputDir: "../test-results/parity-artifacts",
     reporter: [["html", { outputFolder: "../test-results/parity-report", open: "never" }], ["junit", { outputFile: "../test-results/parity-junit.xml" }], ["list"]],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,6 +39,9 @@ export default defineConfig({
     timeout: 60_000,
     retries: 2,
     workers: 2,
+    // On CI, bail on the first failing test (after its retries) to save time;
+    // locally we keep running so devs see every failure in one pass.
+    maxFailures: isCI ? 1 : undefined,
     use: {
         channel: "chrome",
         headless,


### PR DESCRIPTION
## What

Make CI-only Playwright runs bail on the first failing test (after retries) to save time. Sets `maxFailures: 1` gated on `process.env.CI` in:

- `playwright.config.ts` (default config — covers `test:parity:gl` and `test:bundle-size` jobs)
- `config/playwright.parity-cloud.config.ts` (BrowserStack WebGPU parity job)

## Why

A single failing scene shouldn't have to wait for the entire parity/default suite to finish before CI reports red. Bailing early cuts feedback time on failures.

## Scope

- **CI only.** Gated on the existing `isCI` flag (`process.env.CI`), which is set in the pipeline but not locally — local `pnpm test:parity` / `test:parity:gl` still run the full suite and report every failure in one pass.
- `maxFailures` counts a test as failed only *after* its retries are exhausted, so flaky tests still get their normal retries before the run bails.
- Perf tests are intentionally **not** affected — they use separate `playwright.perf*.config.ts` configs.