### PR TITLE
feat: support explicit overlay composition and blend states

### DIFF
--- a/docs/lite/architecture/24-shader-material.md
+++ b/docs/lite/architecture/24-shader-material.md
@@ -38,6 +38,8 @@ export interface ShaderMaterialOptions {
     /** Bind/inject the mesh's optional thin-instance RGBA stream for this material. Default true. */
     readonly useThinInstanceColors?: boolean;
     readonly needAlphaBlending?: boolean;
+    readonly blendMode?: "alpha" | "additive";
+    readonly blend?: GPUBlendState;
     readonly needAlphaTesting?: boolean;
     readonly backFaceCulling?: boolean;
     readonly depthWrite?: boolean;
@@ -66,6 +68,8 @@ export interface ShaderMaterial extends Material {
     readonly samplerDecls: readonly ShaderSamplerDecl[];
     readonly defines: readonly ShaderDefine[];
     readonly needAlphaBlending: boolean;
+    readonly blendMode: "alpha" | "additive";
+    readonly blend?: GPUBlendState;
     readonly needAlphaTesting: boolean;
     readonly backFaceCulling: boolean;
     readonly depthWrite: boolean;
@@ -78,6 +82,8 @@ export interface ShaderMaterial extends Material {
 ```
 
 `_uboVersion` from the base `Material` mirrors `_uniformVersion` for compatibility with existing dirty tracking. `_resourceVersion` is separate because texture/sampler changes require bind group rebuilds, not just UBO writes.
+
+`blend` is an explicit color-target blend-state override. When present, it replaces the state derived from `needAlphaBlending` and `blendMode`, and participates in the cross-material pipeline-cache key.
 
 ### Attributes
 

--- a/docs/lite/architecture/24-shader-material.md
+++ b/docs/lite/architecture/24-shader-material.md
@@ -83,7 +83,7 @@ export interface ShaderMaterial extends Material {
 
 `_uboVersion` from the base `Material` mirrors `_uniformVersion` for compatibility with existing dirty tracking. `_resourceVersion` is separate because texture/sampler changes require bind group rebuilds, not just UBO writes.
 
-`blend` is an explicit color-target blend-state override. When present, it replaces the state derived from `needAlphaBlending` and `blendMode`, and participates in the cross-material pipeline-cache key.
+`blend` is an explicit color-target blend-state override. When present, it replaces the state derived from `blendMode`, implies `needAlphaBlending` unless explicitly overridden, defaults `depthWrite` to `false`, and participates in the cross-material pipeline-cache key.
 
 ### Attributes
 

--- a/docs/lite/architecture/27-render-pipeline.md
+++ b/docs/lite/architecture/27-render-pipeline.md
@@ -87,8 +87,10 @@ export interface RenderTaskConfig {
     clrColor?: GPUColorDict;
     clr?: boolean;
     depthClear?: boolean;
+    sharedRt?: boolean;
     cam?: Camera | null;
     cs?: boolean;
+    autoMirror?: boolean;
 }
 ```
 
@@ -99,10 +101,14 @@ Important fields:
 | `rt`         | Concrete render target. Swapchain tasks use `resolveToSwapchain: true`; RTT tasks allocate color/depth textures.                                         |
 | `clr`        | `true`/undefined clears color; `false` loads previous color content for overlays/multi-scene composition.                                                |
 | `depthClear` | Controls rt-owned depth independently. `true`/undefined clears depth; `false` loads existing depth. External `depth` targets keep their ownership policy. |
+| `sharedRt`   | Uses a target owned and recorded by an earlier task; this task does not build or dispose `rt`/`rst`.                                                      |
 | `cam`        | Per-pass camera override; defaults to `scene.camera`.                                                                                                    |
 | `cs`         | Use canvas dimensions for scene UBO aspect instead of RTT dimensions. Used when an RTT texture must be rendered with canvas aspect.                      |
+| `autoMirror` | Set `false` to keep an empty explicit render list instead of mirroring the scene renderables.                                                             |
 
 `RenderTask.addMesh(mesh, { material })` accepts either a source material or a `MaterialView`. The mesh is resolved at `record()` time through the source material family's `_buildGroup._rebuildSingle` closure, so explicit offscreen tasks can render the same mesh with pass-specific material features without mutating `mesh.material`.
+
+`RenderTask.enabled` defaults to `true`. Setting it to `false` skips the pass before updates, attachment loads, resolves, or draws.
 
 ## Runtime Flow
 

--- a/docs/lite/architecture/27-render-pipeline.md
+++ b/docs/lite/architecture/27-render-pipeline.md
@@ -86,6 +86,7 @@ export interface RenderTaskConfig {
     rt: RenderTarget;
     clrColor?: GPUColorDict;
     clr?: boolean;
+    depthClear?: boolean;
     cam?: Camera | null;
     cs?: boolean;
 }
@@ -93,12 +94,13 @@ export interface RenderTaskConfig {
 
 Important fields:
 
-| Field | Meaning                                                                                                                             |
-| ----- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `rt`  | Concrete render target. Swapchain tasks use `resolveToSwapchain: true`; RTT tasks allocate color/depth textures.                    |
-| `clr` | `true`/undefined clears color+depth; `false` loads previous content for overlays/multi-scene composition.                           |
-| `cam` | Per-pass camera override; defaults to `scene.camera`.                                                                               |
-| `cs`  | Use canvas dimensions for scene UBO aspect instead of RTT dimensions. Used when an RTT texture must be rendered with canvas aspect. |
+| Field        | Meaning                                                                                                                                                  |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rt`         | Concrete render target. Swapchain tasks use `resolveToSwapchain: true`; RTT tasks allocate color/depth textures.                                         |
+| `clr`        | `true`/undefined clears color; `false` loads previous color content for overlays/multi-scene composition.                                                |
+| `depthClear` | Controls rt-owned depth independently. `true`/undefined clears depth; `false` loads existing depth. External `depth` targets keep their ownership policy. |
+| `cam`        | Per-pass camera override; defaults to `scene.camera`.                                                                                                    |
+| `cs`         | Use canvas dimensions for scene UBO aspect instead of RTT dimensions. Used when an RTT texture must be rendered with canvas aspect.                      |
 
 `RenderTask.addMesh(mesh, { material })` accepts either a source material or a `MaterialView`. The mesh is resolved at `record()` time through the source material family's `_buildGroup._rebuildSingle` closure, so explicit offscreen tasks can render the same mesh with pass-specific material features without mutating `mesh.material`.
 

--- a/docs/lite/architecture/28-frame-graph.md
+++ b/docs/lite/architecture/28-frame-graph.md
@@ -175,7 +175,7 @@ addTaskAfter(sceneOrGraph, task, afterTask); // insert immediately after afterTa
 Rules:
 
 - Offscreen producer tasks must run before consumers that sample their output.
-- Overlay tasks should use `clr: false` and run after the task they overlay. Add `depthClear: false` when they must depth-test against rt-owned depth produced by the earlier task.
+- Overlay tasks should use `sharedRt: true`, `clr: false`, and run after the owning task. Add `depthClear: false` when they must depth-test against its rt-owned depth.
 - `addTaskBefore()` appends if the `beforeTask` is not found.
 - `addTaskAfter()` inserts immediately after `afterTask`, and appends if it is not found.
 - If tasks are added or inserted outside the startup/resize path, caller code must rebuild the graph before the next frame.
@@ -271,9 +271,11 @@ export interface RenderTaskConfig {
     clrColor?: GPUColorDict;
     clr?: boolean;
     depthClear?: boolean;
+    sharedRt?: boolean;
     cam?: Camera | null;
     cs?: boolean;
     transmission?: { copyCount?: number; generateMipmaps?: boolean };
+    autoMirror?: boolean;
 }
 ```
 
@@ -284,9 +286,11 @@ export interface RenderTaskConfig {
 | `clrColor`     | Clear color. The object may be mutated between frames.                                                                                                                                                                                                    |
 | `clr`          | Defaults to clear. Set `false` to use color `loadOp: "load"` for overlays or multi-scene composition.                                                                                                                                                     |
 | `depthClear`   | Controls rt-owned depth independently. Defaults to clear; set `false` to load existing depth. Ignored for external `depth` targets, which retain their eager/task-managed ownership policy.                                                               |
+| `sharedRt`     | Marks `rt`/`rst` as owned by another, earlier task. This task uses the live views without rebuilding or disposing them.                                                                                                                                  |
 | `cam`          | Optional per-pass camera. Defaults to `scene.camera`.                                                                                                                                                                                                     |
 | `cs`           | Canvas-sized aspect flag. When true, scene UBO aspect uses canvas dimensions instead of RTT dimensions. This is useful for RTTs that are later sampled as a material texture but should preserve canvas aspect.                                           |
 | `transmission` | Optional scene-texture transmission settings. `copyCount: 0` refreshes before every transmissive draw; otherwise the default is one refresh. `generateMipmaps` defaults to `true`; set `false` to allocate only mip 0 and skip refraction mip generation. |
+| `autoMirror`   | Set `false` for an explicit render list that remains empty until populated with `addMesh()`.                                                                                                                                                              |
 
 ### Image Processing Task
 
@@ -342,7 +346,9 @@ const swapRT = createRenderTarget({
 createRenderTask({ name: "scene", rt: swapRT, clrColor: scene.clearColor }, engine, scene);
 ```
 
-This task auto-mirrors `scene._renderables` when its own `_renderables` list is empty. If the scene renderable version changes because of mesh add/remove/material swap, the task re-syncs and rebinds its draw lists.
+This task auto-mirrors `scene._renderables` when its own `_renderables` list is empty unless `autoMirror: false`. If the scene renderable version changes because of mesh add/remove/material swap, an auto-mirroring task re-syncs and rebinds its draw lists.
+
+`RenderTask.enabled` defaults to `true`. A disabled task exits before per-pass updates and does not load attachments, resolve MSAA, or issue draws.
 
 ### Explicit Task Population
 

--- a/docs/lite/architecture/28-frame-graph.md
+++ b/docs/lite/architecture/28-frame-graph.md
@@ -175,7 +175,7 @@ addTaskAfter(sceneOrGraph, task, afterTask); // insert immediately after afterTa
 Rules:
 
 - Offscreen producer tasks must run before consumers that sample their output.
-- Overlay tasks should use `clr: false` and run after the task they overlay.
+- Overlay tasks should use `clr: false` and run after the task they overlay. Add `depthClear: false` when they must depth-test against rt-owned depth produced by the earlier task.
 - `addTaskBefore()` appends if the `beforeTask` is not found.
 - `addTaskAfter()` inserts immediately after `afterTask`, and appends if it is not found.
 - If tasks are added or inserted outside the startup/resize path, caller code must rebuild the graph before the next frame.
@@ -270,6 +270,7 @@ export interface RenderTaskConfig {
     rt: RenderTarget;
     clrColor?: GPUColorDict;
     clr?: boolean;
+    depthClear?: boolean;
     cam?: Camera | null;
     cs?: boolean;
     transmission?: { copyCount?: number; generateMipmaps?: boolean };
@@ -281,7 +282,8 @@ export interface RenderTaskConfig {
 | `name`         | Used for labels and diagnostics.                                                                                                                                                                                                                          |
 | `rt`           | Concrete render target for this pass.                                                                                                                                                                                                                     |
 | `clrColor`     | Clear color. The object may be mutated between frames.                                                                                                                                                                                                    |
-| `clr`          | Defaults to clear. Set `false` to use color/depth `loadOp: "load"` for overlays or multi-scene composition.                                                                                                                                               |
+| `clr`          | Defaults to clear. Set `false` to use color `loadOp: "load"` for overlays or multi-scene composition.                                                                                                                                                     |
+| `depthClear`   | Controls rt-owned depth independently. Defaults to clear; set `false` to load existing depth. Ignored for external `depth` targets, which retain their eager/task-managed ownership policy.                                                               |
 | `cam`          | Optional per-pass camera. Defaults to `scene.camera`.                                                                                                                                                                                                     |
 | `cs`           | Canvas-sized aspect flag. When true, scene UBO aspect uses canvas dimensions instead of RTT dimensions. This is useful for RTTs that are later sampled as a material texture but should preserve canvas aspect.                                           |
 | `transmission` | Optional scene-texture transmission settings. `copyCount: 0` refreshes before every transmissive draw; otherwise the default is one refresh. `generateMipmaps` defaults to `true`; set `false` to allocate only mip 0 and skip refraction mip generation. |

--- a/lab/public/bundle/manifest/scene1.json
+++ b/lab/public/bundle/manifest/scene1.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 88.5,
+  "rawKB": 88.4,
   "gzipKB": 37.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -16,5 +16,5 @@
     "scene1-wgsl-helpers-BgB2AJrF.js",
     "scene1.js"
   ],
-  "rawBytes": 90578
+  "rawBytes": 90534
 }

--- a/lab/public/bundle/manifest/scene1.json
+++ b/lab/public/bundle/manifest/scene1.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 88.4,
+  "rawKB": 88.5,
   "gzipKB": 37.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -16,5 +16,5 @@
     "scene1-wgsl-helpers-BgB2AJrF.js",
     "scene1.js"
   ],
-  "rawBytes": 90548
+  "rawBytes": 90578
 }

--- a/lab/public/bundle/manifest/scene1.json
+++ b/lab/public/bundle/manifest/scene1.json
@@ -9,12 +9,12 @@
     "scene1-generate-mipmaps-BxsDX3Y-.js",
     "scene1-gltf-glb-parser-Gdq7NHHd.js",
     "scene1-ibl-fragment-CeRrvT96.js",
-    "scene1-pbr-renderable-CIbRqf0m.js",
+    "scene1-pbr-renderable-uhljJvgI.js",
     "scene1-rgbd-decode-BGE2GEn1.js",
     "scene1-scene-uniforms-FTYH6Ct0.js",
     "scene1-singlelight-hemispheric-wgsl-90xDRzhR.js",
     "scene1-wgsl-helpers-BgB2AJrF.js",
     "scene1.js"
   ],
-  "rawBytes": 90534
+  "rawBytes": 90530
 }

--- a/lab/public/bundle/manifest/scene10.json
+++ b/lab/public/bundle/manifest/scene10.json
@@ -7,5 +7,5 @@
     "scene10-singlelight-hemispheric-wgsl-xIKr6fiL.js",
     "scene10.js"
   ],
-  "rawBytes": 54452
+  "rawBytes": 54435
 }

--- a/lab/public/bundle/manifest/scene10.json
+++ b/lab/public/bundle/manifest/scene10.json
@@ -3,9 +3,9 @@
   "gzipKB": 22,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene10-pbr-renderable-D-p5QF8J.js",
+    "scene10-pbr-renderable-HkptNnTf.js",
     "scene10-singlelight-hemispheric-wgsl-xIKr6fiL.js",
     "scene10.js"
   ],
-  "rawBytes": 54435
+  "rawBytes": 54431
 }

--- a/lab/public/bundle/manifest/scene100.json
+++ b/lab/public/bundle/manifest/scene100.json
@@ -6,5 +6,5 @@
     "scene100-standard-renderable-DyIqhwVt.js",
     "scene100.js"
   ],
-  "rawBytes": 52141
+  "rawBytes": 52127
 }

--- a/lab/public/bundle/manifest/scene100.json
+++ b/lab/public/bundle/manifest/scene100.json
@@ -6,5 +6,5 @@
     "scene100-standard-renderable-DyIqhwVt.js",
     "scene100.js"
   ],
-  "rawBytes": 52127
+  "rawBytes": 52123
 }

--- a/lab/public/bundle/manifest/scene101.json
+++ b/lab/public/bundle/manifest/scene101.json
@@ -6,5 +6,5 @@
     "scene101-standard-renderable-D4WI_kqm.js",
     "scene101.js"
   ],
-  "rawBytes": 55182
+  "rawBytes": 55180
 }

--- a/lab/public/bundle/manifest/scene101.json
+++ b/lab/public/bundle/manifest/scene101.json
@@ -6,5 +6,5 @@
     "scene101-standard-renderable-D4WI_kqm.js",
     "scene101.js"
   ],
-  "rawBytes": 55191
+  "rawBytes": 55182
 }

--- a/lab/public/bundle/manifest/scene102.json
+++ b/lab/public/bundle/manifest/scene102.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 59.6,
+  "rawKB": 59.5,
   "gzipKB": 24,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene102-standard-renderable-BfzwhvRR.js",
     "scene102.js"
   ],
-  "rawBytes": 60993
+  "rawBytes": 60979
 }

--- a/lab/public/bundle/manifest/scene102.json
+++ b/lab/public/bundle/manifest/scene102.json
@@ -6,5 +6,5 @@
     "scene102-standard-renderable-BfzwhvRR.js",
     "scene102.js"
   ],
-  "rawBytes": 60979
+  "rawBytes": 60974
 }

--- a/lab/public/bundle/manifest/scene103.json
+++ b/lab/public/bundle/manifest/scene103.json
@@ -8,5 +8,5 @@
     "scene103-thin-instance-gpu-BRZG8wwf.js",
     "scene103.js"
   ],
-  "rawBytes": 64481
+  "rawBytes": 64476
 }

--- a/lab/public/bundle/manifest/scene103.json
+++ b/lab/public/bundle/manifest/scene103.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 63,
+  "rawKB": 63.0,
   "gzipKB": 25.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -8,5 +8,5 @@
     "scene103-thin-instance-gpu-BRZG8wwf.js",
     "scene103.js"
   ],
-  "rawBytes": 64495
+  "rawBytes": 64481
 }

--- a/lab/public/bundle/manifest/scene104.json
+++ b/lab/public/bundle/manifest/scene104.json
@@ -11,5 +11,5 @@
     "scene104-std-lightmap-fragment-BcOGvaSO.js",
     "scene104.js"
   ],
-  "rawBytes": 103727
+  "rawBytes": 103720
 }

--- a/lab/public/bundle/manifest/scene104.json
+++ b/lab/public/bundle/manifest/scene104.json
@@ -11,5 +11,5 @@
     "scene104-std-lightmap-fragment-BcOGvaSO.js",
     "scene104.js"
   ],
-  "rawBytes": 103745
+  "rawBytes": 103727
 }

--- a/lab/public/bundle/manifest/scene105.json
+++ b/lab/public/bundle/manifest/scene105.json
@@ -11,5 +11,5 @@
     "scene105-std-lightmap-fragment-CAyjqaXg.js",
     "scene105.js"
   ],
-  "rawBytes": 104419
+  "rawBytes": 104417
 }

--- a/lab/public/bundle/manifest/scene105.json
+++ b/lab/public/bundle/manifest/scene105.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 102,
+  "rawKB": 102.0,
   "gzipKB": 39.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,5 +11,5 @@
     "scene105-std-lightmap-fragment-CAyjqaXg.js",
     "scene105.js"
   ],
-  "rawBytes": 104435
+  "rawBytes": 104419
 }

--- a/lab/public/bundle/manifest/scene106.json
+++ b/lab/public/bundle/manifest/scene106.json
@@ -6,5 +6,5 @@
     "scene106-standard-renderable-BDRZY4cL.js",
     "scene106.js"
   ],
-  "rawBytes": 53054
+  "rawBytes": 53043
 }

--- a/lab/public/bundle/manifest/scene106.json
+++ b/lab/public/bundle/manifest/scene106.json
@@ -6,5 +6,5 @@
     "scene106-standard-renderable-BDRZY4cL.js",
     "scene106.js"
   ],
-  "rawBytes": 53043
+  "rawBytes": 53039
 }

--- a/lab/public/bundle/manifest/scene11.json
+++ b/lab/public/bundle/manifest/scene11.json
@@ -18,5 +18,5 @@
     "scene11-skeleton-fragment-mGHAIXUr.js",
     "scene11.js"
   ],
-  "rawBytes": 91246
+  "rawBytes": 91232
 }

--- a/lab/public/bundle/manifest/scene11.json
+++ b/lab/public/bundle/manifest/scene11.json
@@ -13,10 +13,10 @@
     "scene11-gltf-feature-skeleton-DzqLJNf9.js",
     "scene11-gltf-glb-parser-DkzNAISh.js",
     "scene11-gltf-sampler-desc-BhDLgho4.js",
-    "scene11-pbr-renderable-Dc4Vkore.js",
+    "scene11-pbr-renderable-Dzmwosoj.js",
     "scene11-singlelight-hemispheric-wgsl-B_Y4cleJ.js",
-    "scene11-skeleton-fragment-mGHAIXUr.js",
+    "scene11-skeleton-fragment-B2P3f0ki.js",
     "scene11.js"
   ],
-  "rawBytes": 91232
+  "rawBytes": 91229
 }

--- a/lab/public/bundle/manifest/scene110.json
+++ b/lab/public/bundle/manifest/scene110.json
@@ -6,5 +6,5 @@
     "scene110-standard-renderable-Ci_axEDg.js",
     "scene110.js"
   ],
-  "rawBytes": 51835
+  "rawBytes": 51828
 }

--- a/lab/public/bundle/manifest/scene110.json
+++ b/lab/public/bundle/manifest/scene110.json
@@ -6,5 +6,5 @@
     "scene110-standard-renderable-Ci_axEDg.js",
     "scene110.js"
   ],
-  "rawBytes": 51849
+  "rawBytes": 51835
 }

--- a/lab/public/bundle/manifest/scene111.json
+++ b/lab/public/bundle/manifest/scene111.json
@@ -29,5 +29,5 @@
     "scene111-vertex-output-C7G5u6Y0.js",
     "scene111.js"
   ],
-  "rawBytes": 135882
+  "rawBytes": 135868
 }

--- a/lab/public/bundle/manifest/scene111.json
+++ b/lab/public/bundle/manifest/scene111.json
@@ -18,7 +18,7 @@
     "scene111-node-registry-nenxaLnw.js",
     "scene111-node-renderable-k613XsA8.js",
     "scene111-node-shadow-CrFRFBZk.js",
-    "scene111-pbr-renderable-CQNmzK85.js",
+    "scene111-pbr-renderable-ZcOyLHbU.js",
     "scene111-pbr-shadow-fragment-CFzpdZcF.js",
     "scene111-shader-composer-BSMzKE4Z.js",
     "scene111-shadow-fragment-core-Dbe1xNkt.js",
@@ -29,5 +29,5 @@
     "scene111-vertex-output-C7G5u6Y0.js",
     "scene111.js"
   ],
-  "rawBytes": 135868
+  "rawBytes": 135849
 }

--- a/lab/public/bundle/manifest/scene112.json
+++ b/lab/public/bundle/manifest/scene112.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 120,
+  "rawKB": 120.0,
   "gzipKB": 49.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -22,5 +22,5 @@
     "scene112-wgsl-helpers-BgB2AJrF.js",
     "scene112.js"
   ],
-  "rawBytes": 122916
+  "rawBytes": 122902
 }

--- a/lab/public/bundle/manifest/scene112.json
+++ b/lab/public/bundle/manifest/scene112.json
@@ -13,14 +13,14 @@
     "scene112-gltf-json-asset-jIhMyCt9.js",
     "scene112-gltf-uri-6vf9MtoR.js",
     "scene112-ibl-fragment-CeRrvT96.js",
-    "scene112-pbr-refraction-BMdiGdWC.js",
-    "scene112-pbr-renderable-BmxbSfeI.js",
-    "scene112-pbr-transmission-ext-DW1b_IKQ.js",
+    "scene112-pbr-refraction-BwIZcHO3.js",
+    "scene112-pbr-renderable-DeEhxD4W.js",
+    "scene112-pbr-transmission-ext-BgYwrkgq.js",
     "scene112-rgbd-decode-CFyrlDIY.js",
     "scene112-scene-uniforms-FTYH6Ct0.js",
     "scene112-singlelight-hemispheric-wgsl-C21KlfrE.js",
     "scene112-wgsl-helpers-BgB2AJrF.js",
     "scene112.js"
   ],
-  "rawBytes": 122902
+  "rawBytes": 122907
 }

--- a/lab/public/bundle/manifest/scene113.json
+++ b/lab/public/bundle/manifest/scene113.json
@@ -7,5 +7,5 @@
     "scene113-standard-renderable-DbCgwXT_.js",
     "scene113.js"
   ],
-  "rawBytes": 63723
+  "rawBytes": 63716
 }

--- a/lab/public/bundle/manifest/scene113.json
+++ b/lab/public/bundle/manifest/scene113.json
@@ -7,5 +7,5 @@
     "scene113-standard-renderable-DbCgwXT_.js",
     "scene113.js"
   ],
-  "rawBytes": 63737
+  "rawBytes": 63723
 }

--- a/lab/public/bundle/manifest/scene114.json
+++ b/lab/public/bundle/manifest/scene114.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene114-deformed-geometry-Brq5fz01.js",
     "scene114-morph-fragment-BxNBj8ez.js",
-    "scene114-pbr-renderable-CDs3DL_7.js",
+    "scene114-pbr-renderable-Domt0Z4E.js",
     "scene114-pbr-template-ext-CiHpOV5G.js",
     "scene114-picking-pipeline-2gjcXSVW.js",
     "scene114-singlelight-hemispheric-wgsl-DV6gJrdt.js",
@@ -13,5 +13,5 @@
     "scene114-unlit-fragment-DWtvt7yQ.js",
     "scene114.js"
   ],
-  "rawBytes": 83464
+  "rawBytes": 83458
 }

--- a/lab/public/bundle/manifest/scene114.json
+++ b/lab/public/bundle/manifest/scene114.json
@@ -13,5 +13,5 @@
     "scene114-unlit-fragment-DWtvt7yQ.js",
     "scene114.js"
   ],
-  "rawBytes": 83478
+  "rawBytes": 83464
 }

--- a/lab/public/bundle/manifest/scene115.json
+++ b/lab/public/bundle/manifest/scene115.json
@@ -17,7 +17,7 @@
     "scene115-mesh-features-Dda6QcW-.js",
     "scene115-morph-fragment-Ck00lP_G.js",
     "scene115-morph-fragment-core-Bg5FFLic.js",
-    "scene115-pbr-renderable-CDrJhVGg.js",
+    "scene115-pbr-renderable-CxjyDaO4.js",
     "scene115-pbr-template-ext-CiHpOV5G.js",
     "scene115-picking-pipeline-C9DxnZjR.js",
     "scene115-singlelight-hemispheric-wgsl-Nr1eJWuy.js",
@@ -25,5 +25,5 @@
     "scene115-standard-renderable-BXC04JFy.js",
     "scene115.js"
   ],
-  "rawBytes": 130050
+  "rawBytes": 130046
 }

--- a/lab/public/bundle/manifest/scene115.json
+++ b/lab/public/bundle/manifest/scene115.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 127,
+  "rawKB": 127.0,
   "gzipKB": 53.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -25,5 +25,5 @@
     "scene115-standard-renderable-BXC04JFy.js",
     "scene115.js"
   ],
-  "rawBytes": 130064
+  "rawBytes": 130050
 }

--- a/lab/public/bundle/manifest/scene116.json
+++ b/lab/public/bundle/manifest/scene116.json
@@ -3,7 +3,7 @@
   "gzipKB": 31.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene116-pbr-renderable-Dx_Zi7dC.js",
+    "scene116-pbr-renderable-D6PXirLO.js",
     "scene116-shader-composer-qxmZVcOJ.js",
     "scene116-singlelight-hemispheric-wgsl-CjLhvUZR.js",
     "scene116-standard-renderable-CMUBOthC.js",
@@ -11,5 +11,5 @@
     "scene116-unlit-fragment-DWtvt7yQ.js",
     "scene116.js"
   ],
-  "rawBytes": 78137
+  "rawBytes": 78135
 }

--- a/lab/public/bundle/manifest/scene116.json
+++ b/lab/public/bundle/manifest/scene116.json
@@ -11,5 +11,5 @@
     "scene116-unlit-fragment-DWtvt7yQ.js",
     "scene116.js"
   ],
-  "rawBytes": 78148
+  "rawBytes": 78137
 }

--- a/lab/public/bundle/manifest/scene118.json
+++ b/lab/public/bundle/manifest/scene118.json
@@ -10,5 +10,5 @@
     "scene118-standard-renderable-CiCWOjTT.js",
     "scene118.js"
   ],
-  "rawBytes": 78855
+  "rawBytes": 78853
 }

--- a/lab/public/bundle/manifest/scene118.json
+++ b/lab/public/bundle/manifest/scene118.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 77,
+  "rawKB": 77.0,
   "gzipKB": 31.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -10,5 +10,5 @@
     "scene118-standard-renderable-CiCWOjTT.js",
     "scene118.js"
   ],
-  "rawBytes": 78869
+  "rawBytes": 78855
 }

--- a/lab/public/bundle/manifest/scene12.json
+++ b/lab/public/bundle/manifest/scene12.json
@@ -11,7 +11,7 @@
     "scene12-gltf-feature-skeleton-yTqcn85p.js",
     "scene12-gltf-glb-parser-BWKwsvg4.js",
     "scene12-ibl-fragment-CeRrvT96.js",
-    "scene12-pbr-renderable-B2sr8gFV.js",
+    "scene12-pbr-renderable-BqkaYYji.js",
     "scene12-reflectance-fragment-DCD0BBZS.js",
     "scene12-rgbd-decode-Dv_uzcWF.js",
     "scene12-scene-uniforms-FTYH6Ct0.js",
@@ -19,5 +19,5 @@
     "scene12-skeleton-fragment-B3HcVmlw.js",
     "scene12.js"
   ],
-  "rawBytes": 106441
+  "rawBytes": 106439
 }

--- a/lab/public/bundle/manifest/scene12.json
+++ b/lab/public/bundle/manifest/scene12.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 104,
+  "rawKB": 103.9,
   "gzipKB": 42.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -19,5 +19,5 @@
     "scene12-skeleton-fragment-B3HcVmlw.js",
     "scene12.js"
   ],
-  "rawBytes": 106455
+  "rawBytes": 106441
 }

--- a/lab/public/bundle/manifest/scene120.json
+++ b/lab/public/bundle/manifest/scene120.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene120.js"
   ],
-  "rawBytes": 37101
+  "rawBytes": 37097
 }

--- a/lab/public/bundle/manifest/scene120.json
+++ b/lab/public/bundle/manifest/scene120.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene120.js"
   ],
-  "rawBytes": 37115
+  "rawBytes": 37101
 }

--- a/lab/public/bundle/manifest/scene121.json
+++ b/lab/public/bundle/manifest/scene121.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene121.js"
   ],
-  "rawBytes": 37280
+  "rawBytes": 37266
 }

--- a/lab/public/bundle/manifest/scene121.json
+++ b/lab/public/bundle/manifest/scene121.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene121.js"
   ],
-  "rawBytes": 37266
+  "rawBytes": 37262
 }

--- a/lab/public/bundle/manifest/scene122.json
+++ b/lab/public/bundle/manifest/scene122.json
@@ -6,5 +6,5 @@
     "scene122-gaussian-splatting-pipeline-sh-B8hG6H-7.js",
     "scene122.js"
   ],
-  "rawBytes": 49105
+  "rawBytes": 49101
 }

--- a/lab/public/bundle/manifest/scene122.json
+++ b/lab/public/bundle/manifest/scene122.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 48,
+  "rawKB": 48.0,
   "gzipKB": 19.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene122-gaussian-splatting-pipeline-sh-B8hG6H-7.js",
     "scene122.js"
   ],
-  "rawBytes": 49118
+  "rawBytes": 49105
 }

--- a/lab/public/bundle/manifest/scene123.json
+++ b/lab/public/bundle/manifest/scene123.json
@@ -6,5 +6,5 @@
     "scene123-gaussian-splatting-pipeline-sh-CQel0Vrc.js",
     "scene123.js"
   ],
-  "rawBytes": 46622
+  "rawBytes": 46615
 }

--- a/lab/public/bundle/manifest/scene123.json
+++ b/lab/public/bundle/manifest/scene123.json
@@ -6,5 +6,5 @@
     "scene123-gaussian-splatting-pipeline-sh-CQel0Vrc.js",
     "scene123.js"
   ],
-  "rawBytes": 46636
+  "rawBytes": 46622
 }

--- a/lab/public/bundle/manifest/scene124.json
+++ b/lab/public/bundle/manifest/scene124.json
@@ -7,5 +7,5 @@
     "scene124-splat-ply-compressed-4vnSZMqI.js",
     "scene124.js"
   ],
-  "rawBytes": 52835
+  "rawBytes": 52831
 }

--- a/lab/public/bundle/manifest/scene124.json
+++ b/lab/public/bundle/manifest/scene124.json
@@ -7,5 +7,5 @@
     "scene124-splat-ply-compressed-4vnSZMqI.js",
     "scene124.js"
   ],
-  "rawBytes": 52849
+  "rawBytes": 52835
 }

--- a/lab/public/bundle/manifest/scene125.json
+++ b/lab/public/bundle/manifest/scene125.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene125.js"
   ],
-  "rawBytes": 39230
+  "rawBytes": 39226
 }

--- a/lab/public/bundle/manifest/scene125.json
+++ b/lab/public/bundle/manifest/scene125.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene125.js"
   ],
-  "rawBytes": 39244
+  "rawBytes": 39230
 }

--- a/lab/public/bundle/manifest/scene126.json
+++ b/lab/public/bundle/manifest/scene126.json
@@ -5,5 +5,5 @@
   "runtimeChunks": [
     "scene126.js"
   ],
-  "rawBytes": 37320
+  "rawBytes": 37316
 }

--- a/lab/public/bundle/manifest/scene126.json
+++ b/lab/public/bundle/manifest/scene126.json
@@ -1,9 +1,9 @@
 {
-  "rawKB": 36.5,
+  "rawKB": 36.4,
   "gzipKB": 14.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene126.js"
   ],
-  "rawBytes": 37334
+  "rawBytes": 37320
 }

--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -7,5 +7,5 @@
     "scene127-uniform-copy-batch-5CRB0N8o.js",
     "scene127.js"
   ],
-  "rawBytes": 61739
+  "rawBytes": 61725
 }

--- a/lab/public/bundle/manifest/scene127.json
+++ b/lab/public/bundle/manifest/scene127.json
@@ -3,9 +3,9 @@
   "gzipKB": 23.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene127-shader-renderable-DvFHudjL.js",
+    "scene127-shader-renderable-CVvVThkc.js",
     "scene127-uniform-copy-batch-5CRB0N8o.js",
     "scene127.js"
   ],
-  "rawBytes": 61725
+  "rawBytes": 61759
 }

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -1,11 +1,11 @@
 {
-  "rawKB": 60.2,
+  "rawKB": 60.3,
   "gzipKB": 23.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene128-shader-renderable-Dx6AIX4y.js",
+    "scene128-shader-renderable-CS8oq2v3.js",
     "scene128-uniform-copy-batch-4Fa5v6Ll.js",
     "scene128.js"
   ],
-  "rawBytes": 61694
+  "rawBytes": 61728
 }

--- a/lab/public/bundle/manifest/scene128.json
+++ b/lab/public/bundle/manifest/scene128.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60.3,
+  "rawKB": 60.2,
   "gzipKB": 23.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene128-uniform-copy-batch-4Fa5v6Ll.js",
     "scene128.js"
   ],
-  "rawBytes": 61708
+  "rawBytes": 61694
 }

--- a/lab/public/bundle/manifest/scene129.json
+++ b/lab/public/bundle/manifest/scene129.json
@@ -8,5 +8,5 @@
     "scene129-standard-renderable-CU0A9Dxg.js",
     "scene129.js"
   ],
-  "rawBytes": 89641
+  "rawBytes": 89627
 }

--- a/lab/public/bundle/manifest/scene129.json
+++ b/lab/public/bundle/manifest/scene129.json
@@ -8,5 +8,5 @@
     "scene129-standard-renderable-CU0A9Dxg.js",
     "scene129.js"
   ],
-  "rawBytes": 89627
+  "rawBytes": 89623
 }

--- a/lab/public/bundle/manifest/scene13.json
+++ b/lab/public/bundle/manifest/scene13.json
@@ -14,5 +14,5 @@
     "scene13-wgsl-helpers-BgB2AJrF.js",
     "scene13.js"
   ],
-  "rawBytes": 86154
+  "rawBytes": 86136
 }

--- a/lab/public/bundle/manifest/scene13.json
+++ b/lab/public/bundle/manifest/scene13.json
@@ -7,12 +7,12 @@
     "scene13-generate-mipmaps-CtVZJxfl.js",
     "scene13-gltf-glb-parser-BZCy2KIt.js",
     "scene13-ibl-fragment-CeRrvT96.js",
-    "scene13-pbr-renderable-C4G-D_QZ.js",
+    "scene13-pbr-renderable-BaO6yqLK.js",
     "scene13-rgbd-decode-BpGE9HNW.js",
     "scene13-scene-uniforms-FTYH6Ct0.js",
     "scene13-singlelight-hemispheric-wgsl-W13_mD5F.js",
     "scene13-wgsl-helpers-BgB2AJrF.js",
     "scene13.js"
   ],
-  "rawBytes": 86136
+  "rawBytes": 86132
 }

--- a/lab/public/bundle/manifest/scene14.json
+++ b/lab/public/bundle/manifest/scene14.json
@@ -9,12 +9,12 @@
     "scene14-generate-mipmaps-Tx1TIb9d.js",
     "scene14-gltf-glb-parser-BW9JifjF.js",
     "scene14-ibl-fragment-CeRrvT96.js",
-    "scene14-pbr-renderable-CBBiRVxp.js",
+    "scene14-pbr-renderable-YyCVAcwu.js",
     "scene14-rgbd-decode-D8VFo9Z-.js",
     "scene14-scene-uniforms-FTYH6Ct0.js",
     "scene14-singlelight-hemispheric-wgsl-I0MLzfP_.js",
     "scene14-wgsl-helpers-BgB2AJrF.js",
     "scene14.js"
   ],
-  "rawBytes": 90770
+  "rawBytes": 90766
 }

--- a/lab/public/bundle/manifest/scene14.json
+++ b/lab/public/bundle/manifest/scene14.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 88.7,
+  "rawKB": 88.6,
   "gzipKB": 37.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -16,5 +16,5 @@
     "scene14-wgsl-helpers-BgB2AJrF.js",
     "scene14.js"
   ],
-  "rawBytes": 90784
+  "rawBytes": 90770
 }

--- a/lab/public/bundle/manifest/scene140.json
+++ b/lab/public/bundle/manifest/scene140.json
@@ -41,5 +41,5 @@
     "scene140-vertex-output-C7G5u6Y0.js",
     "scene140.js"
   ],
-  "rawBytes": 92773
+  "rawBytes": 92769
 }

--- a/lab/public/bundle/manifest/scene140.json
+++ b/lab/public/bundle/manifest/scene140.json
@@ -41,5 +41,5 @@
     "scene140-vertex-output-C7G5u6Y0.js",
     "scene140.js"
   ],
-  "rawBytes": 92787
+  "rawBytes": 92773
 }

--- a/lab/public/bundle/manifest/scene141.json
+++ b/lab/public/bundle/manifest/scene141.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 122.3,
+  "rawKB": 122.2,
   "gzipKB": 50.7,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
@@ -26,5 +26,5 @@
     "scene141-vertex-output-C7G5u6Y0.js",
     "scene141.js"
   ],
-  "rawBytes": 125187
+  "rawBytes": 125173
 }

--- a/lab/public/bundle/manifest/scene141.json
+++ b/lab/public/bundle/manifest/scene141.json
@@ -15,7 +15,7 @@
     "scene141-node-registry-BDSK2ra4.js",
     "scene141-node-renderable-HdoKdPDy.js",
     "scene141-node-shadow-xbpSTfVl.js",
-    "scene141-pbr-renderable-CJUXN3rE.js",
+    "scene141-pbr-renderable-pdFZB2DQ.js",
     "scene141-pbr-shadow-fragment-DHDAZ1HL.js",
     "scene141-shader-composer-nU4_w_gR.js",
     "scene141-shadow-fragment-core-Dbe1xNkt.js",
@@ -26,5 +26,5 @@
     "scene141-vertex-output-C7G5u6Y0.js",
     "scene141.js"
   ],
-  "rawBytes": 125173
+  "rawBytes": 125174
 }

--- a/lab/public/bundle/manifest/scene142.json
+++ b/lab/public/bundle/manifest/scene142.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 61,
+  "rawKB": 61.0,
   "gzipKB": 23.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene142-standard-renderable-Xkd9W1L1.js",
     "scene142.js"
   ],
-  "rawBytes": 62453
+  "rawBytes": 62440
 }

--- a/lab/public/bundle/manifest/scene142.json
+++ b/lab/public/bundle/manifest/scene142.json
@@ -6,5 +6,5 @@
     "scene142-standard-renderable-Xkd9W1L1.js",
     "scene142.js"
   ],
-  "rawBytes": 62440
+  "rawBytes": 62454
 }

--- a/lab/public/bundle/manifest/scene143.json
+++ b/lab/public/bundle/manifest/scene143.json
@@ -13,5 +13,5 @@
     "scene143-std-specular-fragment-BugkvqOj.js",
     "scene143.js"
   ],
-  "rawBytes": 72409
+  "rawBytes": 72394
 }

--- a/lab/public/bundle/manifest/scene143.json
+++ b/lab/public/bundle/manifest/scene143.json
@@ -13,5 +13,5 @@
     "scene143-std-specular-fragment-BugkvqOj.js",
     "scene143.js"
   ],
-  "rawBytes": 72394
+  "rawBytes": 72412
 }

--- a/lab/public/bundle/manifest/scene144.json
+++ b/lab/public/bundle/manifest/scene144.json
@@ -22,5 +22,5 @@
     "scene144-texture-2d-DQo3n8D6.js",
     "scene144.js"
   ],
-  "rawBytes": 114517
+  "rawBytes": 114506
 }

--- a/lab/public/bundle/manifest/scene144.json
+++ b/lab/public/bundle/manifest/scene144.json
@@ -14,13 +14,13 @@
     "scene144-gltf-glb-parser-5J2K-QXc.js",
     "scene144-gltf-pbr-builder-ext-CfC-j6Ec.js",
     "scene144-ibl-fragment-CeRrvT96.js",
-    "scene144-pbr-renderable-B0_JsYt7.js",
+    "scene144-pbr-renderable-Co2F45AM.js",
     "scene144-pbr-template-ext-CiHpOV5G.js",
     "scene144-rgbd-decode-CxdrPy1h.js",
     "scene144-scene-uniforms-FTYH6Ct0.js",
-    "scene144-skeleton-fragment-b8hhtUXh.js",
+    "scene144-skeleton-fragment-88gVE4je.js",
     "scene144-texture-2d-DQo3n8D6.js",
     "scene144.js"
   ],
-  "rawBytes": 114506
+  "rawBytes": 114525
 }

--- a/lab/public/bundle/manifest/scene145.json
+++ b/lab/public/bundle/manifest/scene145.json
@@ -22,5 +22,5 @@
     "scene145-std-specular-fragment-DwjAhaXY.js",
     "scene145.js"
   ],
-  "rawBytes": 91702
+  "rawBytes": 91716
 }

--- a/lab/public/bundle/manifest/scene145.json
+++ b/lab/public/bundle/manifest/scene145.json
@@ -22,5 +22,5 @@
     "scene145-std-specular-fragment-DwjAhaXY.js",
     "scene145.js"
   ],
-  "rawBytes": 91713
+  "rawBytes": 91702
 }

--- a/lab/public/bundle/manifest/scene146.json
+++ b/lab/public/bundle/manifest/scene146.json
@@ -19,5 +19,5 @@
     "scene146-wgsl-helpers-BxdFLrVn.js",
     "scene146.js"
   ],
-  "rawBytes": 113234
+  "rawBytes": 113220
 }

--- a/lab/public/bundle/manifest/scene146.json
+++ b/lab/public/bundle/manifest/scene146.json
@@ -9,8 +9,8 @@
     "scene146-generate-mipmaps-Cga8Me24.js",
     "scene146-gltf-json-asset-CMVwe1IY.js",
     "scene146-ibl-fragment-CeRrvT96.js",
-    "scene146-pbr-geometry-view-Dtcr2krc.js",
-    "scene146-pbr-renderable-DYaItqAu.js",
+    "scene146-pbr-geometry-view-DzcKBqKa.js",
+    "scene146-pbr-renderable-DyuDjpH8.js",
     "scene146-rgbd-decode-DjacYvdz.js",
     "scene146-scene-uniforms-FTYH6Ct0.js",
     "scene146-shader-composer-DOjPUQGI.js",
@@ -19,5 +19,5 @@
     "scene146-wgsl-helpers-BxdFLrVn.js",
     "scene146.js"
   ],
-  "rawBytes": 113220
+  "rawBytes": 113238
 }

--- a/lab/public/bundle/manifest/scene147.json
+++ b/lab/public/bundle/manifest/scene147.json
@@ -10,11 +10,11 @@
     "scene147-gltf-glb-parser-Ctl3KJNN.js",
     "scene147-gltf-light-pointer-state-B7kFTRxK.js",
     "scene147-multilight-wgsl-CLgjeQ_G.js",
-    "scene147-pbr-geometry-view-Cb42h-yR.js",
-    "scene147-pbr-renderable-CKWWqOI5.js",
+    "scene147-pbr-geometry-view-BsSvdI8M.js",
+    "scene147-pbr-renderable-DArx9Paz.js",
     "scene147-scene-uniforms-Ha63NnVx.js",
     "scene147-shader-composer-8GPw9fSv.js",
     "scene147.js"
   ],
-  "rawBytes": 106278
+  "rawBytes": 106285
 }

--- a/lab/public/bundle/manifest/scene147.json
+++ b/lab/public/bundle/manifest/scene147.json
@@ -16,5 +16,5 @@
     "scene147-shader-composer-8GPw9fSv.js",
     "scene147.js"
   ],
-  "rawBytes": 106287
+  "rawBytes": 106278
 }

--- a/lab/public/bundle/manifest/scene148.json
+++ b/lab/public/bundle/manifest/scene148.json
@@ -16,5 +16,5 @@
     "scene148-singlelight-hemispheric-wgsl-Dl8TI5wG.js",
     "scene148.js"
   ],
-  "rawBytes": 112261
+  "rawBytes": 112247
 }

--- a/lab/public/bundle/manifest/scene148.json
+++ b/lab/public/bundle/manifest/scene148.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 109.6,
-  "gzipKB": 43.4,
+  "gzipKB": 44,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene148-directional-light-CLC0TyGx.js",
@@ -9,12 +9,12 @@
     "scene148-gltf-feature-registry-Cl_QAzqZ.js",
     "scene148-gltf-glb-parser-CFOh2GWe.js",
     "scene148-gltf-light-pointer-state-B7kFTRxK.js",
-    "scene148-pbr-geometry-view-UvK3uFtV.js",
-    "scene148-pbr-renderable-CcGQMcKM.js",
+    "scene148-pbr-geometry-view-hMfdknk3.js",
+    "scene148-pbr-renderable-DDdSgm2I.js",
     "scene148-scene-uniforms-Ha63NnVx.js",
     "scene148-shader-composer-BCkp8e9Y.js",
     "scene148-singlelight-hemispheric-wgsl-Dl8TI5wG.js",
     "scene148.js"
   ],
-  "rawBytes": 112247
+  "rawBytes": 112265
 }

--- a/lab/public/bundle/manifest/scene149.json
+++ b/lab/public/bundle/manifest/scene149.json
@@ -22,5 +22,5 @@
     "scene149-vertex-output-C7G5u6Y0.js",
     "scene149.js"
   ],
-  "rawBytes": 109258
+  "rawBytes": 109274
 }

--- a/lab/public/bundle/manifest/scene149.json
+++ b/lab/public/bundle/manifest/scene149.json
@@ -22,5 +22,5 @@
     "scene149-vertex-output-C7G5u6Y0.js",
     "scene149.js"
   ],
-  "rawBytes": 109272
+  "rawBytes": 109258
 }

--- a/lab/public/bundle/manifest/scene15.json
+++ b/lab/public/bundle/manifest/scene15.json
@@ -6,5 +6,5 @@
     "scene15-standard-renderable-s8aJWbW9.js",
     "scene15.js"
   ],
-  "rawBytes": 49041
+  "rawBytes": 49027
 }

--- a/lab/public/bundle/manifest/scene15.json
+++ b/lab/public/bundle/manifest/scene15.json
@@ -6,5 +6,5 @@
     "scene15-standard-renderable-s8aJWbW9.js",
     "scene15.js"
   ],
-  "rawBytes": 49027
+  "rawBytes": 49023
 }

--- a/lab/public/bundle/manifest/scene150.json
+++ b/lab/public/bundle/manifest/scene150.json
@@ -6,5 +6,5 @@
     "scene150-standard-renderable-Dp-b6aUt.js",
     "scene150.js"
   ],
-  "rawBytes": 55731
+  "rawBytes": 55737
 }

--- a/lab/public/bundle/manifest/scene150.json
+++ b/lab/public/bundle/manifest/scene150.json
@@ -6,5 +6,5 @@
     "scene150-standard-renderable-Dp-b6aUt.js",
     "scene150.js"
   ],
-  "rawBytes": 55745
+  "rawBytes": 55731
 }

--- a/lab/public/bundle/manifest/scene151.json
+++ b/lab/public/bundle/manifest/scene151.json
@@ -6,5 +6,5 @@
     "scene151-standard-renderable-BguQYttS.js",
     "scene151.js"
   ],
-  "rawBytes": 56001
+  "rawBytes": 55993
 }

--- a/lab/public/bundle/manifest/scene151.json
+++ b/lab/public/bundle/manifest/scene151.json
@@ -6,5 +6,5 @@
     "scene151-standard-renderable-BguQYttS.js",
     "scene151.js"
   ],
-  "rawBytes": 55993
+  "rawBytes": 55992
 }

--- a/lab/public/bundle/manifest/scene152.json
+++ b/lab/public/bundle/manifest/scene152.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 93,
+  "rawKB": 93.0,
   "gzipKB": 39.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -18,5 +18,5 @@
     "scene152-skeleton-fragment-Cp8N666r.js",
     "scene152.js"
   ],
-  "rawBytes": 95273
+  "rawBytes": 95259
 }

--- a/lab/public/bundle/manifest/scene152.json
+++ b/lab/public/bundle/manifest/scene152.json
@@ -13,10 +13,10 @@
     "scene152-gltf-feature-skeleton-BGDYR5rN.js",
     "scene152-gltf-glb-parser-BeX6MjHH.js",
     "scene152-gltf-sampler-desc-55i7wkXO.js",
-    "scene152-pbr-renderable-CA-xZZZu.js",
+    "scene152-pbr-renderable-DbuqwhwA.js",
     "scene152-singlelight-hemispheric-wgsl-kWPig5Fa.js",
-    "scene152-skeleton-fragment-Cp8N666r.js",
+    "scene152-skeleton-fragment-CCxBuZto.js",
     "scene152.js"
   ],
-  "rawBytes": 95259
+  "rawBytes": 95255
 }

--- a/lab/public/bundle/manifest/scene154.json
+++ b/lab/public/bundle/manifest/scene154.json
@@ -6,5 +6,5 @@
     "scene154-standard-renderable-CcQDuLSA.js",
     "scene154.js"
   ],
-  "rawBytes": 56160
+  "rawBytes": 56166
 }

--- a/lab/public/bundle/manifest/scene154.json
+++ b/lab/public/bundle/manifest/scene154.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 54.9,
+  "rawKB": 54.8,
   "gzipKB": 21.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene154-standard-renderable-CcQDuLSA.js",
     "scene154.js"
   ],
-  "rawBytes": 56174
+  "rawBytes": 56160
 }

--- a/lab/public/bundle/manifest/scene155.json
+++ b/lab/public/bundle/manifest/scene155.json
@@ -6,5 +6,5 @@
     "scene155-standard-renderable-Bdw0ZGGp.js",
     "scene155.js"
   ],
-  "rawBytes": 58244
+  "rawBytes": 58230
 }

--- a/lab/public/bundle/manifest/scene155.json
+++ b/lab/public/bundle/manifest/scene155.json
@@ -1,10 +1,10 @@
 {
   "rawKB": 56.9,
-  "gzipKB": 22.4,
+  "gzipKB": 23,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene155-standard-renderable-Bdw0ZGGp.js",
     "scene155.js"
   ],
-  "rawBytes": 58230
+  "rawBytes": 58226
 }

--- a/lab/public/bundle/manifest/scene156.json
+++ b/lab/public/bundle/manifest/scene156.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 57.9,
+  "rawKB": 57.8,
   "gzipKB": 22.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene156-standard-renderable-BEaiaAAk.js",
     "scene156.js"
   ],
-  "rawBytes": 59240
+  "rawBytes": 59236
 }

--- a/lab/public/bundle/manifest/scene156.json
+++ b/lab/public/bundle/manifest/scene156.json
@@ -6,5 +6,5 @@
     "scene156-standard-renderable-BEaiaAAk.js",
     "scene156.js"
   ],
-  "rawBytes": 59254
+  "rawBytes": 59240
 }

--- a/lab/public/bundle/manifest/scene157.json
+++ b/lab/public/bundle/manifest/scene157.json
@@ -11,9 +11,9 @@
     "scene157-gltf-feature-skeleton-AH5V5HHE.js",
     "scene157-gltf-glb-parser-JLqfZehj.js",
     "scene157-multilight-wgsl-BM2AsepN.js",
-    "scene157-pbr-renderable-3Kg3dsAX.js",
-    "scene157-skeleton-fragment-dNcYumL1.js",
+    "scene157-pbr-renderable-lKBAg4Rp.js",
+    "scene157-skeleton-fragment-DoxXoIes.js",
     "scene157.js"
   ],
-  "rawBytes": 98266
+  "rawBytes": 98263
 }

--- a/lab/public/bundle/manifest/scene157.json
+++ b/lab/public/bundle/manifest/scene157.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 96,
+  "rawKB": 96.0,
   "gzipKB": 39.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -15,5 +15,5 @@
     "scene157-skeleton-fragment-dNcYumL1.js",
     "scene157.js"
   ],
-  "rawBytes": 98285
+  "rawBytes": 98266
 }

--- a/lab/public/bundle/manifest/scene158.json
+++ b/lab/public/bundle/manifest/scene158.json
@@ -15,5 +15,5 @@
     "scene158-skeleton-fragment-Dcx7FBdX.js",
     "scene158.js"
   ],
-  "rawBytes": 98553
+  "rawBytes": 98539
 }

--- a/lab/public/bundle/manifest/scene158.json
+++ b/lab/public/bundle/manifest/scene158.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 96.2,
-  "gzipKB": 39.4,
+  "gzipKB": 40,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene158-create-skeleton-C7-pnbSu.js",
@@ -11,9 +11,9 @@
     "scene158-gltf-feature-skeleton-Kj8g1SVh.js",
     "scene158-gltf-glb-parser-BXXv9nTE.js",
     "scene158-multilight-wgsl-D_3KZk-5.js",
-    "scene158-pbr-renderable-B-wDgacl.js",
-    "scene158-skeleton-fragment-Dcx7FBdX.js",
+    "scene158-pbr-renderable-BvYnfm-f.js",
+    "scene158-skeleton-fragment-D-EeJUTU.js",
     "scene158.js"
   ],
-  "rawBytes": 98539
+  "rawBytes": 98536
 }

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -1,10 +1,10 @@
 {
   "rawKB": 39.1,
-  "gzipKB": 15.4,
+  "gzipKB": 16,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene159-shader-renderable--MFoWMh0.js",
+    "scene159-shader-renderable-BvJF0hyf.js",
     "scene159.js"
   ],
-  "rawBytes": 40006
+  "rawBytes": 40037
 }

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -6,5 +6,5 @@
     "scene159-shader-renderable--MFoWMh0.js",
     "scene159.js"
   ],
-  "rawBytes": 40020
+  "rawBytes": 40006
 }

--- a/lab/public/bundle/manifest/scene16.json
+++ b/lab/public/bundle/manifest/scene16.json
@@ -8,5 +8,5 @@
     "scene16-thin-instance-gpu-d2Yv33aN.js",
     "scene16.js"
   ],
-  "rawBytes": 51106
+  "rawBytes": 51092
 }

--- a/lab/public/bundle/manifest/scene16.json
+++ b/lab/public/bundle/manifest/scene16.json
@@ -8,5 +8,5 @@
     "scene16-thin-instance-gpu-d2Yv33aN.js",
     "scene16.js"
   ],
-  "rawBytes": 51092
+  "rawBytes": 51081
 }

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 41,
+  "rawKB": 41.0,
   "gzipKB": 16.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene160-shader-renderable-zznrc26l.js",
     "scene160.js"
   ],
-  "rawBytes": 41965
+  "rawBytes": 41951
 }

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -3,8 +3,8 @@
   "gzipKB": 16.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene160-shader-renderable-zznrc26l.js",
+    "scene160-shader-renderable-90CyR92R.js",
     "scene160.js"
   ],
-  "rawBytes": 41951
+  "rawBytes": 41975
 }

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -6,5 +6,5 @@
     "scene161-shader-renderable-bR5zgq0U.js",
     "scene161.js"
   ],
-  "rawBytes": 40597
+  "rawBytes": 40583
 }

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 39.6,
+  "rawKB": 39.7,
   "gzipKB": 15.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene161-shader-renderable-bR5zgq0U.js",
+    "scene161-shader-renderable-xlpLRCJ-.js",
     "scene161.js"
   ],
-  "rawBytes": 40583
+  "rawBytes": 40612
 }

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -6,5 +6,5 @@
     "scene162-shader-renderable-Cgg_BGSA.js",
     "scene162.js"
   ],
-  "rawBytes": 40042
+  "rawBytes": 40028
 }

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -3,8 +3,8 @@
   "gzipKB": 15.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene162-shader-renderable-Cgg_BGSA.js",
+    "scene162-shader-renderable-DIRc68T5.js",
     "scene162.js"
   ],
-  "rawBytes": 40028
+  "rawBytes": 40059
 }

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -3,8 +3,8 @@
   "gzipKB": 15.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene163-shader-renderable-BWCFyxcI.js",
+    "scene163-shader-renderable-DhpmYcK5.js",
     "scene163.js"
   ],
-  "rawBytes": 39723
+  "rawBytes": 39751
 }

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -6,5 +6,5 @@
     "scene163-shader-renderable-BWCFyxcI.js",
     "scene163.js"
   ],
-  "rawBytes": 39737
+  "rawBytes": 39723
 }

--- a/lab/public/bundle/manifest/scene164.json
+++ b/lab/public/bundle/manifest/scene164.json
@@ -13,13 +13,13 @@
     "scene164-gltf-feature-registry-4KG20V18.js",
     "scene164-gltf-feature-skeleton-Baf9dxYD.js",
     "scene164-gltf-json-asset-CJmOxkje.js",
-    "scene164-morph-fragment-Cnjy1dL3.js",
-    "scene164-pbr-renderable-B5u3scQD.js",
+    "scene164-morph-fragment-D82p5Qi5.js",
+    "scene164-pbr-renderable-CFYJpNt3.js",
     "scene164-pbr-template-ext-CiHpOV5G.js",
     "scene164-samplers-DuUvRDBP.js",
     "scene164-singlelight-hemispheric-wgsl-B3eEzZwe.js",
-    "scene164-skeleton-fragment-nbbM2eZe.js",
+    "scene164-skeleton-fragment-DKhFDP56.js",
     "scene164.js"
   ],
-  "rawBytes": 97105
+  "rawBytes": 97107
 }

--- a/lab/public/bundle/manifest/scene164.json
+++ b/lab/public/bundle/manifest/scene164.json
@@ -21,5 +21,5 @@
     "scene164-skeleton-fragment-nbbM2eZe.js",
     "scene164.js"
   ],
-  "rawBytes": 97119
+  "rawBytes": 97105
 }

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -3,10 +3,10 @@
   "gzipKB": 17.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene165-shader-renderable-CzI02nqi.js",
+    "scene165-shader-renderable-DS-9toQQ.js",
     "scene165-shader-thin-instance-BKrtjGJ6.js",
     "scene165-thin-instance-gpu-B5cobg4p.js",
     "scene165.js"
   ],
-  "rawBytes": 45424
+  "rawBytes": 45456
 }

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -8,5 +8,5 @@
     "scene165-thin-instance-gpu-B5cobg4p.js",
     "scene165.js"
   ],
-  "rawBytes": 45438
+  "rawBytes": 45424
 }

--- a/lab/public/bundle/manifest/scene17.json
+++ b/lab/public/bundle/manifest/scene17.json
@@ -5,7 +5,7 @@
   "runtimeChunks": [
     "scene17-generate-mipmaps-DNSbr_z3.js",
     "scene17-ibl-fragment-CeRrvT96.js",
-    "scene17-pbr-renderable-Du6PEQVz.js",
+    "scene17-pbr-renderable-BgudVVLQ.js",
     "scene17-rgbd-decode-aydmE8bD.js",
     "scene17-shader-composer-qxmZVcOJ.js",
     "scene17-singlelight-hemispheric-wgsl-DYVKx4Qw.js",
@@ -14,5 +14,5 @@
     "scene17-thin-instance-gpu-BmCYehED.js",
     "scene17.js"
   ],
-  "rawBytes": 89091
+  "rawBytes": 89087
 }

--- a/lab/public/bundle/manifest/scene17.json
+++ b/lab/public/bundle/manifest/scene17.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 87,
+  "rawKB": 87.0,
   "gzipKB": 36.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -14,5 +14,5 @@
     "scene17-thin-instance-gpu-BmCYehED.js",
     "scene17.js"
   ],
-  "rawBytes": 89105
+  "rawBytes": 89091
 }

--- a/lab/public/bundle/manifest/scene170.json
+++ b/lab/public/bundle/manifest/scene170.json
@@ -7,5 +7,5 @@
     "scene170-standard-renderable-CuRVZ66s.js",
     "scene170.js"
   ],
-  "rawBytes": 52875
+  "rawBytes": 52861
 }

--- a/lab/public/bundle/manifest/scene170.json
+++ b/lab/public/bundle/manifest/scene170.json
@@ -7,5 +7,5 @@
     "scene170-standard-renderable-CuRVZ66s.js",
     "scene170.js"
   ],
-  "rawBytes": 52861
+  "rawBytes": 52857
 }

--- a/lab/public/bundle/manifest/scene171.json
+++ b/lab/public/bundle/manifest/scene171.json
@@ -12,5 +12,5 @@
     "scene171-standard-renderable-CPqTayYc.js",
     "scene171.js"
   ],
-  "rawBytes": 97915
+  "rawBytes": 97899
 }

--- a/lab/public/bundle/manifest/scene171.json
+++ b/lab/public/bundle/manifest/scene171.json
@@ -6,11 +6,11 @@
     "scene171-generate-mipmaps-DE46RmYB.js",
     "scene171-gltf-glb-parser-DnHYtVMv.js",
     "scene171-mesh-features-Dda6QcW-.js",
-    "scene171-pbr-renderable-BiridU67.js",
+    "scene171-pbr-renderable-BUjmLxN2.js",
     "scene171-recast-navigation-Ddkygka3-B-kBz3cE.js",
     "scene171-singlelight-hemispheric-wgsl-BrjBFvL6.js",
     "scene171-standard-renderable-CPqTayYc.js",
     "scene171.js"
   ],
-  "rawBytes": 97899
+  "rawBytes": 97905
 }

--- a/lab/public/bundle/manifest/scene172.json
+++ b/lab/public/bundle/manifest/scene172.json
@@ -7,5 +7,5 @@
     "scene172-standard-renderable-dn-Vs64N.js",
     "scene172.js"
   ],
-  "rawBytes": 61329
+  "rawBytes": 61325
 }

--- a/lab/public/bundle/manifest/scene172.json
+++ b/lab/public/bundle/manifest/scene172.json
@@ -7,5 +7,5 @@
     "scene172-standard-renderable-dn-Vs64N.js",
     "scene172.js"
   ],
-  "rawBytes": 61345
+  "rawBytes": 61329
 }

--- a/lab/public/bundle/manifest/scene173.json
+++ b/lab/public/bundle/manifest/scene173.json
@@ -7,5 +7,5 @@
     "scene173-standard-renderable-DmR_ooSM.js",
     "scene173.js"
   ],
-  "rawBytes": 66370
+  "rawBytes": 66356
 }

--- a/lab/public/bundle/manifest/scene173.json
+++ b/lab/public/bundle/manifest/scene173.json
@@ -7,5 +7,5 @@
     "scene173-standard-renderable-DmR_ooSM.js",
     "scene173.js"
   ],
-  "rawBytes": 66356
+  "rawBytes": 66350
 }

--- a/lab/public/bundle/manifest/scene174.json
+++ b/lab/public/bundle/manifest/scene174.json
@@ -12,5 +12,5 @@
     "scene174-standard-renderable-DqflF_n-.js",
     "scene174.js"
   ],
-  "rawBytes": 98555
+  "rawBytes": 98541
 }

--- a/lab/public/bundle/manifest/scene174.json
+++ b/lab/public/bundle/manifest/scene174.json
@@ -6,11 +6,11 @@
     "scene174-generate-mipmaps-yLOoUuIw.js",
     "scene174-gltf-glb-parser-DSegmBgG.js",
     "scene174-mesh-features-Dda6QcW-.js",
-    "scene174-pbr-renderable-DTSq6YW2.js",
+    "scene174-pbr-renderable-BnOiXm1i.js",
     "scene174-recast-navigation-Ddkygka3-B-kBz3cE.js",
     "scene174-singlelight-hemispheric-wgsl-kfMxUQtb.js",
     "scene174-standard-renderable-DqflF_n-.js",
     "scene174.js"
   ],
-  "rawBytes": 98541
+  "rawBytes": 98540
 }

--- a/lab/public/bundle/manifest/scene175.json
+++ b/lab/public/bundle/manifest/scene175.json
@@ -12,5 +12,5 @@
     "scene175-standard-renderable-ge07XCBg.js",
     "scene175.js"
   ],
-  "rawBytes": 97017
+  "rawBytes": 97004
 }

--- a/lab/public/bundle/manifest/scene175.json
+++ b/lab/public/bundle/manifest/scene175.json
@@ -6,11 +6,11 @@
     "scene175-generate-mipmaps-CCmlSqhB.js",
     "scene175-gltf-glb-parser-Bgm7z6kd.js",
     "scene175-mesh-features-Dda6QcW-.js",
-    "scene175-pbr-renderable-D9Y-khO9.js",
+    "scene175-pbr-renderable-86HAqkdY.js",
     "scene175-recast-navigation-Ddkygka3-B-kBz3cE.js",
     "scene175-singlelight-hemispheric-wgsl-Dd8dLzdE.js",
     "scene175-standard-renderable-ge07XCBg.js",
     "scene175.js"
   ],
-  "rawBytes": 97004
+  "rawBytes": 97009
 }

--- a/lab/public/bundle/manifest/scene176.json
+++ b/lab/public/bundle/manifest/scene176.json
@@ -18,5 +18,5 @@
     "scene176-scene-uniforms-FTYH6Ct0.js",
     "scene176.js"
   ],
-  "rawBytes": 106843
+  "rawBytes": 106829
 }

--- a/lab/public/bundle/manifest/scene176.json
+++ b/lab/public/bundle/manifest/scene176.json
@@ -10,13 +10,13 @@
     "scene176-gltf-json-asset-CfnpYb9a.js",
     "scene176-ibl-fragment-CeRrvT96.js",
     "scene176-ibl-skybox-wgsl-CFIBOHHx.js",
-    "scene176-pbr-refraction-CdnV9hwW.js",
-    "scene176-pbr-renderable-C1651-kh.js",
-    "scene176-pbr-transmission-ext-DIkI-_eb.js",
+    "scene176-pbr-refraction-CyAxIkQg.js",
+    "scene176-pbr-renderable-N2u-l1UG.js",
+    "scene176-pbr-transmission-ext-DeUOBUhF.js",
     "scene176-reflectance-fragment-DIy2PFIk.js",
     "scene176-rgbd-decode-DNgLCqYz.js",
     "scene176-scene-uniforms-FTYH6Ct0.js",
     "scene176.js"
   ],
-  "rawBytes": 106829
+  "rawBytes": 106826
 }

--- a/lab/public/bundle/manifest/scene177.json
+++ b/lab/public/bundle/manifest/scene177.json
@@ -11,5 +11,5 @@
     "scene177-scene-uniforms-FTYH6Ct0.js",
     "scene177.js"
   ],
-  "rawBytes": 71971
+  "rawBytes": 71957
 }

--- a/lab/public/bundle/manifest/scene177.json
+++ b/lab/public/bundle/manifest/scene177.json
@@ -6,10 +6,10 @@
     "scene177-ibl-fragment-CeRrvT96.js",
     "scene177-ibl-skybox-wgsl-CFIBOHHx.js",
     "scene177-iridescence-fragment-DbYifzec.js",
-    "scene177-pbr-renderable-A3bAoHL-.js",
+    "scene177-pbr-renderable-DVArKyYT.js",
     "scene177-rgbd-decode-DgyvGBcz.js",
     "scene177-scene-uniforms-FTYH6Ct0.js",
     "scene177.js"
   ],
-  "rawBytes": 71957
+  "rawBytes": 71953
 }

--- a/lab/public/bundle/manifest/scene178.json
+++ b/lab/public/bundle/manifest/scene178.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 88,
+  "rawKB": 88.0,
   "gzipKB": 36.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -15,5 +15,5 @@
     "scene178-scene-uniforms-FTYH6Ct0.js",
     "scene178.js"
   ],
-  "rawBytes": 90099
+  "rawBytes": 90085
 }

--- a/lab/public/bundle/manifest/scene178.json
+++ b/lab/public/bundle/manifest/scene178.json
@@ -10,10 +10,10 @@
     "scene178-ibl-fragment-CeRrvT96.js",
     "scene178-ibl-skybox-wgsl-CFIBOHHx.js",
     "scene178-iridescence-fragment-DhGVbSHo.js",
-    "scene178-pbr-renderable-S4QvJgTF.js",
+    "scene178-pbr-renderable-B3UVI9w6.js",
     "scene178-rgbd-decode-BSZqnPKP.js",
     "scene178-scene-uniforms-FTYH6Ct0.js",
     "scene178.js"
   ],
-  "rawBytes": 90085
+  "rawBytes": 90081
 }

--- a/lab/public/bundle/manifest/scene179.json
+++ b/lab/public/bundle/manifest/scene179.json
@@ -9,5 +9,5 @@
     "scene179-pbr-renderable-Bu__oi5x.js",
     "scene179.js"
   ],
-  "rawBytes": 75987
+  "rawBytes": 75973
 }

--- a/lab/public/bundle/manifest/scene179.json
+++ b/lab/public/bundle/manifest/scene179.json
@@ -6,8 +6,8 @@
     "scene179-alpha-test-fragment-D6L1e1rr.js",
     "scene179-generate-mipmaps-BYbf8dVM.js",
     "scene179-gltf-json-asset-DsQR9Bi3.js",
-    "scene179-pbr-renderable-Bu__oi5x.js",
+    "scene179-pbr-renderable-DfIoeA-T.js",
     "scene179.js"
   ],
-  "rawBytes": 75973
+  "rawBytes": 75978
 }

--- a/lab/public/bundle/manifest/scene18.json
+++ b/lab/public/bundle/manifest/scene18.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 61.3,
+  "rawKB": 61.2,
   "gzipKB": 24.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,5 +11,5 @@
     "scene18-std-shadow-fragment-pwyXRo4i.js",
     "scene18.js"
   ],
-  "rawBytes": 62725
+  "rawBytes": 62708
 }

--- a/lab/public/bundle/manifest/scene18.json
+++ b/lab/public/bundle/manifest/scene18.json
@@ -11,5 +11,5 @@
     "scene18-std-shadow-fragment-pwyXRo4i.js",
     "scene18.js"
   ],
-  "rawBytes": 62708
+  "rawBytes": 62702
 }

--- a/lab/public/bundle/manifest/scene181.json
+++ b/lab/public/bundle/manifest/scene181.json
@@ -6,5 +6,5 @@
     "scene181-text-shaper-CL-qK3Rv.js",
     "scene181.js"
   ],
-  "rawBytes": 44965
+  "rawBytes": 44961
 }

--- a/lab/public/bundle/manifest/scene181.json
+++ b/lab/public/bundle/manifest/scene181.json
@@ -6,5 +6,5 @@
     "scene181-text-shaper-CL-qK3Rv.js",
     "scene181.js"
   ],
-  "rawBytes": 44979
+  "rawBytes": 44965
 }

--- a/lab/public/bundle/manifest/scene19.json
+++ b/lab/public/bundle/manifest/scene19.json
@@ -5,10 +5,10 @@
   "runtimeChunks": [
     "scene19-clearcoat-fragment-CPsIQniL.js",
     "scene19-ibl-fragment-CeRrvT96.js",
-    "scene19-pbr-renderable-lmw_zHkN.js",
+    "scene19-pbr-renderable-BEh6u5Kx.js",
     "scene19-rgbd-decode-Bhk0icKs.js",
     "scene19-singlelight-hemispheric-wgsl-B2Zus5m2.js",
     "scene19.js"
   ],
-  "rawBytes": 72675
+  "rawBytes": 72663
 }

--- a/lab/public/bundle/manifest/scene19.json
+++ b/lab/public/bundle/manifest/scene19.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 71,
+  "rawKB": 71.0,
   "gzipKB": 29.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -10,5 +10,5 @@
     "scene19-singlelight-hemispheric-wgsl-B2Zus5m2.js",
     "scene19.js"
   ],
-  "rawBytes": 72685
+  "rawBytes": 72675
 }

--- a/lab/public/bundle/manifest/scene2.json
+++ b/lab/public/bundle/manifest/scene2.json
@@ -6,5 +6,5 @@
     "scene2-standard-renderable-BPU8LiG6.js",
     "scene2.js"
   ],
-  "rawBytes": 48705
+  "rawBytes": 48701
 }

--- a/lab/public/bundle/manifest/scene2.json
+++ b/lab/public/bundle/manifest/scene2.json
@@ -6,5 +6,5 @@
     "scene2-standard-renderable-BPU8LiG6.js",
     "scene2.js"
   ],
-  "rawBytes": 48719
+  "rawBytes": 48705
 }

--- a/lab/public/bundle/manifest/scene20.json
+++ b/lab/public/bundle/manifest/scene20.json
@@ -15,5 +15,5 @@
     "scene20-wgsl-helpers-BgB2AJrF.js",
     "scene20.js"
   ],
-  "rawBytes": 80840
+  "rawBytes": 80826
 }

--- a/lab/public/bundle/manifest/scene20.json
+++ b/lab/public/bundle/manifest/scene20.json
@@ -8,12 +8,12 @@
     "scene20-cubemap-skybox-material-B495OxWx.js",
     "scene20-emissive-fragment-B_pIHOBu.js",
     "scene20-ibl-fragment-CeRrvT96.js",
-    "scene20-pbr-renderable-BXqdgh_I.js",
+    "scene20-pbr-renderable-CowOcuaE.js",
     "scene20-rgbd-decode-ChiiPMbr.js",
     "scene20-scene-uniforms-FTYH6Ct0.js",
     "scene20-singlelight-hemispheric-wgsl-C-TDyaB0.js",
     "scene20-wgsl-helpers-BgB2AJrF.js",
     "scene20.js"
   ],
-  "rawBytes": 80826
+  "rawBytes": 80821
 }

--- a/lab/public/bundle/manifest/scene200.json
+++ b/lab/public/bundle/manifest/scene200.json
@@ -6,5 +6,5 @@
     "scene200-standard-renderable-DM4CrBQ9.js",
     "scene200.js"
   ],
-  "rawBytes": 48837
+  "rawBytes": 48836
 }

--- a/lab/public/bundle/manifest/scene200.json
+++ b/lab/public/bundle/manifest/scene200.json
@@ -6,5 +6,5 @@
     "scene200-standard-renderable-DM4CrBQ9.js",
     "scene200.js"
   ],
-  "rawBytes": 48850
+  "rawBytes": 48837
 }

--- a/lab/public/bundle/manifest/scene201.json
+++ b/lab/public/bundle/manifest/scene201.json
@@ -9,5 +9,5 @@
     "scene201-standard-renderable-BNIyIXML.js",
     "scene201.js"
   ],
-  "rawBytes": 50195
+  "rawBytes": 50194
 }

--- a/lab/public/bundle/manifest/scene201.json
+++ b/lab/public/bundle/manifest/scene201.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 49,
+  "rawKB": 49.0,
   "gzipKB": 20.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -9,5 +9,5 @@
     "scene201-standard-renderable-BNIyIXML.js",
     "scene201.js"
   ],
-  "rawBytes": 50208
+  "rawBytes": 50195
 }

--- a/lab/public/bundle/manifest/scene202.json
+++ b/lab/public/bundle/manifest/scene202.json
@@ -9,5 +9,5 @@
     "scene202-standard-renderable-CcaYInzj.js",
     "scene202.js"
   ],
-  "rawBytes": 50973
+  "rawBytes": 50967
 }

--- a/lab/public/bundle/manifest/scene202.json
+++ b/lab/public/bundle/manifest/scene202.json
@@ -9,5 +9,5 @@
     "scene202-standard-renderable-CcaYInzj.js",
     "scene202.js"
   ],
-  "rawBytes": 50987
+  "rawBytes": 50973
 }

--- a/lab/public/bundle/manifest/scene203.json
+++ b/lab/public/bundle/manifest/scene203.json
@@ -9,5 +9,5 @@
     "scene203-standard-renderable-C3xBSzxG.js",
     "scene203.js"
   ],
-  "rawBytes": 51285
+  "rawBytes": 51271
 }

--- a/lab/public/bundle/manifest/scene203.json
+++ b/lab/public/bundle/manifest/scene203.json
@@ -9,5 +9,5 @@
     "scene203-standard-renderable-C3xBSzxG.js",
     "scene203.js"
   ],
-  "rawBytes": 51271
+  "rawBytes": 51267
 }

--- a/lab/public/bundle/manifest/scene204.json
+++ b/lab/public/bundle/manifest/scene204.json
@@ -11,5 +11,5 @@
     "scene204-thin-instance-gpu-DMvEkqgI.js",
     "scene204.js"
   ],
-  "rawBytes": 53542
+  "rawBytes": 53525
 }

--- a/lab/public/bundle/manifest/scene204.json
+++ b/lab/public/bundle/manifest/scene204.json
@@ -11,5 +11,5 @@
     "scene204-thin-instance-gpu-DMvEkqgI.js",
     "scene204.js"
   ],
-  "rawBytes": 53525
+  "rawBytes": 53518
 }

--- a/lab/public/bundle/manifest/scene205.json
+++ b/lab/public/bundle/manifest/scene205.json
@@ -11,5 +11,5 @@
     "scene205-standard-renderable-BmvrsxXJ.js",
     "scene205.js"
   ],
-  "rawBytes": 63588
+  "rawBytes": 63574
 }

--- a/lab/public/bundle/manifest/scene206.json
+++ b/lab/public/bundle/manifest/scene206.json
@@ -11,5 +11,5 @@
     "scene206-standard-renderable-IGLP4f9w.js",
     "scene206.js"
   ],
-  "rawBytes": 63941
+  "rawBytes": 63926
 }

--- a/lab/public/bundle/manifest/scene206.json
+++ b/lab/public/bundle/manifest/scene206.json
@@ -11,5 +11,5 @@
     "scene206-standard-renderable-IGLP4f9w.js",
     "scene206.js"
   ],
-  "rawBytes": 63926
+  "rawBytes": 63922
 }

--- a/lab/public/bundle/manifest/scene207.json
+++ b/lab/public/bundle/manifest/scene207.json
@@ -13,5 +13,5 @@
     "scene207-std-shadow-fragment-pwyXRo4i.js",
     "scene207.js"
   ],
-  "rawBytes": 61712
+  "rawBytes": 61698
 }

--- a/lab/public/bundle/manifest/scene207.json
+++ b/lab/public/bundle/manifest/scene207.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 60.3,
-  "gzipKB": 24.4,
+  "gzipKB": 25,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene207-_mat4-storage-f64-B_0HYOAx.js",
@@ -13,5 +13,5 @@
     "scene207-std-shadow-fragment-pwyXRo4i.js",
     "scene207.js"
   ],
-  "rawBytes": 61698
+  "rawBytes": 61696
 }

--- a/lab/public/bundle/manifest/scene209.json
+++ b/lab/public/bundle/manifest/scene209.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 55,
+  "rawKB": 55.0,
   "gzipKB": 22.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -10,5 +10,5 @@
     "scene209-standard-renderable-D5SRe5mq.js",
     "scene209.js"
   ],
-  "rawBytes": 56286
+  "rawBytes": 56272
 }

--- a/lab/public/bundle/manifest/scene209.json
+++ b/lab/public/bundle/manifest/scene209.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 55.0,
+  "rawKB": 54.9,
   "gzipKB": 22.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -10,5 +10,5 @@
     "scene209-standard-renderable-D5SRe5mq.js",
     "scene209.js"
   ],
-  "rawBytes": 56272
+  "rawBytes": 56263
 }

--- a/lab/public/bundle/manifest/scene21.json
+++ b/lab/public/bundle/manifest/scene21.json
@@ -14,5 +14,5 @@
     "scene21-sheen-fragment-_mQhtdZq.js",
     "scene21.js"
   ],
-  "rawBytes": 88155
+  "rawBytes": 88141
 }

--- a/lab/public/bundle/manifest/scene21.json
+++ b/lab/public/bundle/manifest/scene21.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 86.1,
-  "gzipKB": 35.4,
+  "gzipKB": 36,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene21-background-hdr-skybox-CfN-gxQH.js",
@@ -8,11 +8,11 @@
     "scene21-generate-mipmaps-CfM7UHZZ.js",
     "scene21-gltf-glb-parser-DF3kRg-R.js",
     "scene21-ibl-fragment-CeRrvT96.js",
-    "scene21-pbr-renderable-DynbkTrY.js",
+    "scene21-pbr-renderable-DfRgkN8f.js",
     "scene21-rgbd-decode-Btjg7lXq.js",
     "scene21-scene-uniforms-FTYH6Ct0.js",
     "scene21-sheen-fragment-_mQhtdZq.js",
     "scene21.js"
   ],
-  "rawBytes": 88141
+  "rawBytes": 88137
 }

--- a/lab/public/bundle/manifest/scene210.json
+++ b/lab/public/bundle/manifest/scene210.json
@@ -13,5 +13,5 @@
     "scene210-singlelight-hemispheric-wgsl-9sNVHX0R.js",
     "scene210.js"
   ],
-  "rawBytes": 78993
+  "rawBytes": 78977
 }

--- a/lab/public/bundle/manifest/scene210.json
+++ b/lab/public/bundle/manifest/scene210.json
@@ -9,9 +9,9 @@
     "scene210-gltf-glb-parser-DX-hcw7S.js",
     "scene210-gltf-interleave-C_9dpKt3.js",
     "scene210-gltf-normals-DYhLwXNX.js",
-    "scene210-pbr-renderable-DO__-4j4.js",
+    "scene210-pbr-renderable-BDnwOjuH.js",
     "scene210-singlelight-hemispheric-wgsl-9sNVHX0R.js",
     "scene210.js"
   ],
-  "rawBytes": 78977
+  "rawBytes": 78975
 }

--- a/lab/public/bundle/manifest/scene211.json
+++ b/lab/public/bundle/manifest/scene211.json
@@ -14,10 +14,10 @@
     "scene211-gltf-json-asset-T03W-2QH.js",
     "scene211-gltf-multi-buffer-CBbIh8uw.js",
     "scene211-gltf-sampler-denorm-8Qd5zsOW.js",
-    "scene211-pbr-renderable-DX_Kw3UB.js",
+    "scene211-pbr-renderable-CkfF2ZbB.js",
     "scene211-singlelight-hemispheric-wgsl-DJoiVzVD.js",
-    "scene211-skeleton-fragment-DxASZDwF.js",
+    "scene211-skeleton-fragment-CCqTCdYK.js",
     "scene211.js"
   ],
-  "rawBytes": 92974
+  "rawBytes": 92970
 }

--- a/lab/public/bundle/manifest/scene211.json
+++ b/lab/public/bundle/manifest/scene211.json
@@ -19,5 +19,5 @@
     "scene211-skeleton-fragment-DxASZDwF.js",
     "scene211.js"
   ],
-  "rawBytes": 92995
+  "rawBytes": 92974
 }

--- a/lab/public/bundle/manifest/scene212.json
+++ b/lab/public/bundle/manifest/scene212.json
@@ -18,5 +18,5 @@
     "scene212-scene-uniforms-FTYH6Ct0.js",
     "scene212.js"
   ],
-  "rawBytes": 106888
+  "rawBytes": 106874
 }

--- a/lab/public/bundle/manifest/scene212.json
+++ b/lab/public/bundle/manifest/scene212.json
@@ -9,14 +9,14 @@
     "scene212-gltf-glb-parser-DENT1Vui.js",
     "scene212-ibl-fragment-CeRrvT96.js",
     "scene212-ibl-skybox-wgsl-CFIBOHHx.js",
-    "scene212-pbr-refraction-BF416Uii.js",
-    "scene212-pbr-renderable--em13Xaz.js",
-    "scene212-pbr-transmission-ext-CHWBJX3Q.js",
+    "scene212-pbr-refraction-CAq0RV5l.js",
+    "scene212-pbr-renderable-D4SDUlPe.js",
+    "scene212-pbr-transmission-ext-HQUYE-PN.js",
     "scene212-reflectance-fragment-DUx_mf3I.js",
     "scene212-refraction-dispersion-wgsl-BKvBCmZU.js",
     "scene212-rgbd-decode-DF0dlKYa.js",
     "scene212-scene-uniforms-FTYH6Ct0.js",
     "scene212.js"
   ],
-  "rawBytes": 106874
+  "rawBytes": 106870
 }

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -3,10 +3,10 @@
   "gzipKB": 19.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene213-shader-pipeline-cache-Dga-Orlp.js",
-    "scene213-shader-renderable-BzT1Rdlk.js",
+    "scene213-shader-pipeline-cache-BVbK7X_V.js",
+    "scene213-shader-renderable-DDz6aQWo.js",
     "scene213-uniform-copy-batch-dw98bObp.js",
     "scene213.js"
   ],
-  "rawBytes": 50252
+  "rawBytes": 50299
 }

--- a/lab/public/bundle/manifest/scene213.json
+++ b/lab/public/bundle/manifest/scene213.json
@@ -8,5 +8,5 @@
     "scene213-uniform-copy-batch-dw98bObp.js",
     "scene213.js"
   ],
-  "rawBytes": 50266
+  "rawBytes": 50252
 }

--- a/lab/public/bundle/manifest/scene214.json
+++ b/lab/public/bundle/manifest/scene214.json
@@ -10,5 +10,5 @@
     "scene214-std-shadow-fragment-DUILnYou.js",
     "scene214.js"
   ],
-  "rawBytes": 71063
+  "rawBytes": 71059
 }

--- a/lab/public/bundle/manifest/scene214.json
+++ b/lab/public/bundle/manifest/scene214.json
@@ -10,5 +10,5 @@
     "scene214-std-shadow-fragment-DUILnYou.js",
     "scene214.js"
   ],
-  "rawBytes": 71079
+  "rawBytes": 71063
 }

--- a/lab/public/bundle/manifest/scene215.json
+++ b/lab/public/bundle/manifest/scene215.json
@@ -12,5 +12,5 @@
     "scene215-singlelight-directional-wgsl-BpRi11tU.js",
     "scene215.js"
   ],
-  "rawBytes": 82830
+  "rawBytes": 82816
 }

--- a/lab/public/bundle/manifest/scene215.json
+++ b/lab/public/bundle/manifest/scene215.json
@@ -6,11 +6,11 @@
     "scene215-material-view-Dua1bl7W.js",
     "scene215-multilight-wgsl-SRROL6UG.js",
     "scene215-no-color-view-DS70AbGo.js",
-    "scene215-pbr-renderable-g7SIBRxt.js",
+    "scene215-pbr-renderable-CcJogh3K.js",
     "scene215-pbr-shadow-fragment-DGl6YcUJ.js",
     "scene215-shadow-task-BM34zMuF.js",
     "scene215-singlelight-directional-wgsl-BpRi11tU.js",
     "scene215.js"
   ],
-  "rawBytes": 82816
+  "rawBytes": 82812
 }

--- a/lab/public/bundle/manifest/scene216.json
+++ b/lab/public/bundle/manifest/scene216.json
@@ -8,5 +8,5 @@
     "scene216-singlelight-hemispheric-wgsl-D6t-GAaw.js",
     "scene216.js"
   ],
-  "rawBytes": 55641
+  "rawBytes": 55627
 }

--- a/lab/public/bundle/manifest/scene216.json
+++ b/lab/public/bundle/manifest/scene216.json
@@ -4,9 +4,9 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene216-pbr-fog-wgsl-BuLKZvgv.js",
-    "scene216-pbr-renderable-eKvLQ1Tn.js",
+    "scene216-pbr-renderable-C52h3PJs.js",
     "scene216-singlelight-hemispheric-wgsl-D6t-GAaw.js",
     "scene216.js"
   ],
-  "rawBytes": 55627
+  "rawBytes": 55624
 }

--- a/lab/public/bundle/manifest/scene217.json
+++ b/lab/public/bundle/manifest/scene217.json
@@ -4,10 +4,10 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene217-multilight-wgsl-ha4VqrXz.js",
-    "scene217-pbr-renderable-DPQbqwsq.js",
+    "scene217-pbr-renderable-D_8UQswf.js",
     "scene217-shader-composer-CRnzWPZ6.js",
     "scene217-standard-renderable-BsszhK6j.js",
     "scene217.js"
   ],
-  "rawBytes": 80263
+  "rawBytes": 80258
 }

--- a/lab/public/bundle/manifest/scene217.json
+++ b/lab/public/bundle/manifest/scene217.json
@@ -9,5 +9,5 @@
     "scene217-standard-renderable-BsszhK6j.js",
     "scene217.js"
   ],
-  "rawBytes": 80277
+  "rawBytes": 80263
 }

--- a/lab/public/bundle/manifest/scene218.json
+++ b/lab/public/bundle/manifest/scene218.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 94.6,
-  "gzipKB": 39.4,
+  "gzipKB": 40,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene218-create-skeleton-B1aCh-5N.js",
@@ -13,9 +13,9 @@
     "scene218-gltf-feature-skeleton-BGy1CNCx.js",
     "scene218-gltf-glb-parser-CteHv7lF.js",
     "scene218-gltf-sampler-desc-DTA5QGlT.js",
-    "scene218-pbr-renderable-CFiHPxGC.js",
+    "scene218-pbr-renderable-BgwNXC4L.js",
     "scene218-singlelight-hemispheric-wgsl-C0jht4qY.js",
     "scene218.js"
   ],
-  "rawBytes": 96848
+  "rawBytes": 96849
 }

--- a/lab/public/bundle/manifest/scene218.json
+++ b/lab/public/bundle/manifest/scene218.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 94.6,
-  "gzipKB": 39.5,
+  "gzipKB": 39.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene218-create-skeleton-B1aCh-5N.js",
@@ -17,5 +17,5 @@
     "scene218-singlelight-hemispheric-wgsl-C0jht4qY.js",
     "scene218.js"
   ],
-  "rawBytes": 96862
+  "rawBytes": 96848
 }

--- a/lab/public/bundle/manifest/scene219.json
+++ b/lab/public/bundle/manifest/scene219.json
@@ -13,11 +13,11 @@
     "scene219-gltf-feature-skeleton-lMdcCevx.js",
     "scene219-gltf-glb-parser-DJMPJo6n.js",
     "scene219-gltf-sampler-desc-BRbZ0K5P.js",
-    "scene219-pbr-renderable-Vaa6o6Nq.js",
+    "scene219-pbr-renderable-D0eV1Gu-.js",
     "scene219-singlelight-hemispheric-wgsl-EeXbMoFE.js",
     "scene219-thin-instance-fragment-CBn2miAC.js",
     "scene219-thin-instance-gpu-CCiryIV4.js",
     "scene219.js"
   ],
-  "rawBytes": 100007
+  "rawBytes": 99998
 }

--- a/lab/public/bundle/manifest/scene219.json
+++ b/lab/public/bundle/manifest/scene219.json
@@ -19,5 +19,5 @@
     "scene219-thin-instance-gpu-CCiryIV4.js",
     "scene219.js"
   ],
-  "rawBytes": 100021
+  "rawBytes": 100007
 }

--- a/lab/public/bundle/manifest/scene22.json
+++ b/lab/public/bundle/manifest/scene22.json
@@ -8,7 +8,7 @@
     "scene22-material-view-Dua1bl7W.js",
     "scene22-multilight-wgsl-Ci23qBxe.js",
     "scene22-no-color-view-CXRYDInI.js",
-    "scene22-pbr-renderable-D25RHz94.js",
+    "scene22-pbr-renderable-BwM2m0k6.js",
     "scene22-pbr-shadow-fragment-CSEDArnD.js",
     "scene22-pbr-template-gamma-CVmXdy8B.js",
     "scene22-shader-composer-qxmZVcOJ.js",
@@ -17,5 +17,5 @@
     "scene22-standard-renderable-wBGGANmr.js",
     "scene22.js"
   ],
-  "rawBytes": 100714
+  "rawBytes": 100715
 }

--- a/lab/public/bundle/manifest/scene22.json
+++ b/lab/public/bundle/manifest/scene22.json
@@ -17,5 +17,5 @@
     "scene22-standard-renderable-wBGGANmr.js",
     "scene22.js"
   ],
-  "rawBytes": 100725
+  "rawBytes": 100714
 }

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -9,5 +9,5 @@
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221.js"
   ],
-  "rawBytes": 101993
+  "rawBytes": 101979
 }

--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -4,10 +4,10 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene221-scene-uniforms-CGHhMjxH.js",
-    "scene221-shader-renderable-Dc6eXmOR.js",
+    "scene221-shader-renderable-Bi5ojZWD.js",
     "scene221-standard-renderable-CuU3EPds.js",
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221.js"
   ],
-  "rawBytes": 101979
+  "rawBytes": 102007
 }

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -12,5 +12,5 @@
     "scene222-uniform-copy-batch-DrEP8HMR.js",
     "scene222.js"
   ],
-  "rawBytes": 115248
+  "rawBytes": 115234
 }

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -1,16 +1,16 @@
 {
-  "rawKB": 112.5,
+  "rawKB": 112.6,
   "gzipKB": 42.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene222-gpu-pool-CHlSfwGp.js",
     "scene222-scene-uniforms-Ha63NnVx.js",
-    "scene222-shader-pipeline-cache-CRfxG7iY.js",
-    "scene222-shader-renderable-BJN_GE6S.js",
+    "scene222-shader-pipeline-cache-CpP1R0Xs.js",
+    "scene222-shader-renderable-DnQrVHpu.js",
     "scene222-standard-renderable-C0AiwZng.js",
     "scene222-swapchain-overlay-ilhN4El_.js",
     "scene222-uniform-copy-batch-DrEP8HMR.js",
     "scene222.js"
   ],
-  "rawBytes": 115234
+  "rawBytes": 115278
 }

--- a/lab/public/bundle/manifest/scene223.json
+++ b/lab/public/bundle/manifest/scene223.json
@@ -7,5 +7,5 @@
     "scene223-swapchain-overlay-ilhN4El_.js",
     "scene223.js"
   ],
-  "rawBytes": 68267
+  "rawBytes": 68253
 }

--- a/lab/public/bundle/manifest/scene223.json
+++ b/lab/public/bundle/manifest/scene223.json
@@ -1,11 +1,11 @@
 {
   "rawKB": 66.7,
-  "gzipKB": 25.4,
+  "gzipKB": 26,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene223-standard-renderable-DH7UZmV5.js",
     "scene223-swapchain-overlay-ilhN4El_.js",
     "scene223.js"
   ],
-  "rawBytes": 68253
+  "rawBytes": 68255
 }

--- a/lab/public/bundle/manifest/scene224.json
+++ b/lab/public/bundle/manifest/scene224.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 80.3,
+  "rawKB": 80.2,
   "gzipKB": 30.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene224-swapchain-overlay-ilhN4El_.js",
     "scene224.js"
   ],
-  "rawBytes": 82176
+  "rawBytes": 82165
 }

--- a/lab/public/bundle/manifest/scene224.json
+++ b/lab/public/bundle/manifest/scene224.json
@@ -7,5 +7,5 @@
     "scene224-swapchain-overlay-ilhN4El_.js",
     "scene224.js"
   ],
-  "rawBytes": 82165
+  "rawBytes": 82157
 }

--- a/lab/public/bundle/manifest/scene225.json
+++ b/lab/public/bundle/manifest/scene225.json
@@ -6,5 +6,5 @@
     "scene225-standard-renderable-Cr5JfdXs.js",
     "scene225.js"
   ],
-  "rawBytes": 59976
+  "rawBytes": 59962
 }

--- a/lab/public/bundle/manifest/scene225.json
+++ b/lab/public/bundle/manifest/scene225.json
@@ -6,5 +6,5 @@
     "scene225-standard-renderable-Cr5JfdXs.js",
     "scene225.js"
   ],
-  "rawBytes": 59962
+  "rawBytes": 59963
 }

--- a/lab/public/bundle/manifest/scene227.json
+++ b/lab/public/bundle/manifest/scene227.json
@@ -6,5 +6,5 @@
     "scene227-standard-renderable-B4Yx2Gcb.js",
     "scene227.js"
   ],
-  "rawBytes": 49948
+  "rawBytes": 49934
 }

--- a/lab/public/bundle/manifest/scene227.json
+++ b/lab/public/bundle/manifest/scene227.json
@@ -6,5 +6,5 @@
     "scene227-standard-renderable-B4Yx2Gcb.js",
     "scene227.js"
   ],
-  "rawBytes": 49934
+  "rawBytes": 49930
 }

--- a/lab/public/bundle/manifest/scene228.json
+++ b/lab/public/bundle/manifest/scene228.json
@@ -6,5 +6,5 @@
     "scene228-standard-renderable-BLdwheuI.js",
     "scene228.js"
   ],
-  "rawBytes": 51982
+  "rawBytes": 51985
 }

--- a/lab/public/bundle/manifest/scene228.json
+++ b/lab/public/bundle/manifest/scene228.json
@@ -6,5 +6,5 @@
     "scene228-standard-renderable-BLdwheuI.js",
     "scene228.js"
   ],
-  "rawBytes": 51996
+  "rawBytes": 51982
 }

--- a/lab/public/bundle/manifest/scene229.json
+++ b/lab/public/bundle/manifest/scene229.json
@@ -1,15 +1,15 @@
 {
   "rawKB": 68.3,
-  "gzipKB": 28.4,
+  "gzipKB": 29,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene229-flat-normal-wgsl-Cm9mM4tC.js",
     "scene229-generate-mipmaps-JbqPm3IE.js",
     "scene229-gltf-json-asset-C9e6w5p4.js",
     "scene229-gltf-normals-DYhLwXNX.js",
-    "scene229-pbr-renderable-hitU3c88.js",
+    "scene229-pbr-renderable-DYUJk8ua.js",
     "scene229-unlit-fragment-DWtvt7yQ.js",
     "scene229.js"
   ],
-  "rawBytes": 69912
+  "rawBytes": 69908
 }

--- a/lab/public/bundle/manifest/scene229.json
+++ b/lab/public/bundle/manifest/scene229.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 68.3,
-  "gzipKB": 28.5,
+  "gzipKB": 28.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene229-flat-normal-wgsl-Cm9mM4tC.js",
@@ -11,5 +11,5 @@
     "scene229-unlit-fragment-DWtvt7yQ.js",
     "scene229.js"
   ],
-  "rawBytes": 69926
+  "rawBytes": 69912
 }

--- a/lab/public/bundle/manifest/scene23.json
+++ b/lab/public/bundle/manifest/scene23.json
@@ -8,11 +8,11 @@
     "scene23-background-ground-DmmKHN9b.js",
     "scene23-cubemap-skybox-material-sjF5EPm1.js",
     "scene23-ibl-fragment-CeRrvT96.js",
-    "scene23-pbr-renderable-UgkvImT5.js",
+    "scene23-pbr-renderable-B5VAOxAa.js",
     "scene23-rgbd-decode-BeChsxxY.js",
     "scene23-scene-uniforms-FTYH6Ct0.js",
     "scene23-wgsl-helpers-BgB2AJrF.js",
     "scene23.js"
   ],
-  "rawBytes": 80631
+  "rawBytes": 80625
 }

--- a/lab/public/bundle/manifest/scene23.json
+++ b/lab/public/bundle/manifest/scene23.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 78.8,
+  "rawKB": 78.7,
   "gzipKB": 32.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -14,5 +14,5 @@
     "scene23-wgsl-helpers-BgB2AJrF.js",
     "scene23.js"
   ],
-  "rawBytes": 80645
+  "rawBytes": 80631
 }

--- a/lab/public/bundle/manifest/scene231.json
+++ b/lab/public/bundle/manifest/scene231.json
@@ -7,5 +7,5 @@
     "scene231-std-skeleton-fragment-BIMTVdV3.js",
     "scene231.js"
   ],
-  "rawBytes": 55240
+  "rawBytes": 55236
 }

--- a/lab/public/bundle/manifest/scene231.json
+++ b/lab/public/bundle/manifest/scene231.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 54,
+  "rawKB": 53.9,
   "gzipKB": 21.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -7,5 +7,5 @@
     "scene231-std-skeleton-fragment-BIMTVdV3.js",
     "scene231.js"
   ],
-  "rawBytes": 55254
+  "rawBytes": 55240
 }

--- a/lab/public/bundle/manifest/scene24.json
+++ b/lab/public/bundle/manifest/scene24.json
@@ -15,5 +15,5 @@
     "scene24-std-specular-fragment-DhCYMq1P.js",
     "scene24.js"
   ],
-  "rawBytes": 60773
+  "rawBytes": 60759
 }

--- a/lab/public/bundle/manifest/scene24.json
+++ b/lab/public/bundle/manifest/scene24.json
@@ -15,5 +15,5 @@
     "scene24-std-specular-fragment-DhCYMq1P.js",
     "scene24.js"
   ],
-  "rawBytes": 60759
+  "rawBytes": 60757
 }

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -12,10 +12,10 @@
     "scene240-gltf-multi-buffer-DQ-JVZha.js",
     "scene240-gltf-normals-DYhLwXNX.js",
     "scene240-ibl-fragment-CeRrvT96.js",
-    "scene240-pbr-renderable-DN_GsPk2.js",
+    "scene240-pbr-renderable-C2DSqGuM.js",
     "scene240-rgbd-decode-CuZL2LZR.js",
     "scene240-scene-uniforms-FTYH6Ct0.js",
     "scene240.js"
   ],
-  "rawBytes": 93506
+  "rawBytes": 93502
 }

--- a/lab/public/bundle/manifest/scene240.json
+++ b/lab/public/bundle/manifest/scene240.json
@@ -17,5 +17,5 @@
     "scene240-scene-uniforms-FTYH6Ct0.js",
     "scene240.js"
   ],
-  "rawBytes": 93520
+  "rawBytes": 93506
 }

--- a/lab/public/bundle/manifest/scene241.json
+++ b/lab/public/bundle/manifest/scene241.json
@@ -45,5 +45,5 @@
     "scene241-visibility-CKB7eGDU.js",
     "scene241.js"
   ],
-  "rawBytes": 165963
+  "rawBytes": 165949
 }

--- a/lab/public/bundle/manifest/scene241.json
+++ b/lab/public/bundle/manifest/scene241.json
@@ -29,10 +29,10 @@
     "scene241-iridescence-fragment-wl-ip2dN.js",
     "scene241-light-base-BpyK7ED4.js",
     "scene241-light-matrix-CtsX4GmG.js",
-    "scene241-pbr-refraction-D8houi5b.js",
-    "scene241-pbr-renderable-B65TGWeQ.js",
+    "scene241-pbr-refraction-CXyshy9G.js",
+    "scene241-pbr-renderable-DpPGJJOf.js",
     "scene241-pbr-template-ext-CiHpOV5G.js",
-    "scene241-pbr-transmission-ext--zzBNHdn.js",
+    "scene241-pbr-transmission-ext-BWN0b1Bf.js",
     "scene241-reflectance-fragment-B1IUP2So.js",
     "scene241-rgbd-decode-DH-gSQt2.js",
     "scene241-scene-uniforms-FTYH6Ct0.js",
@@ -45,5 +45,5 @@
     "scene241-visibility-CKB7eGDU.js",
     "scene241.js"
   ],
-  "rawBytes": 165949
+  "rawBytes": 165951
 }

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -19,5 +19,5 @@
     "scene242-visibility-ZqejguTC.js",
     "scene242.js"
   ],
-  "rawBytes": 99933
+  "rawBytes": 99919
 }

--- a/lab/public/bundle/manifest/scene242.json
+++ b/lab/public/bundle/manifest/scene242.json
@@ -13,11 +13,11 @@
     "scene242-gltf-feature-registry-DYpB6IFM.js",
     "scene242-gltf-json-asset-Yii58NL7.js",
     "scene242-ibl-fragment-CeRrvT96.js",
-    "scene242-pbr-renderable-C8J3gDSb.js",
+    "scene242-pbr-renderable-CQgmNc0c.js",
     "scene242-rgbd-decode-Ck0VLYV5.js",
     "scene242-scene-uniforms-FTYH6Ct0.js",
     "scene242-visibility-ZqejguTC.js",
     "scene242.js"
   ],
-  "rawBytes": 99919
+  "rawBytes": 99915
 }

--- a/lab/public/bundle/manifest/scene243.json
+++ b/lab/public/bundle/manifest/scene243.json
@@ -21,5 +21,5 @@
     "scene243-texture-2d-DQo3n8D6.js",
     "scene243.js"
   ],
-  "rawBytes": 100054
+  "rawBytes": 100040
 }

--- a/lab/public/bundle/manifest/scene243.json
+++ b/lab/public/bundle/manifest/scene243.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 97.7,
-  "gzipKB": 41.4,
+  "gzipKB": 42,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene243-create-morph-targets-C_lcfVOA.js",
@@ -13,13 +13,13 @@
     "scene243-gltf-json-asset-CpMCrBLi.js",
     "scene243-gltf-pbr-builder-ext-Dcy7_zeN.js",
     "scene243-ibl-fragment-CeRrvT96.js",
-    "scene243-morph-fragment-ApL-P2Xn.js",
-    "scene243-pbr-renderable-DqJ0_kjx.js",
+    "scene243-morph-fragment--j5j0ZJc.js",
+    "scene243-pbr-renderable-Do7lkvBE.js",
     "scene243-pbr-template-ext-CiHpOV5G.js",
     "scene243-rgbd-decode-DDQmA7q4.js",
     "scene243-scene-uniforms-FTYH6Ct0.js",
     "scene243-texture-2d-DQo3n8D6.js",
     "scene243.js"
   ],
-  "rawBytes": 100040
+  "rawBytes": 100036
 }

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -16,10 +16,10 @@
     "scene244-gltf-json-asset-Dz1M9M4x.js",
     "scene244-gltf-pbr-builder-ext-Cs5PHlG2.js",
     "scene244-ibl-fragment-CeRrvT96.js",
-    "scene244-pbr-refraction-DFGA7nfE.js",
-    "scene244-pbr-renderable-CLPCLjv1.js",
+    "scene244-pbr-refraction-Bd9CdGH4.js",
+    "scene244-pbr-renderable-C3mi2_it.js",
     "scene244-pbr-template-ext-CiHpOV5G.js",
-    "scene244-pbr-transmission-ext-DjiWTBVp.js",
+    "scene244-pbr-transmission-ext-BGaDZMDx.js",
     "scene244-reflectance-fragment-D94Ii1em.js",
     "scene244-rgbd-decode-BeAjygUm.js",
     "scene244-scene-uniforms-FTYH6Ct0.js",
@@ -28,5 +28,5 @@
     "scene244-visibility-BcAL-WaI.js",
     "scene244.js"
   ],
-  "rawBytes": 137025
+  "rawBytes": 137021
 }

--- a/lab/public/bundle/manifest/scene244.json
+++ b/lab/public/bundle/manifest/scene244.json
@@ -28,5 +28,5 @@
     "scene244-visibility-BcAL-WaI.js",
     "scene244.js"
   ],
-  "rawBytes": 137037
+  "rawBytes": 137025
 }

--- a/lab/public/bundle/manifest/scene245.json
+++ b/lab/public/bundle/manifest/scene245.json
@@ -16,12 +16,12 @@
     "scene245-gltf-share-CeStaSTa.js",
     "scene245-gltf-strided-attribute-CGKc0Sx6.js",
     "scene245-ibl-fragment-CeRrvT96.js",
-    "scene245-pbr-renderable-BrZFTVJ4.js",
+    "scene245-pbr-renderable-D2Pu1ksP.js",
     "scene245-pbr-template-ext-CiHpOV5G.js",
     "scene245-rgbd-decode-EC97mNh4.js",
     "scene245-scene-uniforms-FTYH6Ct0.js",
-    "scene245-skeleton-fragment-z5wK1LIV.js",
+    "scene245-skeleton-fragment-Byw_CNcK.js",
     "scene245.js"
   ],
-  "rawBytes": 104640
+  "rawBytes": 104636
 }

--- a/lab/public/bundle/manifest/scene245.json
+++ b/lab/public/bundle/manifest/scene245.json
@@ -23,5 +23,5 @@
     "scene245-skeleton-fragment-z5wK1LIV.js",
     "scene245.js"
   ],
-  "rawBytes": 104654
+  "rawBytes": 104640
 }

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -16,11 +16,11 @@
     "scene246-gltf-normals-DYhLwXNX.js",
     "scene246-gltf-strided-attribute-R3NdoKEL.js",
     "scene246-ibl-fragment-CeRrvT96.js",
-    "scene246-pbr-renderable-DZ7bz1U5.js",
+    "scene246-pbr-renderable-DrAL4Od2.js",
     "scene246-rgbd-decode-C8g2iZPi.js",
     "scene246-scene-uniforms-FTYH6Ct0.js",
-    "scene246-skeleton-fragment-DDPZpBXK.js",
+    "scene246-skeleton-fragment-B5-4NrQ9.js",
     "scene246.js"
   ],
-  "rawBytes": 102217
+  "rawBytes": 102213
 }

--- a/lab/public/bundle/manifest/scene246.json
+++ b/lab/public/bundle/manifest/scene246.json
@@ -22,5 +22,5 @@
     "scene246-skeleton-fragment-DDPZpBXK.js",
     "scene246.js"
   ],
-  "rawBytes": 102231
+  "rawBytes": 102217
 }

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 86.4,
+  "rawKB": 86.3,
   "gzipKB": 36.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -18,5 +18,5 @@
     "scene247-thin-instance-gpu-DJosAWKP.js",
     "scene247.js"
   ],
-  "rawBytes": 88430
+  "rawBytes": 88415
 }

--- a/lab/public/bundle/manifest/scene247.json
+++ b/lab/public/bundle/manifest/scene247.json
@@ -11,12 +11,12 @@
     "scene247-gltf-multi-buffer-BzFIY2Yd.js",
     "scene247-gltf-share-DF9ijqo2.js",
     "scene247-ibl-fragment-CeRrvT96.js",
-    "scene247-pbr-renderable-DQdrAJb4.js",
+    "scene247-pbr-renderable-ajlBHDc7.js",
     "scene247-rgbd-decode-BGfzKZhs.js",
     "scene247-scene-uniforms-FTYH6Ct0.js",
     "scene247-thin-instance-fragment-CBn2miAC.js",
     "scene247-thin-instance-gpu-DJosAWKP.js",
     "scene247.js"
   ],
-  "rawBytes": 88415
+  "rawBytes": 88411
 }

--- a/lab/public/bundle/manifest/scene248.json
+++ b/lab/public/bundle/manifest/scene248.json
@@ -7,10 +7,10 @@
     "scene248-gltf-json-asset-qd3UIiW6.js",
     "scene248-gltf-sampler-desc-PTkgH6lM.js",
     "scene248-ibl-fragment-CeRrvT96.js",
-    "scene248-pbr-renderable-CSIamdPh.js",
+    "scene248-pbr-renderable-Bi6cpvK_.js",
     "scene248-rgbd-decode-C6qoiNS2.js",
     "scene248-scene-uniforms-FTYH6Ct0.js",
     "scene248.js"
   ],
-  "rawBytes": 79173
+  "rawBytes": 79168
 }

--- a/lab/public/bundle/manifest/scene248.json
+++ b/lab/public/bundle/manifest/scene248.json
@@ -12,5 +12,5 @@
     "scene248-scene-uniforms-FTYH6Ct0.js",
     "scene248.js"
   ],
-  "rawBytes": 79187
+  "rawBytes": 79173
 }

--- a/lab/public/bundle/manifest/scene249.json
+++ b/lab/public/bundle/manifest/scene249.json
@@ -8,11 +8,11 @@
     "scene249-gltf-color-normalize-4-WGzPL2.js",
     "scene249-gltf-json-asset-4LgA1-9c.js",
     "scene249-ibl-fragment-CeRrvT96.js",
-    "scene249-pbr-renderable-CKDAVdLV.js",
+    "scene249-pbr-renderable-B_3a-MWN.js",
     "scene249-pbr-template-ext-CiHpOV5G.js",
     "scene249-rgbd-decode-aJFzOIzF.js",
     "scene249-scene-uniforms-FTYH6Ct0.js",
     "scene249.js"
   ],
-  "rawBytes": 80793
+  "rawBytes": 80787
 }

--- a/lab/public/bundle/manifest/scene249.json
+++ b/lab/public/bundle/manifest/scene249.json
@@ -14,5 +14,5 @@
     "scene249-scene-uniforms-FTYH6Ct0.js",
     "scene249.js"
   ],
-  "rawBytes": 80806
+  "rawBytes": 80793
 }

--- a/lab/public/bundle/manifest/scene25.json
+++ b/lab/public/bundle/manifest/scene25.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 52,
+  "rawKB": 52.0,
   "gzipKB": 20.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene25-standard-renderable-DXEXI8AF.js",
     "scene25.js"
   ],
-  "rawBytes": 53223
+  "rawBytes": 53209
 }

--- a/lab/public/bundle/manifest/scene25.json
+++ b/lab/public/bundle/manifest/scene25.json
@@ -6,5 +6,5 @@
     "scene25-standard-renderable-DXEXI8AF.js",
     "scene25.js"
   ],
-  "rawBytes": 53209
+  "rawBytes": 53205
 }

--- a/lab/public/bundle/manifest/scene251.json
+++ b/lab/public/bundle/manifest/scene251.json
@@ -15,5 +15,5 @@
     "scene251-skeleton-fragment-tNizWAYO.js",
     "scene251.js"
   ],
-  "rawBytes": 92087
+  "rawBytes": 92073
 }

--- a/lab/public/bundle/manifest/scene251.json
+++ b/lab/public/bundle/manifest/scene251.json
@@ -11,9 +11,9 @@
     "scene251-gltf-feature-skeleton--AOJPJ-6.js",
     "scene251-gltf-glb-parser-BxMi87nG.js",
     "scene251-multilight-wgsl-BTjKzv_v.js",
-    "scene251-pbr-renderable-BPhynRMl.js",
-    "scene251-skeleton-fragment-tNizWAYO.js",
+    "scene251-pbr-renderable-yuNJo6Rh.js",
+    "scene251-skeleton-fragment-DnepgmZk.js",
     "scene251.js"
   ],
-  "rawBytes": 92073
+  "rawBytes": 92070
 }

--- a/lab/public/bundle/manifest/scene252.json
+++ b/lab/public/bundle/manifest/scene252.json
@@ -7,5 +7,5 @@
     "scene252-standard-renderable-D8h8Bqs7.js",
     "scene252.js"
   ],
-  "rawBytes": 50685
+  "rawBytes": 50677
 }

--- a/lab/public/bundle/manifest/scene252.json
+++ b/lab/public/bundle/manifest/scene252.json
@@ -7,5 +7,5 @@
     "scene252-standard-renderable-D8h8Bqs7.js",
     "scene252.js"
   ],
-  "rawBytes": 50698
+  "rawBytes": 50685
 }

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -52,5 +52,5 @@
     "scene253-visibility-BVgAow7R.js",
     "scene253.js"
   ],
-  "rawBytes": 157835
+  "rawBytes": 157821
 }

--- a/lab/public/bundle/manifest/scene253.json
+++ b/lab/public/bundle/manifest/scene253.json
@@ -35,16 +35,16 @@
     "scene253-iridescence-fragment-ChMtYpez.js",
     "scene253-light-base-ClJ8rhI7.js",
     "scene253-light-matrix-BpE3lP6k.js",
-    "scene253-morph-fragment-BuvUKqCn.js",
+    "scene253-morph-fragment-0RogeYeq.js",
     "scene253-multilight-wgsl-DLargEvA.js",
-    "scene253-pbr-refraction-4yGsrdtr.js",
-    "scene253-pbr-renderable-DaY_EgOa.js",
+    "scene253-pbr-refraction-B7pMTtDo.js",
+    "scene253-pbr-renderable-Dwxsc6_j.js",
     "scene253-pbr-template-ext-CiHpOV5G.js",
-    "scene253-pbr-transmission-ext-DAqUiaHZ.js",
+    "scene253-pbr-transmission-ext-CpvBQuRM.js",
     "scene253-reflectance-fragment-DSbSfZ2W.js",
     "scene253-rgbd-decode-hJNa3Ibl.js",
     "scene253-scene-uniforms-FTYH6Ct0.js",
-    "scene253-skeleton-fragment-BKt6O2OI.js",
+    "scene253-skeleton-fragment-Dy1kuhWd.js",
     "scene253-spot-light-FVONncEV.js",
     "scene253-texture-2d-DQo3n8D6.js",
     "scene253-unlit-fragment-DWtvt7yQ.js",
@@ -52,5 +52,5 @@
     "scene253-visibility-BVgAow7R.js",
     "scene253.js"
   ],
-  "rawBytes": 157821
+  "rawBytes": 157815
 }

--- a/lab/public/bundle/manifest/scene254.json
+++ b/lab/public/bundle/manifest/scene254.json
@@ -16,5 +16,5 @@
     "scene254-singlelight-hemispheric-wgsl-CqFh488F.js",
     "scene254.js"
   ],
-  "rawBytes": 95022
+  "rawBytes": 95008
 }

--- a/lab/public/bundle/manifest/scene254.json
+++ b/lab/public/bundle/manifest/scene254.json
@@ -10,11 +10,11 @@
     "scene254-gltf-json-asset-CuuycPiY.js",
     "scene254-gltf-sampler-denorm-BzFzUiaO.js",
     "scene254-ibl-fragment-CeRrvT96.js",
-    "scene254-pbr-renderable-DsZjVAAc.js",
+    "scene254-pbr-renderable-D8R2NHQT.js",
     "scene254-rgbd-decode-CsBw0n-g.js",
     "scene254-scene-uniforms-FTYH6Ct0.js",
     "scene254-singlelight-hemispheric-wgsl-CqFh488F.js",
     "scene254.js"
   ],
-  "rawBytes": 95008
+  "rawBytes": 95005
 }

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -13,11 +13,11 @@
     "scene255-gltf-json-asset-BJyr96Ic.js",
     "scene255-gltf-normals-DYhLwXNX.js",
     "scene255-ibl-fragment-CeRrvT96.js",
-    "scene255-pbr-renderable-Bq5QgQPl.js",
+    "scene255-pbr-renderable-CU2saEmK.js",
     "scene255-rgbd-decode-jKIQpb6O.js",
     "scene255-scene-uniforms-FTYH6Ct0.js",
-    "scene255-skeleton-fragment-CbYcTW3P.js",
+    "scene255-skeleton-fragment-CclhrKGp.js",
     "scene255.js"
   ],
-  "rawBytes": 96756
+  "rawBytes": 96752
 }

--- a/lab/public/bundle/manifest/scene255.json
+++ b/lab/public/bundle/manifest/scene255.json
@@ -19,5 +19,5 @@
     "scene255-skeleton-fragment-CbYcTW3P.js",
     "scene255.js"
   ],
-  "rawBytes": 96770
+  "rawBytes": 96756
 }

--- a/lab/public/bundle/manifest/scene257.json
+++ b/lab/public/bundle/manifest/scene257.json
@@ -15,5 +15,5 @@
     "scene257-scene-uniforms-FTYH6Ct0.js",
     "scene257.js"
   ],
-  "rawBytes": 82310
+  "rawBytes": 82298
 }

--- a/lab/public/bundle/manifest/scene257.json
+++ b/lab/public/bundle/manifest/scene257.json
@@ -10,10 +10,10 @@
     "scene257-gltf-json-asset-BowOnmOI.js",
     "scene257-gltf-normals-DYhLwXNX.js",
     "scene257-ibl-fragment-CeRrvT96.js",
-    "scene257-pbr-renderable-B940m_W4.js",
+    "scene257-pbr-renderable-BkGXRGtk.js",
     "scene257-rgbd-decode-C4X6l6Ro.js",
     "scene257-scene-uniforms-FTYH6Ct0.js",
     "scene257.js"
   ],
-  "rawBytes": 82298
+  "rawBytes": 82292
 }

--- a/lab/public/bundle/manifest/scene258.json
+++ b/lab/public/bundle/manifest/scene258.json
@@ -10,11 +10,11 @@
     "scene258-gltf-normals-DYhLwXNX.js",
     "scene258-gltf-uv-denorm-BTmmiHmh.js",
     "scene258-ibl-fragment-CeRrvT96.js",
-    "scene258-pbr-renderable-DfaNkcsy.js",
+    "scene258-pbr-renderable-ClrinArM.js",
     "scene258-pbr-template-ext-CiHpOV5G.js",
     "scene258-rgbd-decode-BPg8jfWX.js",
     "scene258-scene-uniforms-FTYH6Ct0.js",
     "scene258.js"
   ],
-  "rawBytes": 85342
+  "rawBytes": 85338
 }

--- a/lab/public/bundle/manifest/scene258.json
+++ b/lab/public/bundle/manifest/scene258.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 83.4,
+  "rawKB": 83.3,
   "gzipKB": 35.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -16,5 +16,5 @@
     "scene258-scene-uniforms-FTYH6Ct0.js",
     "scene258.js"
   ],
-  "rawBytes": 85356
+  "rawBytes": 85342
 }

--- a/lab/public/bundle/manifest/scene259.json
+++ b/lab/public/bundle/manifest/scene259.json
@@ -14,5 +14,5 @@
     "scene259-scene-uniforms-FTYH6Ct0.js",
     "scene259.js"
   ],
-  "rawBytes": 79379
+  "rawBytes": 79367
 }

--- a/lab/public/bundle/manifest/scene259.json
+++ b/lab/public/bundle/manifest/scene259.json
@@ -9,10 +9,10 @@
     "scene259-gltf-json-asset-GYS0qLwe.js",
     "scene259-gltf-normals-DYhLwXNX.js",
     "scene259-ibl-fragment-CeRrvT96.js",
-    "scene259-pbr-renderable-CLLtKCGP.js",
+    "scene259-pbr-renderable-BO4HIUTx.js",
     "scene259-rgbd-decode-CkmHf8hT.js",
     "scene259-scene-uniforms-FTYH6Ct0.js",
     "scene259.js"
   ],
-  "rawBytes": 79367
+  "rawBytes": 79361
 }

--- a/lab/public/bundle/manifest/scene26.json
+++ b/lab/public/bundle/manifest/scene26.json
@@ -8,11 +8,11 @@
     "scene26-gltf-glb-parser-Di7OzzyU.js",
     "scene26-ibl-fragment-CeRrvT96.js",
     "scene26-ibl-skybox-wgsl-CFIBOHHx.js",
-    "scene26-pbr-renderable-CwPMYHia.js",
+    "scene26-pbr-renderable-Dr2yyB69.js",
     "scene26-rgbd-decode-DuD8fsG3.js",
     "scene26-singlelight-point-wgsl-CfgbevHh.js",
     "scene26-subsurface-fragment-PWl6-_mP.js",
     "scene26.js"
   ],
-  "rawBytes": 92253
+  "rawBytes": 92249
 }

--- a/lab/public/bundle/manifest/scene26.json
+++ b/lab/public/bundle/manifest/scene26.json
@@ -14,5 +14,5 @@
     "scene26-subsurface-fragment-PWl6-_mP.js",
     "scene26.js"
   ],
-  "rawBytes": 92267
+  "rawBytes": 92253
 }

--- a/lab/public/bundle/manifest/scene260.json
+++ b/lab/public/bundle/manifest/scene260.json
@@ -15,5 +15,5 @@
     "scene260-scene-uniforms-FTYH6Ct0.js",
     "scene260.js"
   ],
-  "rawBytes": 82278
+  "rawBytes": 82266
 }

--- a/lab/public/bundle/manifest/scene260.json
+++ b/lab/public/bundle/manifest/scene260.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 80.3,
-  "gzipKB": 33.4,
+  "gzipKB": 34,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene260-flat-normal-wgsl-Cm9mM4tC.js",
@@ -10,10 +10,10 @@
     "scene260-gltf-json-asset-yi5RiuZK.js",
     "scene260-gltf-normals-DYhLwXNX.js",
     "scene260-ibl-fragment-CeRrvT96.js",
-    "scene260-pbr-renderable-CVs3Z-A-.js",
+    "scene260-pbr-renderable-DaW6RwDW.js",
     "scene260-rgbd-decode-BHKCP5vu.js",
     "scene260-scene-uniforms-FTYH6Ct0.js",
     "scene260.js"
   ],
-  "rawBytes": 82266
+  "rawBytes": 82260
 }

--- a/lab/public/bundle/manifest/scene261.json
+++ b/lab/public/bundle/manifest/scene261.json
@@ -6,5 +6,5 @@
     "scene261-standard-renderable-BDD27p3e.js",
     "scene261.js"
   ],
-  "rawBytes": 55580
+  "rawBytes": 55566
 }

--- a/lab/public/bundle/manifest/scene261.json
+++ b/lab/public/bundle/manifest/scene261.json
@@ -1,10 +1,10 @@
 {
   "rawKB": 54.3,
-  "gzipKB": 21.4,
+  "gzipKB": 22,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene261-standard-renderable-BDD27p3e.js",
     "scene261.js"
   ],
-  "rawBytes": 55566
+  "rawBytes": 55584
 }

--- a/lab/public/bundle/manifest/scene262.json
+++ b/lab/public/bundle/manifest/scene262.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 39.7,
-  "rawBytes": 40676,
+  "rawBytes": 40677,
   "gzipKB": 24.1,
   "ignoredRawKB": 28.5,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene262.json
+++ b/lab/public/bundle/manifest/scene262.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 39.7,
-  "rawBytes": 40690,
+  "rawBytes": 40676,
   "gzipKB": 24.1,
   "ignoredRawKB": 28.5,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene263.json
+++ b/lab/public/bundle/manifest/scene263.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 41.8,
-  "rawBytes": 42825,
+  "rawBytes": 42811,
   "gzipKB": 24.7,
   "ignoredRawKB": 27.5,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene263.json
+++ b/lab/public/bundle/manifest/scene263.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 41.8,
-  "rawBytes": 42811,
+  "rawBytes": 42809,
   "gzipKB": 24.7,
   "ignoredRawKB": 27.5,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene264.json
+++ b/lab/public/bundle/manifest/scene264.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 40,
-  "rawBytes": 40943,
+  "rawKB": 40.0,
+  "rawBytes": 40929,
   "gzipKB": 25.9,
   "ignoredRawKB": 34.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene264.json
+++ b/lab/public/bundle/manifest/scene264.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 40.0,
-  "rawBytes": 40929,
+  "rawBytes": 40925,
   "gzipKB": 25.9,
   "ignoredRawKB": 34.4,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene265.json
+++ b/lab/public/bundle/manifest/scene265.json
@@ -14,5 +14,5 @@
     "scene265-pbr-renderable-5lgJLtaN.js",
     "scene265.js"
   ],
-  "rawBytes": 82306
+  "rawBytes": 82290
 }

--- a/lab/public/bundle/manifest/scene265.json
+++ b/lab/public/bundle/manifest/scene265.json
@@ -11,8 +11,8 @@
     "scene265-ibl-cubemap-upload-DubDFVEU.js",
     "scene265-ibl-env-assembly-SsMSSCaM.js",
     "scene265-ibl-fragment-CeRrvT96.js",
-    "scene265-pbr-renderable-5lgJLtaN.js",
+    "scene265-pbr-renderable-ChSXMZJN.js",
     "scene265.js"
   ],
-  "rawBytes": 82290
+  "rawBytes": 82286
 }

--- a/lab/public/bundle/manifest/scene266.json
+++ b/lab/public/bundle/manifest/scene266.json
@@ -14,5 +14,5 @@
     "scene266-scene-uniforms-FTYH6Ct0.js",
     "scene266.js"
   ],
-  "rawBytes": 82224
+  "rawBytes": 82209
 }

--- a/lab/public/bundle/manifest/scene266.json
+++ b/lab/public/bundle/manifest/scene266.json
@@ -9,10 +9,10 @@
     "scene266-gltf-glb-parser-D-h9Fgu9.js",
     "scene266-gltf-share-D0T73tB6.js",
     "scene266-ibl-fragment-CeRrvT96.js",
-    "scene266-pbr-renderable-D1yB1DTQ.js",
+    "scene266-pbr-renderable-BvGqhML5.js",
     "scene266-rgbd-decode-BlUmJD6L.js",
     "scene266-scene-uniforms-FTYH6Ct0.js",
     "scene266.js"
   ],
-  "rawBytes": 82209
+  "rawBytes": 82205
 }

--- a/lab/public/bundle/manifest/scene267.json
+++ b/lab/public/bundle/manifest/scene267.json
@@ -6,5 +6,5 @@
     "scene267-standard-renderable-BDPNqQcL.js",
     "scene267.js"
   ],
-  "rawBytes": 44302
+  "rawBytes": 44298
 }

--- a/lab/public/bundle/manifest/scene267.json
+++ b/lab/public/bundle/manifest/scene267.json
@@ -6,5 +6,5 @@
     "scene267-standard-renderable-BDPNqQcL.js",
     "scene267.js"
   ],
-  "rawBytes": 44320
+  "rawBytes": 44302
 }

--- a/lab/public/bundle/manifest/scene268.json
+++ b/lab/public/bundle/manifest/scene268.json
@@ -6,5 +6,5 @@
     "scene268-standard-renderable-BEBAGFCB.js",
     "scene268.js"
   ],
-  "rawBytes": 47389
+  "rawBytes": 47382
 }

--- a/lab/public/bundle/manifest/scene268.json
+++ b/lab/public/bundle/manifest/scene268.json
@@ -6,5 +6,5 @@
     "scene268-standard-renderable-BEBAGFCB.js",
     "scene268.js"
   ],
-  "rawBytes": 47402
+  "rawBytes": 47389
 }

--- a/lab/public/bundle/manifest/scene269.json
+++ b/lab/public/bundle/manifest/scene269.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 89.1,
-  "rawBytes": 91197,
+  "rawBytes": 91193,
   "gzipKB": 37.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -11,7 +11,7 @@
     "scene269-gltf-json-asset-CGkzVmki.js",
     "scene269-gltf-normals-DYhLwXNX.js",
     "scene269-ibl-fragment-CeRrvT96.js",
-    "scene269-pbr-renderable-DO4mP_PR.js",
+    "scene269-pbr-renderable-D7LNm-kr.js",
     "scene269-rgbd-decode-C_O1tSEE.js",
     "scene269-scene-uniforms-FTYH6Ct0.js",
     "scene269-singlelight-hemispheric-wgsl-2Mj900p8.js",

--- a/lab/public/bundle/manifest/scene269.json
+++ b/lab/public/bundle/manifest/scene269.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 89.1,
-  "rawBytes": 91211,
+  "rawBytes": 91197,
   "gzipKB": 37.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene27.json
+++ b/lab/public/bundle/manifest/scene27.json
@@ -16,5 +16,5 @@
     "scene27-texture-2d-DQo3n8D6.js",
     "scene27.js"
   ],
-  "rawBytes": 84823
+  "rawBytes": 84807
 }

--- a/lab/public/bundle/manifest/scene27.json
+++ b/lab/public/bundle/manifest/scene27.json
@@ -10,11 +10,11 @@
     "scene27-gltf-glb-parser-DJVUqR7n.js",
     "scene27-gltf-pbr-builder-ext-ws3zROCS.js",
     "scene27-gltf-variants-CUrk4X5k.js",
-    "scene27-pbr-renderable-BvSFLGzx.js",
+    "scene27-pbr-renderable-CSYg6xlO.js",
     "scene27-reflectance-fragment-BCUsDb7K.js",
     "scene27-singlelight-hemispheric-wgsl-CY3dPlaq.js",
     "scene27-texture-2d-DQo3n8D6.js",
     "scene27.js"
   ],
-  "rawBytes": 84807
+  "rawBytes": 84805
 }

--- a/lab/public/bundle/manifest/scene270.json
+++ b/lab/public/bundle/manifest/scene270.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 51.3,
-  "rawBytes": 52490,
+  "rawKB": 51.2,
+  "rawBytes": 52476,
   "gzipKB": 20.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene270.json
+++ b/lab/public/bundle/manifest/scene270.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 51.2,
-  "rawBytes": 52476,
+  "rawBytes": 52478,
   "gzipKB": 20.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene271.json
+++ b/lab/public/bundle/manifest/scene271.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 70.2,
-  "rawBytes": 71932,
+  "rawBytes": 71923,
   "gzipKB": 27.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene271.json
+++ b/lab/public/bundle/manifest/scene271.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 70.3,
-  "rawBytes": 71944,
+  "rawKB": 70.2,
+  "rawBytes": 71932,
   "gzipKB": 27.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene272.json
+++ b/lab/public/bundle/manifest/scene272.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 55.2,
-  "rawBytes": 56524,
+  "rawBytes": 56516,
   "gzipKB": 21.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene272.json
+++ b/lab/public/bundle/manifest/scene272.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 55.2,
-  "rawBytes": 56538,
+  "rawBytes": 56524,
   "gzipKB": 21.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene273.json
+++ b/lab/public/bundle/manifest/scene273.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 80.9,
-  "rawBytes": 82847,
+  "rawBytes": 82835,
   "gzipKB": 33.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene273.json
+++ b/lab/public/bundle/manifest/scene273.json
@@ -1,10 +1,10 @@
 {
   "rawKB": 80.9,
-  "rawBytes": 82835,
+  "rawBytes": 82840,
   "gzipKB": 33.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene273-pbr-renderable-j0W2stXB.js",
+    "scene273-pbr-renderable-x4h8WMvT.js",
     "scene273-scene-rebuild-UORNb8ue.js",
     "scene273-scene-runtime-mesh-build-DBbHF9DR.js",
     "scene273-shader-composer-qxmZVcOJ.js",

--- a/lab/public/bundle/manifest/scene274.json
+++ b/lab/public/bundle/manifest/scene274.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 43.4,
-  "rawBytes": 44460,
+  "rawBytes": 44446,
   "gzipKB": 17.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene274.json
+++ b/lab/public/bundle/manifest/scene274.json
@@ -1,11 +1,11 @@
 {
   "rawKB": 43.4,
-  "rawBytes": 44446,
+  "rawBytes": 44487,
   "gzipKB": 17.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene274-shader-pipeline-cache-BlqTVl3L.js",
-    "scene274-shader-renderable-C1HuFJgB.js",
+    "scene274-shader-pipeline-cache-DX3HJCz_.js",
+    "scene274-shader-renderable-DIhKx0tm.js",
     "scene274-uniform-copy-batch-BHris-Ik.js",
     "scene274.js"
   ]

--- a/lab/public/bundle/manifest/scene275.json
+++ b/lab/public/bundle/manifest/scene275.json
@@ -1,7 +1,7 @@
 {
-  "rawKB": 41.9,
-  "rawBytes": 42856,
-  "gzipKB": 15.4,
+  "rawKB": 41.8,
+  "rawBytes": 42852,
+  "gzipKB": 16,
   "ignoredRawKB": 682.1,
   "runtimeChunks": [
     "scene275-text-shaper-CL-qK3Rv.js",

--- a/lab/public/bundle/manifest/scene275.json
+++ b/lab/public/bundle/manifest/scene275.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 41.9,
-  "rawBytes": 42870,
+  "rawBytes": 42856,
   "gzipKB": 15.4,
   "ignoredRawKB": 682.1,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene276.json
+++ b/lab/public/bundle/manifest/scene276.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 44.0,
-  "rawBytes": 45066,
+  "rawBytes": 45064,
   "gzipKB": 25.2,
   "ignoredRawKB": 27.1,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene276.json
+++ b/lab/public/bundle/manifest/scene276.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 44,
-  "rawBytes": 45080,
+  "rawKB": 44.0,
+  "rawBytes": 45066,
   "gzipKB": 25.2,
   "ignoredRawKB": 27.1,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene277.json
+++ b/lab/public/bundle/manifest/scene277.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 41.6,
-  "rawBytes": 42575,
+  "rawBytes": 42561,
   "gzipKB": 25.2,
   "ignoredRawKB": 29.8,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene277.json
+++ b/lab/public/bundle/manifest/scene277.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 41.6,
-  "rawBytes": 42561,
+  "rawBytes": 42563,
   "gzipKB": 25.2,
   "ignoredRawKB": 29.8,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -9,10 +9,10 @@
     "scene28-gltf-feature-registry-Bqjc4FAJ.js",
     "scene28-gltf-json-asset-B8WAjZ11.js",
     "scene28-ibl-fragment-CeRrvT96.js",
-    "scene28-pbr-renderable-CdVuM_8c.js",
+    "scene28-pbr-renderable-B8EVZhmv.js",
     "scene28-rgbd-decode-DNHi-djf.js",
     "scene28-scene-uniforms-FTYH6Ct0.js",
     "scene28.js"
   ],
-  "rawBytes": 89086
+  "rawBytes": 89081
 }

--- a/lab/public/bundle/manifest/scene28.json
+++ b/lab/public/bundle/manifest/scene28.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 87,
+  "rawKB": 87.0,
   "gzipKB": 35.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -14,5 +14,5 @@
     "scene28-scene-uniforms-FTYH6Ct0.js",
     "scene28.js"
   ],
-  "rawBytes": 89100
+  "rawBytes": 89086
 }

--- a/lab/public/bundle/manifest/scene29.json
+++ b/lab/public/bundle/manifest/scene29.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 90.7,
+  "rawKB": 90.6,
   "gzipKB": 37.8,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -19,5 +19,5 @@
     "scene29-uv-transform-fragment-B8ijWmAK.js",
     "scene29.js"
   ],
-  "rawBytes": 92826
+  "rawBytes": 92812
 }

--- a/lab/public/bundle/manifest/scene29.json
+++ b/lab/public/bundle/manifest/scene29.json
@@ -10,7 +10,7 @@
     "scene29-gltf-json-asset-JowKGjPS.js",
     "scene29-gltf-pbr-builder-ext-0Tgp6igg.js",
     "scene29-ibl-fragment-CeRrvT96.js",
-    "scene29-pbr-renderable-DGMXArlj.js",
+    "scene29-pbr-renderable-XLNCGYTk.js",
     "scene29-pbr-template-ext-CiHpOV5G.js",
     "scene29-rgbd-decode-CwmTpUIN.js",
     "scene29-scene-uniforms-FTYH6Ct0.js",
@@ -19,5 +19,5 @@
     "scene29-uv-transform-fragment-B8ijWmAK.js",
     "scene29.js"
   ],
-  "rawBytes": 92812
+  "rawBytes": 92810
 }

--- a/lab/public/bundle/manifest/scene3.json
+++ b/lab/public/bundle/manifest/scene3.json
@@ -10,5 +10,5 @@
     "scene3-wgsl-fog-m3PkjS7i.js",
     "scene3.js"
   ],
-  "rawBytes": 56519
+  "rawBytes": 56515
 }

--- a/lab/public/bundle/manifest/scene3.json
+++ b/lab/public/bundle/manifest/scene3.json
@@ -10,5 +10,5 @@
     "scene3-wgsl-fog-m3PkjS7i.js",
     "scene3.js"
   ],
-  "rawBytes": 56533
+  "rawBytes": 56519
 }

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -12,15 +12,15 @@
     "scene30-gltf-glb-parser-CPRfMQrD.js",
     "scene30-gltf-pbr-builder-ext-CqZZdTfz.js",
     "scene30-ibl-fragment-CeRrvT96.js",
-    "scene30-pbr-refraction-MdMa9C5w.js",
-    "scene30-pbr-renderable-D75zSB7L.js",
+    "scene30-pbr-refraction-BFLfUi9Q.js",
+    "scene30-pbr-renderable-BhZZjYDH.js",
     "scene30-pbr-template-ext-CiHpOV5G.js",
-    "scene30-pbr-transmission-ext-BLvJF0Ft.js",
+    "scene30-pbr-transmission-ext-CaQlAfpk.js",
     "scene30-rgbd-decode-PXl8kXni.js",
     "scene30-scene-uniforms-FTYH6Ct0.js",
     "scene30-texture-2d-DQo3n8D6.js",
     "scene30-uv-transform-fragment-B8ijWmAK.js",
     "scene30.js"
   ],
-  "rawBytes": 106507
+  "rawBytes": 106505
 }

--- a/lab/public/bundle/manifest/scene30.json
+++ b/lab/public/bundle/manifest/scene30.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 104,
+  "rawKB": 104.0,
   "gzipKB": 43.3,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -22,5 +22,5 @@
     "scene30-uv-transform-fragment-B8ijWmAK.js",
     "scene30.js"
   ],
-  "rawBytes": 106519
+  "rawBytes": 106507
 }

--- a/lab/public/bundle/manifest/scene31.json
+++ b/lab/public/bundle/manifest/scene31.json
@@ -9,10 +9,10 @@
     "scene31-gltf-feature-registry-jSFo6afa.js",
     "scene31-gltf-glb-parser-DzBScCtC.js",
     "scene31-ibl-fragment-CeRrvT96.js",
-    "scene31-pbr-renderable-j7q-3ZB5.js",
+    "scene31-pbr-renderable-DTkexr5o.js",
     "scene31-rgbd-decode-CT6Q-rdi.js",
     "scene31-scene-uniforms-FTYH6Ct0.js",
     "scene31.js"
   ],
-  "rawBytes": 82328
+  "rawBytes": 82324
 }

--- a/lab/public/bundle/manifest/scene31.json
+++ b/lab/public/bundle/manifest/scene31.json
@@ -14,5 +14,5 @@
     "scene31-scene-uniforms-FTYH6Ct0.js",
     "scene31.js"
   ],
-  "rawBytes": 82342
+  "rawBytes": 82328
 }

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -8,11 +8,11 @@
     "scene32-gltf-feature-registry-DSwxv2YD.js",
     "scene32-gltf-glb-parser-Cr0xOgAx.js",
     "scene32-ibl-fragment-CeRrvT96.js",
-    "scene32-pbr-renderable-DGIiTcM4.js",
+    "scene32-pbr-renderable-CH6Hezzv.js",
     "scene32-rgbd-decode-BtmH8I2g.js",
     "scene32-scene-uniforms-FTYH6Ct0.js",
     "scene32-unlit-fragment-DWtvt7yQ.js",
     "scene32.js"
   ],
-  "rawBytes": 82157
+  "rawBytes": 82153
 }

--- a/lab/public/bundle/manifest/scene32.json
+++ b/lab/public/bundle/manifest/scene32.json
@@ -14,5 +14,5 @@
     "scene32-unlit-fragment-DWtvt7yQ.js",
     "scene32.js"
   ],
-  "rawBytes": 82171
+  "rawBytes": 82157
 }

--- a/lab/public/bundle/manifest/scene33.json
+++ b/lab/public/bundle/manifest/scene33.json
@@ -13,13 +13,13 @@
     "scene33-ibl-fragment-CeRrvT96.js",
     "scene33-light-base-B7HN_7C7.js",
     "scene33-multilight-wgsl-CBu6p_7G.js",
-    "scene33-pbr-refraction-B5UM6uRt.js",
-    "scene33-pbr-renderable-BW0CMNwc.js",
-    "scene33-pbr-transmission-ext-BpxGMShc.js",
+    "scene33-pbr-refraction-B8CxBfmT.js",
+    "scene33-pbr-renderable-CpuGJAsv.js",
+    "scene33-pbr-transmission-ext-C2UyXh18.js",
     "scene33-point-light-D5Fl0aQR.js",
     "scene33-rgbd-decode-CBCiayil.js",
     "scene33-scene-uniforms-FTYH6Ct0.js",
     "scene33.js"
   ],
-  "rawBytes": 106353
+  "rawBytes": 106352
 }

--- a/lab/public/bundle/manifest/scene33.json
+++ b/lab/public/bundle/manifest/scene33.json
@@ -21,5 +21,5 @@
     "scene33-scene-uniforms-FTYH6Ct0.js",
     "scene33.js"
   ],
-  "rawBytes": 106367
+  "rawBytes": 106353
 }

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 98.3,
+  "rawKB": 98.2,
   "gzipKB": 41,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -19,5 +19,5 @@
     "scene34-visibility-CRkrFthj.js",
     "scene34.js"
   ],
-  "rawBytes": 100614
+  "rawBytes": 100600
 }

--- a/lab/public/bundle/manifest/scene34.json
+++ b/lab/public/bundle/manifest/scene34.json
@@ -13,11 +13,11 @@
     "scene34-gltf-sampler-denorm-CTv2yBPK.js",
     "scene34-gltf-share-CD7RSpVC.js",
     "scene34-ibl-fragment-CeRrvT96.js",
-    "scene34-pbr-renderable-DV9c_H0s.js",
+    "scene34-pbr-renderable-CZtsqpY6.js",
     "scene34-rgbd-decode-EQ-YQ9oq.js",
     "scene34-scene-uniforms-FTYH6Ct0.js",
     "scene34-visibility-CRkrFthj.js",
     "scene34.js"
   ],
-  "rawBytes": 100600
+  "rawBytes": 100599
 }

--- a/lab/public/bundle/manifest/scene35.json
+++ b/lab/public/bundle/manifest/scene35.json
@@ -8,12 +8,12 @@
     "scene35-gltf-feature-registry-BOGDyOow.js",
     "scene35-gltf-glb-parser-CK3Suivb.js",
     "scene35-ibl-fragment-CeRrvT96.js",
-    "scene35-pbr-renderable-BUOnvc5n.js",
+    "scene35-pbr-renderable-CaAgrr0A.js",
     "scene35-rgbd-decode-BRXFAjBk.js",
     "scene35-scene-uniforms-FTYH6Ct0.js",
     "scene35-thin-instance-fragment-CBn2miAC.js",
     "scene35-thin-instance-gpu-C0sF7s2H.js",
     "scene35.js"
   ],
-  "rawBytes": 86193
+  "rawBytes": 86189
 }

--- a/lab/public/bundle/manifest/scene35.json
+++ b/lab/public/bundle/manifest/scene35.json
@@ -15,5 +15,5 @@
     "scene35-thin-instance-gpu-C0sF7s2H.js",
     "scene35.js"
   ],
-  "rawBytes": 86207
+  "rawBytes": 86193
 }

--- a/lab/public/bundle/manifest/scene36.json
+++ b/lab/public/bundle/manifest/scene36.json
@@ -7,5 +7,5 @@
     "scene36-std-emissive-fragment-DthzsVUc.js",
     "scene36.js"
   ],
-  "rawBytes": 53090
+  "rawBytes": 53076
 }

--- a/lab/public/bundle/manifest/scene36.json
+++ b/lab/public/bundle/manifest/scene36.json
@@ -7,5 +7,5 @@
     "scene36-std-emissive-fragment-DthzsVUc.js",
     "scene36.js"
   ],
-  "rawBytes": 53076
+  "rawBytes": 53070
 }

--- a/lab/public/bundle/manifest/scene37.json
+++ b/lab/public/bundle/manifest/scene37.json
@@ -22,5 +22,5 @@
     "scene37-uv-transform-fragment-B8ijWmAK.js",
     "scene37.js"
   ],
-  "rawBytes": 99681
+  "rawBytes": 99667
 }

--- a/lab/public/bundle/manifest/scene37.json
+++ b/lab/public/bundle/manifest/scene37.json
@@ -12,7 +12,7 @@
     "scene37-gltf-glb-parser-BvLkUAFg.js",
     "scene37-gltf-pbr-builder-ext-DBkuxTnO.js",
     "scene37-ibl-fragment-CeRrvT96.js",
-    "scene37-pbr-renderable-BivSBHsK.js",
+    "scene37-pbr-renderable-De-lUiqX.js",
     "scene37-pbr-template-ext-CiHpOV5G.js",
     "scene37-reflectance-fragment-CbFq_491.js",
     "scene37-rgbd-decode-Ow3m-YWC.js",
@@ -22,5 +22,5 @@
     "scene37-uv-transform-fragment-B8ijWmAK.js",
     "scene37.js"
   ],
-  "rawBytes": 99667
+  "rawBytes": 99670
 }

--- a/lab/public/bundle/manifest/scene38.json
+++ b/lab/public/bundle/manifest/scene38.json
@@ -6,5 +6,5 @@
     "scene38-standard-renderable-Dh_oMFSC.js",
     "scene38.js"
   ],
-  "rawBytes": 63264
+  "rawBytes": 63257
 }

--- a/lab/public/bundle/manifest/scene38.json
+++ b/lab/public/bundle/manifest/scene38.json
@@ -6,5 +6,5 @@
     "scene38-standard-renderable-Dh_oMFSC.js",
     "scene38.js"
   ],
-  "rawBytes": 63278
+  "rawBytes": 63264
 }

--- a/lab/public/bundle/manifest/scene39.json
+++ b/lab/public/bundle/manifest/scene39.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 110,
+  "rawKB": 110.0,
   "gzipKB": 47,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -31,5 +31,5 @@
     "scene39-visibility-D_WcxQMp.js",
     "scene39.js"
   ],
-  "rawBytes": 112682
+  "rawBytes": 112668
 }

--- a/lab/public/bundle/manifest/scene39.json
+++ b/lab/public/bundle/manifest/scene39.json
@@ -21,7 +21,7 @@
     "scene39-ibl-fragment-CeRrvT96.js",
     "scene39-light-base-DJIAgtv-.js",
     "scene39-light-matrix-CBTBdGsb.js",
-    "scene39-pbr-renderable-C8zF1SFU.js",
+    "scene39-pbr-renderable-DaooKF5K.js",
     "scene39-pbr-template-ext-CiHpOV5G.js",
     "scene39-rgbd-decode-DqA5PDQg.js",
     "scene39-scene-uniforms-FTYH6Ct0.js",
@@ -31,5 +31,5 @@
     "scene39-visibility-D_WcxQMp.js",
     "scene39.js"
   ],
-  "rawBytes": 112668
+  "rawBytes": 112664
 }

--- a/lab/public/bundle/manifest/scene4.json
+++ b/lab/public/bundle/manifest/scene4.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 73.4,
+  "rawKB": 73.3,
   "gzipKB": 29,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -12,5 +12,5 @@
     "scene4-std-shadow-fragment-pwyXRo4i.js",
     "scene4.js"
   ],
-  "rawBytes": 75112
+  "rawBytes": 75098
 }

--- a/lab/public/bundle/manifest/scene4.json
+++ b/lab/public/bundle/manifest/scene4.json
@@ -12,5 +12,5 @@
     "scene4-std-shadow-fragment-pwyXRo4i.js",
     "scene4.js"
   ],
-  "rawBytes": 75098
+  "rawBytes": 75093
 }

--- a/lab/public/bundle/manifest/scene40.json
+++ b/lab/public/bundle/manifest/scene40.json
@@ -6,5 +6,5 @@
     "scene40-standard-renderable-D7_myor6.js",
     "scene40.js"
   ],
-  "rawBytes": 51389
+  "rawBytes": 51380
 }

--- a/lab/public/bundle/manifest/scene40.json
+++ b/lab/public/bundle/manifest/scene40.json
@@ -6,5 +6,5 @@
     "scene40-standard-renderable-D7_myor6.js",
     "scene40.js"
   ],
-  "rawBytes": 51403
+  "rawBytes": 51389
 }

--- a/lab/public/bundle/manifest/scene41.json
+++ b/lab/public/bundle/manifest/scene41.json
@@ -13,5 +13,5 @@
     "scene41-standard-renderable-D52DjuE5.js",
     "scene41.js"
   ],
-  "rawBytes": 94872
+  "rawBytes": 94870
 }

--- a/lab/public/bundle/manifest/scene41.json
+++ b/lab/public/bundle/manifest/scene41.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92.7,
+  "rawKB": 92.6,
   "gzipKB": 37.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -13,5 +13,5 @@
     "scene41-standard-renderable-D52DjuE5.js",
     "scene41.js"
   ],
-  "rawBytes": 94886
+  "rawBytes": 94872
 }

--- a/lab/public/bundle/manifest/scene42.json
+++ b/lab/public/bundle/manifest/scene42.json
@@ -6,5 +6,5 @@
     "scene42-standard-renderable-CTATVaLu.js",
     "scene42.js"
   ],
-  "rawBytes": 53128
+  "rawBytes": 53124
 }

--- a/lab/public/bundle/manifest/scene42.json
+++ b/lab/public/bundle/manifest/scene42.json
@@ -6,5 +6,5 @@
     "scene42-standard-renderable-CTATVaLu.js",
     "scene42.js"
   ],
-  "rawBytes": 53142
+  "rawBytes": 53128
 }

--- a/lab/public/bundle/manifest/scene43.json
+++ b/lab/public/bundle/manifest/scene43.json
@@ -8,5 +8,5 @@
     "scene43-thin-instance-gpu-BBn8oq97.js",
     "scene43.js"
   ],
-  "rawBytes": 60700
+  "rawBytes": 60686
 }

--- a/lab/public/bundle/manifest/scene43.json
+++ b/lab/public/bundle/manifest/scene43.json
@@ -8,5 +8,5 @@
     "scene43-thin-instance-gpu-BBn8oq97.js",
     "scene43.js"
   ],
-  "rawBytes": 60686
+  "rawBytes": 60697
 }

--- a/lab/public/bundle/manifest/scene44.json
+++ b/lab/public/bundle/manifest/scene44.json
@@ -6,5 +6,5 @@
     "scene44-standard-renderable-D7O_trHZ.js",
     "scene44.js"
   ],
-  "rawBytes": 51763
+  "rawBytes": 51757
 }

--- a/lab/public/bundle/manifest/scene44.json
+++ b/lab/public/bundle/manifest/scene44.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 50.6,
+  "rawKB": 50.5,
   "gzipKB": 20.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene44-standard-renderable-D7O_trHZ.js",
     "scene44.js"
   ],
-  "rawBytes": 51777
+  "rawBytes": 51763
 }

--- a/lab/public/bundle/manifest/scene45.json
+++ b/lab/public/bundle/manifest/scene45.json
@@ -6,5 +6,5 @@
     "scene45-standard-renderable-B6Nd9Dzc.js",
     "scene45.js"
   ],
-  "rawBytes": 53082
+  "rawBytes": 53068
 }

--- a/lab/public/bundle/manifest/scene45.json
+++ b/lab/public/bundle/manifest/scene45.json
@@ -6,5 +6,5 @@
     "scene45-standard-renderable-B6Nd9Dzc.js",
     "scene45.js"
   ],
-  "rawBytes": 53068
+  "rawBytes": 53061
 }

--- a/lab/public/bundle/manifest/scene46.json
+++ b/lab/public/bundle/manifest/scene46.json
@@ -6,5 +6,5 @@
     "scene46-standard-renderable-pSfqo6O9.js",
     "scene46.js"
   ],
-  "rawBytes": 56110
+  "rawBytes": 56104
 }

--- a/lab/public/bundle/manifest/scene46.json
+++ b/lab/public/bundle/manifest/scene46.json
@@ -6,5 +6,5 @@
     "scene46-standard-renderable-pSfqo6O9.js",
     "scene46.js"
   ],
-  "rawBytes": 56124
+  "rawBytes": 56110
 }

--- a/lab/public/bundle/manifest/scene47.json
+++ b/lab/public/bundle/manifest/scene47.json
@@ -12,5 +12,5 @@
     "scene47-standard-renderable-CLVbHJlI.js",
     "scene47.js"
   ],
-  "rawBytes": 93636
+  "rawBytes": 93622
 }

--- a/lab/public/bundle/manifest/scene48.json
+++ b/lab/public/bundle/manifest/scene48.json
@@ -6,5 +6,5 @@
     "scene48-standard-renderable-DmbKr-oj.js",
     "scene48.js"
   ],
-  "rawBytes": 55926
+  "rawBytes": 55910
 }

--- a/lab/public/bundle/manifest/scene48.json
+++ b/lab/public/bundle/manifest/scene48.json
@@ -6,5 +6,5 @@
     "scene48-standard-renderable-DmbKr-oj.js",
     "scene48.js"
   ],
-  "rawBytes": 55910
+  "rawBytes": 55906
 }

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -8,5 +8,5 @@
     "scene49-swapchain-overlay-ilhN4El_.js",
     "scene49.js"
   ],
-  "rawBytes": 92855
+  "rawBytes": 92841
 }

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -8,5 +8,5 @@
     "scene49-swapchain-overlay-ilhN4El_.js",
     "scene49.js"
   ],
-  "rawBytes": 92841
+  "rawBytes": 92847
 }

--- a/lab/public/bundle/manifest/scene5.json
+++ b/lab/public/bundle/manifest/scene5.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 92.3,
+  "rawKB": 92.2,
   "gzipKB": 39.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -20,5 +20,5 @@
     "scene5-skeleton-fragment-BOwMGPIa.js",
     "scene5.js"
   ],
-  "rawBytes": 94467
+  "rawBytes": 94453
 }

--- a/lab/public/bundle/manifest/scene5.json
+++ b/lab/public/bundle/manifest/scene5.json
@@ -13,12 +13,12 @@
     "scene5-gltf-feature-registry-D8HRJeVR.js",
     "scene5-gltf-feature-skeleton-BcZBHJWQ.js",
     "scene5-gltf-json-asset-PrBgaXiL.js",
-    "scene5-morph-fragment-IR7nFz9h.js",
-    "scene5-pbr-renderable-8sg7wcDa.js",
+    "scene5-morph-fragment-CslqN4qy.js",
+    "scene5-pbr-renderable-BWwVnlfF.js",
     "scene5-pbr-template-ext-CiHpOV5G.js",
     "scene5-singlelight-hemispheric-wgsl-a_zJjBYS.js",
-    "scene5-skeleton-fragment-BOwMGPIa.js",
+    "scene5-skeleton-fragment-CNrku9y0.js",
     "scene5.js"
   ],
-  "rawBytes": 94453
+  "rawBytes": 94450
 }

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -6,5 +6,5 @@
     "scene52-standard-renderable-B93G7FTA.js",
     "scene52.js"
   ],
-  "rawBytes": 59236
+  "rawBytes": 59216
 }

--- a/lab/public/bundle/manifest/scene52.json
+++ b/lab/public/bundle/manifest/scene52.json
@@ -6,5 +6,5 @@
     "scene52-standard-renderable-B93G7FTA.js",
     "scene52.js"
   ],
-  "rawBytes": 59216
+  "rawBytes": 59219
 }

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -6,5 +6,5 @@
     "scene53-standard-renderable-B8GrpWDK.js",
     "scene53.js"
   ],
-  "rawBytes": 59305
+  "rawBytes": 59296
 }

--- a/lab/public/bundle/manifest/scene53.json
+++ b/lab/public/bundle/manifest/scene53.json
@@ -6,5 +6,5 @@
     "scene53-standard-renderable-B8GrpWDK.js",
     "scene53.js"
   ],
-  "rawBytes": 59319
+  "rawBytes": 59305
 }

--- a/lab/public/bundle/manifest/scene54.json
+++ b/lab/public/bundle/manifest/scene54.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 60,
+  "rawKB": 60.0,
   "gzipKB": 24.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -8,5 +8,5 @@
     "scene54-standard-renderable-vGBAQ-9A.js",
     "scene54.js"
   ],
-  "rawBytes": 61456
+  "rawBytes": 61441
 }

--- a/lab/public/bundle/manifest/scene54.json
+++ b/lab/public/bundle/manifest/scene54.json
@@ -8,5 +8,5 @@
     "scene54-standard-renderable-vGBAQ-9A.js",
     "scene54.js"
   ],
-  "rawBytes": 61441
+  "rawBytes": 61439
 }

--- a/lab/public/bundle/manifest/scene55.json
+++ b/lab/public/bundle/manifest/scene55.json
@@ -6,5 +6,5 @@
     "scene55-billboard-renderable-B6pPgmb-.js",
     "scene55.js"
   ],
-  "rawBytes": 32527
+  "rawBytes": 32523
 }

--- a/lab/public/bundle/manifest/scene55.json
+++ b/lab/public/bundle/manifest/scene55.json
@@ -6,5 +6,5 @@
     "scene55-billboard-renderable-B6pPgmb-.js",
     "scene55.js"
   ],
-  "rawBytes": 32536
+  "rawBytes": 32527
 }

--- a/lab/public/bundle/manifest/scene56.json
+++ b/lab/public/bundle/manifest/scene56.json
@@ -8,5 +8,5 @@
     "scene56-standard-renderable-Dm9mFrnO.js",
     "scene56.js"
   ],
-  "rawBytes": 61651
+  "rawBytes": 61641
 }

--- a/lab/public/bundle/manifest/scene56.json
+++ b/lab/public/bundle/manifest/scene56.json
@@ -8,5 +8,5 @@
     "scene56-standard-renderable-Dm9mFrnO.js",
     "scene56.js"
   ],
-  "rawBytes": 61664
+  "rawBytes": 61651
 }

--- a/lab/public/bundle/manifest/scene57.json
+++ b/lab/public/bundle/manifest/scene57.json
@@ -8,5 +8,5 @@
     "scene57-standard-renderable-B61xdak7.js",
     "scene57.js"
   ],
-  "rawBytes": 62052
+  "rawBytes": 62048
 }

--- a/lab/public/bundle/manifest/scene57.json
+++ b/lab/public/bundle/manifest/scene57.json
@@ -8,5 +8,5 @@
     "scene57-standard-renderable-B61xdak7.js",
     "scene57.js"
   ],
-  "rawBytes": 62066
+  "rawBytes": 62052
 }

--- a/lab/public/bundle/manifest/scene59.json
+++ b/lab/public/bundle/manifest/scene59.json
@@ -8,5 +8,5 @@
     "scene59-standard-renderable-Bal23tGp.js",
     "scene59.js"
   ],
-  "rawBytes": 64146
+  "rawBytes": 64141
 }

--- a/lab/public/bundle/manifest/scene59.json
+++ b/lab/public/bundle/manifest/scene59.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 62.7,
+  "rawKB": 62.6,
   "gzipKB": 25.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -8,5 +8,5 @@
     "scene59-standard-renderable-Bal23tGp.js",
     "scene59.js"
   ],
-  "rawBytes": 64160
+  "rawBytes": 64146
 }

--- a/lab/public/bundle/manifest/scene6.json
+++ b/lab/public/bundle/manifest/scene6.json
@@ -7,11 +7,11 @@
     "scene6-background-ground-O1nPh-aw.js",
     "scene6-cubemap-skybox-material-VKHB2CT9.js",
     "scene6-ibl-fragment-CeRrvT96.js",
-    "scene6-pbr-renderable-D5-bUGvv.js",
+    "scene6-pbr-renderable-D-anH0HV.js",
     "scene6-rgbd-decode-DltNvrvh.js",
     "scene6-scene-uniforms-FTYH6Ct0.js",
     "scene6-wgsl-helpers-BgB2AJrF.js",
     "scene6.js"
   ],
-  "rawBytes": 74694
+  "rawBytes": 74687
 }

--- a/lab/public/bundle/manifest/scene6.json
+++ b/lab/public/bundle/manifest/scene6.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 73,
+  "rawKB": 72.9,
   "gzipKB": 30.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -13,5 +13,5 @@
     "scene6-wgsl-helpers-BgB2AJrF.js",
     "scene6.js"
   ],
-  "rawBytes": 74708
+  "rawBytes": 74694
 }

--- a/lab/public/bundle/manifest/scene60.json
+++ b/lab/public/bundle/manifest/scene60.json
@@ -12,5 +12,5 @@
     "scene60-vertex-output-C7G5u6Y0.js",
     "scene60.js"
   ],
-  "rawBytes": 55927
+  "rawBytes": 55923
 }

--- a/lab/public/bundle/manifest/scene60.json
+++ b/lab/public/bundle/manifest/scene60.json
@@ -12,5 +12,5 @@
     "scene60-vertex-output-C7G5u6Y0.js",
     "scene60.js"
   ],
-  "rawBytes": 55941
+  "rawBytes": 55927
 }

--- a/lab/public/bundle/manifest/scene61.json
+++ b/lab/public/bundle/manifest/scene61.json
@@ -14,5 +14,5 @@
     "scene61-vertex-output-C7G5u6Y0.js",
     "scene61.js"
   ],
-  "rawBytes": 54817
+  "rawBytes": 54815
 }

--- a/lab/public/bundle/manifest/scene61.json
+++ b/lab/public/bundle/manifest/scene61.json
@@ -14,5 +14,5 @@
     "scene61-vertex-output-C7G5u6Y0.js",
     "scene61.js"
   ],
-  "rawBytes": 54831
+  "rawBytes": 54817
 }

--- a/lab/public/bundle/manifest/scene62.json
+++ b/lab/public/bundle/manifest/scene62.json
@@ -14,5 +14,5 @@
     "scene62-vertex-output-C7G5u6Y0.js",
     "scene62.js"
   ],
-  "rawBytes": 60538
+  "rawBytes": 60534
 }

--- a/lab/public/bundle/manifest/scene62.json
+++ b/lab/public/bundle/manifest/scene62.json
@@ -14,5 +14,5 @@
     "scene62-vertex-output-C7G5u6Y0.js",
     "scene62.js"
   ],
-  "rawBytes": 60552
+  "rawBytes": 60538
 }

--- a/lab/public/bundle/manifest/scene63.json
+++ b/lab/public/bundle/manifest/scene63.json
@@ -13,5 +13,5 @@
     "scene63-vertex-output-C7G5u6Y0.js",
     "scene63.js"
   ],
-  "rawBytes": 59204
+  "rawBytes": 59201
 }

--- a/lab/public/bundle/manifest/scene63.json
+++ b/lab/public/bundle/manifest/scene63.json
@@ -13,5 +13,5 @@
     "scene63-vertex-output-C7G5u6Y0.js",
     "scene63.js"
   ],
-  "rawBytes": 59218
+  "rawBytes": 59204
 }

--- a/lab/public/bundle/manifest/scene64.json
+++ b/lab/public/bundle/manifest/scene64.json
@@ -13,5 +13,5 @@
     "scene64-vertex-output-C7G5u6Y0.js",
     "scene64.js"
   ],
-  "rawBytes": 57147
+  "rawBytes": 57133
 }

--- a/lab/public/bundle/manifest/scene64.json
+++ b/lab/public/bundle/manifest/scene64.json
@@ -13,5 +13,5 @@
     "scene64-vertex-output-C7G5u6Y0.js",
     "scene64.js"
   ],
-  "rawBytes": 57133
+  "rawBytes": 57132
 }

--- a/lab/public/bundle/manifest/scene65.json
+++ b/lab/public/bundle/manifest/scene65.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 73.8,
+  "rawKB": 73.7,
   "gzipKB": 30.6,
   "ignoredRawKB": 6.4,
   "runtimeChunks": [
@@ -18,5 +18,5 @@
     "scene65-vertex-output-C7G5u6Y0.js",
     "scene65.js"
   ],
-  "rawBytes": 75531
+  "rawBytes": 75517
 }

--- a/lab/public/bundle/manifest/scene65.json
+++ b/lab/public/bundle/manifest/scene65.json
@@ -18,5 +18,5 @@
     "scene65-vertex-output-C7G5u6Y0.js",
     "scene65.js"
   ],
-  "rawBytes": 75517
+  "rawBytes": 75518
 }

--- a/lab/public/bundle/manifest/scene66.json
+++ b/lab/public/bundle/manifest/scene66.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 88,
+  "rawKB": 88.0,
   "gzipKB": 40.9,
   "ignoredRawKB": 5.5,
   "runtimeChunks": [
@@ -41,5 +41,5 @@
     "scene66-vertex-output-C7G5u6Y0.js",
     "scene66.js"
   ],
-  "rawBytes": 90102
+  "rawBytes": 90088
 }

--- a/lab/public/bundle/manifest/scene66.json
+++ b/lab/public/bundle/manifest/scene66.json
@@ -41,5 +41,5 @@
     "scene66-vertex-output-C7G5u6Y0.js",
     "scene66.js"
   ],
-  "rawBytes": 90088
+  "rawBytes": 90084
 }

--- a/lab/public/bundle/manifest/scene67.json
+++ b/lab/public/bundle/manifest/scene67.json
@@ -17,5 +17,5 @@
     "scene67-vertex-output-C7G5u6Y0.js",
     "scene67.js"
   ],
-  "rawBytes": 77129
+  "rawBytes": 77115
 }

--- a/lab/public/bundle/manifest/scene67.json
+++ b/lab/public/bundle/manifest/scene67.json
@@ -17,5 +17,5 @@
     "scene67-vertex-output-C7G5u6Y0.js",
     "scene67.js"
   ],
-  "rawBytes": 77115
+  "rawBytes": 77111
 }

--- a/lab/public/bundle/manifest/scene68.json
+++ b/lab/public/bundle/manifest/scene68.json
@@ -17,5 +17,5 @@
     "scene68-vertex-output-C7G5u6Y0.js",
     "scene68.js"
   ],
-  "rawBytes": 91992
+  "rawBytes": 91988
 }

--- a/lab/public/bundle/manifest/scene68.json
+++ b/lab/public/bundle/manifest/scene68.json
@@ -17,5 +17,5 @@
     "scene68-vertex-output-C7G5u6Y0.js",
     "scene68.js"
   ],
-  "rawBytes": 92006
+  "rawBytes": 91992
 }

--- a/lab/public/bundle/manifest/scene69.json
+++ b/lab/public/bundle/manifest/scene69.json
@@ -18,5 +18,5 @@
     "scene69-vertex-output-C7G5u6Y0.js",
     "scene69.js"
   ],
-  "rawBytes": 91437
+  "rawBytes": 91433
 }

--- a/lab/public/bundle/manifest/scene69.json
+++ b/lab/public/bundle/manifest/scene69.json
@@ -18,5 +18,5 @@
     "scene69-vertex-output-C7G5u6Y0.js",
     "scene69.js"
   ],
-  "rawBytes": 91451
+  "rawBytes": 91437
 }

--- a/lab/public/bundle/manifest/scene7.json
+++ b/lab/public/bundle/manifest/scene7.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 105.7,
+  "rawKB": 105.6,
   "gzipKB": 45,
   "ignoredRawKB": 0,
   "runtimeChunks": [
@@ -23,5 +23,5 @@
     "scene7-wgsl-helpers-BgB2AJrF.js",
     "scene7.js"
   ],
-  "rawBytes": 108190
+  "rawBytes": 108176
 }

--- a/lab/public/bundle/manifest/scene7.json
+++ b/lab/public/bundle/manifest/scene7.json
@@ -14,14 +14,14 @@
     "scene7-gltf-feature-skeleton-C4mxkxAa.js",
     "scene7-gltf-json-asset-DboJkkGT.js",
     "scene7-ibl-fragment-CeRrvT96.js",
-    "scene7-pbr-renderable-CZC_1qbV.js",
+    "scene7-pbr-renderable-YDg823lf.js",
     "scene7-rgbd-decode-B_BnEftW.js",
     "scene7-scene-uniforms-FTYH6Ct0.js",
     "scene7-singlelight-hemispheric-wgsl-DoH1sdOa.js",
-    "scene7-skeleton-fragment-DIj210_e.js",
+    "scene7-skeleton-fragment-BOQfF7WU.js",
     "scene7-skybox.vertex-Ban7q6IM-D1KSfOUq.js",
     "scene7-wgsl-helpers-BgB2AJrF.js",
     "scene7.js"
   ],
-  "rawBytes": 108176
+  "rawBytes": 108175
 }

--- a/lab/public/bundle/manifest/scene70.json
+++ b/lab/public/bundle/manifest/scene70.json
@@ -19,5 +19,5 @@
     "scene70-vertex-output-C7G5u6Y0.js",
     "scene70.js"
   ],
-  "rawBytes": 91746
+  "rawBytes": 91742
 }

--- a/lab/public/bundle/manifest/scene70.json
+++ b/lab/public/bundle/manifest/scene70.json
@@ -19,5 +19,5 @@
     "scene70-vertex-output-C7G5u6Y0.js",
     "scene70.js"
   ],
-  "rawBytes": 91760
+  "rawBytes": 91746
 }

--- a/lab/public/bundle/manifest/scene71.json
+++ b/lab/public/bundle/manifest/scene71.json
@@ -18,5 +18,5 @@
     "scene71-vertex-output-C7G5u6Y0.js",
     "scene71.js"
   ],
-  "rawBytes": 91625
+  "rawBytes": 91611
 }

--- a/lab/public/bundle/manifest/scene71.json
+++ b/lab/public/bundle/manifest/scene71.json
@@ -18,5 +18,5 @@
     "scene71-vertex-output-C7G5u6Y0.js",
     "scene71.js"
   ],
-  "rawBytes": 91611
+  "rawBytes": 91607
 }

--- a/lab/public/bundle/manifest/scene72.json
+++ b/lab/public/bundle/manifest/scene72.json
@@ -32,5 +32,5 @@
     "scene72-vertex-output-C7G5u6Y0.js",
     "scene72.js"
   ],
-  "rawBytes": 109926
+  "rawBytes": 109912
 }

--- a/lab/public/bundle/manifest/scene72.json
+++ b/lab/public/bundle/manifest/scene72.json
@@ -32,5 +32,5 @@
     "scene72-vertex-output-C7G5u6Y0.js",
     "scene72.js"
   ],
-  "rawBytes": 109912
+  "rawBytes": 109908
 }

--- a/lab/public/bundle/manifest/scene73.json
+++ b/lab/public/bundle/manifest/scene73.json
@@ -17,7 +17,7 @@
     "scene73-node-env-BKUuQX2w.js",
     "scene73-node-renderable-KxpNMtGy.js",
     "scene73-pbr-metallic-roughness-block-full-CUhffh-6.js",
-    "scene73-pbr-renderable-Cefj8HZ7.js",
+    "scene73-pbr-renderable-BF7Ray2C.js",
     "scene73-perturb-normal-Bqx-TYaB.js",
     "scene73-reflection-block-CIXuH-z0.js",
     "scene73-rgbd-decode-BSh_ziDi.js",
@@ -27,5 +27,5 @@
     "scene73-vertex-output-C7G5u6Y0.js",
     "scene73.js"
   ],
-  "rawBytes": 145216
+  "rawBytes": 145215
 }

--- a/lab/public/bundle/manifest/scene73.json
+++ b/lab/public/bundle/manifest/scene73.json
@@ -27,5 +27,5 @@
     "scene73-vertex-output-C7G5u6Y0.js",
     "scene73.js"
   ],
-  "rawBytes": 145230
+  "rawBytes": 145216
 }

--- a/lab/public/bundle/manifest/scene75.json
+++ b/lab/public/bundle/manifest/scene75.json
@@ -6,5 +6,5 @@
     "scene75-standard-renderable-CUCYhRZj.js",
     "scene75.js"
   ],
-  "rawBytes": 51233
+  "rawBytes": 51229
 }

--- a/lab/public/bundle/manifest/scene75.json
+++ b/lab/public/bundle/manifest/scene75.json
@@ -1,10 +1,10 @@
 {
-  "rawKB": 50,
+  "rawKB": 50.0,
   "gzipKB": 20.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene75-standard-renderable-CUCYhRZj.js",
     "scene75.js"
   ],
-  "rawBytes": 51247
+  "rawBytes": 51233
 }

--- a/lab/public/bundle/manifest/scene77.json
+++ b/lab/public/bundle/manifest/scene77.json
@@ -21,5 +21,5 @@
     "scene77-vertex-output-C7G5u6Y0.js",
     "scene77.js"
   ],
-  "rawBytes": 59721
+  "rawBytes": 59717
 }

--- a/lab/public/bundle/manifest/scene77.json
+++ b/lab/public/bundle/manifest/scene77.json
@@ -21,5 +21,5 @@
     "scene77-vertex-output-C7G5u6Y0.js",
     "scene77.js"
   ],
-  "rawBytes": 59735
+  "rawBytes": 59721
 }

--- a/lab/public/bundle/manifest/scene78.json
+++ b/lab/public/bundle/manifest/scene78.json
@@ -29,5 +29,5 @@
     "scene78-vertex-output-C7G5u6Y0.js",
     "scene78.js"
   ],
-  "rawBytes": 58085
+  "rawBytes": 58071
 }

--- a/lab/public/bundle/manifest/scene78.json
+++ b/lab/public/bundle/manifest/scene78.json
@@ -29,5 +29,5 @@
     "scene78-vertex-output-C7G5u6Y0.js",
     "scene78.js"
   ],
-  "rawBytes": 58071
+  "rawBytes": 58067
 }

--- a/lab/public/bundle/manifest/scene79.json
+++ b/lab/public/bundle/manifest/scene79.json
@@ -23,5 +23,5 @@
     "scene79-wave-block-BSzEr0oO.js",
     "scene79.js"
   ],
-  "rawBytes": 61278
+  "rawBytes": 61264
 }

--- a/lab/public/bundle/manifest/scene79.json
+++ b/lab/public/bundle/manifest/scene79.json
@@ -23,5 +23,5 @@
     "scene79-wave-block-BSzEr0oO.js",
     "scene79.js"
   ],
-  "rawBytes": 61264
+  "rawBytes": 61260
 }

--- a/lab/public/bundle/manifest/scene8.json
+++ b/lab/public/bundle/manifest/scene8.json
@@ -11,5 +11,5 @@
     "scene8-singlelight-point-wgsl-DwaRtc_Q.js",
     "scene8.js"
   ],
-  "rawBytes": 76714
+  "rawBytes": 76700
 }

--- a/lab/public/bundle/manifest/scene8.json
+++ b/lab/public/bundle/manifest/scene8.json
@@ -5,11 +5,11 @@
   "runtimeChunks": [
     "scene8-background-hdr-skybox-SLLLfGoG.js",
     "scene8-ibl-fragment-CeRrvT96.js",
-    "scene8-pbr-renderable-DFUAelMn.js",
+    "scene8-pbr-renderable-BJ6i56S9.js",
     "scene8-scene-size-CBRA6KcU.js",
     "scene8-scene-uniforms-FTYH6Ct0.js",
     "scene8-singlelight-point-wgsl-DwaRtc_Q.js",
     "scene8.js"
   ],
-  "rawBytes": 76700
+  "rawBytes": 76699
 }

--- a/lab/public/bundle/manifest/scene80.json
+++ b/lab/public/bundle/manifest/scene80.json
@@ -20,5 +20,5 @@
     "scene80-vertex-output-C7G5u6Y0.js",
     "scene80.js"
   ],
-  "rawBytes": 60950
+  "rawBytes": 60931
 }

--- a/lab/public/bundle/manifest/scene80.json
+++ b/lab/public/bundle/manifest/scene80.json
@@ -20,5 +20,5 @@
     "scene80-vertex-output-C7G5u6Y0.js",
     "scene80.js"
   ],
-  "rawBytes": 60931
+  "rawBytes": 60927
 }

--- a/lab/public/bundle/manifest/scene81.json
+++ b/lab/public/bundle/manifest/scene81.json
@@ -20,5 +20,5 @@
     "scene81-vertex-output-C7G5u6Y0.js",
     "scene81.js"
   ],
-  "rawBytes": 67034
+  "rawBytes": 67030
 }

--- a/lab/public/bundle/manifest/scene81.json
+++ b/lab/public/bundle/manifest/scene81.json
@@ -20,5 +20,5 @@
     "scene81-vertex-output-C7G5u6Y0.js",
     "scene81.js"
   ],
-  "rawBytes": 67048
+  "rawBytes": 67034
 }

--- a/lab/public/bundle/manifest/scene82.json
+++ b/lab/public/bundle/manifest/scene82.json
@@ -24,5 +24,5 @@
     "scene82-worley-noise-3d-block-DvnzjY-o.js",
     "scene82.js"
   ],
-  "rawBytes": 66791
+  "rawBytes": 66787
 }

--- a/lab/public/bundle/manifest/scene82.json
+++ b/lab/public/bundle/manifest/scene82.json
@@ -24,5 +24,5 @@
     "scene82-worley-noise-3d-block-DvnzjY-o.js",
     "scene82.js"
   ],
-  "rawBytes": 66805
+  "rawBytes": 66791
 }

--- a/lab/public/bundle/manifest/scene83.json
+++ b/lab/public/bundle/manifest/scene83.json
@@ -28,5 +28,5 @@
     "scene83-vertex-output-C7G5u6Y0.js",
     "scene83.js"
   ],
-  "rawBytes": 70866
+  "rawBytes": 70854
 }

--- a/lab/public/bundle/manifest/scene83.json
+++ b/lab/public/bundle/manifest/scene83.json
@@ -28,5 +28,5 @@
     "scene83-vertex-output-C7G5u6Y0.js",
     "scene83.js"
   ],
-  "rawBytes": 70854
+  "rawBytes": 70859
 }

--- a/lab/public/bundle/manifest/scene84.json
+++ b/lab/public/bundle/manifest/scene84.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 83,
+  "rawKB": 83.0,
   "gzipKB": 35.6,
   "ignoredRawKB": 5.5,
   "runtimeChunks": [
@@ -24,5 +24,5 @@
     "scene84-vertex-output-C7G5u6Y0.js",
     "scene84.js"
   ],
-  "rawBytes": 85034
+  "rawBytes": 85024
 }

--- a/lab/public/bundle/manifest/scene84.json
+++ b/lab/public/bundle/manifest/scene84.json
@@ -24,5 +24,5 @@
     "scene84-vertex-output-C7G5u6Y0.js",
     "scene84.js"
   ],
-  "rawBytes": 85024
+  "rawBytes": 85017
 }

--- a/lab/public/bundle/manifest/scene85.json
+++ b/lab/public/bundle/manifest/scene85.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 59.3,
+  "rawKB": 59.2,
   "gzipKB": 26,
   "ignoredRawKB": 6.5,
   "runtimeChunks": [
@@ -20,5 +20,5 @@
     "scene85-vertex-output-C7G5u6Y0.js",
     "scene85.js"
   ],
-  "rawBytes": 60674
+  "rawBytes": 60660
 }

--- a/lab/public/bundle/manifest/scene85.json
+++ b/lab/public/bundle/manifest/scene85.json
@@ -20,5 +20,5 @@
     "scene85-vertex-output-C7G5u6Y0.js",
     "scene85.js"
   ],
-  "rawBytes": 60660
+  "rawBytes": 60656
 }

--- a/lab/public/bundle/manifest/scene86.json
+++ b/lab/public/bundle/manifest/scene86.json
@@ -23,5 +23,5 @@
     "scene86-vertex-output-C7G5u6Y0.js",
     "scene86.js"
   ],
-  "rawBytes": 59929
+  "rawBytes": 59915
 }

--- a/lab/public/bundle/manifest/scene86.json
+++ b/lab/public/bundle/manifest/scene86.json
@@ -23,5 +23,5 @@
     "scene86-vertex-output-C7G5u6Y0.js",
     "scene86.js"
   ],
-  "rawBytes": 59915
+  "rawBytes": 59911
 }

--- a/lab/public/bundle/manifest/scene87.json
+++ b/lab/public/bundle/manifest/scene87.json
@@ -19,5 +19,5 @@
     "scene87-vertex-output-C7G5u6Y0.js",
     "scene87.js"
   ],
-  "rawBytes": 94796
+  "rawBytes": 94792
 }

--- a/lab/public/bundle/manifest/scene87.json
+++ b/lab/public/bundle/manifest/scene87.json
@@ -19,5 +19,5 @@
     "scene87-vertex-output-C7G5u6Y0.js",
     "scene87.js"
   ],
-  "rawBytes": 94813
+  "rawBytes": 94796
 }

--- a/lab/public/bundle/manifest/scene88.json
+++ b/lab/public/bundle/manifest/scene88.json
@@ -24,5 +24,5 @@
     "scene88-vertex-output-C7G5u6Y0.js",
     "scene88.js"
   ],
-  "rawBytes": 60541
+  "rawBytes": 60527
 }

--- a/lab/public/bundle/manifest/scene88.json
+++ b/lab/public/bundle/manifest/scene88.json
@@ -24,5 +24,5 @@
     "scene88-vertex-output-C7G5u6Y0.js",
     "scene88.js"
   ],
-  "rawBytes": 60527
+  "rawBytes": 60523
 }

--- a/lab/public/bundle/manifest/scene89.json
+++ b/lab/public/bundle/manifest/scene89.json
@@ -24,5 +24,5 @@
     "scene89-vertex-output-C7G5u6Y0.js",
     "scene89.js"
   ],
-  "rawBytes": 59954
+  "rawBytes": 59950
 }

--- a/lab/public/bundle/manifest/scene89.json
+++ b/lab/public/bundle/manifest/scene89.json
@@ -1,5 +1,5 @@
 {
-  "rawKB": 58.6,
+  "rawKB": 58.5,
   "gzipKB": 26.6,
   "ignoredRawKB": 7.6,
   "runtimeChunks": [
@@ -24,5 +24,5 @@
     "scene89-vertex-output-C7G5u6Y0.js",
     "scene89.js"
   ],
-  "rawBytes": 59970
+  "rawBytes": 59954
 }

--- a/lab/public/bundle/manifest/scene9.json
+++ b/lab/public/bundle/manifest/scene9.json
@@ -13,5 +13,5 @@
     "scene9-std-specular-fragment-lgpgl8DR.js",
     "scene9.js"
   ],
-  "rawBytes": 61952
+  "rawBytes": 61939
 }

--- a/lab/public/bundle/manifest/scene9.json
+++ b/lab/public/bundle/manifest/scene9.json
@@ -13,5 +13,5 @@
     "scene9-std-specular-fragment-lgpgl8DR.js",
     "scene9.js"
   ],
-  "rawBytes": 61971
+  "rawBytes": 61952
 }

--- a/lab/public/bundle/manifest/scene90.json
+++ b/lab/public/bundle/manifest/scene90.json
@@ -7,5 +7,5 @@
     "scene90-standard-renderable-CdRf9hlg.js",
     "scene90.js"
   ],
-  "rawBytes": 60693
+  "rawBytes": 60681
 }

--- a/lab/public/bundle/manifest/scene90.json
+++ b/lab/public/bundle/manifest/scene90.json
@@ -7,5 +7,5 @@
     "scene90-standard-renderable-CdRf9hlg.js",
     "scene90.js"
   ],
-  "rawBytes": 60681
+  "rawBytes": 60679
 }

--- a/lab/public/bundle/manifest/scene91.json
+++ b/lab/public/bundle/manifest/scene91.json
@@ -1,6 +1,6 @@
 {
-  "rawKB": 57.9,
-  "rawBytes": 59250,
+  "rawKB": 57.8,
+  "rawBytes": 59236,
   "gzipKB": 23.4,
   "ignoredRawKB": 1451.1,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene91.json
+++ b/lab/public/bundle/manifest/scene91.json
@@ -1,6 +1,6 @@
 {
   "rawKB": 57.8,
-  "rawBytes": 59236,
+  "rawBytes": 59232,
   "gzipKB": 23.4,
   "ignoredRawKB": 1451.1,
   "runtimeChunks": [

--- a/lab/public/bundle/manifest/scene94.json
+++ b/lab/public/bundle/manifest/scene94.json
@@ -7,5 +7,5 @@
     "scene94-standard-renderable-CRuUFWr4.js",
     "scene94.js"
   ],
-  "rawBytes": 65301
+  "rawBytes": 65294
 }

--- a/lab/public/bundle/manifest/scene94.json
+++ b/lab/public/bundle/manifest/scene94.json
@@ -7,5 +7,5 @@
     "scene94-standard-renderable-CRuUFWr4.js",
     "scene94.js"
   ],
-  "rawBytes": 65294
+  "rawBytes": 65288
 }

--- a/lab/public/bundle/manifest/scene95.json
+++ b/lab/public/bundle/manifest/scene95.json
@@ -7,5 +7,5 @@
     "scene95-standard-renderable-Dm9EzkUk.js",
     "scene95.js"
   ],
-  "rawBytes": 66364
+  "rawBytes": 66360
 }

--- a/lab/public/bundle/manifest/scene95.json
+++ b/lab/public/bundle/manifest/scene95.json
@@ -7,5 +7,5 @@
     "scene95-standard-renderable-Dm9EzkUk.js",
     "scene95.js"
   ],
-  "rawBytes": 66378
+  "rawBytes": 66364
 }

--- a/lab/public/bundle/manifest/scene98.json
+++ b/lab/public/bundle/manifest/scene98.json
@@ -8,5 +8,5 @@
     "scene98-standard-renderable-aPXwOKJJ.js",
     "scene98.js"
   ],
-  "rawBytes": 61721
+  "rawBytes": 61713
 }

--- a/lab/public/bundle/manifest/scene98.json
+++ b/lab/public/bundle/manifest/scene98.json
@@ -8,5 +8,5 @@
     "scene98-standard-renderable-aPXwOKJJ.js",
     "scene98.js"
   ],
-  "rawBytes": 61735
+  "rawBytes": 61721
 }

--- a/lab/public/bundle/manifest/scene99.json
+++ b/lab/public/bundle/manifest/scene99.json
@@ -17,5 +17,5 @@
     "scene99-types-BVAXdTdf.js",
     "scene99.js"
   ],
-  "rawBytes": 94622
+  "rawBytes": 94608
 }

--- a/lab/public/bundle/manifest/scene99.json
+++ b/lab/public/bundle/manifest/scene99.json
@@ -12,10 +12,10 @@
     "scene99-gltf-feature-skeleton-CdNN_36B.js",
     "scene99-gltf-glb-parser-Bz7upPhi.js",
     "scene99-multilight-wgsl-CZoyLoRC.js",
-    "scene99-pbr-renderable-D55HyogB.js",
-    "scene99-skeleton-fragment-CBUAgJp7.js",
+    "scene99-pbr-renderable-Df33EXQU.js",
+    "scene99-skeleton-fragment-OUF0zj53.js",
     "scene99-types-BVAXdTdf.js",
     "scene99.js"
   ],
-  "rawBytes": 94608
+  "rawBytes": 94604
 }

--- a/packages/babylon-lite/src/engine/recovery-rebuild.ts
+++ b/packages/babylon-lite/src/engine/recovery-rebuild.ts
@@ -31,7 +31,7 @@ interface RecoverableRenderTask {
     _opaqueBindings: unknown[];
     _directBindings: unknown[];
     _transparentBindings: unknown[];
-    _opaqueBundles: unknown[];
+    _ob: unknown[];
     _lastVersion: number;
     _su: unknown[];
 }
@@ -111,7 +111,7 @@ function resetFrameGraphTasks(engine: EngineContext, scene: SceneContext): void 
         rt._opaqueBindings.length = 0;
         rt._directBindings.length = 0;
         rt._transparentBindings.length = 0;
-        rt._opaqueBundles.length = 0;
+        rt._ob.length = 0;
         rt._lastVersion = -1;
         rt._su.length = 0;
     }

--- a/packages/babylon-lite/src/engine/recovery-rebuild.ts
+++ b/packages/babylon-lite/src/engine/recovery-rebuild.ts
@@ -31,7 +31,7 @@ interface RecoverableRenderTask {
     _opaqueBindings: unknown[];
     _directBindings: unknown[];
     _transparentBindings: unknown[];
-    _ob: unknown[];
+    _opaqueBundles: unknown[];
     _lastVersion: number;
     _su: unknown[];
 }
@@ -111,7 +111,7 @@ function resetFrameGraphTasks(engine: EngineContext, scene: SceneContext): void 
         rt._opaqueBindings.length = 0;
         rt._directBindings.length = 0;
         rt._transparentBindings.length = 0;
-        rt._ob.length = 0;
+        rt._opaqueBundles.length = 0;
         rt._lastVersion = -1;
         rt._su.length = 0;
     }

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -24,8 +24,8 @@
  * The engine `scRT` is just another `RenderTarget` here: a task that
  * targets it (`rt`) or resolves into it (`rst`) re-reads its per-frame color view
  * at execute time (the swap texture is re-acquired each frame). `clr: false`
- * switches color + depth `loadOp` to `"load"` so multiple scenes can share the
- * swapchain in one frame (e.g., a 3D scene + a UI overlay scene).
+ * preserves color content, while `depthClear: false` preserves rt-owned depth,
+ * so multiple tasks can share a target in one frame.
  */
 
 import { F32 } from "../engine/typed-arrays.js";
@@ -78,9 +78,14 @@ export interface RenderTaskConfig {
     /** Background clear color. May be mutated frame-to-frame. */
     clrColor?: GPUColorDict;
     /** When true, color `loadOp` is "clear"; when false, "load" (overlays previous
-     *  color content). Depth is always cleared when rt-owned and always loaded when
-     *  supplied via `depth`. */
+     *  color content). Depth is cleared when rt-owned (unless `depthClear: false`) and
+     *  always loaded when supplied via `depth`. */
     clr?: boolean;
+    /** rt-owned depth `loadOp`. Default true = "clear" (unchanged behaviour). Set false so an
+     *  overlay task drawn into another task's target LOADS that target's existing depth and can
+     *  depth-test against the scene already rendered there. Ignored when `depth` is supplied
+     *  (an external depth is always loaded when eager, task-managed otherwise). */
+    depthClear?: boolean;
     /** Per-pass camera override. Null/undefined uses `scene.camera`. */
     cam?: Camera | null;
     /** Use canvas dimensions, not render-target dimensions, for this pass's scene UBO aspect. */
@@ -422,7 +427,9 @@ function buildRenderPassDescriptor(task: RenderTask, rt: RenderTarget): void {
     let depthAttachment: GPURenderPassDepthStencilAttachment | undefined;
     if (depthView) {
         const dd = depthSrc._descriptor;
-        const loadOp = task._depthLoadOp ?? "clear";
+        // rt-owned depth honours `depthClear: false` (overlay tasks keep the target's depth);
+        // an external `depth` keeps its established load/clear split via `_depthLoadOp`.
+        const loadOp = task._depthLoadOp ?? (task._config.depthClear === false ? "load" : "clear");
         depthAttachment = {
             view: depthView,
             depthClearValue: dd._depthClearValue ?? 0,

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -137,9 +137,6 @@ export interface RenderTask extends Task {
     _renderPassDescriptor: GPURenderPassDescriptor;
     /** @internal */
     _colorAttachment: GPURenderPassColorAttachment;
-    /** @internal Resolved depth/stencil `loadOp` override from external-depth ownership
-     *  or `depthClear: false`. When unset, defaults to `"clear"`. */
-    _depthLoadOp?: GPULoadOp;
 
     /** Per-task scene UBO + bind group. Created eagerly in createRenderTask
      *  so renderables can reference `_sceneBG` at `bind()` time. Written each
@@ -227,7 +224,6 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
         _recorded: false,
         _renderPassDescriptor: { colorAttachments: [colorAttachment] },
         _colorAttachment: colorAttachment,
-        _depthLoadOp: config.depth ? (config.depth._eager ? "load" : "clear") : config.depthClear === false ? "load" : undefined,
         _sceneUBO: sceneUBO,
         _sceneBG: sceneBG,
         _lightsUBO: lightsUBO,
@@ -409,21 +405,22 @@ function buildBindings(task: RenderTask, eng: EngineContext, targetSignature: Re
 }
 
 function buildRenderPassDescriptor(task: RenderTask, rt: RenderTarget): void {
+    const config = task._config;
     const att = task._colorAttachment;
     att.view = rt._colorView!;
     // End-of-pass MSAA resolve into a caller-supplied single-sample target.
     // record() only builds the target's color view for an MSAA rt, so its
     // presence is the gate. The swapchain case is wired per-frame in
     // executePass (its view changes each frame); this custom view is stable.
-    att.resolveTarget = task._config.rst?._colorView ?? undefined;
+    att.resolveTarget = config.rst?._colorView ?? undefined;
     task._renderPassDescriptor.colorAttachments = rt._colorView ? [att] : [];
 
-    const depthSrc = task._config.depth ?? rt;
+    const depthSrc = config.depth ?? rt;
     const depthView = depthSrc._depthView;
     let depthAttachment: GPURenderPassDepthStencilAttachment | undefined;
     if (depthView) {
         const dd = depthSrc._descriptor;
-        const loadOp = task._depthLoadOp ?? "clear";
+        const loadOp = (config.depth ? depthSrc._eager : config.depthClear === false) ? "load" : "clear";
         depthAttachment = {
             view: depthView,
             depthClearValue: dd._depthClearValue ?? 0,

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -79,7 +79,7 @@ export interface RenderTaskConfig {
     clrColor?: GPUColorDict;
     /** When true, color `loadOp` is "clear"; when false, "load" (overlays previous
      *  color content). Depth is cleared when rt-owned (unless `depthClear: false`) and
-     *  always loaded when supplied via `depth`. */
+     *  follows the eager/task-managed ownership policy when supplied via `depth`. */
     clr?: boolean;
     /** rt-owned depth `loadOp`. Default true = "clear" (unchanged behaviour). Set false so an
      *  overlay task drawn into another task's target LOADS that target's existing depth and can
@@ -137,11 +137,8 @@ export interface RenderTask extends Task {
     _renderPassDescriptor: GPURenderPassDescriptor;
     /** @internal */
     _colorAttachment: GPURenderPassColorAttachment;
-    /** @internal External depth source from `config.depth`. When unset,
-     *  the pass uses `config.rt._depthView`. */
-    _depthSrc?: RenderTarget;
-    /** @internal External depth/stencil `loadOp` ("load" when `config.depth` is
-     *  set). When unset, defaults to `"clear"`. */
+    /** @internal Resolved depth/stencil `loadOp` override from external-depth ownership
+     *  or `depthClear: false`. When unset, defaults to `"clear"`. */
     _depthLoadOp?: GPULoadOp;
 
     /** Per-task scene UBO + bind group. Created eagerly in createRenderTask
@@ -230,8 +227,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
         _recorded: false,
         _renderPassDescriptor: { colorAttachments: [colorAttachment] },
         _colorAttachment: colorAttachment,
-        _depthSrc: config.depth,
-        _depthLoadOp: config.depth ? (config.depth._eager ? "load" : "clear") : undefined,
+        _depthLoadOp: config.depth ? (config.depth._eager ? "load" : "clear") : config.depthClear === false ? "load" : undefined,
         _sceneUBO: sceneUBO,
         _sceneBG: sceneBG,
         _lightsUBO: lightsUBO,
@@ -422,14 +418,12 @@ function buildRenderPassDescriptor(task: RenderTask, rt: RenderTarget): void {
     att.resolveTarget = task._config.rst?._colorView ?? undefined;
     task._renderPassDescriptor.colorAttachments = rt._colorView ? [att] : [];
 
-    const depthSrc = task._depthSrc ?? rt;
+    const depthSrc = task._config.depth ?? rt;
     const depthView = depthSrc._depthView;
     let depthAttachment: GPURenderPassDepthStencilAttachment | undefined;
     if (depthView) {
         const dd = depthSrc._descriptor;
-        // rt-owned depth honours `depthClear: false` (overlay tasks keep the target's depth);
-        // an external `depth` keeps its established load/clear split via `_depthLoadOp`.
-        const loadOp = task._depthLoadOp ?? (task._config.depthClear === false ? "load" : "clear");
+        const loadOp = task._depthLoadOp ?? "clear";
         depthAttachment = {
             view: depthView,
             depthClearValue: dd._depthClearValue ?? 0,

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -86,6 +86,11 @@ export interface RenderTaskConfig {
      *  depth-test against the scene already rendered there. Ignored when `depth` is supplied
      *  (an external depth is always loaded when eager, task-managed otherwise). */
     depthClear?: boolean;
+    /** This task draws into a target OWNED BY ANOTHER TASK: it neither builds nor disposes `rt`/
+     *  `rst` (the owner does; `record()` here only wires the pass to the owner's live views, so
+     *  the owning task must be recorded first — place this task after it). Pair with `clr: false`
+     *  and `depthClear: false` for a full overlay pass. Default false. */
+    sharedRt?: boolean;
     /** Per-pass camera override. Null/undefined uses `scene.camera`. */
     cam?: Camera | null;
     /** Use canvas dimensions, not render-target dimensions, for this pass's scene UBO aspect. */
@@ -96,6 +101,9 @@ export interface RenderTaskConfig {
      *  `grabDepth: true` also snapshots the task's DEPTH attachment at the same mid-pass grab (see
      *  `TransmissionOptions.grabDepth`). */
     transmission?: { copyCount?: number; generateMipmaps?: boolean; mipLevelCount?: number; grabDepth?: boolean };
+    /** Set false for an explicit render list that never auto-mirrors the scene's renderables,
+     *  even while the task list is empty. Undefined preserves the default auto-mirror behavior. */
+    autoMirror?: boolean;
     /** @internal Skip clustered-light preparation for passes that never run forward lighting. */
     _skipClusteredLights?: boolean;
 }
@@ -103,6 +111,12 @@ export interface RenderTaskConfig {
 /** A frame-graph task that records a single `RenderPass`, binds the scene's `RenderTarget`, and draws renderables into it. */
 export interface RenderTask extends Task {
     readonly name: string;
+    /** App-driven execute gate, default true. When false the pass is skipped entirely — no
+     *  attachment load, no MSAA resolve, no draws. The owner that KNOWS the task's content toggles
+     *  this (e.g. when its last mesh hides); the engine never scans bindings to decide. Disabling a
+     *  task that owns its target leaves the target's previous content stale — meant for overlay
+     *  tasks (`sharedRt`/`clr: false`), where skipping is a semantic no-op. */
+    enabled: boolean;
     /** Render tasks are scene-bound because they consume scene camera, lights, and renderables. */
     readonly scene: SceneContext;
     /** Live task configuration. Mutating `clr` or `clrColor` affects subsequent frames. */
@@ -209,6 +223,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
     const updateContext: MutableDrawUpdateContext = { targetWidth: 0, targetHeight: 0 };
     const task: RenderTask = {
         name: config.name,
+        enabled: true,
         _config: config,
         engine: engine,
         scene: sc,
@@ -255,16 +270,20 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
                 task._renderables.length = 0;
             }
             resolvePendingMeshes(task, sc);
-            task._autoFromScene = !task._renderables.length;
+            task._autoFromScene = config.autoMirror === false ? false : !task._renderables.length;
             if (task._autoFromScene) {
                 task._renderables.push(...sc._renderables);
             }
             // Read config.rt dynamically — transmission retargeting swaps it after
             // the task is created, and the engine scRT must never be rebuilt.
             const rt = config.rt;
-            buildRenderTarget(rt, engine);
-            if (config.rst && (rt._descriptor.samples ?? 1) > 1) {
-                buildRenderTarget(config.rst, engine);
+            // A shared target belongs to another task: (re)building it here would destroy the
+            // textures the owner's recorded pass still references.
+            if (!config.sharedRt) {
+                buildRenderTarget(rt, engine);
+                if (config.rst && (rt._descriptor.samples ?? 1) > 1) {
+                    buildRenderTarget(config.rst, engine);
+                }
             }
             // A non-eager external depth (e.g. the default single-sample scene task's
             // depth, whose colour rt is the depth-less scRT) is task-managed:
@@ -287,9 +306,12 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
             task._passes.length = 0;
             // disposeRenderTarget no-ops on the engine scRT and on eager
             // GeometryRendererTask depth outputs (both `_eager`), and on an undefined
-            // rst/depth — so these can be passed unconditionally.
-            disposeRenderTarget(config.rt);
-            disposeRenderTarget(config.rst);
+            // rst/depth — so these can be passed unconditionally. A shared target remains
+            // owned by the task that created it.
+            if (!config.sharedRt) {
+                disposeRenderTarget(config.rt);
+                disposeRenderTarget(config.rst);
+            }
             disposeRenderTarget(config.depth);
             task._opaqueBindings.length = 0;
             task._directBindings.length = 0;
@@ -477,6 +499,9 @@ function prepareRenderTaskPass(task: RenderTask, eng: EngineContext, targetSigna
 }
 
 function executePass(task: RenderTask, eng: EngineContext, targetSignature: RenderTargetSignature, context: DrawUpdateContext): number {
+    if (!task.enabled) {
+        return 0;
+    }
     const sc = task.scene;
     const sampleCount = targetSignature._sampleCount;
     prepareRenderTaskPass(task, eng, targetSignature, context);

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -138,7 +138,7 @@ export interface RenderTask extends Task {
     /** Cached opaque render bundle. Invalidated by renderable list mutations
      *  (`_lastVersion`) and the global visibility/resource epoch (`_lastVis`). */
     /** @internal */
-    _ob: GPURenderBundle[];
+    _opaqueBundles: GPURenderBundle[];
     /** @internal */
     _lastVersion: number;
     /** @internal */
@@ -196,7 +196,6 @@ interface MutableDrawUpdateContext {
  *  Swapchain-targeted tasks acquire the swap view per-frame at execute time. */
 export function createRenderTask(config: RenderTaskConfig, engine: EngineContext, scene: SceneContext): RenderTask {
     const sc = scene as SceneContext;
-    config.clrColor ??= { r: 0.2, g: 0.2, b: 0.3, a: 1.0 };
     config.clr ??= true;
     const desc = config.rt._descriptor;
     // Render upright: row 0 of the GPU texture is the top of the scene. Every
@@ -233,7 +232,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
         _opaqueBindings: [],
         _directBindings: [],
         _transparentBindings: [],
-        _ob: [],
+        _opaqueBundles: [],
         _lastVersion: -1,
         _lastVis: 0,
         _recorded: false,
@@ -303,13 +302,8 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
             return executePass(task, engine, targetSignature, updateContext);
         },
         dispose(): void {
-            task._passes.length =
-                task._opaqueBindings.length =
-                task._directBindings.length =
-                task._transparentBindings.length =
-                task._renderables.length =
-                task._ob.length =
-                    0;
+            task._passes.length = task._opaqueBindings.length = task._directBindings.length = 0;
+            task._transparentBindings.length = task._renderables.length = task._opaqueBundles.length = 0;
             // disposeRenderTarget no-ops on the engine scRT and on eager
             // GeometryRendererTask depth outputs (both `_eager`), and on an undefined
             // rst/depth — so these can be passed unconditionally. A shared target remains
@@ -358,7 +352,7 @@ export function removeMeshFromTask(task: RenderTask, mesh: object): void {
         }
     }
     if (removed) {
-        task._ob.length = 0;
+        task._opaqueBundles.length = 0;
         task._lastVersion = -1;
     }
 }
@@ -421,7 +415,7 @@ function buildBindings(task: RenderTask, eng: EngineContext, targetSignature: Re
     }
     opaque.sort((a, b) => a.renderable.order - b.renderable.order);
     direct.sort((a, b) => a.renderable.order - b.renderable.order);
-    task._ob.length = 0;
+    task._opaqueBundles.length = 0;
     task._lastVersion = (task.scene as SceneContext)._renderableVersion;
 }
 
@@ -517,7 +511,7 @@ function executePass(task: RenderTask, eng: EngineContext, targetSignature: Rend
         }
         att.resolveTarget = cfg.rst?._colorView ?? undefined;
         att.clearValue = cfg.clrColor ?? sc.clearColor;
-        att.loadOp = cfg.clr === false ? "load" : "clear";
+        att.loadOp = cfg.clr ? "clear" : "load";
     }
     if (task._executeWithTransmission) {
         return task._executeWithTransmission(sampleCount);
@@ -537,7 +531,7 @@ function executePassBody(task: RenderTask, pass: GPURenderPassEncoder): number {
     const rt = cfg.rt;
     const scene = task.scene as SceneContext;
     const opaqueBindings = task._opaqueBindings;
-    const opaqueBundles = task._ob;
+    const opaqueBundles = task._opaqueBundles;
     const sceneBG = task._sceneBG;
 
     const camera = cfg.cam ?? scene.camera;
@@ -597,7 +591,7 @@ function refreshTaskSceneBindGroup(task: RenderTask, eng: EngineContext): void {
             { binding: 1, resource: { buffer: lightsUBO } },
         ],
     });
-    task._ob.length = 0;
+    task._opaqueBundles.length = 0;
     task._lastVersion = -1;
 }
 

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -138,7 +138,7 @@ export interface RenderTask extends Task {
     /** Cached opaque render bundle. Invalidated by renderable list mutations
      *  (`_lastVersion`) and the global visibility/resource epoch (`_lastVis`). */
     /** @internal */
-    _opaqueBundles: GPURenderBundle[];
+    _ob: GPURenderBundle[];
     /** @internal */
     _lastVersion: number;
     /** @internal */
@@ -232,7 +232,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
         _opaqueBindings: [],
         _directBindings: [],
         _transparentBindings: [],
-        _opaqueBundles: [],
+        _ob: [],
         _lastVersion: -1,
         _lastVis: 0,
         _recorded: false,
@@ -303,7 +303,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
         },
         dispose(): void {
             task._passes.length = task._opaqueBindings.length = task._directBindings.length = 0;
-            task._transparentBindings.length = task._renderables.length = task._opaqueBundles.length = 0;
+            task._transparentBindings.length = task._renderables.length = task._ob.length = 0;
             // disposeRenderTarget no-ops on the engine scRT and on eager
             // GeometryRendererTask depth outputs (both `_eager`), and on an undefined
             // rst/depth — so these can be passed unconditionally. A shared target remains
@@ -352,7 +352,7 @@ export function removeMeshFromTask(task: RenderTask, mesh: object): void {
         }
     }
     if (removed) {
-        task._opaqueBundles.length = 0;
+        task._ob.length = 0;
         task._lastVersion = -1;
     }
 }
@@ -415,7 +415,7 @@ function buildBindings(task: RenderTask, eng: EngineContext, targetSignature: Re
     }
     opaque.sort((a, b) => a.renderable.order - b.renderable.order);
     direct.sort((a, b) => a.renderable.order - b.renderable.order);
-    task._opaqueBundles.length = 0;
+    task._ob.length = 0;
     task._lastVersion = (task.scene as SceneContext)._renderableVersion;
 }
 
@@ -531,7 +531,7 @@ function executePassBody(task: RenderTask, pass: GPURenderPassEncoder): number {
     const rt = cfg.rt;
     const scene = task.scene as SceneContext;
     const opaqueBindings = task._opaqueBindings;
-    const opaqueBundles = task._opaqueBundles;
+    const opaqueBundles = task._ob;
     const sceneBG = task._sceneBG;
 
     const camera = cfg.cam ?? scene.camera;
@@ -591,7 +591,7 @@ function refreshTaskSceneBindGroup(task: RenderTask, eng: EngineContext): void {
             { binding: 1, resource: { buffer: lightsUBO } },
         ],
     });
-    task._opaqueBundles.length = 0;
+    task._ob.length = 0;
     task._lastVersion = -1;
 }
 

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -123,7 +123,7 @@ export interface RenderTask extends Task {
     /** @internal */
     readonly _config: RenderTaskConfig;
     /** @internal */
-    _autoFromScene: boolean;
+    _af: boolean;
 
     /** Source-of-truth renderables. Bucketed binding lists below are derived from
      *  this list at `record()` (or re-sync when auto-filled and `_renderableVersion` changes). */
@@ -228,7 +228,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
         engine: engine,
         scene: sc,
         _passes: [],
-        _autoFromScene: false,
+        _af: false,
         _renderables: [],
         _opaqueBindings: [],
         _directBindings: [],
@@ -259,19 +259,19 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
                 // shared scene UBO + every task's render target mid-frame and crashes the in-flight submit).
                 resolvePendingMeshes(task, sc);
                 // A live add makes the render list explicit (mirrors record(), where a pending mesh forces
-                // _autoFromScene = false). Without this, an auto-mirroring task's next scene-version resync in
+                // _af = false). Without this, an auto-mirroring task's next scene-version resync in
                 // prepareRenderTaskPass would clear _renderables and drop the just-added mesh.
-                task._autoFromScene = false;
+                task._af = false;
                 buildBindings(task, engine, targetSignature);
             }
         },
         record(): void {
-            if (task._autoFromScene) {
+            if (task._af) {
                 task._renderables.length = 0;
             }
             resolvePendingMeshes(task, sc);
-            task._autoFromScene = config.autoMirror === false ? false : !task._renderables.length;
-            if (task._autoFromScene) {
+            task._af = config.autoMirror !== false && !task._renderables.length;
+            if (task._af) {
                 task._renderables.push(...sc._renderables);
             }
             // Read config.rt dynamically — transmission retargeting swaps it after
@@ -462,7 +462,7 @@ function buildRenderPassDescriptor(task: RenderTask, rt: RenderTarget): void {
 function prepareRenderTaskPass(task: RenderTask, eng: EngineContext, targetSignature: RenderTargetSignature, context: DrawUpdateContext): void {
     const sc = task.scene as SceneContext;
     // Auto-resync when the source scene mutates.
-    if (task._autoFromScene && task._lastVersion !== sc._renderableVersion) {
+    if (task._af && task._lastVersion !== sc._renderableVersion) {
         task._renderables.length = 0;
         task._renderables.push(...sc._renderables);
         buildBindings(task, eng, targetSignature);
@@ -517,7 +517,7 @@ function executePass(task: RenderTask, eng: EngineContext, targetSignature: Rend
             att.view = cfg.rt._colorView;
         }
         att.resolveTarget = cfg.rst?._colorView ?? undefined;
-        att.clearValue = task._autoFromScene ? sc.clearColor : cfg.clrColor!;
+        att.clearValue = task._af ? sc.clearColor : cfg.clrColor!;
         att.loadOp = cfg.clr ? "clear" : "load";
     }
     if (task._executeWithTransmission) {

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -116,14 +116,14 @@ export interface RenderTask extends Task {
      *  this (e.g. when its last mesh hides); the engine never scans bindings to decide. Disabling a
      *  task that owns its target leaves the target's previous content stale — meant for overlay
      *  tasks (`sharedRt`/`clr: false`), where skipping is a semantic no-op. */
-    enabled: boolean;
+    enabled?: boolean;
     /** Render tasks are scene-bound because they consume scene camera, lights, and renderables. */
     readonly scene: SceneContext;
     /** Live task configuration. Mutating `clr` or `clrColor` affects subsequent frames. */
     /** @internal */
     readonly _config: RenderTaskConfig;
     /** @internal */
-    _af: boolean;
+    _af?: boolean;
 
     /** Source-of-truth renderables. Bucketed binding lists below are derived from
      *  this list at `record()` (or re-sync when auto-filled and `_renderableVersion` changes). */
@@ -221,14 +221,14 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
     });
     const colorAttachment = { loadOp: "clear", storeOp: "store" } as GPURenderPassColorAttachment;
     const updateContext: MutableDrawUpdateContext = { targetWidth: 0, targetHeight: 0 };
+    const autoMirror = config.autoMirror !== false;
+    const ownsRt = !config.sharedRt;
     const task: RenderTask = {
         name: config.name,
-        enabled: true,
         _config: config,
         engine: engine,
         scene: sc,
         _passes: [],
-        _af: false,
         _renderables: [],
         _opaqueBindings: [],
         _directBindings: [],
@@ -270,7 +270,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
                 task._renderables.length = 0;
             }
             resolvePendingMeshes(task, sc);
-            task._af = config.autoMirror !== false && !task._renderables.length;
+            task._af = autoMirror && !task._renderables.length;
             if (task._af) {
                 task._renderables.push(...sc._renderables);
             }
@@ -279,7 +279,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
             const rt = config.rt;
             // A shared target belongs to another task: (re)building it here would destroy the
             // textures the owner's recorded pass still references.
-            if (!config.sharedRt) {
+            if (ownsRt) {
                 buildRenderTarget(rt, engine);
                 if (config.rst && (rt._descriptor.samples ?? 1) > 1) {
                     buildRenderTarget(config.rst, engine);
@@ -303,21 +303,22 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
             return executePass(task, engine, targetSignature, updateContext);
         },
         dispose(): void {
-            task._passes.length = 0;
+            task._passes.length =
+                task._opaqueBindings.length =
+                task._directBindings.length =
+                task._transparentBindings.length =
+                task._renderables.length =
+                task._opaqueBundles.length =
+                    0;
             // disposeRenderTarget no-ops on the engine scRT and on eager
             // GeometryRendererTask depth outputs (both `_eager`), and on an undefined
             // rst/depth — so these can be passed unconditionally. A shared target remains
             // owned by the task that created it.
-            if (!config.sharedRt) {
+            if (ownsRt) {
                 disposeRenderTarget(config.rt);
                 disposeRenderTarget(config.rst);
             }
             disposeRenderTarget(config.depth);
-            task._opaqueBindings.length = 0;
-            task._directBindings.length = 0;
-            task._transparentBindings.length = 0;
-            task._renderables.length = 0;
-            task._opaqueBundles.length = 0;
             task._sceneUBO.destroy();
             for (const batch of task._updateBatches) {
                 batch.destroy();
@@ -402,9 +403,7 @@ function buildBindings(task: RenderTask, eng: EngineContext, targetSignature: Re
     const opaque = task._opaqueBindings;
     const direct = task._directBindings;
     const transparent = task._transparentBindings;
-    opaque.length = 0;
-    direct.length = 0;
-    transparent.length = 0;
+    opaque.length = direct.length = transparent.length = 0;
     for (const r of task._renderables) {
         const binding = r.bind(eng, targetSignature);
         for (const batch of binding._updateBatches ?? []) {
@@ -499,7 +498,7 @@ function prepareRenderTaskPass(task: RenderTask, eng: EngineContext, targetSigna
 }
 
 function executePass(task: RenderTask, eng: EngineContext, targetSignature: RenderTargetSignature, context: DrawUpdateContext): number {
-    if (!task.enabled) {
+    if (task.enabled === false) {
         return 0;
     }
     const sc = task.scene;

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -138,7 +138,7 @@ export interface RenderTask extends Task {
     /** Cached opaque render bundle. Invalidated by renderable list mutations
      *  (`_lastVersion`) and the global visibility/resource epoch (`_lastVis`). */
     /** @internal */
-    _opaqueBundles: GPURenderBundle[];
+    _ob: GPURenderBundle[];
     /** @internal */
     _lastVersion: number;
     /** @internal */
@@ -233,7 +233,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
         _opaqueBindings: [],
         _directBindings: [],
         _transparentBindings: [],
-        _opaqueBundles: [],
+        _ob: [],
         _lastVersion: -1,
         _lastVis: 0,
         _recorded: false,
@@ -308,7 +308,7 @@ export function createRenderTask(config: RenderTaskConfig, engine: EngineContext
                 task._directBindings.length =
                 task._transparentBindings.length =
                 task._renderables.length =
-                task._opaqueBundles.length =
+                task._ob.length =
                     0;
             // disposeRenderTarget no-ops on the engine scRT and on eager
             // GeometryRendererTask depth outputs (both `_eager`), and on an undefined
@@ -358,7 +358,7 @@ export function removeMeshFromTask(task: RenderTask, mesh: object): void {
         }
     }
     if (removed) {
-        task._opaqueBundles.length = 0;
+        task._ob.length = 0;
         task._lastVersion = -1;
     }
 }
@@ -421,7 +421,7 @@ function buildBindings(task: RenderTask, eng: EngineContext, targetSignature: Re
     }
     opaque.sort((a, b) => a.renderable.order - b.renderable.order);
     direct.sort((a, b) => a.renderable.order - b.renderable.order);
-    task._opaqueBundles.length = 0;
+    task._ob.length = 0;
     task._lastVersion = (task.scene as SceneContext)._renderableVersion;
 }
 
@@ -516,8 +516,8 @@ function executePass(task: RenderTask, eng: EngineContext, targetSignature: Rend
             att.view = cfg.rt._colorView;
         }
         att.resolveTarget = cfg.rst?._colorView ?? undefined;
-        att.clearValue = task._af ? sc.clearColor : cfg.clrColor!;
-        att.loadOp = cfg.clr ? "clear" : "load";
+        att.clearValue = cfg.clrColor ?? sc.clearColor;
+        att.loadOp = cfg.clr === false ? "load" : "clear";
     }
     if (task._executeWithTransmission) {
         return task._executeWithTransmission(sampleCount);
@@ -537,7 +537,7 @@ function executePassBody(task: RenderTask, pass: GPURenderPassEncoder): number {
     const rt = cfg.rt;
     const scene = task.scene as SceneContext;
     const opaqueBindings = task._opaqueBindings;
-    const opaqueBundles = task._opaqueBundles;
+    const opaqueBundles = task._ob;
     const sceneBG = task._sceneBG;
 
     const camera = cfg.cam ?? scene.camera;
@@ -597,7 +597,7 @@ function refreshTaskSceneBindGroup(task: RenderTask, eng: EngineContext): void {
             { binding: 1, resource: { buffer: lightsUBO } },
         ],
     });
-    task._opaqueBundles.length = 0;
+    task._ob.length = 0;
     task._lastVersion = -1;
 }
 

--- a/packages/babylon-lite/src/frame-graph/transmission.ts
+++ b/packages/babylon-lite/src/frame-graph/transmission.ts
@@ -253,7 +253,7 @@ function retargetRenderTaskToLinearOffscreen(task: RenderTask): void {
     sig._depthStencilFormat = cfg.depth?._descriptor.dFormat ?? newRt._descriptor.dFormat;
     sig._depthCompare = newRt._descriptor._depthCompare;
     sig._sampleCount = sampleCount;
-    task._ob.length = 0;
+    task._opaqueBundles.length = 0;
     task._lastVersion = -1;
 }
 
@@ -575,7 +575,7 @@ function drawBaseTask(task: RenderTask, pass: GPURenderPassEncoder): number {
     const rt = task._config.rt;
     const scene = task.scene;
     const opaqueBindings = task._opaqueBindings;
-    const opaqueBundles = task._ob;
+    const opaqueBundles = task._opaqueBundles;
 
     setPassState(task, pass);
 

--- a/packages/babylon-lite/src/frame-graph/transmission.ts
+++ b/packages/babylon-lite/src/frame-graph/transmission.ts
@@ -253,7 +253,7 @@ function retargetRenderTaskToLinearOffscreen(task: RenderTask): void {
     sig._depthStencilFormat = cfg.depth?._descriptor.dFormat ?? newRt._descriptor.dFormat;
     sig._depthCompare = newRt._descriptor._depthCompare;
     sig._sampleCount = sampleCount;
-    task._opaqueBundles.length = 0;
+    task._ob.length = 0;
     task._lastVersion = -1;
 }
 
@@ -575,7 +575,7 @@ function drawBaseTask(task: RenderTask, pass: GPURenderPassEncoder): number {
     const rt = task._config.rt;
     const scene = task.scene;
     const opaqueBindings = task._opaqueBindings;
-    const opaqueBundles = task._opaqueBundles;
+    const opaqueBundles = task._ob;
 
     setPassState(task, pass);
 

--- a/packages/babylon-lite/src/material/shader/shader-material.ts
+++ b/packages/babylon-lite/src/material/shader/shader-material.ts
@@ -299,7 +299,8 @@ export function createShaderMaterial(options: ShaderMaterialOptions): ShaderMate
     }
     defines.sort((a, b) => a.name.localeCompare(b.name));
 
-    if (options.transmissive && !(options.needAlphaBlending ?? false)) {
+    const needAlphaBlending = options.needAlphaBlending ?? !!options.blend;
+    if (options.transmissive && !needAlphaBlending) {
         throw new Error("ShaderMaterial: `transmissive` requires `needAlphaBlending` (the surface composites over the grabbed opaque scene color).");
     }
 
@@ -313,7 +314,7 @@ export function createShaderMaterial(options: ShaderMaterialOptions): ShaderMate
         storageBufferDecls,
         defines,
         _tic: options.useThinInstanceColors,
-        needAlphaBlending: options.needAlphaBlending ?? false,
+        needAlphaBlending,
         blendMode: options.blendMode ?? "alpha",
         ...(options.blend ? { blend: options.blend } : {}),
         transmissive: options.transmissive ?? false,
@@ -321,7 +322,7 @@ export function createShaderMaterial(options: ShaderMaterialOptions): ShaderMate
         backFaceCulling: options.backFaceCulling ?? true,
         // Blended materials default to depth-read-only; an explicit option always wins (see the
         // ShaderMaterialOptions doc). Opaque materials keep the depth-writing default.
-        depthWrite: options.depthWrite ?? !(options.needAlphaBlending ?? false),
+        depthWrite: options.depthWrite ?? !needAlphaBlending,
         depthCompare: options.depthCompare ?? "greater-equal",
         depthOnlyFragment: options.depthOnlyFragment ?? false,
         depthBias: options.depthBias ?? 0,

--- a/packages/babylon-lite/src/material/shader/shader-material.ts
+++ b/packages/babylon-lite/src/material/shader/shader-material.ts
@@ -47,6 +47,10 @@ export interface ShaderMaterialOptions {
      *  standard src-over; "additive" adds the fragment's premultiplied-by-alpha
      *  color to the framebuffer, which is the right choice for glows/light FX. */
     readonly blendMode?: "alpha" | "additive";
+    /** Explicit color-target blend state. When provided it REPLACES the blend `needAlphaBlending`/
+     *  `blendMode` would have chosen entirely — e.g. a material compositing color as ordinary
+     *  src-over while stamping the target's ALPHA channel to a fixed value (alpha zero/zero). */
+    readonly blend?: GPUBlendState;
     /** Mark this surface as transmissive/refractive: the renderer grabs the opaque scene color
      *  behind it just before it draws, so the fragment can sample what is *through* it (water,
      *  glass). Requires `needAlphaBlending` (the surface composites over the grabbed scene
@@ -137,6 +141,8 @@ export interface ShaderMaterial extends Material {
     readonly _tic?: boolean | 0;
     readonly needAlphaBlending: boolean;
     readonly blendMode: "alpha" | "additive";
+    /** Explicit blend-state override (see `ShaderMaterialOptions.blend`). */
+    readonly blend?: GPUBlendState;
     /** True for transmissive/refractive surfaces (see `ShaderMaterialOptions.transmissive`). */
     readonly transmissive: boolean;
     readonly needAlphaTesting: boolean;
@@ -309,6 +315,7 @@ export function createShaderMaterial(options: ShaderMaterialOptions): ShaderMate
         _tic: options.useThinInstanceColors,
         needAlphaBlending: options.needAlphaBlending ?? false,
         blendMode: options.blendMode ?? "alpha",
+        ...(options.blend ? { blend: options.blend } : {}),
         transmissive: options.transmissive ?? false,
         needAlphaTesting: options.needAlphaTesting ?? false,
         backFaceCulling: options.backFaceCulling ?? true,

--- a/packages/babylon-lite/src/material/shader/shader-pipeline-cache.ts
+++ b/packages/babylon-lite/src/material/shader/shader-pipeline-cache.ts
@@ -83,6 +83,9 @@ function getDeviceCache(device: GPUDevice): DeviceCache {
                 ]),
                 material.needAlphaBlending,
                 material.blendMode,
+                // The explicit blend override participates in the cross-material key: two materials
+                // sharing modules but differing only by `blend` must not collide on one pipeline.
+                material.blend ?? null,
                 material.depthWrite,
                 material.depthCompare,
                 material.backFaceCulling,

--- a/packages/babylon-lite/src/material/shader/shader-pipeline.ts
+++ b/packages/babylon-lite/src/material/shader/shader-pipeline.ts
@@ -145,20 +145,24 @@ export function getOrCreateShaderPipeline(
     const colorTarget: GPUColorTargetState | null = sig._colorFormat
         ? {
               format: sig._colorFormat,
-              ...(material.needAlphaBlending
-                  ? {
-                        blend:
-                            material.blendMode === "additive"
-                                ? ({
-                                      color: { srcFactor: "src-alpha", dstFactor: "one", operation: "add" },
-                                      alpha: { srcFactor: "one", dstFactor: "one", operation: "add" },
-                                  } satisfies GPUBlendState)
-                                : ({
-                                      color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha", operation: "add" },
-                                      alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha", operation: "add" },
-                                  } satisfies GPUBlendState),
-                    }
-                  : {}),
+              // An explicit material.blend REPLACES the needAlphaBlending-derived state entirely
+              // (see ShaderMaterialOptions.blend).
+              ...(material.blend
+                  ? { blend: material.blend }
+                  : material.needAlphaBlending
+                    ? {
+                          blend:
+                              material.blendMode === "additive"
+                                  ? ({
+                                        color: { srcFactor: "src-alpha", dstFactor: "one", operation: "add" },
+                                        alpha: { srcFactor: "one", dstFactor: "one", operation: "add" },
+                                    } satisfies GPUBlendState)
+                                  : ({
+                                        color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha", operation: "add" },
+                                        alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha", operation: "add" },
+                                    } satisfies GPUBlendState),
+                      }
+                    : {}),
           }
         : null;
 

--- a/packages/babylon-lite/src/scene/scene-core.ts
+++ b/packages/babylon-lite/src/scene/scene-core.ts
@@ -310,7 +310,7 @@ export function createSceneContext(surface: SurfaceContext, options?: SceneConte
             ? createRenderTarget({ lbl: "scene-color", format: surface.format, dFormat: "depth24plus-stencil8", samples: surface.msaaSamples, size: surface })
             : surface.scRT;
         const depth = msaa ? undefined : createRenderTarget({ lbl: "scene-depth", dFormat: "depth24plus-stencil8", samples: 1, size: surface });
-        _appendTask(fg, createRenderTask({ name: "scene", rt, rst: msaa ? surface.scRT : undefined, depth, clrColor: ctx.clearColor }, eng, ctx));
+        _appendTask(fg, createRenderTask({ name: "scene", rt, rst: msaa ? surface.scRT : undefined, depth }, eng, ctx));
     }
     ctx._disposables.push(() => fg.dispose());
     return ctx;

--- a/tests/lite/unit/render-pass-task.test.ts
+++ b/tests/lite/unit/render-pass-task.test.ts
@@ -779,7 +779,7 @@ describe("RenderPassTask transparent sorting", () => {
 
         task.record();
 
-        expect(task._autoFromScene).toBe(false);
+        expect(task._af).toBe(false);
         expect(task._renderables).toHaveLength(0);
     });
 

--- a/tests/lite/unit/render-pass-task.test.ts
+++ b/tests/lite/unit/render-pass-task.test.ts
@@ -713,6 +713,61 @@ describe("RenderPassTask transparent sorting", () => {
         const colorAtt = (descriptor!.colorAttachments as GPURenderPassColorAttachment[])[0]!;
         expect(colorAtt.loadOp).toBe("load");
     });
+
+    it("loads an rt-owned depth attachment when depthClear is false", async () => {
+        const seenDescriptors: GPURenderPassDescriptor[] = [];
+        const engine = makeMockEngine({ msaaSamples: 1, onBeginPass: (d) => seenDescriptors.push(d) });
+        const scene = createSceneContext(engine, { defaultRenderTask: false }) as SceneContext;
+        scene.camera = makeCamera();
+
+        const rt = createRenderTarget({
+            lbl: "overlay",
+            format: "bgra8unorm",
+            dFormat: "depth32float",
+            samples: 1,
+            size: { width: 16, height: 16 },
+        });
+        const task = createRenderTask({ name: "overlay", rt, clr: false, depthClear: false }, engine, scene);
+        scene._frameGraph._tasks.push(task);
+
+        await registerScene(scene);
+        scene._record();
+
+        const descriptor = seenDescriptors.find((d) => d.depthStencilAttachment);
+        const depthAtt = descriptor!.depthStencilAttachment as GPURenderPassDepthStencilAttachment;
+        expect(depthAtt.depthLoadOp).toBe("load");
+        const colorAtt = (descriptor!.colorAttachments as GPURenderPassColorAttachment[])[0]!;
+        expect(colorAtt.loadOp).toBe("load");
+    });
+
+    it("keeps task-managed external depth clearing when depthClear is false", async () => {
+        const seenDescriptors: GPURenderPassDescriptor[] = [];
+        const engine = makeMockEngine({ msaaSamples: 1, onBeginPass: (d) => seenDescriptors.push(d) });
+        const scene = createSceneContext(engine, { defaultRenderTask: false }) as SceneContext;
+        scene.camera = makeCamera();
+
+        const colorRt = createRenderTarget({
+            lbl: "overlay-color",
+            format: "bgra8unorm",
+            samples: 1,
+            size: { width: 16, height: 16 },
+        });
+        const externalDepth = createRenderTarget({
+            lbl: "task-managed-depth",
+            dFormat: "depth32float",
+            samples: 1,
+            size: { width: 16, height: 16 },
+        });
+        const task = createRenderTask({ name: "overlay", rt: colorRt, depth: externalDepth, depthClear: false }, engine, scene);
+        scene._frameGraph._tasks.push(task);
+
+        await registerScene(scene);
+        scene._record();
+
+        const descriptor = seenDescriptors.find((d) => d.depthStencilAttachment);
+        const depthAtt = descriptor!.depthStencilAttachment as GPURenderPassDepthStencilAttachment;
+        expect(depthAtt.depthLoadOp).toBe("clear");
+    });
 });
 
 describe("RenderTask MSAA resolveTarget", () => {

--- a/tests/lite/unit/render-pass-task.test.ts
+++ b/tests/lite/unit/render-pass-task.test.ts
@@ -783,6 +783,22 @@ describe("RenderPassTask transparent sorting", () => {
         expect(task._renderables).toHaveLength(0);
     });
 
+    it("uses the scene clear color when an explicit task omits clrColor", () => {
+        const seenDescriptors: GPURenderPassDescriptor[] = [];
+        const engine = makeMockEngine({ msaaSamples: 1, onBeginPass: (descriptor) => seenDescriptors.push(descriptor) });
+        const scene = createSceneContext(engine, { defaultRenderTask: false }) as SceneContext;
+        scene.camera = makeCamera();
+        const rt = createRenderTarget({ lbl: "explicit-clear", format: "rgba8unorm", samples: 1, size: { width: 16, height: 16 } });
+        const task = createRenderTask({ name: "explicit-clear", rt, autoMirror: false }, engine, scene);
+        task.record();
+
+        task.execute?.();
+
+        const color = (seenDescriptors[0]!.colorAttachments as GPURenderPassColorAttachment[])[0]!;
+        expect(color.loadOp).toBe("clear");
+        expect(color.clearValue).toBe(scene.clearColor);
+    });
+
     it("skips all pass work while disabled", () => {
         const seenDescriptors: GPURenderPassDescriptor[] = [];
         const engine = makeMockEngine({ msaaSamples: 1, onBeginPass: (descriptor) => seenDescriptors.push(descriptor) });

--- a/tests/lite/unit/render-pass-task.test.ts
+++ b/tests/lite/unit/render-pass-task.test.ts
@@ -768,6 +768,54 @@ describe("RenderPassTask transparent sorting", () => {
         const depthAtt = descriptor!.depthStencilAttachment as GPURenderPassDepthStencilAttachment;
         expect(depthAtt.depthLoadOp).toBe("clear");
     });
+
+    it("keeps an explicit empty render list when autoMirror is false", () => {
+        const engine = makeMockEngine({ msaaSamples: 1 });
+        const scene = createSceneContext(engine, { defaultRenderTask: false }) as SceneContext;
+        scene.camera = makeCamera();
+        scene._renderables.push(makeDrawOrderRenderable("scene", {}, []));
+        const rt = createRenderTarget({ lbl: "explicit", format: "rgba8unorm", samples: 1, size: { width: 16, height: 16 } });
+        const task = createRenderTask({ name: "explicit", rt, autoMirror: false }, engine, scene);
+
+        task.record();
+
+        expect(task._autoFromScene).toBe(false);
+        expect(task._renderables).toHaveLength(0);
+    });
+
+    it("skips all pass work while disabled", () => {
+        const seenDescriptors: GPURenderPassDescriptor[] = [];
+        const engine = makeMockEngine({ msaaSamples: 1, onBeginPass: (descriptor) => seenDescriptors.push(descriptor) });
+        const scene = createSceneContext(engine, { defaultRenderTask: false }) as SceneContext;
+        scene.camera = makeCamera();
+        const rt = createRenderTarget({ lbl: "disabled", format: "rgba8unorm", samples: 1, size: { width: 16, height: 16 } });
+        const task = createRenderTask({ name: "disabled", rt }, engine, scene);
+        task.record();
+        task.enabled = false;
+
+        expect(task.execute?.()).toBe(0);
+        expect(seenDescriptors).toHaveLength(0);
+    });
+
+    it("does not rebuild or dispose a shared render target", () => {
+        const engine = makeMockEngine({ msaaSamples: 1 });
+        const scene = createSceneContext(engine, { defaultRenderTask: false }) as SceneContext;
+        scene.camera = makeCamera();
+        const rt = createRenderTarget({ lbl: "shared", format: "rgba8unorm", dFormat: "depth32float", samples: 1, size: { width: 16, height: 16 } });
+        const owner = createRenderTask({ name: "owner", rt }, engine, scene);
+        owner.record();
+        const colorView = rt._colorView;
+        const depthView = rt._depthView;
+        const overlay = createRenderTask({ name: "overlay", rt, sharedRt: true, clr: false, depthClear: false, autoMirror: false }, engine, scene);
+
+        overlay.record();
+        expect(rt._colorView).toBe(colorView);
+        expect(rt._depthView).toBe(depthView);
+
+        overlay.dispose();
+        expect(rt._colorView).toBe(colorView);
+        expect(rt._depthView).toBe(depthView);
+    });
 });
 
 describe("RenderTask MSAA resolveTarget", () => {

--- a/tests/lite/unit/shader-pipeline-cache.test.ts
+++ b/tests/lite/unit/shader-pipeline-cache.test.ts
@@ -27,12 +27,13 @@ function makeEngine() {
     };
 }
 
-function makeMaterial(fragment = "@fragment fn mainFragment() -> @location(0) vec4f { return vec4f(1); }") {
+function makeMaterial(fragment = "@fragment fn mainFragment() -> @location(0) vec4f { return vec4f(1); }", blend?: GPUBlendState) {
     return createShaderMaterial({
         vertexSource: "@vertex fn mainVertex(input: VertexInput) -> @builtin(position) vec4f { return vec4f(input.position, 1); }",
         fragmentSource: fragment,
         attributes: ["position"],
         uniforms: ["world", { name: "tint", type: "vec3<f32>" }],
+        ...(blend ? { blend } : {}),
     });
 }
 
@@ -105,5 +106,33 @@ describe("ShaderMaterial pipeline cache", () => {
 
         expect(after).not.toBe(before);
         expect((second as unknown as { _shaderPipelineCache: object })._shaderPipelineCache).toBe(after);
+    });
+
+    it("uses explicit blend overrides and keeps different states in separate pipelines", () => {
+        clearShaderPipelineCache();
+        clearSceneBGLCache();
+        const { engine, createRenderPipeline } = makeEngine();
+        const colorBlend = {
+            color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha", operation: "add" },
+            alpha: { srcFactor: "zero", dstFactor: "zero", operation: "add" },
+        } satisfies GPUBlendState;
+        const additiveBlend = {
+            color: { srcFactor: "one", dstFactor: "one", operation: "add" },
+            alpha: { srcFactor: "one", dstFactor: "one", operation: "add" },
+        } satisfies GPUBlendState;
+        const first = makeMaterial(undefined, colorBlend);
+        const second = makeMaterial(undefined, additiveBlend);
+        enableShaderPipelineCache(engine, [{ material: first }, { material: second }]);
+
+        getOrCreateShaderPipeline(engine, signature, first, getOrCreateShaderPipelineBindings(engine, first));
+        getOrCreateShaderPipeline(engine, signature, second, getOrCreateShaderPipelineBindings(engine, second));
+
+        expect(createRenderPipeline).toHaveBeenCalledTimes(2);
+        const firstDescriptor = createRenderPipeline.mock.calls[0]![0];
+        const secondDescriptor = createRenderPipeline.mock.calls[1]![0];
+        const firstTarget = (firstDescriptor.fragment!.targets as GPUColorTargetState[])[0];
+        const secondTarget = (secondDescriptor.fragment!.targets as GPUColorTargetState[])[0];
+        expect(firstTarget?.blend).toEqual(colorBlend);
+        expect(secondTarget?.blend).toEqual(additiveBlend);
     });
 });

--- a/tests/lite/unit/shader-pipeline-cache.test.ts
+++ b/tests/lite/unit/shader-pipeline-cache.test.ts
@@ -122,6 +122,8 @@ describe("ShaderMaterial pipeline cache", () => {
         } satisfies GPUBlendState;
         const first = makeMaterial(undefined, colorBlend);
         const second = makeMaterial(undefined, additiveBlend);
+        expect(first.needAlphaBlending).toBe(true);
+        expect(first.depthWrite).toBe(false);
         enableShaderPipelineCache(engine, [{ material: first }, { material: second }]);
 
         getOrCreateShaderPipeline(engine, signature, first, getOrCreateShaderPipelineBindings(engine, first));

--- a/tests/lite/unit/shadow-caster-max-cascade.test.ts
+++ b/tests/lite/unit/shadow-caster-max-cascade.test.ts
@@ -20,7 +20,7 @@ function makeTask(mesh: Mesh): RenderTask {
         _opaqueBindings: [],
         _directBindings: [],
         _transparentBindings: [],
-        _opaqueBundles: [],
+        _ob: [],
         _lastVersion: 0,
         addMesh: vi.fn((added: Mesh, opts?: { material?: Material }) => {
             task._pendingMeshes.push({ mesh: added, material: opts?.material ?? added.material });

--- a/tests/lite/unit/shadow-caster-max-cascade.test.ts
+++ b/tests/lite/unit/shadow-caster-max-cascade.test.ts
@@ -20,7 +20,7 @@ function makeTask(mesh: Mesh): RenderTask {
         _opaqueBindings: [],
         _directBindings: [],
         _transparentBindings: [],
-        _ob: [],
+        _opaqueBundles: [],
         _lastVersion: 0,
         addMesh: vi.fn((added: Mesh, opts?: { material?: Material }) => {
             task._pendingMeshes.push({ mesh: added, material: opts?.material ?? added.material });


### PR DESCRIPTION
## Summary
- add independent rt-owned depth loading for overlay render tasks
- support shared render targets, explicit non-mirroring render lists, and app-controlled task enablement
- add explicit `ShaderMaterial` blend-state overrides with transparent sorting, depth-write defaults, and pipeline-cache separation
- preserve external-depth ownership behavior and document/test the new public surfaces

## Validation
- GitHub and Azure Pipelines CI only; no local tests were run for the follow-up changes