### PR TITLE
fix(shader): honor explicit depth writes for blended materials

### DIFF
--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -3,9 +3,9 @@
   "gzipKB": 23.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene127-shader-renderable-CZsk7b0i.js",
+    "scene127-shader-renderable-DvFHudjL.js",
     "scene127-uniform-copy-batch-5CRB0N8o.js",
     "scene127.js"
   ],
-  "rawBytes": 61743
+  "rawBytes": 61739
 }

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -3,9 +3,9 @@
   "gzipKB": 23.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene128-shader-renderable-k1RcSTxJ.js",
+    "scene128-shader-renderable-Dx6AIX4y.js",
     "scene128-uniform-copy-batch-4Fa5v6Ll.js",
     "scene128.js"
   ],
-  "rawBytes": 61712
+  "rawBytes": 61708
 }

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -3,8 +3,8 @@
   "gzipKB": 15.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene159-shader-renderable-DrGOTc71.js",
+    "scene159-shader-renderable--MFoWMh0.js",
     "scene159.js"
   ],
-  "rawBytes": 40022
+  "rawBytes": 40020
 }

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -3,8 +3,8 @@
   "gzipKB": 16.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene160-shader-renderable-R_xxdgYY.js",
+    "scene160-shader-renderable-zznrc26l.js",
     "scene160.js"
   ],
-  "rawBytes": 41971
+  "rawBytes": 41965
 }

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -3,8 +3,8 @@
   "gzipKB": 15.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene161-shader-renderable--2sQAtNL.js",
+    "scene161-shader-renderable-bR5zgq0U.js",
     "scene161.js"
   ],
-  "rawBytes": 40601
+  "rawBytes": 40597
 }

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -3,8 +3,8 @@
   "gzipKB": 15.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene162-shader-renderable-COlVCrMx.js",
+    "scene162-shader-renderable-Cgg_BGSA.js",
     "scene162.js"
   ],
-  "rawBytes": 40046
+  "rawBytes": 40042
 }

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -3,8 +3,8 @@
   "gzipKB": 15.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene163-shader-renderable-D0m54VaO.js",
+    "scene163-shader-renderable-BWCFyxcI.js",
     "scene163.js"
   ],
-  "rawBytes": 39741
+  "rawBytes": 39737
 }

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -3,10 +3,10 @@
   "gzipKB": 17.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene165-shader-renderable-CvEti6UY.js",
+    "scene165-shader-renderable-CzI02nqi.js",
     "scene165-shader-thin-instance-BKrtjGJ6.js",
     "scene165-thin-instance-gpu-B5cobg4p.js",
     "scene165.js"
   ],
-  "rawBytes": 45442
+  "rawBytes": 45438
 }

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -4,9 +4,9 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene213-shader-pipeline-cache-Dga-Orlp.js",
-    "scene213-shader-renderable-JGOHFbG9.js",
+    "scene213-shader-renderable-BzT1Rdlk.js",
     "scene213-uniform-copy-batch-dw98bObp.js",
     "scene213.js"
   ],
-  "rawBytes": 50270
+  "rawBytes": 50266
 }

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -4,10 +4,10 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene221-scene-uniforms-CGHhMjxH.js",
-    "scene221-shader-renderable-Dr3TcjIM.js",
+    "scene221-shader-renderable-Dc6eXmOR.js",
     "scene221-standard-renderable-CuU3EPds.js",
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221.js"
   ],
-  "rawBytes": 101997
+  "rawBytes": 101993
 }

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -1,16 +1,16 @@
 {
-  "rawKB": 112.6,
+  "rawKB": 112.5,
   "gzipKB": 42.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene222-gpu-pool-CHlSfwGp.js",
     "scene222-scene-uniforms-Ha63NnVx.js",
     "scene222-shader-pipeline-cache-CRfxG7iY.js",
-    "scene222-shader-renderable-WoGTPvpq.js",
+    "scene222-shader-renderable-BJN_GE6S.js",
     "scene222-standard-renderable-C0AiwZng.js",
     "scene222-swapchain-overlay-ilhN4El_.js",
     "scene222-uniform-copy-batch-DrEP8HMR.js",
     "scene222.js"
   ],
-  "rawBytes": 115252
+  "rawBytes": 115248
 }

--- a/lab/public/bundle/manifest/scene274.json
+++ b/lab/public/bundle/manifest/scene274.json
@@ -1,11 +1,11 @@
 {
   "rawKB": 43.4,
-  "rawBytes": 44464,
+  "rawBytes": 44460,
   "gzipKB": 17.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene274-shader-pipeline-cache-BlqTVl3L.js",
-    "scene274-shader-renderable-iT2TqeKr.js",
+    "scene274-shader-renderable-C1HuFJgB.js",
     "scene274-uniform-copy-batch-BHris-Ik.js",
     "scene274.js"
   ]

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -8,5 +8,5 @@
     "scene49-swapchain-overlay-ilhN4El_.js",
     "scene49.js"
   ],
-  "rawBytes": 92837
+  "rawBytes": 92855
 }

--- a/packages/babylon-lite/src/material/shader/shader-material.ts
+++ b/packages/babylon-lite/src/material/shader/shader-material.ts
@@ -56,6 +56,10 @@ export interface ShaderMaterialOptions {
     readonly transmissive?: boolean;
     readonly needAlphaTesting?: boolean;
     readonly backFaceCulling?: boolean;
+    /** Depth-buffer writes for this material's draws. Defaults to `true` for opaque materials and
+     *  `false` for alpha-blended ones (`needAlphaBlending`). An EXPLICIT value always wins: a blended
+     *  volume/veil may set `depthWrite: true` to publish its fragment depth so later draws depth-test
+     *  against it instead of compositing over it. */
     readonly depthWrite?: boolean;
     readonly depthCompare?: GPUCompareFunction;
     /** Compile/run the fragment stage even for depth-only render targets (no colour attachments).
@@ -308,7 +312,9 @@ export function createShaderMaterial(options: ShaderMaterialOptions): ShaderMate
         transmissive: options.transmissive ?? false,
         needAlphaTesting: options.needAlphaTesting ?? false,
         backFaceCulling: options.backFaceCulling ?? true,
-        depthWrite: options.depthWrite ?? true,
+        // Blended materials default to depth-read-only; an explicit option always wins (see the
+        // ShaderMaterialOptions doc). Opaque materials keep the depth-writing default.
+        depthWrite: options.depthWrite ?? !(options.needAlphaBlending ?? false),
         depthCompare: options.depthCompare ?? "greater-equal",
         depthOnlyFragment: options.depthOnlyFragment ?? false,
         depthBias: options.depthBias ?? 0,

--- a/packages/babylon-lite/src/material/shader/shader-pipeline.ts
+++ b/packages/babylon-lite/src/material/shader/shader-pipeline.ts
@@ -176,7 +176,10 @@ export function getOrCreateShaderPipeline(
                       // correctly when drawn into a reverse-Z camera depth prepass that declares
                       // "greater-equal" — otherwise every fragment fails against the 0-cleared buffer.
                       depthCompare: sig._depthCompare ?? material.depthCompare,
-                      depthWriteEnabled: material.needAlphaBlending ? false : material.depthWrite,
+                      // material.depthWrite is authoritative: the material factory already defaults
+                      // blended materials to false, and an explicit depthWrite on a blended material
+                      // (a volume/veil publishing its fragment depth) must be honoured here.
+                      depthWriteEnabled: material.depthWrite,
                       ...(material.depthBias ? { depthBias: material.depthBias } : {}),
                       ...(material.depthBiasSlopeScale ? { depthBiasSlopeScale: material.depthBiasSlopeScale } : {}),
                       // Pre-baked stencil sub-fields, resolved through the opt-in `_stencilResolver` hook above;

--- a/tests/lite/unit/alpha-to-coverage.test.ts
+++ b/tests/lite/unit/alpha-to-coverage.test.ts
@@ -205,10 +205,15 @@ describe("WebGPU alpha-to-coverage", () => {
         clearSceneBGLCache();
         const { engine } = makeEngine();
 
-        const shader = makeShaderMaterial({ needAlphaBlending: true, depthWrite: true });
-        setAlphaToCoverage(shader, true);
-        const shaderBindings = getOrCreateShaderPipelineBindings(engine, shader);
-        const shaderPipeline = getOrCreateShaderPipeline(engine, multisampledSignature, shader, shaderBindings);
+        const depthWritingShader = makeShaderMaterial({ needAlphaBlending: true, depthWrite: true });
+        setAlphaToCoverage(depthWritingShader, true);
+        const depthWritingShaderBindings = getOrCreateShaderPipelineBindings(engine, depthWritingShader);
+        const depthWritingShaderPipeline = getOrCreateShaderPipeline(engine, multisampledSignature, depthWritingShader, depthWritingShaderBindings);
+
+        const readOnlyDepthShader = makeShaderMaterial({ needAlphaBlending: true });
+        setAlphaToCoverage(readOnlyDepthShader, true);
+        const readOnlyDepthShaderBindings = getOrCreateShaderPipelineBindings(engine, readOnlyDepthShader);
+        const readOnlyDepthShaderPipeline = getOrCreateShaderPipeline(engine, multisampledSignature, readOnlyDepthShader, readOnlyDepthShaderBindings);
 
         const standard = createStandardMaterial();
         standard.alpha = 0.5;
@@ -226,7 +231,8 @@ describe("WebGPU alpha-to-coverage", () => {
         pbrScene._groups.set(pbr._buildGroup, pbrMeshes);
         const pbrPipeline = (await buildPbrRenderables(pbrScene, pbrMeshes, undefined)).renderables[0]!.bind(engine, multisampledSignature).pipeline;
 
-        for (const pipeline of [shaderPipeline, standardPipeline, pbrPipeline]) {
+        expect(depthWriteEnabled(depthWritingShaderPipeline)).toBe(true);
+        for (const pipeline of [readOnlyDepthShaderPipeline, standardPipeline, pbrPipeline]) {
             expect(alphaToCoverageEnabled(pipeline)).toBe(true);
             expect(colorTarget(pipeline).blend).toBeDefined();
             expect(depthWriteEnabled(pipeline)).toBe(false);

--- a/tests/lite/unit/alpha-to-coverage.test.ts
+++ b/tests/lite/unit/alpha-to-coverage.test.ts
@@ -231,6 +231,8 @@ describe("WebGPU alpha-to-coverage", () => {
         pbrScene._groups.set(pbr._buildGroup, pbrMeshes);
         const pbrPipeline = (await buildPbrRenderables(pbrScene, pbrMeshes, undefined)).renderables[0]!.bind(engine, multisampledSignature).pipeline;
 
+        expect(alphaToCoverageEnabled(depthWritingShaderPipeline)).toBe(true);
+        expect(colorTarget(depthWritingShaderPipeline).blend).toBeDefined();
         expect(depthWriteEnabled(depthWritingShaderPipeline)).toBe(true);
         for (const pipeline of [readOnlyDepthShaderPipeline, standardPipeline, pbrPipeline]) {
             expect(alphaToCoverageEnabled(pipeline)).toBe(true);


### PR DESCRIPTION
## Summary
- default blended ShaderMaterials to read-only depth while preserving opaque depth writes
- honor an explicit `depthWrite: true` in the WebGPU pipeline
- cover both default and explicit depth policies and refresh the affected scene bundle manifest

## Validation
- `pnpm exec vitest run --project unit tests/lite/unit/alpha-to-coverage.test.ts tests/lite/unit/shader-pipeline-cache.test.ts`
- `pnpm exec eslint packages/babylon-lite/src/material/shader/shader-material.ts packages/babylon-lite/src/material/shader/shader-pipeline.ts tests/lite/unit/alpha-to-coverage.test.ts`
- `pnpm exec tsc -p packages/babylon-lite/tsconfig.json --noEmit`
- `pnpm exec playwright test tests/lite/parity/scenes/scene163-shader-material-alpha.spec.ts` (MAD 0.000)
- filtered scene163 bundle build (39,737 raw bytes; 4 bytes smaller)