### PR TITLE
feat(ci): surface bundle ceiling headroom in the PR comment

### DIFF
--- a/scripts/build-perf-baseline.ts
+++ b/scripts/build-perf-baseline.ts
@@ -120,7 +120,15 @@ try {
 // comparisons focused on runtime source changes, not historical bundler bugs.
 // Keep helper imports in sync too, so baseline refs that predate helper files
 // (or helper exports) still build with the current bundle builder.
-for (const scriptName of ["bundle-scenes-core.ts", "bundle-size-accounting.ts", "wgsl-minify-plugin.ts"]) {
+//
+// This list is the full import closure of bundle-scenes-core.ts within scripts/,
+// and it has to be maintained by hand: the baseline worktree is checked out at an
+// older ref, so any sibling module the *current* core imports is absent there
+// unless it is copied in. Extracting a new helper out of bundle-scenes-core.ts
+// without adding it here fails the perf job with "Cannot find module './<helper>'"
+// — and only the perf job, because every other consumer builds from a full
+// checkout where the file simply exists.
+for (const scriptName of ["bundle-scenes-core.ts", "bundle-ceiling-headroom.ts", "bundle-size-accounting.ts", "wgsl-minify-plugin.ts"]) {
     cpSync(resolve(ROOT, "scripts", scriptName), resolve(WORKTREE_DIR, "scripts", scriptName));
 }
 

--- a/scripts/bundle-ceiling-headroom.ts
+++ b/scripts/bundle-ceiling-headroom.ts
@@ -89,6 +89,17 @@ export interface SceneHeadroomInput {
     name?: string;
     measuredBytes: number;
     ceilingKB: number;
+    /**
+     * The same measurement taken from the baseline, when the scene exists there at all.
+     *
+     * `undefined` means the scene is new on this branch, which is a distinct state from "the same
+     * size as the baseline" and must not be conflated with it: a new scene has no baseline
+     * behaviour to have inherited. Consumers that need to attribute a ceiling breach — was it
+     * already broken, or did this change break it — read this rather than a movement delta,
+     * because movement cannot answer the question. A scene absent from the baseline has no delta,
+     * and a scene already over its ceiling still has a delta if the branch touched it at all.
+     */
+    masterBytes?: number;
 }
 
 export interface SceneHeadroom extends SceneHeadroomInput {

--- a/scripts/bundle-ceiling-headroom.ts
+++ b/scripts/bundle-ceiling-headroom.ts
@@ -125,6 +125,15 @@ export interface SceneHeadroomInput {
      * and a scene already over its ceiling still has a delta if the branch touched it at all.
      */
     masterBytes?: number;
+    /**
+     * The ceiling that applied when `masterBytes` was measured.
+     *
+     * Baselines published before ceiling stamping do not have this field. That absence means the
+     * historical ceiling state is unknown; consumers must not substitute the branch's current
+     * ceiling, because doing so makes a newly tightened ceiling look like a breach inherited from
+     * master.
+     */
+    masterCeilingKB?: number;
 }
 
 export interface SceneHeadroom extends SceneHeadroomInput {

--- a/scripts/bundle-ceiling-headroom.ts
+++ b/scripts/bundle-ceiling-headroom.ts
@@ -11,15 +11,18 @@
  * ## Why headroom is worth reporting at all
  *
  * The ceilings are, in practice, ratchets pinned to whatever each scene measured when it
- * was last touched, not budgets with slack. Measured across the 224 scenes on master that
- * have both a tracked manifest and a ceiling:
+ * was last touched, not budgets with slack. Measured across the 241 scenes that have both a
+ * size and a ceiling, from ADO build 58227 — the first run to measure every scene at a single
+ * master commit rather than relying on per-scene manifests each author regenerated at a
+ * different time:
  *
- *   median headroom   1251 B      p25   103 B      p10   56 B
- *   under  256 B       87 scenes (39%)
- *   under 1024 B      104 scenes (46%)
- *   under 2048 B      122 scenes (54%)
+ *   median headroom   1536 B      p25   205 B      p10   113 B
+ *   under  256 B       71 scenes (29%)
+ *   under 1024 B      105 scenes (44%)
+ *   under 2048 B      131 scenes (54%)
  *
- * That distribution is what makes concurrent PRs dangerous. Two PRs can each measure under
+ * The tightest scene on master sits 9 bytes below its ceiling.
+ * * That distribution is what makes concurrent PRs dangerous. Two PRs can each measure under
  * a ceiling — each was built against a master that did not contain the other — and breach
  * it together once both land. Azure DevOps builds the *merge commit* for a PR, so once
  * master is over a ceiling, every subsequent PR's Bundle Size job fails until the bytes are
@@ -38,11 +41,11 @@
  * `0 KB` or `+1 KB`. Below this line an author cannot see the risk from the numbers they are
  * shown, which is precisely where a warning earns its place.
  *
- * It is also where the population splits: median headroom is 1251 B, so 1 KB flags the tight
- * ~46% and stays quiet about the roomy half. The previous value of 256 B was not a "quiet"
- * threshold — it already flagged 87 scenes — it was just an arbitrary point well inside the
+ * It is also where the population splits: median headroom is 1536 B, so 1 KB flags the tight
+ * ~44% and stays quiet about the roomy half. The previous value of 256 B was not a "quiet"
+ * threshold — it already flagged 71 scenes — it was just an arbitrary point well inside the
  * risk band, and it said nothing about the ~1 KB range where most near-ceiling scenes
- * actually sit. Raising further was rejected: 2 KB flags 54% of scenes and 4 KB flags 71%,
+ * actually sit. Raising further was rejected: 2 KB flags 54% of scenes and 4 KB flags 72%,
  * at which point the warning is wallpaper nobody reads.
  *
  * This is a WARNING threshold. It is not a ceiling and it never fails a build.
@@ -62,10 +65,13 @@ export const CRITICAL_HEADROOM_BYTES = 256;
 /**
  * How many scenes to name explicitly before collapsing the rest into a count.
  *
- * The tight set is ~104 scenes on master and would swamp both a build log and a PR comment
+ * The tight set is ~105 scenes on master and would swamp both a build log and a PR comment
  * if listed in full. Naming a fixed handful of the tightest and counting the remainder keeps
  * the output a constant size no matter how the flagged set grows, so widening the threshold
  * changes the numbers in the report without changing how much of it there is to read.
+ *
+ * Build 58227 shows the failure this avoids: at the old 256 B threshold its log already had to
+ * truncate, printing ten scenes and then "… and 61 more under 256 B".
  */
 export const HEADROOM_LIST_LIMIT = 10;
 
@@ -144,7 +150,12 @@ export function computeSceneHeadroom(inputs: readonly SceneHeadroomInput[]): Sce
     return { over, under };
 }
 
-/** Scenes at or below a headroom threshold, preserving the tightest-first order. */
+/**
+ * Scenes strictly below a headroom threshold, preserving the tightest-first order.
+ *
+ * Strict rather than inclusive, so the predicate reads the way the reports word it — "under
+ * 1.0 KB" — and a scene sitting exactly on the boundary is not counted as having crossed it.
+ */
 export function scenesUnderHeadroom(under: readonly SceneHeadroom[], thresholdBytes: number): SceneHeadroom[] {
     return under.filter((s) => s.headroomBytes < thresholdBytes);
 }

--- a/scripts/bundle-ceiling-headroom.ts
+++ b/scripts/bundle-ceiling-headroom.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared ceiling-headroom arithmetic for the bundle-size build log and the PR comment.
+ *
+ * Headroom is the distance between a scene's measured runtime size and its `maxRawKB`
+ * ceiling in `scene-config.json`. The ceiling check itself is absolute and lives elsewhere
+ * (`tests/lite/parity/bundle-size.spec.ts` and `reportCeilingHeadroom` in
+ * `bundle-scenes-core.ts`); nothing here decides whether a build passes or fails. This
+ * module exists so the two places that *report* headroom — a build log and a GitHub
+ * comment — cannot drift apart on thresholds or on the rounding rules below.
+ *
+ * ## Why headroom is worth reporting at all
+ *
+ * The ceilings are, in practice, ratchets pinned to whatever each scene measured when it
+ * was last touched, not budgets with slack. Measured across the 224 scenes on master that
+ * have both a tracked manifest and a ceiling:
+ *
+ *   median headroom   1251 B      p25   103 B      p10   56 B
+ *   under  256 B       87 scenes (39%)
+ *   under 1024 B      104 scenes (46%)
+ *   under 2048 B      122 scenes (54%)
+ *
+ * That distribution is what makes concurrent PRs dangerous. Two PRs can each measure under
+ * a ceiling — each was built against a master that did not contain the other — and breach
+ * it together once both land. Azure DevOps builds the *merge commit* for a PR, so once
+ * master is over a ceiling, every subsequent PR's Bundle Size job fails until the bytes are
+ * recovered. The recovery options are emergency size work or raising a ceiling, and raising
+ * a ceiling requires explicit user approval (see GUIDANCE.md). Making headroom visible at
+ * review time is what lets an author notice they are in the danger zone and serialize on
+ * purpose instead of discovering it from a repo-wide stall.
+ */
+
+/**
+ * Headroom below which a scene is reported as tight.
+ *
+ * Chosen as one kilobyte because that is exactly the granularity at which the existing
+ * reporting goes blind: the PR delta table rounds every size to a whole KB, so a scene with
+ * less than 1 KB of headroom can be pushed over its ceiling by a change the table renders as
+ * `0 KB` or `+1 KB`. Below this line an author cannot see the risk from the numbers they are
+ * shown, which is precisely where a warning earns its place.
+ *
+ * It is also where the population splits: median headroom is 1251 B, so 1 KB flags the tight
+ * ~46% and stays quiet about the roomy half. The previous value of 256 B was not a "quiet"
+ * threshold — it already flagged 87 scenes — it was just an arbitrary point well inside the
+ * risk band, and it said nothing about the ~1 KB range where most near-ceiling scenes
+ * actually sit. Raising further was rejected: 2 KB flags 54% of scenes and 4 KB flags 71%,
+ * at which point the warning is wallpaper nobody reads.
+ *
+ * This is a WARNING threshold. It is not a ceiling and it never fails a build.
+ */
+export const TIGHT_HEADROOM_BYTES = 1024;
+
+/**
+ * Inner band, reported as a count alongside the tight count.
+ *
+ * This is the old tight threshold, kept rather than deleted: at under a quarter kilobyte a
+ * scene is not merely at risk from an unrelated shared-path change, it is effectively
+ * guaranteed to move with the next one. Splitting the report into "tight" and "critical"
+ * keeps that emergency signal legible now that the outer band is four times wider.
+ */
+export const CRITICAL_HEADROOM_BYTES = 256;
+
+/**
+ * How many scenes to name explicitly before collapsing the rest into a count.
+ *
+ * The tight set is ~104 scenes on master and would swamp both a build log and a PR comment
+ * if listed in full. Naming a fixed handful of the tightest and counting the remainder keeps
+ * the output a constant size no matter how the flagged set grows, so widening the threshold
+ * changes the numbers in the report without changing how much of it there is to read.
+ */
+export const HEADROOM_LIST_LIMIT = 10;
+
+/** The subset of a bundle manifest entry that headroom needs. */
+export interface MeasuredSizeEntry {
+    rawKB?: number;
+    /** Exact runtime-fetched byte count, when the manifest recorded one. */
+    rawBytes?: number;
+}
+
+export interface SceneHeadroomInput {
+    /** Manifest key, e.g. `scene12`. */
+    scene: string;
+    /** Display label for reports; falls back to the manifest key. */
+    name?: string;
+    measuredBytes: number;
+    ceilingKB: number;
+}
+
+export interface SceneHeadroom extends SceneHeadroomInput {
+    /**
+     * Bytes remaining under the ceiling for a scene that fits, floored; bytes by which the
+     * ceiling is exceeded for one that does not, ceiled. Always a non-negative magnitude —
+     * `over` and `under` distinguish the direction.
+     */
+    headroomBytes: number;
+}
+
+export interface SceneHeadroomReport {
+    /** Scenes past their ceiling, tightest overflow first. */
+    over: SceneHeadroom[];
+    /** Scenes within their ceiling, least headroom first. */
+    under: SceneHeadroom[];
+}
+
+/**
+ * Exact measured bytes for a manifest entry, or `null` when it recorded no size.
+ *
+ * `rawKB` is rounded to 0.1 KB, which hides up to ~51 bytes of drift — enough to conceal a
+ * ceiling overflow on a zero-headroom scene. Prefer the exact `rawBytes` the measurement
+ * records and fall back to `rawKB` only for older entries that predate it, where a
+ * 0.1 KB-quantised answer is still better than none.
+ */
+export function measuredBytesOf(entry: MeasuredSizeEntry | undefined): number | null {
+    if (entry?.rawBytes != null) {
+        return entry.rawBytes;
+    }
+    if (entry?.rawKB != null) {
+        return entry.rawKB * 1024;
+    }
+    return null;
+}
+
+/**
+ * Split scenes into those over their ceiling and those under it, sorted tightest-first.
+ *
+ * Comparison happens before any rounding. A ceiling of 92.2 KB is 94412.8 bytes, so a scene
+ * measuring 94413 bytes is over by 0.2 — a difference `Math.round` would collapse to `-0`
+ * and wave through.
+ */
+export function computeSceneHeadroom(inputs: readonly SceneHeadroomInput[]): SceneHeadroomReport {
+    const over: SceneHeadroom[] = [];
+    const under: SceneHeadroom[] = [];
+
+    for (const input of inputs) {
+        const ceilingBytes = input.ceilingKB * 1024;
+        if (input.measuredBytes > ceilingBytes) {
+            over.push({ ...input, headroomBytes: Math.ceil(input.measuredBytes - ceilingBytes) });
+        } else {
+            under.push({ ...input, headroomBytes: Math.floor(ceilingBytes - input.measuredBytes) });
+        }
+    }
+
+    over.sort((a, b) => b.headroomBytes - a.headroomBytes);
+    under.sort((a, b) => a.headroomBytes - b.headroomBytes);
+    return { over, under };
+}
+
+/** Scenes at or below a headroom threshold, preserving the tightest-first order. */
+export function scenesUnderHeadroom(under: readonly SceneHeadroom[], thresholdBytes: number): SceneHeadroom[] {
+    return under.filter((s) => s.headroomBytes < thresholdBytes);
+}
+
+/** Render a byte threshold the way the reports name it, e.g. `1.0 KB` / `256 B`. */
+export function formatHeadroomThreshold(bytes: number): string {
+    return bytes >= 1024 ? `${(bytes / 1024).toFixed(1)} KB` : `${bytes} B`;
+}

--- a/scripts/bundle-ceiling-headroom.ts
+++ b/scripts/bundle-ceiling-headroom.ts
@@ -21,8 +21,26 @@
  *   under 1024 B      105 scenes (44%)
  *   under 2048 B      131 scenes (54%)
  *
- * The tightest scene on master sits 9 bytes below its ceiling.
- * * That distribution is what makes concurrent PRs dangerous. Two PRs can each measure under
+ * Re-measured later against the published baseline artifact at master `c5f8f660` (243 scenes,
+ * 0 over ceiling), which is a different instrument from the one above — a CDN-hosted manifest
+ * rather than a build's own output:
+ *
+ *   median headroom   1825 B      p25   471 B      p10   360 B
+ *   under  256 B        4 scenes ( 2%)
+ *   under 1024 B       97 scenes (40%)
+ *   under 2048 B      127 scenes (52%)
+ *
+ * Both vintages are kept deliberately. The body of the distribution barely moved — 44% → 40%
+ * under 1 KB, 54% → 52% under 2 KB — while the extreme tail collapsed, from 71 scenes under
+ * 256 B to 4. A core-engine deletion recovering a few hundred bytes across many scenes at
+ * once does exactly that: it lifts the scenes nearest their ceilings without changing the
+ * shape of the rest. That is the same shared-path leverage this report exists to warn about,
+ * observed in the safe direction. Keeping both readings is the point — a threshold justified
+ * by a single snapshot cannot be told apart from one fitted to it.
+ *
+ * The tightest scene on master sits 9 bytes below its ceiling, in both measurements.
+ *
+ * That distribution is what makes concurrent PRs dangerous. Two PRs can each measure under
  * a ceiling — each was built against a master that did not contain the other — and breach
  * it together once both land. Azure DevOps builds the *merge commit* for a PR, so once
  * master is over a ceiling, every subsequent PR's Bundle Size job fails until the bytes are
@@ -41,12 +59,19 @@
  * `0 KB` or `+1 KB`. Below this line an author cannot see the risk from the numbers they are
  * shown, which is precisely where a warning earns its place.
  *
- * It is also where the population splits: median headroom is 1536 B, so 1 KB flags the tight
- * ~44% and stays quiet about the roomy half. The previous value of 256 B was not a "quiet"
- * threshold — it already flagged 71 scenes — it was just an arbitrary point well inside the
- * risk band, and it said nothing about the ~1 KB range where most near-ceiling scenes
- * actually sit. Raising further was rejected: 2 KB flags 54% of scenes and 4 KB flags 72%,
- * at which point the warning is wallpaper nobody reads.
+ * It is also where the population splits, and it stays there across both measurements above:
+ * 1 KB flags the tight 44% / 40% and stays quiet about the roomy half, against a median of
+ * 1536 B / 1825 B. That stability is the argument for it — the threshold's coverage barely
+ * moved while the sub-256 B band collapsed from 71 scenes to 4, so 1 KB is tracking where
+ * near-ceiling scenes actually sit rather than tracking one snapshot's tail.
+ *
+ * The previous value of 256 B is what that collapse disqualifies. It was already arbitrary —
+ * a point well inside the risk band that said nothing about the ~1 KB range where most
+ * near-ceiling scenes live — but it has since become nearly silent as well, flagging 4 scenes
+ * where it once flagged 71. A threshold whose coverage can fall by a factor of seventeen
+ * without anyone changing it is not reporting a risk level; it is reporting the tail's
+ * position. Raising further was rejected in the other direction: 2 KB flags 52-54% of scenes
+ * and 4 KB flags 67-72%, at which point the warning is wallpaper nobody reads.
  *
  * This is a WARNING threshold. It is not a ceiling and it never fails a build.
  */

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -16,6 +16,15 @@ import { resolve, dirname, join, extname } from "path";
 import { rmSync, readdirSync, readFileSync, writeFileSync, renameSync, mkdirSync, existsSync, statSync } from "fs";
 import { minify as terserMinify, type ECMA, type SourceMapOptions } from "terser";
 import { bytesToRoundedKB, IGNORED_BUNDLE_MODULE_PATTERN, isVendorRuntimeChunkFile, summarizeRuntimeBundle, type RuntimeJsPayload } from "./bundle-size-accounting";
+import {
+    computeSceneHeadroom,
+    CRITICAL_HEADROOM_BYTES,
+    formatHeadroomThreshold,
+    HEADROOM_LIST_LIMIT,
+    scenesUnderHeadroom,
+    TIGHT_HEADROOM_BYTES,
+    type SceneHeadroomInput,
+} from "./bundle-ceiling-headroom";
 import { wgslMinifyPlugin } from "./wgsl-minify-plugin";
 
 /**
@@ -1342,13 +1351,6 @@ function softwareRenderRequested(): boolean {
  *  measurement as the authoritative one for these three. */
 const DEVICE_DEPENDENT_NOTE = "device-dependent chunk set — differs from the CI-measured baseline (reproduce CI with: pnpm build:bundle-manifest:device)";
 
-/** A scene with less than this much room under its ceiling is reported after a build: at
- *  that margin the next shared-path change lands on it, and finding that out from CI costs
- *  ~35 minutes. */
-const TIGHT_HEADROOM_BYTES = 256;
-/** Cap the tight-headroom list so a build's output stays readable; the rest are counted. */
-const TIGHT_HEADROOM_LIST_LIMIT = 10;
-
 export async function buildBundleScenes(): Promise<void> {
     const t0 = performance.now();
     // Scenes are bundled against the built `build/lib` tree by default; old baseline
@@ -1579,40 +1581,43 @@ export async function buildBundleScenes(): Promise<void> {
  * surfaces in CI's bundle-size job, ~35 minutes later.
  * Comparing exact bytes here surfaces it immediately, and listing the tightest scenes makes
  * a zero-margin scene visible *before* it is the thing that breaks someone else's PR.
+ *
+ * The thresholds and the arithmetic live in `bundle-ceiling-headroom.ts` because the PR
+ * comment reports the same numbers; see that module for why the tight band is 1 KB. Only
+ * the `over` set affects the exit code — the tight list is advisory and never fails a build.
  */
 function reportCeilingHeadroom(scenes: readonly string[], manifest: Record<string, BundleManifestEntry>): void {
-    const over: string[] = [];
-    const tight: { scene: string; headroom: number; ceilingKB: number }[] = [];
+    const inputs: SceneHeadroomInput[] = [];
 
     for (const scene of scenes) {
-        const measured = manifest[scene]?.rawBytes;
+        // Exact bytes only, deliberately: this is the path that can set a non-zero exit code,
+        // and a `rawKB` fallback would let a 0.1 KB-quantised size decide it. The PR comment
+        // does fall back, because being approximate there costs nothing.
+        const measuredBytes = manifest[scene]?.rawBytes;
         const config = sceneConfigByName.get(scene);
         const ceilingKB = config?.maxRawKB;
         // Honour the same opt-out as the ceiling test in bundle-size.spec.ts.
-        if (measured == null || ceilingKB == null || config?.skipBundleSize) {
+        if (measuredBytes == null || ceilingKB == null || config?.skipBundleSize) {
             continue;
         }
-        const ceilingBytes = ceilingKB * 1024;
-        // Compare before rounding: a ceiling like 92.2 KB is 94412.8 bytes, so 94413 bytes is
-        // over by 0.2 — which `Math.round` would turn into `-0` and wave through.
-        if (measured > ceilingBytes) {
-            over.push(`  ${scene}: ${(measured / 1024).toFixed(3)} KB exceeds ceiling ${ceilingKB} KB by ${Math.ceil(measured - ceilingBytes)} bytes`);
-        } else {
-            const headroom = Math.floor(ceilingBytes - measured);
-            if (headroom < TIGHT_HEADROOM_BYTES) {
-                tight.push({ scene, headroom, ceilingKB });
-            }
-        }
+        inputs.push({ scene, measuredBytes, ceilingKB });
     }
 
+    const { over, under } = computeSceneHeadroom(inputs);
+    const tight = scenesUnderHeadroom(under, TIGHT_HEADROOM_BYTES);
+    const critical = scenesUnderHeadroom(under, CRITICAL_HEADROOM_BYTES);
+
     if (tight.length > 0) {
-        tight.sort((a, b) => a.headroom - b.headroom);
-        const shown = tight.slice(0, TIGHT_HEADROOM_LIST_LIMIT).map((t) => `  ${t.scene}: ${t.headroom} B below its ${t.ceilingKB} KB ceiling`);
-        const more = tight.length > shown.length ? `\n  … and ${tight.length - shown.length} more under ${TIGHT_HEADROOM_BYTES} B` : "";
-        console.log(`\n⚠ ${tight.length} scene(s) with little headroom — a shared-path change may push them over:\n${shown.join("\n")}${more}`);
+        const shown = tight.slice(0, HEADROOM_LIST_LIMIT).map((t) => `  ${t.scene}: ${t.headroomBytes} B below its ${t.ceilingKB} KB ceiling`);
+        const more = tight.length > shown.length ? `\n  … and ${tight.length - shown.length} more under ${formatHeadroomThreshold(TIGHT_HEADROOM_BYTES)}` : "";
+        const criticalNote = critical.length > 0 ? `, ${critical.length} under ${formatHeadroomThreshold(CRITICAL_HEADROOM_BYTES)}` : "";
+        console.log(
+            `\n⚠ ${tight.length} scene(s) under ${formatHeadroomThreshold(TIGHT_HEADROOM_BYTES)} of headroom${criticalNote} — a shared-path change may push them over:\n${shown.join("\n")}${more}`
+        );
     }
     if (over.length > 0) {
-        console.error(`\n✘ Bundle-size ceiling exceeded (exact bytes; scene-config.json maxRawKB):\n${over.join("\n")}`);
+        const lines = over.map((o) => `  ${o.scene}: ${(o.measuredBytes / 1024).toFixed(3)} KB exceeds ceiling ${o.ceilingKB} KB by ${o.headroomBytes} bytes`);
+        console.error(`\n✘ Bundle-size ceiling exceeded (exact bytes; scene-config.json maxRawKB):\n${lines.join("\n")}`);
         console.error(`\nRaising a ceiling requires explicit user approval — see GUIDANCE.md.`);
         process.exitCode = 1;
     }

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -127,7 +127,7 @@ export function computeMovedBytes(current: Manifest, master: Manifest): Map<stri
 }
 
 /** Headroom inputs for every scene that has both a measured size and a ceiling. */
-export function collectHeadroomInputs(current: Manifest, sceneConfigs: SceneConfig[]): SceneHeadroomInput[] {
+export function collectHeadroomInputs(current: Manifest, sceneConfigs: SceneConfig[], master: Manifest = {}): SceneHeadroomInput[] {
     const inputs: SceneHeadroomInput[] = [];
     for (const config of sceneConfigs) {
         const key = `scene${config.id}`;
@@ -136,7 +136,13 @@ export function collectHeadroomInputs(current: Manifest, sceneConfigs: SceneConf
         if (measuredBytes == null || config.maxRawKB == null || config.skipBundleSize) {
             continue;
         }
-        inputs.push({ scene: key, name: config.name, measuredBytes, ceilingKB: config.maxRawKB });
+        inputs.push({
+            scene: key,
+            name: config.name,
+            measuredBytes,
+            ceilingKB: config.maxRawKB,
+            masterBytes: measuredBytesOf(master[key]) ?? undefined,
+        });
     }
     return inputs;
 }
@@ -200,13 +206,17 @@ export interface HeadroomReport {
      */
     movedIntoDangerZone: boolean;
     /**
-     * Whether any scene is over its ceiling that this PR did *not* grow — an inherited breach.
+     * Whether any scene was *already* over its ceiling on the baseline — an inherited breach.
+     *
+     * Determined from the baseline measurement, not from movement. Movement gets this wrong in
+     * both directions: a scene this branch adds has no baseline entry and so no delta, and a
+     * scene already breached has a delta as soon as the branch touches it at all. The question
+     * is whether the baseline was over the ceiling, so that is what this asks.
      *
      * This is a separate trigger from {@link movedIntoDangerZone} because it is not the author's
-     * doing and cannot be filtered by direction: the scene was already over before they branched.
-     * It still has to be posted, and posted on PRs that moved nothing, because it is the exact
-     * state this whole section exists for. Master over a ceiling fails the Bundle Size job on
-     * *every* open PR, so the author whose build just went red needs the comment to say why —
+     * doing. It still has to be posted, and posted on PRs that moved nothing, because it is the
+     * exact state this whole section exists for. Master over a ceiling fails the Bundle Size job
+     * on *every* open PR, so the author whose build just went red needs the comment to say why —
      * otherwise the only explanation lives in a ~42-minute log, which is the problem we started
      * from. Unlike repo-wide tightness this does not fire on almost every PR; it fires only while
      * master is actually breached, which is a loud, short-lived emergency by construction, since
@@ -245,6 +255,15 @@ export interface HeadroomReport {
  * runs `condition: always()`, so it is still generated on exactly those failing builds — it just
  * had nothing to say about the failure. An inherited breach is therefore called out separately
  * from one this PR caused, so the author can tell "you did this" from "this was already broken".
+ *
+ * That attribution is made from the *baseline measurement*, not from a movement delta, because
+ * movement answers a different question and gets both edges wrong. A scene this branch adds is
+ * absent from the baseline, so it has no delta at all and reads as inherited — asserting it was
+ * already over on master, of a scene that does not exist there. A scene that is genuinely
+ * inherited acquires a delta the moment the branch grows it by a single byte, which a shared-path
+ * change does across many scenes at once — and then the whole overage is attributed to the author
+ * and the "rebasing will not clear this" note disappears, in the middle of the repo-wide stall
+ * that note exists for. Only the baseline can distinguish the two, so only the baseline is asked.
  */
 export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], movedBytes: ReadonlyMap<string, number>): HeadroomReport {
     if (inputs.length === 0) {
@@ -258,15 +277,26 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     // Only growth consumes headroom. See the note on direction in this function's doc comment.
     const grewBy = (scene: SceneHeadroom): number => movedBytes.get(scene.scene) ?? 0;
     const movedAndTight = tight.filter((s) => grewBy(s) > 0);
-    const movedAndOver = over.filter((s) => grewBy(s) > 0);
-    const inheritedOver = over.filter((s) => grewBy(s) <= 0);
+    // Attribution is a question about the *baseline*, not about movement, and the two answer
+    // differently in both directions. A scene this branch adds has no baseline entry, so it has no
+    // delta and movement calls it inherited — while claiming it was "already over on master" and
+    // that rebasing will not clear it, of a scene that does not exist on master. A scene already
+    // over its ceiling that this branch grows by one byte — what a shared-path change does across
+    // many scenes at once — has a positive delta, so movement blames the author for the whole
+    // overage and drops the note explaining that rebasing will not help. Ask the baseline instead:
+    // a breach is inherited only if the baseline was already over the same ceiling.
+    const wasOverOnMaster = (scene: SceneHeadroom): boolean => scene.masterBytes != null && scene.masterBytes > scene.ceilingKB * 1024;
+    const inheritedOver = over.filter((s) => wasOverOnMaster(s));
+    const movedAndOver = over.filter((s) => !wasOverOnMaster(s));
 
     const lines = ["### Ceiling headroom", ""];
 
     if (movedAndOver.length > 0) {
         const named = movedAndOver.map((s) => `\`${s.scene}\` (+${formatBytes(s.headroomBytes)} over its ${formatCeilingKB(s.ceilingKB)} ceiling)`);
-        const verb = movedAndOver.length === 1 ? "now exceeds its ceiling" : "now exceed their ceiling";
-        lines.push(`🚨 **${pluralizeScenes(movedAndOver.length)} this PR grew ${verb}:** ${named.join(", ")}`);
+        // "puts over" rather than "grew": this set now also holds scenes the branch *added*, which
+        // have no baseline size to have grown from, and saying they grew would be false of them.
+        const verb = movedAndOver.length === 1 ? "its ceiling" : "their ceiling";
+        lines.push(`🚨 **${pluralizeScenes(movedAndOver.length)} put over ${verb} by this PR:** ${named.join(", ")}`);
         lines.push("");
     }
 
@@ -293,14 +323,21 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     }
 
     if (inheritedOver.length > 0) {
-        const named = inheritedOver.slice(0, HEADROOM_LIST_LIMIT).map((s) => `\`${s.scene}\` (+${formatBytes(s.headroomBytes)} over its ${formatCeilingKB(s.ceilingKB)} ceiling)`);
+        const named = inheritedOver.slice(0, HEADROOM_LIST_LIMIT).map((s) => {
+            // A scene can be over on master *and* grown here. Report the branch's contribution
+            // separately from the total rather than folding them together: the author can act on
+            // the bytes they added, and cannot act on the ones that were already there.
+            const added = movedBytes.get(s.scene) ?? 0;
+            const addedNote = added > 0 ? `, ${formatBytes(added)} of it added here` : "";
+            return `\`${s.scene}\` (+${formatBytes(s.headroomBytes)} over its ${formatCeilingKB(s.ceilingKB)} ceiling${addedNote})`;
+        });
         const overflow = inheritedOver.length > HEADROOM_LIST_LIMIT ? `, and ${inheritedOver.length - HEADROOM_LIST_LIMIT} more` : "";
-        const verb = inheritedOver.length === 1 ? "is" : "are";
-        lines.push(`🛑 **${pluralizeScenes(inheritedOver.length)} ${verb} over ceiling on master, not from this PR:** ${named.join(", ")}${overflow}`);
+        const verb = inheritedOver.length === 1 ? "was" : "were";
+        lines.push(`🛑 **${pluralizeScenes(inheritedOver.length)} ${verb} already over ceiling on master:** ${named.join(", ")}${overflow}`);
         lines.push("");
         lines.push(
             "This fails the Bundle Size job on every open PR, including ones that changed no bundle bytes, " +
-                "until the bytes are recovered on master. It is not caused by this branch and rebasing will not clear it."
+                "until the bytes are recovered on master. The breach did not originate on this branch and rebasing will not clear it."
         );
         lines.push("");
     }
@@ -365,7 +402,15 @@ export function formatComment(deltas: BundleDelta[], headroom: HeadroomReport = 
     const lines = ["## Bundle Size Changes", ""];
 
     if (deltas.length === 0) {
-        lines.push("No changes at whole-KB resolution — but this PR moved a scene close to its ceiling.");
+        // Pick the sentence from the flag that actually fired. The movement wording predates the
+        // inherited-breach trigger, which reaches this branch with nothing moved at all — so on a
+        // PR that touched no bundle bytes it asserted movement, and pointed the author at their
+        // own diff immediately above a block saying the breach came from master.
+        lines.push(
+            headroom.movedIntoDangerZone
+                ? "No changes at whole-KB resolution — but this PR moved a scene close to its ceiling."
+                : "No bundle-size changes on this branch — but a scene is over its ceiling on master, which fails this job on every open PR."
+        );
         lines.push("");
         lines.push(...headroom.lines);
         return lines.join("\n");
@@ -436,7 +481,7 @@ function main(): void {
 
     const sceneConfigs = loadSceneConfig(sceneConfigPath);
     const deltas = computeDeltas(current, master, sceneConfigs);
-    const headroom = buildHeadroomReport(collectHeadroomInputs(current, sceneConfigs), computeMovedBytes(current, master));
+    const headroom = buildHeadroomReport(collectHeadroomInputs(current, sceneConfigs, master), computeMovedBytes(current, master));
     const comment = formatComment(deltas, headroom);
 
     mkdirSync(dirname(outputPath), { recursive: true });

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -314,6 +314,13 @@ function main(): void {
     }
 
     if (!master) {
+        // Bail entirely rather than falling back to a headroom-only report. Headroom is absolute
+        // and would be computable from the current manifest alone, which makes "report headroom
+        // anyway" a tempting change — but movement is not computable without a baseline, and
+        // movement is the sole reason this comment is not posted on every single PR. Roughly half
+        // the scenes sit inside the tight band at any moment, so a baseline-free headroom report
+        // would hand every PR a warning about scenes it never touched. Silence is the correct
+        // degraded behaviour here.
         console.log("Master manifest not found; skipping delta report.");
         console.log("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
         return;

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -243,12 +243,12 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     if (movedAndOver.length > 0) {
         const named = movedAndOver.map((s) => `\`${s.scene}\` (+${formatBytes(s.headroomBytes)} over its ${formatCeilingKB(s.ceilingKB)} ceiling)`);
         const verb = movedAndOver.length === 1 ? "now exceeds its ceiling" : "now exceed their ceiling";
-        lines.push(`🚨 **${pluralizeScenes(movedAndOver.length)} this PR moved ${verb}:** ${named.join(", ")}`);
+        lines.push(`🚨 **${pluralizeScenes(movedAndOver.length)} this PR grew ${verb}:** ${named.join(", ")}`);
         lines.push("");
     }
 
     if (movedAndTight.length > 0) {
-        lines.push(`⚠️ **${pluralizeScenes(movedAndTight.length)} this PR moved ${movedAndTight.length === 1 ? "sits" : "sit"} under ${tightLabel} of headroom.**`);
+        lines.push(`⚠️ **${pluralizeScenes(movedAndTight.length)} this PR grew now ${movedAndTight.length === 1 ? "sits" : "sit"} under ${tightLabel} of headroom.**`);
         lines.push("");
         lines.push("| Scene | Size | Ceiling | Headroom | Δ this PR |");
         lines.push("|-------|------|---------|----------|-----------|");

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -293,6 +293,14 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     // many scenes at once — has a positive delta, so movement blames the author for the whole
     // overage and drops the note explaining that rebasing will not help. Ask the baseline instead:
     // a breach is inherited only if the baseline was already over the same ceiling.
+    //
+    // Known gap, tracked in #628: "the same ceiling" is an assumption, not a guarantee. The bytes
+    // come from the baseline but `ceilingKB` comes from *this branch's* scene-config, so the
+    // predicate really asks "is master's size over MY ceiling". Those diverge only when a branch
+    // edits that scene's ceiling — a PR that lowers one below master's measured size gets its own
+    // breach reported as inherited, and is told rebasing will not clear it when reverting the
+    // ceiling edit would. Closing it properly needs the baseline to carry the ceiling it was
+    // measured against, which is new plumbing rather than a change to this predicate.
     const wasOverOnMaster = (scene: SceneHeadroom): boolean => scene.masterBytes != null && scene.masterBytes > scene.ceilingKB * 1024;
     const inheritedOver = over.filter((s) => wasOverOnMaster(s));
     const movedAndOver = over.filter((s) => !wasOverOnMaster(s));

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -32,6 +32,11 @@ interface ManifestEntry {
     rawKB?: number;
     rawBytes?: number;
     gzipKB?: number;
+    /**
+     * Ceiling that applied when this manifest entry was measured. Published baseline entries carry
+     * it; older baselines may not, in which case historical ceiling state is unknown.
+     */
+    ceilingKB?: number;
 }
 
 type Manifest = Record<string, ManifestEntry>;
@@ -142,6 +147,7 @@ export function collectHeadroomInputs(current: Manifest, sceneConfigs: SceneConf
             measuredBytes,
             ceilingKB: config.maxRawKB,
             masterBytes: measuredBytesOf(master[key]) ?? undefined,
+            masterCeilingKB: master[key]?.ceilingKB,
         });
     }
     return inputs;
@@ -291,19 +297,18 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     // that rebasing will not clear it, of a scene that does not exist on master. A scene already
     // over its ceiling that this branch grows by one byte — what a shared-path change does across
     // many scenes at once — has a positive delta, so movement blames the author for the whole
-    // overage and drops the note explaining that rebasing will not help. Ask the baseline instead:
-    // a breach is inherited only if the baseline was already over the same ceiling.
+    // overage and drops the note explaining that rebasing will not help. Ask the baseline instead,
+    // using the ceiling published with those bytes rather than this branch's current ceiling.
     //
-    // Known gap, tracked in #628: "the same ceiling" is an assumption, not a guarantee. The bytes
-    // come from the baseline but `ceilingKB` comes from *this branch's* scene-config, so the
-    // predicate really asks "is master's size over MY ceiling". Those diverge only when a branch
-    // edits that scene's ceiling — a PR that lowers one below master's measured size gets its own
-    // breach reported as inherited, and is told rebasing will not clear it when reverting the
-    // ceiling edit would. Closing it properly needs the baseline to carry the ceiling it was
-    // measured against, which is new plumbing rather than a change to this predicate.
-    const wasOverOnMaster = (scene: SceneHeadroom): boolean => scene.masterBytes != null && scene.masterBytes > scene.ceilingKB * 1024;
+    // Older baselines carry bytes but no ceiling. That is "unknown", not "not over": substituting
+    // the branch ceiling recreates #628, while treating it as unlimited silently asserts master
+    // was healthy. Such scenes remain visible in the repo-wide current-state table, but neither
+    // attribution callout makes a historical claim that the available data cannot support.
+    type SceneWithKnownMasterCeiling = SceneHeadroom & { masterBytes: number; masterCeilingKB: number };
+    const hasKnownMasterCeiling = (scene: SceneHeadroom): scene is SceneWithKnownMasterCeiling => scene.masterBytes != null && scene.masterCeilingKB != null;
+    const wasOverOnMaster = (scene: SceneHeadroom): scene is SceneWithKnownMasterCeiling => hasKnownMasterCeiling(scene) && scene.masterBytes > scene.masterCeilingKB * 1024;
     const inheritedOver = over.filter((s) => wasOverOnMaster(s));
-    const movedAndOver = over.filter((s) => !wasOverOnMaster(s));
+    const movedAndOver = over.filter((s) => isAddedHere(s) || (hasKnownMasterCeiling(s) && !wasOverOnMaster(s)));
 
     const lines = ["### Ceiling headroom", ""];
 
@@ -349,7 +354,8 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
             // the bytes they added, and cannot act on the ones that were already there.
             const added = movedBytes.get(s.scene) ?? 0;
             const addedNote = added > 0 ? `, ${formatBytes(added)} of it added here` : "";
-            return `\`${s.scene}\` (+${formatBytes(s.headroomBytes)} over its ${formatCeilingKB(s.ceilingKB)} ceiling${addedNote})`;
+            const masterOverage = Math.ceil(s.masterBytes - s.masterCeilingKB * 1024);
+            return `\`${s.scene}\` (+${formatBytes(masterOverage)} over its ${formatCeilingKB(s.masterCeilingKB)} baseline ceiling${addedNote})`;
         });
         const overflow = inheritedOver.length > HEADROOM_LIST_LIMIT ? `, and ${inheritedOver.length - HEADROOM_LIST_LIMIT} more` : "";
         const verb = inheritedOver.length === 1 ? "was" : "were";

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -98,12 +98,17 @@ export function computeDeltas(current: Manifest, master: Manifest, sceneConfigs:
 }
 
 /**
- * Exact byte movement per scene, keyed by manifest key.
+ * Byte-level movement per scene, keyed by manifest key.
  *
  * Deliberately not derived from `computeDeltas`: that rounds to whole KB and drops anything
  * that rounds to zero, which is exactly the movement that matters here. A +400 B change shows
  * up in the delta table as nothing at all, yet it is enough to push a scene with 300 B of
  * headroom over its ceiling.
+ *
+ * Resolution is whatever `measuredBytesOf` can supply: byte-exact when both manifests recorded
+ * `rawBytes`, which is what the current measurement writes, and quantised to 0.1 KB (~±51 B)
+ * only for older entries that predate that field. So the values below are reported in whole
+ * bytes without promising that every input was measured to the byte.
  */
 export function computeMovedBytes(current: Manifest, master: Manifest): Map<string, number> {
     const moved = new Map<string, number>();
@@ -232,7 +237,7 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     lines.push("</details>");
     lines.push("");
     lines.push(
-        "*Headroom is the exact distance to a scene's `maxRawKB` ceiling in `scene-config.json`. " +
+        "*Headroom is the distance to a scene's `maxRawKB` ceiling in `scene-config.json`. " +
             "Two PRs can each measure under a ceiling and still breach it together once both land — and because CI builds the merge commit, " +
             "every later PR's Bundle Size job then fails until the bytes are recovered. If a scene you touched is near zero, consider landing separately.*"
     );
@@ -246,7 +251,7 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
  * A headroom-only comment is a real case, not a degenerate one. The delta tables round to whole
  * KB, so a PR whose only effect is a few hundred bytes produces no rows at all — and that is
  * exactly the change this feature exists to catch, because a few hundred bytes is enough to
- * consume the headroom of the ~46% of scenes that have under 1 KB of it. Suppressing the comment
+ * consume the headroom of the ~44% of scenes that have under 1 KB of it. Suppressing the comment
  * whenever the tables are empty would make the report inert in its most important case.
  */
 export function formatComment(deltas: BundleDelta[], headroom: HeadroomReport = { lines: [], movedIntoDangerZone: false }): string {

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -8,8 +8,11 @@
  *
  * Outputs:
  *  - Markdown comment listing all changes rounded to nearest whole KB, followed by a
- *    ceiling-headroom section (see `formatHeadroomSection`)
- *  - Azure DevOps variables for conditional GitHubComment@0 posting
+ *    ceiling-headroom section (see `buildHeadroomReport`)
+ *  - Azure DevOps variables for conditional GitHubComment@0 posting. The comment is posted
+ *    when a rounded delta is nonzero OR when this PR moved a scene into the tight/critical
+ *    headroom band, since sub-KB movement produces no delta rows yet is exactly what puts a
+ *    near-ceiling scene over.
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
@@ -155,6 +158,19 @@ function pluralizeScenes(count: number): string {
     return count === 1 ? "1 scene" : `${count} scenes`;
 }
 
+export interface HeadroomReport {
+    /** Rendered markdown lines, empty when no scene has a ceiling to report against. */
+    lines: string[];
+    /**
+     * Whether this PR moved a scene that is now tight, critical, or over its ceiling.
+     *
+     * This is the signal that makes the comment worth posting on its own. Repo-wide tightness
+     * deliberately does not count: it is true on almost every PR, so triggering on it would put
+     * a comment on everything and train people to ignore it.
+     */
+    movedIntoDangerZone: boolean;
+}
+
 /**
  * Render the ceiling-headroom section of the PR comment.
  *
@@ -169,9 +185,9 @@ function pluralizeScenes(count: number): string {
  * Putting it in the comment is what turns it into something an author acts on — so the scenes
  * *this PR moved* are called out uncollapsed, and the repo-wide picture is folded away.
  */
-export function formatHeadroomSection(inputs: readonly SceneHeadroomInput[], movedBytes: ReadonlyMap<string, number>): string[] {
+export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], movedBytes: ReadonlyMap<string, number>): HeadroomReport {
     if (inputs.length === 0) {
-        return [];
+        return { lines: [], movedIntoDangerZone: false };
     }
 
     const { over, under } = computeSceneHeadroom(inputs);
@@ -221,15 +237,32 @@ export function formatHeadroomSection(inputs: readonly SceneHeadroomInput[], mov
             "every later PR's Bundle Size job then fails until the bytes are recovered. If a scene you touched is near zero, consider landing separately.*"
     );
 
-    return lines;
+    return { lines, movedIntoDangerZone: movedAndTight.length > 0 || movedAndOver.length > 0 };
 }
 
-export function formatComment(deltas: BundleDelta[], headroomLines: readonly string[] = []): string {
-    if (deltas.length === 0) {
+/**
+ * Render the comment, or the "nothing to say" placeholder.
+ *
+ * A headroom-only comment is a real case, not a degenerate one. The delta tables round to whole
+ * KB, so a PR whose only effect is a few hundred bytes produces no rows at all — and that is
+ * exactly the change this feature exists to catch, because a few hundred bytes is enough to
+ * consume the headroom of the ~46% of scenes that have under 1 KB of it. Suppressing the comment
+ * whenever the tables are empty would make the report inert in its most important case.
+ */
+export function formatComment(deltas: BundleDelta[], headroom: HeadroomReport = { lines: [], movedIntoDangerZone: false }): string {
+    if (deltas.length === 0 && !headroom.movedIntoDangerZone) {
         return "**Bundle Size**: No changes detected.";
     }
 
     const lines = ["## Bundle Size Changes", ""];
+
+    if (deltas.length === 0) {
+        lines.push("No changes at whole-KB resolution — but this PR moved a scene close to its ceiling.");
+        lines.push("");
+        lines.push(...headroom.lines);
+        return lines.join("\n");
+    }
+
     const increases = deltas.filter((d) => d.deltaKB > 0);
     const decreases = deltas.filter((d) => d.deltaKB < 0);
 
@@ -257,9 +290,9 @@ export function formatComment(deltas: BundleDelta[], headroomLines: readonly str
 
     lines.push("*Sizes rounded to nearest KB. Run `pnpm build:bundle-scenes` locally to verify.*");
 
-    if (headroomLines.length > 0) {
+    if (headroom.lines.length > 0) {
         lines.push("");
-        lines.push(...headroomLines);
+        lines.push(...headroom.lines);
     }
 
     return lines.join("\n");
@@ -288,8 +321,8 @@ function main(): void {
 
     const sceneConfigs = loadSceneConfig(sceneConfigPath);
     const deltas = computeDeltas(current, master, sceneConfigs);
-    const headroomLines = formatHeadroomSection(collectHeadroomInputs(current, sceneConfigs), computeMovedBytes(current, master));
-    const comment = formatComment(deltas, headroomLines);
+    const headroom = buildHeadroomReport(collectHeadroomInputs(current, sceneConfigs), computeMovedBytes(current, master));
+    const comment = formatComment(deltas, headroom);
 
     mkdirSync(dirname(outputPath), { recursive: true });
     writeFileSync(outputPath, comment, "utf-8");
@@ -297,7 +330,12 @@ function main(): void {
     console.log("");
     console.log(comment);
 
-    if (deltas.length > 0) {
+    // Post on a whole-KB delta OR on a move into the danger zone. The second disjunct is not a
+    // nicety: a sub-KB change produces no delta rows at all, so gating on the tables alone would
+    // silence the report in precisely the case it was built for — a few hundred bytes landing on
+    // a scene that had a few hundred bytes of room. Repo-wide tightness is deliberately not a
+    // trigger; without the "this PR moved it" requirement every PR would get a comment.
+    if (deltas.length > 0 || headroom.movedIntoDangerZone) {
         console.log("");
         console.log("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
         const escapedComment = escapeAzureVariableValue(comment);

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -276,7 +276,15 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     const tightLabel = formatHeadroomThreshold(TIGHT_HEADROOM_BYTES);
     // Only growth consumes headroom. See the note on direction in this function's doc comment.
     const grewBy = (scene: SceneHeadroom): number => movedBytes.get(scene.scene) ?? 0;
-    const movedAndTight = tight.filter((s) => grewBy(s) > 0);
+    // A scene missing from the baseline is one this branch adds. It has no delta at all, so every
+    // movement-based test answers "no" for it — which is the wrong answer to "is this PR
+    // responsible for this scene?", the question the callouts below are actually asking. Without
+    // this, a PR that lands a brand-new scene a few hundred bytes under its ceiling produces no
+    // comment whatsoever: no delta rows, no danger-zone flag, nothing to post. That is silence in
+    // exactly the case this report exists for, aimed at the author best placed to act on it, and
+    // it is the same mistake as attributing a breach by movement — corrected there, missed here.
+    const isAddedHere = (scene: SceneHeadroom): boolean => scene.masterBytes == null;
+    const movedAndTight = tight.filter((s) => grewBy(s) > 0 || isAddedHere(s));
     // Attribution is a question about the *baseline*, not about movement, and the two answer
     // differently in both directions. A scene this branch adds has no baseline entry, so it has no
     // delta and movement calls it inherited — while claiming it was "already over on master" and
@@ -301,12 +309,16 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     }
 
     if (movedAndTight.length > 0) {
-        lines.push(`⚠️ **${pluralizeScenes(movedAndTight.length)} this PR grew now ${movedAndTight.length === 1 ? "sits" : "sit"} under ${tightLabel} of headroom.**`);
+        // "added or grew" rather than "grew": this set now also holds scenes the branch created,
+        // which have no baseline size to have grown from.
+        lines.push(`⚠️ **${pluralizeScenes(movedAndTight.length)} this PR added or grew now ${movedAndTight.length === 1 ? "sits" : "sit"} under ${tightLabel} of headroom.**`);
         lines.push("");
         lines.push("| Scene | Size | Ceiling | Headroom | Δ this PR |");
         lines.push("|-------|------|---------|----------|-----------|");
         for (const scene of movedAndTight.slice(0, HEADROOM_LIST_LIMIT)) {
-            const delta = formatSignedBytes(movedBytes.get(scene.scene) ?? 0);
+            // A new scene has no baseline to subtract, so a signed delta would render as "0 B" and
+            // read as "this PR did not touch it" — the opposite of why it is in this table.
+            const delta = isAddedHere(scene) ? "new scene" : formatSignedBytes(movedBytes.get(scene.scene) ?? 0);
             lines.push(
                 `| ${sceneLabel(scene)} | ${formatSizeKB(scene.measuredBytes)} | ${formatCeilingKB(scene.ceilingKB)} | **${formatBytes(scene.headroomBytes)}** | ${delta} |`
             );
@@ -362,8 +374,11 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
         ...under.map((scene) => ({ scene, headroom: formatBytes(scene.headroomBytes) })),
     ];
     for (const { scene, headroom } of rankedRows.slice(0, HEADROOM_LIST_LIMIT)) {
-        const moved = movedBytes.has(scene.scene) ? " ⬅ moved by this PR" : "";
-        lines.push(`| ${sceneLabel(scene)}${moved} | ${formatSizeKB(scene.measuredBytes)} | ${formatCeilingKB(scene.ceilingKB)} | ${headroom} |`);
+        // Mark the branch's own scenes in the repo-wide list so an author can find theirs among
+        // rows that are mostly other people's. A scene this branch adds belongs to it just as much
+        // as one it grew, but has no delta entry, so `movedBytes` alone would leave it unmarked.
+        const attribution = isAddedHere(scene) ? " ⬅ added by this PR" : movedBytes.has(scene.scene) ? " ⬅ moved by this PR" : "";
+        lines.push(`| ${sceneLabel(scene)}${attribution} | ${formatSizeKB(scene.measuredBytes)} | ${formatCeilingKB(scene.ceilingKB)} | ${headroom} |`);
     }
     lines.push("");
     lines.push("</details>");
@@ -408,7 +423,7 @@ export function formatComment(deltas: BundleDelta[], headroom: HeadroomReport = 
         // own diff immediately above a block saying the breach came from master.
         lines.push(
             headroom.movedIntoDangerZone
-                ? "No changes at whole-KB resolution — but this PR moved a scene close to its ceiling."
+                ? "No changes at whole-KB resolution — but this PR put a scene close to its ceiling."
                 : "No bundle-size changes on this branch — but a scene is over its ceiling on master, which fails this job on every open PR."
         );
         lines.push("");

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -211,6 +211,15 @@ export interface HeadroomReport {
  * The build log already computed this, but a ~42-minute job's log is not where anyone looks.
  * Putting it in the comment is what turns it into something an author acts on — so the scenes
  * *this PR moved* are called out uncollapsed, and the repo-wide picture is folded away.
+ *
+ * "Moved" means moved *toward* the ceiling. Direction matters and the first run against a real
+ * baseline is what proved it: a branch that had merged a size-reducing master change showed 94
+ * scenes in the uncollapsed block, every one of them shrinking (many by 46 B), because presence
+ * in the moved set was tested with `has()` rather than by sign. A scene that got smaller gained
+ * headroom — it cannot be pushed over its ceiling by this PR, and it was already tight before it
+ * was touched. Reporting it as actionable inverts the signal: it asks the author to look hardest
+ * at the changes that helped. Only increases can consume headroom, so only increases are called
+ * out here; shrinking scenes still appear in the collapsed repo-wide list if they are tight.
  */
 export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], movedBytes: ReadonlyMap<string, number>): HeadroomReport {
     if (inputs.length === 0) {
@@ -221,8 +230,10 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     const tight = scenesUnderHeadroom(under, TIGHT_HEADROOM_BYTES);
     const critical = scenesUnderHeadroom(under, CRITICAL_HEADROOM_BYTES);
     const tightLabel = formatHeadroomThreshold(TIGHT_HEADROOM_BYTES);
-    const movedAndTight = tight.filter((s) => movedBytes.has(s.scene));
-    const movedAndOver = over.filter((s) => movedBytes.has(s.scene));
+    // Only growth consumes headroom. See the note on direction in this function's doc comment.
+    const grewBy = (scene: SceneHeadroom): number => movedBytes.get(scene.scene) ?? 0;
+    const movedAndTight = tight.filter((s) => grewBy(s) > 0);
+    const movedAndOver = over.filter((s) => grewBy(s) > 0);
 
     const lines = ["### Ceiling headroom", ""];
 
@@ -238,11 +249,19 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
         lines.push("");
         lines.push("| Scene | Size | Ceiling | Headroom | Δ this PR |");
         lines.push("|-------|------|---------|----------|-----------|");
-        for (const scene of movedAndTight) {
+        for (const scene of movedAndTight.slice(0, HEADROOM_LIST_LIMIT)) {
             const delta = formatSignedBytes(movedBytes.get(scene.scene) ?? 0);
             lines.push(
                 `| ${sceneLabel(scene)} | ${formatSizeKB(scene.measuredBytes)} | ${formatCeilingKB(scene.ceilingKB)} | **${formatBytes(scene.headroomBytes)}** | ${delta} |`
             );
+        }
+        if (movedAndTight.length > HEADROOM_LIST_LIMIT) {
+            // Cap the uncollapsed block so its length is bounded no matter how many scenes qualify.
+            // The tightest are listed first, so the overflow is always the least urgent tail, and a
+            // fixed-height block stays readable in the case that matters — a wall of rows is
+            // skimmed past exactly like the build log this section exists to replace.
+            lines.push("");
+            lines.push(`…and ${movedAndTight.length - HEADROOM_LIST_LIMIT} more, listed tightest first.`);
         }
         lines.push("");
     }

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -199,6 +199,20 @@ export interface HeadroomReport {
      * a comment on everything and train people to ignore it.
      */
     movedIntoDangerZone: boolean;
+    /**
+     * Whether any scene is over its ceiling that this PR did *not* grow — an inherited breach.
+     *
+     * This is a separate trigger from {@link movedIntoDangerZone} because it is not the author's
+     * doing and cannot be filtered by direction: the scene was already over before they branched.
+     * It still has to be posted, and posted on PRs that moved nothing, because it is the exact
+     * state this whole section exists for. Master over a ceiling fails the Bundle Size job on
+     * *every* open PR, so the author whose build just went red needs the comment to say why —
+     * otherwise the only explanation lives in a ~42-minute log, which is the problem we started
+     * from. Unlike repo-wide tightness this does not fire on almost every PR; it fires only while
+     * master is actually breached, which is a loud, short-lived emergency by construction, since
+     * it blocks everyone until it is fixed.
+     */
+    inheritedCeilingBreach: boolean;
 }
 
 /**
@@ -223,10 +237,18 @@ export interface HeadroomReport {
  * was touched. Reporting it as actionable inverts the signal: it asks the author to look hardest
  * at the changes that helped. Only increases can consume headroom, so only increases are called
  * out here; shrinking scenes still appear in the collapsed repo-wide list if they are tight.
+ *
+ * Scenes *already* over their ceiling are reported whether or not this PR touched them. Filtering
+ * the over-ceiling set by direction the way the tight set is filtered would have made this section
+ * silent in the one situation it was built for: once master is breached, the Bundle Size job fails
+ * on every open PR, and none of those authors grew the offending scene. The delta-comment step
+ * runs `condition: always()`, so it is still generated on exactly those failing builds — it just
+ * had nothing to say about the failure. An inherited breach is therefore called out separately
+ * from one this PR caused, so the author can tell "you did this" from "this was already broken".
  */
 export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], movedBytes: ReadonlyMap<string, number>): HeadroomReport {
     if (inputs.length === 0) {
-        return { lines: [], movedIntoDangerZone: false };
+        return { lines: [], movedIntoDangerZone: false, inheritedCeilingBreach: false };
     }
 
     const { over, under } = computeSceneHeadroom(inputs);
@@ -237,6 +259,7 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     const grewBy = (scene: SceneHeadroom): number => movedBytes.get(scene.scene) ?? 0;
     const movedAndTight = tight.filter((s) => grewBy(s) > 0);
     const movedAndOver = over.filter((s) => grewBy(s) > 0);
+    const inheritedOver = over.filter((s) => grewBy(s) <= 0);
 
     const lines = ["### Ceiling headroom", ""];
 
@@ -269,15 +292,41 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
         lines.push("");
     }
 
+    if (inheritedOver.length > 0) {
+        const named = inheritedOver.slice(0, HEADROOM_LIST_LIMIT).map((s) => `\`${s.scene}\` (+${formatBytes(s.headroomBytes)} over its ${formatCeilingKB(s.ceilingKB)} ceiling)`);
+        const overflow = inheritedOver.length > HEADROOM_LIST_LIMIT ? `, and ${inheritedOver.length - HEADROOM_LIST_LIMIT} more` : "";
+        const verb = inheritedOver.length === 1 ? "is" : "are";
+        lines.push(`🛑 **${pluralizeScenes(inheritedOver.length)} ${verb} over ceiling on master, not from this PR:** ${named.join(", ")}${overflow}`);
+        lines.push("");
+        lines.push(
+            "This fails the Bundle Size job on every open PR, including ones that changed no bundle bytes, " +
+                "until the bytes are recovered on master. It is not caused by this branch and rebasing will not clear it."
+        );
+        lines.push("");
+    }
+
     const criticalNote = critical.length > 0 ? `, ${critical.length} under ${formatHeadroomThreshold(CRITICAL_HEADROOM_BYTES)}` : "";
+    // Name the breach count in the summary too. Without it a reader sees "0 of 2 under 1.0 KB"
+    // heading a table whose first row is over its ceiling: the tight band counts only scenes still
+    // *under* theirs, so a breached scene is excluded from the count while still being listed.
+    const overNote = over.length > 0 ? `${pluralizeScenes(over.length)} over ceiling, ` : "";
     lines.push("<details>");
-    lines.push(`<summary>Tightest scenes repo-wide — ${tight.length} of ${inputs.length} under ${tightLabel}${criticalNote}</summary>`);
+    lines.push(`<summary>Tightest scenes repo-wide — ${overNote}${tight.length} of ${inputs.length} under ${tightLabel}${criticalNote}</summary>`);
     lines.push("");
     lines.push("| Scene | Size | Ceiling | Headroom |");
     lines.push("|-------|------|---------|----------|");
-    for (const scene of under.slice(0, HEADROOM_LIST_LIMIT)) {
+    // Over-ceiling scenes lead the list: negative headroom is tighter than any positive amount, so
+    // omitting them would head a "tightest scenes" table with something that is not the tightest.
+    // They are labelled rather than printed bare, because `computeSceneHeadroom` stores an overage
+    // as a *positive* number — an unlabelled `909 B` would read as a comfortable margin in a column
+    // where every other row means the opposite.
+    const rankedRows = [
+        ...over.map((scene) => ({ scene, headroom: `⚠️ ${formatBytes(scene.headroomBytes)} over` })),
+        ...under.map((scene) => ({ scene, headroom: formatBytes(scene.headroomBytes) })),
+    ];
+    for (const { scene, headroom } of rankedRows.slice(0, HEADROOM_LIST_LIMIT)) {
         const moved = movedBytes.has(scene.scene) ? " ⬅ moved by this PR" : "";
-        lines.push(`| ${sceneLabel(scene)}${moved} | ${formatSizeKB(scene.measuredBytes)} | ${formatCeilingKB(scene.ceilingKB)} | ${formatBytes(scene.headroomBytes)} |`);
+        lines.push(`| ${sceneLabel(scene)}${moved} | ${formatSizeKB(scene.measuredBytes)} | ${formatCeilingKB(scene.ceilingKB)} | ${headroom} |`);
     }
     lines.push("");
     lines.push("</details>");
@@ -288,7 +337,11 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
             "every later PR's Bundle Size job then fails until the bytes are recovered. If a scene you touched is near zero, consider landing separately.*"
     );
 
-    return { lines, movedIntoDangerZone: movedAndTight.length > 0 || movedAndOver.length > 0 };
+    return {
+        lines,
+        movedIntoDangerZone: movedAndTight.length > 0 || movedAndOver.length > 0,
+        inheritedCeilingBreach: inheritedOver.length > 0,
+    };
 }
 
 /**
@@ -299,9 +352,13 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
  * exactly the change this feature exists to catch, because a few hundred bytes is enough to
  * consume the headroom of the ~44% of scenes that have under 1 KB of it. Suppressing the comment
  * whenever the tables are empty would make the report inert in its most important case.
+ *
+ * An inherited ceiling breach counts too, and it is the case with no delta rows at all by
+ * construction: the scene went over on master, so a PR that touched nothing still gets a red
+ * Bundle Size job and needs to be told why.
  */
-export function formatComment(deltas: BundleDelta[], headroom: HeadroomReport = { lines: [], movedIntoDangerZone: false }): string {
-    if (deltas.length === 0 && !headroom.movedIntoDangerZone) {
+export function formatComment(deltas: BundleDelta[], headroom: HeadroomReport = { lines: [], movedIntoDangerZone: false, inheritedCeilingBreach: false }): string {
+    if (deltas.length === 0 && !headroom.movedIntoDangerZone && !headroom.inheritedCeilingBreach) {
         return "**Bundle Size**: No changes detected.";
     }
 
@@ -388,12 +445,14 @@ function main(): void {
     console.log("");
     console.log(comment);
 
-    // Post on a whole-KB delta OR on a move into the danger zone. The second disjunct is not a
-    // nicety: a sub-KB change produces no delta rows at all, so gating on the tables alone would
-    // silence the report in precisely the case it was built for — a few hundred bytes landing on
-    // a scene that had a few hundred bytes of room. Repo-wide tightness is deliberately not a
-    // trigger; without the "this PR moved it" requirement every PR would get a comment.
-    if (deltas.length > 0 || headroom.movedIntoDangerZone) {
+    // Post on a whole-KB delta OR on a move into the danger zone OR on an inherited breach. The
+    // second disjunct is not a nicety: a sub-KB change produces no delta rows at all, so gating on
+    // the tables alone would silence the report in precisely the case it was built for — a few
+    // hundred bytes landing on a scene that had a few hundred bytes of room. The third covers the
+    // author who changed nothing and still has a red Bundle Size job because master is breached.
+    // Repo-wide *tightness* remains deliberately not a trigger; without the "this PR moved it"
+    // requirement every PR would get a comment.
+    if (deltas.length > 0 || headroom.movedIntoDangerZone || headroom.inheritedCeilingBreach) {
         console.log("");
         console.log("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
         const escapedComment = escapeAzureVariableValue(comment);

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -155,8 +155,30 @@ function formatSignedBytes(bytes: number): string {
     return bytes > 0 ? `+${formatBytes(bytes)}` : formatBytes(bytes);
 }
 
+/**
+ * Decimal places shared by the size and ceiling columns of the headroom tables.
+ *
+ * These two columns MUST render at the same precision, and the reason is a correctness one rather
+ * than a cosmetic one. Ceilings are authored as free-form decimals in `scene-config.json` (`16.56`,
+ * `103.4`, `39.1`), so printing the ceiling verbatim while rounding the measured size to one decimal
+ * compares two numbers at different precisions — and rounding is only order-preserving between
+ * values rounded the *same* way. The real case that exposed it: `scene117` measures 16948 B against a
+ * 16.56 KB ceiling and is 9 B *under*, yet rendered as `16.6 KB` vs `16.56 KB`, which reads as
+ * already over. A reporter whose job is to flag scenes near their ceiling must never make a
+ * compliant scene look breaching; that is the one misread that would send an author chasing bytes
+ * they do not owe. Rounding both sides identically restores monotonicity — if size < ceiling then
+ * the rendered size can never exceed the rendered ceiling, at worst tying — and the exact remaining
+ * bytes live in their own column, so a tie is never ambiguous.
+ */
+const KB_DECIMALS = 2;
+
 function formatSizeKB(bytes: number): string {
-    return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / 1024).toFixed(KB_DECIMALS)} KB`;
+}
+
+/** Ceilings come from config as raw decimals; render them at {@link KB_DECIMALS} to match sizes. */
+function formatCeilingKB(ceilingKB: number): string {
+    return `${ceilingKB.toFixed(KB_DECIMALS)} KB`;
 }
 
 function pluralizeScenes(count: number): string {
@@ -205,7 +227,7 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     const lines = ["### Ceiling headroom", ""];
 
     if (movedAndOver.length > 0) {
-        const named = movedAndOver.map((s) => `\`${s.scene}\` (+${formatBytes(s.headroomBytes)} over its ${s.ceilingKB} KB ceiling)`);
+        const named = movedAndOver.map((s) => `\`${s.scene}\` (+${formatBytes(s.headroomBytes)} over its ${formatCeilingKB(s.ceilingKB)} ceiling)`);
         const verb = movedAndOver.length === 1 ? "now exceeds its ceiling" : "now exceed their ceiling";
         lines.push(`🚨 **${pluralizeScenes(movedAndOver.length)} this PR moved ${verb}:** ${named.join(", ")}`);
         lines.push("");
@@ -218,7 +240,9 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
         lines.push("|-------|------|---------|----------|-----------|");
         for (const scene of movedAndTight) {
             const delta = formatSignedBytes(movedBytes.get(scene.scene) ?? 0);
-            lines.push(`| ${sceneLabel(scene)} | ${formatSizeKB(scene.measuredBytes)} | ${scene.ceilingKB} KB | **${formatBytes(scene.headroomBytes)}** | ${delta} |`);
+            lines.push(
+                `| ${sceneLabel(scene)} | ${formatSizeKB(scene.measuredBytes)} | ${formatCeilingKB(scene.ceilingKB)} | **${formatBytes(scene.headroomBytes)}** | ${delta} |`
+            );
         }
         lines.push("");
     }
@@ -231,7 +255,7 @@ export function buildHeadroomReport(inputs: readonly SceneHeadroomInput[], moved
     lines.push("|-------|------|---------|----------|");
     for (const scene of under.slice(0, HEADROOM_LIST_LIMIT)) {
         const moved = movedBytes.has(scene.scene) ? " ⬅ moved by this PR" : "";
-        lines.push(`| ${sceneLabel(scene)}${moved} | ${formatSizeKB(scene.measuredBytes)} | ${scene.ceilingKB} KB | ${formatBytes(scene.headroomBytes)} |`);
+        lines.push(`| ${sceneLabel(scene)}${moved} | ${formatSizeKB(scene.measuredBytes)} | ${formatCeilingKB(scene.ceilingKB)} | ${formatBytes(scene.headroomBytes)} |`);
     }
     lines.push("");
     lines.push("</details>");

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -4,17 +4,30 @@
  * Reads:
  *  - lab/public/bundle/manifest.json (current)
  *  - lab/public/bundle/master-manifest.json (baseline)
- *  - scene-config.json (scene metadata)
+ *  - scene-config.json (scene metadata, including the `maxRawKB` ceilings)
  *
  * Outputs:
- *  - Markdown comment listing all changes rounded to nearest whole KB
+ *  - Markdown comment listing all changes rounded to nearest whole KB, followed by a
+ *    ceiling-headroom section (see `formatHeadroomSection`)
  *  - Azure DevOps variables for conditional GitHubComment@0 posting
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
+import {
+    computeSceneHeadroom,
+    CRITICAL_HEADROOM_BYTES,
+    formatHeadroomThreshold,
+    HEADROOM_LIST_LIMIT,
+    measuredBytesOf,
+    scenesUnderHeadroom,
+    TIGHT_HEADROOM_BYTES,
+    type SceneHeadroom,
+    type SceneHeadroomInput,
+} from "./bundle-ceiling-headroom";
 
 interface ManifestEntry {
     rawKB?: number;
+    rawBytes?: number;
     gzipKB?: number;
 }
 
@@ -24,6 +37,8 @@ interface SceneConfig {
     id: number;
     slug: string;
     name: string;
+    maxRawKB?: number;
+    skipBundleSize?: boolean;
 }
 
 interface BundleDelta {
@@ -79,7 +94,137 @@ export function computeDeltas(current: Manifest, master: Manifest, sceneConfigs:
     return deltas.sort((a, b) => Math.abs(b.deltaKB) - Math.abs(a.deltaKB));
 }
 
-export function formatComment(deltas: BundleDelta[]): string {
+/**
+ * Exact byte movement per scene, keyed by manifest key.
+ *
+ * Deliberately not derived from `computeDeltas`: that rounds to whole KB and drops anything
+ * that rounds to zero, which is exactly the movement that matters here. A +400 B change shows
+ * up in the delta table as nothing at all, yet it is enough to push a scene with 300 B of
+ * headroom over its ceiling.
+ */
+export function computeMovedBytes(current: Manifest, master: Manifest): Map<string, number> {
+    const moved = new Map<string, number>();
+    for (const key of Object.keys(current)) {
+        const currentBytes = measuredBytesOf(current[key]);
+        const masterBytes = measuredBytesOf(master[key]);
+        if (currentBytes == null || masterBytes == null) {
+            continue;
+        }
+        const delta = Math.round(currentBytes - masterBytes);
+        if (delta !== 0) {
+            moved.set(key, delta);
+        }
+    }
+    return moved;
+}
+
+/** Headroom inputs for every scene that has both a measured size and a ceiling. */
+export function collectHeadroomInputs(current: Manifest, sceneConfigs: SceneConfig[]): SceneHeadroomInput[] {
+    const inputs: SceneHeadroomInput[] = [];
+    for (const config of sceneConfigs) {
+        const key = `scene${config.id}`;
+        const measuredBytes = measuredBytesOf(current[key]);
+        // Honour the same opt-out as the ceiling test in bundle-size.spec.ts.
+        if (measuredBytes == null || config.maxRawKB == null || config.skipBundleSize) {
+            continue;
+        }
+        inputs.push({ scene: key, name: config.name, measuredBytes, ceilingKB: config.maxRawKB });
+    }
+    return inputs;
+}
+
+function sceneLabel(entry: SceneHeadroom): string {
+    return `${entry.name ?? entry.scene}<br/>\`${entry.scene}\``;
+}
+
+/** Bytes below 1 KB stay bytes; above it, one decimal of KB is enough to compare at a glance. */
+function formatBytes(bytes: number): string {
+    const magnitude = Math.abs(bytes);
+    return magnitude < 1024 ? `${bytes} B` : `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function formatSignedBytes(bytes: number): string {
+    return bytes > 0 ? `+${formatBytes(bytes)}` : formatBytes(bytes);
+}
+
+function formatSizeKB(bytes: number): string {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function pluralizeScenes(count: number): string {
+    return count === 1 ? "1 scene" : `${count} scenes`;
+}
+
+/**
+ * Render the ceiling-headroom section of the PR comment.
+ *
+ * The absolute ceiling check is pass/fail with no early warning, and the ceilings sit close
+ * enough to current sizes that roughly half the scenes have under a kilobyte of room. That
+ * makes a specific concurrency failure easy to hit: two PRs each measure under a ceiling
+ * against a master that lacks the other, then breach it together once both land. Because CI
+ * builds the merge commit, master being over a ceiling fails *every* later PR's Bundle Size
+ * job until the bytes are recovered, and raising a ceiling needs explicit approval.
+ *
+ * The build log already computed this, but a ~42-minute job's log is not where anyone looks.
+ * Putting it in the comment is what turns it into something an author acts on — so the scenes
+ * *this PR moved* are called out uncollapsed, and the repo-wide picture is folded away.
+ */
+export function formatHeadroomSection(inputs: readonly SceneHeadroomInput[], movedBytes: ReadonlyMap<string, number>): string[] {
+    if (inputs.length === 0) {
+        return [];
+    }
+
+    const { over, under } = computeSceneHeadroom(inputs);
+    const tight = scenesUnderHeadroom(under, TIGHT_HEADROOM_BYTES);
+    const critical = scenesUnderHeadroom(under, CRITICAL_HEADROOM_BYTES);
+    const tightLabel = formatHeadroomThreshold(TIGHT_HEADROOM_BYTES);
+    const movedAndTight = tight.filter((s) => movedBytes.has(s.scene));
+    const movedAndOver = over.filter((s) => movedBytes.has(s.scene));
+
+    const lines = ["### Ceiling headroom", ""];
+
+    if (movedAndOver.length > 0) {
+        const named = movedAndOver.map((s) => `\`${s.scene}\` (+${formatBytes(s.headroomBytes)} over its ${s.ceilingKB} KB ceiling)`);
+        const verb = movedAndOver.length === 1 ? "now exceeds its ceiling" : "now exceed their ceiling";
+        lines.push(`🚨 **${pluralizeScenes(movedAndOver.length)} this PR moved ${verb}:** ${named.join(", ")}`);
+        lines.push("");
+    }
+
+    if (movedAndTight.length > 0) {
+        lines.push(`⚠️ **${pluralizeScenes(movedAndTight.length)} this PR moved ${movedAndTight.length === 1 ? "sits" : "sit"} under ${tightLabel} of headroom.**`);
+        lines.push("");
+        lines.push("| Scene | Size | Ceiling | Headroom | Δ this PR |");
+        lines.push("|-------|------|---------|----------|-----------|");
+        for (const scene of movedAndTight) {
+            const delta = formatSignedBytes(movedBytes.get(scene.scene) ?? 0);
+            lines.push(`| ${sceneLabel(scene)} | ${formatSizeKB(scene.measuredBytes)} | ${scene.ceilingKB} KB | **${formatBytes(scene.headroomBytes)}** | ${delta} |`);
+        }
+        lines.push("");
+    }
+
+    const criticalNote = critical.length > 0 ? `, ${critical.length} under ${formatHeadroomThreshold(CRITICAL_HEADROOM_BYTES)}` : "";
+    lines.push("<details>");
+    lines.push(`<summary>Tightest scenes repo-wide — ${tight.length} of ${inputs.length} under ${tightLabel}${criticalNote}</summary>`);
+    lines.push("");
+    lines.push("| Scene | Size | Ceiling | Headroom |");
+    lines.push("|-------|------|---------|----------|");
+    for (const scene of under.slice(0, HEADROOM_LIST_LIMIT)) {
+        const moved = movedBytes.has(scene.scene) ? " ⬅ moved by this PR" : "";
+        lines.push(`| ${sceneLabel(scene)}${moved} | ${formatSizeKB(scene.measuredBytes)} | ${scene.ceilingKB} KB | ${formatBytes(scene.headroomBytes)} |`);
+    }
+    lines.push("");
+    lines.push("</details>");
+    lines.push("");
+    lines.push(
+        "*Headroom is the exact distance to a scene's `maxRawKB` ceiling in `scene-config.json`. " +
+            "Two PRs can each measure under a ceiling and still breach it together once both land — and because CI builds the merge commit, " +
+            "every later PR's Bundle Size job then fails until the bytes are recovered. If a scene you touched is near zero, consider landing separately.*"
+    );
+
+    return lines;
+}
+
+export function formatComment(deltas: BundleDelta[], headroomLines: readonly string[] = []): string {
     if (deltas.length === 0) {
         return "**Bundle Size**: No changes detected.";
     }
@@ -112,6 +257,11 @@ export function formatComment(deltas: BundleDelta[]): string {
 
     lines.push("*Sizes rounded to nearest KB. Run `pnpm build:bundle-scenes` locally to verify.*");
 
+    if (headroomLines.length > 0) {
+        lines.push("");
+        lines.push(...headroomLines);
+    }
+
     return lines.join("\n");
 }
 
@@ -138,7 +288,8 @@ function main(): void {
 
     const sceneConfigs = loadSceneConfig(sceneConfigPath);
     const deltas = computeDeltas(current, master, sceneConfigs);
-    const comment = formatComment(deltas);
+    const headroomLines = formatHeadroomSection(collectHeadroomInputs(current, sceneConfigs), computeMovedBytes(current, master));
+    const comment = formatComment(deltas, headroomLines);
 
     mkdirSync(dirname(outputPath), { recursive: true });
     writeFileSync(outputPath, comment, "utf-8");

--- a/scripts/report-bundle-size-deltas.ts
+++ b/scripts/report-bundle-size-deltas.ts
@@ -189,7 +189,10 @@ export interface HeadroomReport {
     /** Rendered markdown lines, empty when no scene has a ceiling to report against. */
     lines: string[];
     /**
-     * Whether this PR moved a scene that is now tight, critical, or over its ceiling.
+     * Whether this PR grew a scene that is now tight, critical, or over its ceiling.
+     *
+     * Growth specifically, not movement: a scene this PR shrank gained headroom and cannot have
+     * been pushed toward its ceiling by this PR, so it is not a reason to post.
      *
      * This is the signal that makes the comment worth posting on its own. Repo-wide tightness
      * deliberately does not count: it is true on almost every PR, so triggering on it would put

--- a/tests/lite/unit/bundle-ceiling-headroom.test.ts
+++ b/tests/lite/unit/bundle-ceiling-headroom.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+    computeSceneHeadroom,
+    CRITICAL_HEADROOM_BYTES,
+    formatHeadroomThreshold,
+    HEADROOM_LIST_LIMIT,
+    measuredBytesOf,
+    scenesUnderHeadroom,
+    TIGHT_HEADROOM_BYTES,
+    type SceneHeadroomInput,
+} from "../../../scripts/bundle-ceiling-headroom";
+
+describe("bundle ceiling headroom", () => {
+    it("keeps the tight band at one kilobyte with the old value as the inner band", () => {
+        // The 1 KB band is the point below which the PR delta table (whole KB) cannot show the
+        // risk at all; 256 B is retained as "critical" rather than deleted. Both are warning
+        // thresholds only — nothing here fails a build.
+        expect(TIGHT_HEADROOM_BYTES).toBe(1024);
+        expect(CRITICAL_HEADROOM_BYTES).toBe(256);
+        expect(CRITICAL_HEADROOM_BYTES).toBeLessThan(TIGHT_HEADROOM_BYTES);
+        expect(HEADROOM_LIST_LIMIT).toBeGreaterThan(0);
+    });
+
+    it("prefers exact bytes and falls back to the rounded KB size", () => {
+        expect(measuredBytesOf({ rawKB: 88.7, rawBytes: 90780 })).toBe(90780);
+        expect(measuredBytesOf({ rawKB: 2 })).toBe(2048);
+        expect(measuredBytesOf({})).toBeNull();
+        expect(measuredBytesOf(undefined)).toBeNull();
+    });
+
+    it("separates over-ceiling scenes from those with headroom, tightest first", () => {
+        const inputs: SceneHeadroomInput[] = [
+            { scene: "scene1", measuredBytes: 1024, ceilingKB: 2 },
+            { scene: "scene2", measuredBytes: 2000, ceilingKB: 2 },
+            { scene: "scene3", measuredBytes: 3000, ceilingKB: 2 },
+            { scene: "scene4", measuredBytes: 5000, ceilingKB: 2 },
+        ];
+
+        const { over, under } = computeSceneHeadroom(inputs);
+
+        expect(under.map((s) => s.scene)).toEqual(["scene2", "scene1"]);
+        expect(under.map((s) => s.headroomBytes)).toEqual([48, 1024]);
+        expect(over.map((s) => s.scene)).toEqual(["scene4", "scene3"]);
+        expect(over.map((s) => s.headroomBytes)).toEqual([2952, 952]);
+    });
+
+    it("compares before rounding so a fractional ceiling cannot wave an overflow through", () => {
+        // 92.2 KB is 94412.8 bytes: 94413 is over by 0.2, which Math.round would turn into -0.
+        const { over, under } = computeSceneHeadroom([
+            { scene: "scene5", measuredBytes: 94413, ceilingKB: 92.2 },
+            { scene: "scene6", measuredBytes: 94412, ceilingKB: 92.2 },
+        ]);
+
+        expect(over.map((s) => s.scene)).toEqual(["scene5"]);
+        expect(over[0]!.headroomBytes).toBe(1);
+        expect(under.map((s) => s.scene)).toEqual(["scene6"]);
+        expect(under[0]!.headroomBytes).toBe(0);
+    });
+
+    it("selects scenes strictly below a threshold", () => {
+        const { under } = computeSceneHeadroom([
+            { scene: "critical", measuredBytes: 2048 - 100, ceilingKB: 2 },
+            { scene: "exactly-critical", measuredBytes: 2048 - CRITICAL_HEADROOM_BYTES, ceilingKB: 2 },
+            { scene: "tight", measuredBytes: 2048 - 900, ceilingKB: 2 },
+            { scene: "roomy", measuredBytes: 0, ceilingKB: 2 },
+        ]);
+
+        expect(scenesUnderHeadroom(under, CRITICAL_HEADROOM_BYTES).map((s) => s.scene)).toEqual(["critical"]);
+        expect(scenesUnderHeadroom(under, TIGHT_HEADROOM_BYTES).map((s) => s.scene)).toEqual(["critical", "exactly-critical", "tight"]);
+    });
+
+    it("names thresholds the way the reports print them", () => {
+        expect(formatHeadroomThreshold(TIGHT_HEADROOM_BYTES)).toBe("1.0 KB");
+        expect(formatHeadroomThreshold(CRITICAL_HEADROOM_BYTES)).toBe("256 B");
+    });
+});

--- a/tests/lite/unit/perf-baseline-script-closure.test.ts
+++ b/tests/lite/unit/perf-baseline-script-closure.test.ts
@@ -67,6 +67,27 @@ function copiedScriptList(): string[] {
 }
 
 describe("perf baseline script copy list", () => {
+    it("walks a non-empty import closure (vacuity bound — do not remove)", () => {
+        // The assertion below is "nothing required is missing", which an empty closure
+        // satisfies trivially. So the walk itself has to be pinned, or this suite degrades
+        // into a test that cannot fail: narrow the specifier regex — a `.js` extension
+        // convention change, a switch to single quotes, a move to `import(...)` — and the
+        // closure silently returns nothing, `missing` is empty, and the guard reports green
+        // while blind. That is the failure mode it exists to prevent, reproduced inside the
+        // guard itself.
+        //
+        // Pinned as a floor rather than an exact set on purpose. Asserting the full closure
+        // would make this a second hand-maintained mirror of the import graph — the very
+        // coupling the suite was written to kill — and it would need editing every time a
+        // helper is added. A floor only ever needs revisiting if a named file stops being a
+        // real dependency, which is a deliberate act.
+        const required = importClosureOf(ENTRY);
+        expect(required.size, "import closure came back empty; the specifier regex has stopped matching").toBeGreaterThan(0);
+        // The specimen the suite was written for: extracting this helper out of
+        // bundle-scenes-core.ts is what broke the perf job in the first place.
+        expect([...required], "the known extracted helper is missing from the walked closure").toContain("bundle-ceiling-headroom.ts");
+    });
+
     it("includes every scripts/ module that the bundle builder imports", () => {
         const copied = copiedScriptList();
         const required = importClosureOf(ENTRY);

--- a/tests/lite/unit/perf-baseline-script-closure.test.ts
+++ b/tests/lite/unit/perf-baseline-script-closure.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const SCRIPTS_DIR = resolve(ROOT, "scripts");
+const PERF_BASELINE = resolve(SCRIPTS_DIR, "build-perf-baseline.ts");
+const ENTRY = "bundle-scenes-core.ts";
+
+/**
+ * `build-perf-baseline.ts` checks the baseline ref out into a worktree and then copies
+ * a hand-maintained list of `scripts/` files over it, so the baseline is measured with
+ * the *current* bundle builder rather than a historical one.
+ *
+ * That list is a manual mirror of an import graph, which is exactly the kind of coupling
+ * that rots silently: extracting a helper out of bundle-scenes-core.ts leaves the list
+ * stale, and nothing complains until the perf job — the slowest job in the pipeline, and
+ * one that only runs in CI — dies with "Cannot find module './<helper>'". Every other
+ * consumer builds from a full checkout where the file is simply present, so local runs,
+ * unit tests, and the bundle-size job all stay green while perf is broken.
+ *
+ * This test closes that gap statically: it recomputes the import closure from the source
+ * and fails in milliseconds, at the moment the helper is extracted.
+ */
+function relativeImportsOf(fileName: string): string[] {
+    const source = readFileSync(resolve(SCRIPTS_DIR, fileName), "utf8");
+    // Strip comments first. bundle-scenes-core.ts documents its own re-export handling
+    // with illustrative `export { A } from "./foo.js"` snippets inside doc comments, and
+    // matching those would invent dependencies on files that never existed.
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+    // Matches `from "./x"` in both import and re-export position. Only same-directory
+    // specifiers matter: the copy step is flat, so anything deeper would need a different
+    // fix than adding a name to the list, and should fail loudly here rather than be
+    // silently normalised into a passing assertion.
+    const specifiers = [...code.matchAll(/\bfrom\s+"(\.\/[^"]+)"/g)].flatMap((match) => (match[1] ? [match[1]] : []));
+    return specifiers.map((specifier) => {
+        const bare = specifier.replace(/^\.\//, "").replace(/\.js$/, "");
+        return bare.endsWith(".ts") ? bare : `${bare}.ts`;
+    });
+}
+
+function importClosureOf(entry: string): Set<string> {
+    const seen = new Set<string>();
+    const queue = [entry];
+    while (queue.length > 0) {
+        const current = queue.shift()!;
+        if (seen.has(current)) continue;
+        seen.add(current);
+        // Relative imports that don't resolve to a scripts/ file (e.g. a directory index)
+        // are out of scope for the flat copy step; skip rather than crash.
+        if (!existsSync(resolve(SCRIPTS_DIR, current))) continue;
+        queue.push(...relativeImportsOf(current));
+    }
+    seen.delete(entry);
+    return seen;
+}
+
+function copiedScriptList(): string[] {
+    const source = readFileSync(PERF_BASELINE, "utf8");
+    const match = source.match(/for\s*\(const scriptName of \[([\s\S]*?)\]\)/);
+    const listBody = match?.[1];
+    // A rename or refactor of the copy loop must fail loudly here. Silently returning an
+    // empty list would make the closure assertion below pass for the wrong reason.
+    expect(listBody, "could not locate the script copy list in build-perf-baseline.ts").toBeTruthy();
+    return [...(listBody ?? "").matchAll(/"([^"]+)"/g)].flatMap((entry) => (entry[1] ? [entry[1]] : []));
+}
+
+describe("perf baseline script copy list", () => {
+    it("includes every scripts/ module that the bundle builder imports", () => {
+        const copied = copiedScriptList();
+        const required = importClosureOf(ENTRY);
+
+        const missing = [...required].filter((name) => !copied.includes(name));
+        expect(
+            missing,
+            `build-perf-baseline.ts copies ${ENTRY} into the baseline worktree but not ${missing.join(", ")}. ` +
+                `The baseline ref predates these files, so the perf job fails with "Cannot find module". ` +
+                `Add them to the copy list in scripts/build-perf-baseline.ts.`
+        ).toEqual([]);
+    });
+
+    it("copies the bundle builder itself", () => {
+        // The closure check above is vacuous if the entry point ever drops off the list.
+        expect(copiedScriptList()).toContain(ENTRY);
+    });
+});

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -140,7 +140,7 @@ describe("report-bundle-size-deltas", () => {
             const comment = runReporter(headroomFixture).comment ?? "";
 
             expect(comment).toContain("### Ceiling headroom");
-            expect(comment).toContain("⚠️ **1 scene this PR grew now sits under 1.0 KB of headroom.**");
+            expect(comment).toContain("⚠️ **1 scene this PR added or grew now sits under 1.0 KB of headroom.**");
             expect(comment).toContain("| Scene | Size | Ceiling | Headroom | Δ this PR |");
             expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.90 KB | 50.00 KB | **100 B** | +400 B");
             // scene3 is tight too, but this PR did not touch it — it belongs in the collapsed
@@ -296,7 +296,7 @@ describe("report-bundle-size-deltas", () => {
                 }).comment ?? "";
 
             expect(comment).toContain("No bundle-size changes on this branch — but a scene is over its ceiling on master");
-            expect(comment).not.toContain("this PR moved a scene close to its ceiling");
+            expect(comment).not.toContain("this PR put a scene close to its ceiling");
         });
 
         it("posts a comment for an inherited breach even when this PR moves no bundle bytes", () => {
@@ -349,7 +349,7 @@ describe("report-bundle-size-deltas", () => {
             expect(comment).not.toContain("### Increases");
             expect(comment).not.toContain("### Decreases");
             expect(comment).toContain("### Ceiling headroom");
-            expect(comment).toContain("⚠️ **1 scene this PR grew now sits under 1.0 KB of headroom.**");
+            expect(comment).toContain("⚠️ **1 scene this PR added or grew now sits under 1.0 KB of headroom.**");
             expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.90 KB | 50.00 KB | **100 B** | +400 B");
             // scene1 moved by 100 B too, but it has 2400 B of room — not a reason to warn.
             expect(comment).not.toContain("Scene 1 - BoomBox PBR<br/>`scene1` | 97.7 KB");
@@ -409,16 +409,25 @@ describe("report-bundle-size-deltas", () => {
             expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
         });
 
-        it("does not treat a scene absent from master as having grown by its whole size", () => {
-            // A scene added by this PR has no baseline to move from. If the null guard in
-            // computeMovedBytes were dropped, its delta would come out as its entire size, which
-            // would then read as the largest growth in the PR and, if the scene were tight, flag it
-            // as freshly pushed into the danger zone. Both claims would be false: a new scene did
-            // not "move", and its size is whatever it was authored at.
+        it("flags a scene absent from master without inventing a delta the size of the whole scene", () => {
+            // Two separate claims used to live in this test, and conflating them hid a bug.
             //
-            // This is live rather than hypothetical — scene186 was added to scene-config.json by
-            // #610 while this PR was open, and appeared in the current manifest before any baseline
-            // contained it. The behaviour is already correct; this pins it.
+            // The invariant, unchanged: a scene added by this PR has no baseline to move from, so
+            // if the null guard in computeMovedBytes were dropped its delta would come out as its
+            // entire size — reading as by far the largest growth in the PR. That must never happen,
+            // and the Δ column says "new scene" rather than a number for exactly that reason.
+            //
+            // What changed: this test also asserted the scene was not flagged *at all*, reasoning
+            // that "a new scene did not move". That is the same movement-as-proxy-for-attribution
+            // mistake corrected for over-ceiling scenes, and here it produced the worst outcome in
+            // the whole feature — a PR landing a brand-new scene 352 B under its ceiling got no
+            // comment whatsoever. The author chose both the contents and the ceiling in that same
+            // PR, which makes it the most actionable case the report has rather than the least.
+            // Attribution asks who is responsible; a scene that exists only on this branch is
+            // unambiguously this branch's.
+            //
+            // Live rather than hypothetical — scene186 arrived in scene-config.json via #610 while
+            // this PR was open, and appeared in the current manifest before any baseline held it.
             const result = runReporter({
                 current: {
                     scene1: { rawKB: 49.9, rawBytes: 51100 },
@@ -430,10 +439,41 @@ describe("report-bundle-size-deltas", () => {
                     { id: 2, slug: "scene2", name: "Scene 2 - Brand New", maxRawKB: 98 },
                 ],
             });
+            const comment = result.comment ?? "";
 
-            // scene2 is 355 B from its ceiling, but this PR did not move it there.
-            expect(result.comment ?? "").not.toContain("sits under 1.0 KB of headroom");
+            // scene2 lands 352 B from its ceiling, and this PR is the reason it exists.
+            expect(comment).toContain("⚠️ **1 scene this PR added or grew now sits under 1.0 KB of headroom.**");
+            expect(comment).toContain("**352 B**");
+            // The delta is named, never computed against a baseline of zero.
+            expect(comment).toContain("| new scene |");
+            expect(comment).not.toContain("+97.7 KB");
+            expect(comment).not.toContain("+100000");
+            expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
+        });
+
+        it("stays silent about a scene this PR added that is nowhere near its ceiling", () => {
+            // The bound on the fix above. Treating "exists only on this branch" as attribution is
+            // correct, but attribution alone must not summon a comment — otherwise every PR that
+            // adds a scene gets a headroom callout, and a callout that fires on healthy scenes is
+            // worse than none, because it trains authors to scroll past the one that matters.
+            //
+            // The tight threshold remains the sole trigger. isAddedHere only decides *whose* a
+            // tight scene is; it never decides *whether* a scene is tight. This test fails if the
+            // two are ever collapsed into one predicate.
+            const result = runReporter({
+                current: {
+                    scene1: { rawKB: 40.0, rawBytes: 40960 },
+                    scene2: { rawKB: 40.0, rawBytes: 40960 },
+                },
+                master: { scene1: { rawKB: 40.0, rawBytes: 40960 } },
+                scenes: [
+                    { id: 1, slug: "scene1", name: "Scene 1 - Sphere", maxRawKB: 80 },
+                    { id: 2, slug: "scene2", name: "Scene 2 - Brand New", maxRawKB: 80 },
+                ],
+            });
+
             expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
+            expect(result.comment ?? "").not.toContain("headroom");
         });
 
         it("caps the uncollapsed block so it cannot become a wall of rows", () => {
@@ -454,7 +494,7 @@ describe("report-bundle-size-deltas", () => {
             const comment = runReporter({ current, master, scenes }).comment ?? "";
             const actionable = comment.slice(comment.indexOf("### Ceiling headroom"), comment.indexOf("<details>"));
 
-            expect(comment).toContain("⚠️ **14 scenes this PR grew now sit under 1.0 KB of headroom.**");
+            expect(comment).toContain("⚠️ **14 scenes this PR added or grew now sit under 1.0 KB of headroom.**");
             expect(actionable).toContain("…and 4 more, listed tightest first.");
             // 10 data rows plus the header and separator.
             expect(actionable.split("\n").filter((l) => l.startsWith("| ")).length).toBe(11);

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -255,6 +255,55 @@ describe("report-bundle-size-deltas", () => {
             expect(result.comment).not.toContain("16.6 KB | 16.56 KB");
         });
 
+        it("does not flag a tight scene this PR made smaller (direction — do not remove)", () => {
+            // Found on the first run against a real published baseline: the uncollapsed block came
+            // back with 94 rows, every one of them a scene that had SHRUNK (most by 46 B), because
+            // membership in the moved set was tested with `has()` and ignored the sign.
+            //
+            // A scene that got smaller gained headroom. It cannot be pushed over its ceiling by this
+            // PR, and it was already tight before this PR touched it — so calling it actionable
+            // points the author at the changes that helped. That is worse than silence: it is the
+            // wallpaper failure this section was specifically designed to avoid.
+            //
+            // scene1 shrinks by 300 B and is still only 400 B from its ceiling. It must not be
+            // called out, and it must not trigger a post on its own.
+            const result = runReporter({
+                current: { scene1: { rawKB: 49.6, rawBytes: 50800 } },
+                master: { scene1: { rawKB: 49.9, rawBytes: 51100 } },
+                scenes: [{ id: 1, slug: "scene1", name: "Scene 1 - Sphere", maxRawKB: 50 }],
+            });
+
+            expect(result.comment ?? "").not.toContain("sits under 1.0 KB of headroom");
+            expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
+        });
+
+        it("caps the uncollapsed block so it cannot become a wall of rows", () => {
+            // Length must be bounded by the limit, not by how many scenes happen to qualify. The
+            // same real-baseline run that exposed the direction bug also printed every qualifying
+            // row, which is unreadable for the same reason the build log is.
+            const scenes = [];
+            const current: Record<string, unknown> = {};
+            const master: Record<string, unknown> = {};
+            for (let id = 1; id <= 14; id++) {
+                // Each scene grows 200 B and lands 100+id B short of a 50 KB ceiling.
+                const headroom = 100 + id;
+                current[`scene${id}`] = { rawKB: 49.9, rawBytes: 51200 - headroom };
+                master[`scene${id}`] = { rawKB: 49.7, rawBytes: 51200 - headroom - 200 };
+                scenes.push({ id, slug: `scene${id}`, name: `Scene ${id}`, maxRawKB: 50 });
+            }
+
+            const comment = runReporter({ current, master, scenes }).comment ?? "";
+            const actionable = comment.slice(comment.indexOf("### Ceiling headroom"), comment.indexOf("<details>"));
+
+            expect(comment).toContain("⚠️ **14 scenes this PR moved sit under 1.0 KB of headroom.**");
+            expect(actionable).toContain("…and 4 more, listed tightest first.");
+            // 10 data rows plus the header and separator.
+            expect(actionable.split("\n").filter((l) => l.startsWith("| ")).length).toBe(11);
+            // Tightest first, so the overflow is the least urgent tail.
+            expect(actionable).toContain("`scene1`");
+            expect(actionable).not.toContain("`scene14`");
+        });
+
         it("stays silent when tight scenes this PR did not move are the only tight scenes (noise bound — do not remove)", () => {
             // This is the guard that keeps the headroom report off every PR, and it is the one
             // case here that looks redundant from the outside: it asserts an absence, so a

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -220,6 +220,29 @@ describe("report-bundle-size-deltas", () => {
             expect(details.indexOf("`scene2`")).toBeLessThan(details.indexOf("`scene1`"));
         });
 
+        it("caps the inherited-breach callout so it cannot become a wall of scene names", () => {
+            // Same failure mode as the uncollapsed-block cap: a repo-wide stall can breach many
+            // scenes at once, and an uncapped inline list is skimmed past exactly like the build
+            // log this section replaces. 12 breached scenes, none of them touched by this PR.
+            const breached = Array.from({ length: 12 }, (_, i) => i + 1);
+            const manifest = Object.fromEntries(breached.map((id) => [`scene${id}`, { rawKB: 50.3, rawBytes: 51512 }]));
+            const result = runReporter({
+                current: manifest,
+                master: manifest,
+                scenes: breached.map((id) => ({ id, slug: `scene${id}`, name: `Scene ${id}`, maxRawKB: 50 })),
+            });
+            const comment = result.comment ?? "";
+
+            expect(comment).toContain("🛑 **12 scenes are over ceiling on master, not from this PR:**");
+            expect(comment).toContain(", and 2 more");
+            // The callout names at most HEADROOM_LIST_LIMIT scenes, and the table is capped too.
+            const callout = comment.slice(comment.indexOf("🛑"), comment.indexOf("This fails the Bundle Size job"));
+            expect(callout.match(/over its 50\.00 KB ceiling/g) ?? []).toHaveLength(10);
+            const details = comment.slice(comment.indexOf("<details>"), comment.indexOf("</details>"));
+            expect(details.match(/⚠️ \d+ B over/g) ?? []).toHaveLength(10);
+            expect(details).toContain("12 scenes over ceiling");
+        });
+
         it("posts a comment for an inherited breach even when this PR moves no bundle bytes", () => {
             // Identical manifests on both sides: zero deltas, nothing moved, tables empty. The
             // author still has a red Bundle Size job and this comment is the only explanation.

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -192,5 +192,68 @@ describe("report-bundle-size-deltas", () => {
             expect(comment).toContain("## Bundle Size Changes");
             expect(comment).not.toContain("Ceiling headroom");
         });
+
+        it("posts a headroom-only comment when the sole change is sub-KB movement into the tight band", () => {
+            // Every rounded delta is zero here, so the delta tables are empty. Gating the comment
+            // on those tables alone would silence the report in exactly the case it exists for.
+            const result = runReporter({
+                current: {
+                    scene1: { rawKB: 97.7, rawBytes: 100000 },
+                    scene2: { rawKB: 49.9, rawBytes: 51100 },
+                },
+                master: {
+                    scene1: { rawKB: 97.6, rawBytes: 99900 },
+                    scene2: { rawKB: 49.5, rawBytes: 50700 },
+                },
+                scenes: [
+                    { id: 1, slug: "scene1", name: "Scene 1 - BoomBox PBR", maxRawKB: 100 },
+                    { id: 2, slug: "scene2", name: "Scene 2 - Sphere", maxRawKB: 50 },
+                ],
+            });
+            const comment = result.comment ?? "";
+
+            expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
+            expect(comment).toContain("No changes at whole-KB resolution");
+            expect(comment).not.toContain("### Increases");
+            expect(comment).not.toContain("### Decreases");
+            expect(comment).toContain("### Ceiling headroom");
+            expect(comment).toContain("⚠️ **1 scene this PR moved sits under 1.0 KB of headroom.**");
+            expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.9 KB | 50 KB | **100 B** | +400 B");
+            // scene1 moved by 100 B too, but it has 2400 B of room — not a reason to warn.
+            expect(comment).not.toContain("Scene 1 - BoomBox PBR<br/>`scene1` | 97.7 KB");
+        });
+
+        it("posts a headroom-only comment when sub-KB movement pushes a scene over its ceiling", () => {
+            const result = runReporter({
+                current: { scene1: { rawKB: 50.3, rawBytes: 51512 } },
+                master: { scene1: { rawKB: 50.0, rawBytes: 51200 } },
+                scenes: [{ id: 1, slug: "scene1", name: "Scene 1 - Sphere", maxRawKB: 50 }],
+            });
+
+            expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
+            expect(result.comment).toContain("🚨 **1 scene this PR moved now exceeds its ceiling:** `scene1` (+312 B over its 50 KB ceiling)");
+        });
+
+        it("stays silent when repo-wide tightness is untouched by the PR", () => {
+            // scene2 is 100 B from its ceiling but this PR did not move it; scene1 moved but has
+            // room to spare. Triggering on repo-wide tightness would put a comment on every PR.
+            const result = runReporter({
+                current: {
+                    scene1: { rawKB: 97.7, rawBytes: 100000 },
+                    scene2: { rawKB: 49.9, rawBytes: 51100 },
+                },
+                master: {
+                    scene1: { rawKB: 97.6, rawBytes: 99900 },
+                    scene2: { rawKB: 49.9, rawBytes: 51100 },
+                },
+                scenes: [
+                    { id: 1, slug: "scene1", name: "Scene 1 - BoomBox PBR", maxRawKB: 100 },
+                    { id: 2, slug: "scene2", name: "Scene 2 - Sphere", maxRawKB: 50 },
+                ],
+            });
+
+            expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
+            expect(result.comment).toContain("No changes detected");
+        });
     });
 });

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -277,6 +277,33 @@ describe("report-bundle-size-deltas", () => {
             expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
         });
 
+        it("does not treat a scene absent from master as having grown by its whole size", () => {
+            // A scene added by this PR has no baseline to move from. If the null guard in
+            // computeMovedBytes were dropped, its delta would come out as its entire size, which
+            // would then read as the largest growth in the PR and, if the scene were tight, flag it
+            // as freshly pushed into the danger zone. Both claims would be false: a new scene did
+            // not "move", and its size is whatever it was authored at.
+            //
+            // This is live rather than hypothetical — scene186 was added to scene-config.json by
+            // #610 while this PR was open, and appeared in the current manifest before any baseline
+            // contained it. The behaviour is already correct; this pins it.
+            const result = runReporter({
+                current: {
+                    scene1: { rawKB: 49.9, rawBytes: 51100 },
+                    scene2: { rawKB: 97.7, rawBytes: 100000 },
+                },
+                master: { scene1: { rawKB: 49.9, rawBytes: 51100 } },
+                scenes: [
+                    { id: 1, slug: "scene1", name: "Scene 1 - Sphere", maxRawKB: 50 },
+                    { id: 2, slug: "scene2", name: "Scene 2 - Brand New", maxRawKB: 98 },
+                ],
+            });
+
+            // scene2 is 355 B from its ceiling, but this PR did not move it there.
+            expect(result.comment ?? "").not.toContain("sits under 1.0 KB of headroom");
+            expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
+        });
+
         it("caps the uncollapsed block so it cannot become a wall of rows", () => {
             // Length must be bounded by the limit, not by how many scenes happen to qualify. The
             // same real-baseline run that exposed the direction bug also printed every qualifying

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -181,6 +181,59 @@ describe("report-bundle-size-deltas", () => {
             expect(comment).toContain("🚨 **1 scene this PR grew now exceeds its ceiling:** `scene2` (+312 B over its 50.00 KB ceiling)");
         });
 
+        // The scenario this whole section exists for. Once master is over a ceiling, the Bundle
+        // Size job fails on every open PR — and none of those authors grew the offending scene.
+        // Filtering the over-ceiling set by direction the way the tight set is filtered made the
+        // report silent on exactly those builds, which still generate a comment because the step
+        // runs `condition: always()`. These fixtures pin the un-filtered path.
+        const inheritedBreachFixture = {
+            // scene2 is 312 B over its ceiling and identical on both sides: this PR did not touch it.
+            current: { scene1: { rawKB: 97.7, rawBytes: 100000 }, scene2: { rawKB: 50.3, rawBytes: 51512 } },
+            master: { scene1: { rawKB: 95.0, rawBytes: 97280 }, scene2: { rawKB: 50.3, rawBytes: 51512 } },
+            scenes: [
+                { id: 1, slug: "scene1", name: "Scene 1 - BoomBox PBR", maxRawKB: 100 },
+                { id: 2, slug: "scene2", name: "Scene 2 - Sphere", maxRawKB: 50 },
+            ],
+        };
+
+        it("reports a scene already over its ceiling that this PR did not grow", () => {
+            const comment = runReporter(inheritedBreachFixture).comment ?? "";
+
+            expect(comment).toContain("🛑 **1 scene is over ceiling on master, not from this PR:** `scene2` (+312 B over its 50.00 KB ceiling)");
+            expect(comment).toContain("This fails the Bundle Size job on every open PR");
+            // It is not the author's doing, so it must not be reported as something they caused.
+            expect(comment).not.toContain("this PR grew now exceeds its ceiling");
+        });
+
+        it("ranks an over-ceiling scene above every scene still under its ceiling", () => {
+            const comment = runReporter(inheritedBreachFixture).comment ?? "";
+
+            // A breached scene is tighter than any positive margin, so it heads the list. And its
+            // overage is stored positive, so it is labelled — a bare "312 B" in a headroom column
+            // would read as a comfortable margin, the exact inverse of what it means.
+            expect(comment).toContain("`scene2` | 50.30 KB | 50.00 KB | ⚠️ 312 B over |");
+            // Scope the ordering check to the repo-wide table — scene1 also appears earlier in the
+            // Increases delta table, so searching the whole comment answers a different question.
+            const details = comment.slice(comment.indexOf("<details>"), comment.indexOf("</details>"));
+            expect(details).toContain("1 scene over ceiling, 0 of 2 under 1.0 KB");
+            // Match without a trailing pipe: scene1 carries the "⬅ moved by this PR" marker here.
+            expect(details.indexOf("`scene2`")).toBeLessThan(details.indexOf("`scene1`"));
+        });
+
+        it("posts a comment for an inherited breach even when this PR moves no bundle bytes", () => {
+            // Identical manifests on both sides: zero deltas, nothing moved, tables empty. The
+            // author still has a red Bundle Size job and this comment is the only explanation.
+            const result = runReporter({
+                current: { scene1: { rawKB: 50.3, rawBytes: 51512 } },
+                master: { scene1: { rawKB: 50.3, rawBytes: 51512 } },
+                scenes: [{ id: 1, slug: "scene1", name: "Scene 1 - Sphere", maxRawKB: 50 }],
+            });
+
+            expect(result.stdout).toContain("POST_BUNDLE_COMMENT]true");
+            expect(result.comment ?? "").not.toBe("**Bundle Size**: No changes detected.");
+            expect(result.comment ?? "").toContain("🛑 **1 scene is over ceiling on master, not from this PR:**");
+        });
+
         it("omits the headroom section for scenes that opt out of the ceiling check", () => {
             const comment =
                 runReporter({

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -171,7 +171,7 @@ describe("report-bundle-size-deltas", () => {
             const comment =
                 runReporter({
                     current: { scene1: { rawKB: 97.7, rawBytes: 100000 }, scene2: { rawKB: 50.3, rawBytes: 51512 } },
-                    master: { scene1: { rawKB: 95.0, rawBytes: 97280 }, scene2: { rawKB: 49.5, rawBytes: 50700 } },
+                    master: { scene1: { rawKB: 95.0, rawBytes: 97280, ceilingKB: 100 }, scene2: { rawKB: 49.5, rawBytes: 50700, ceilingKB: 50 } },
                     scenes: [
                         { id: 1, slug: "scene1", name: "Scene 1 - BoomBox PBR", maxRawKB: 100 },
                         { id: 2, slug: "scene2", name: "Scene 2 - Sphere", maxRawKB: 50 },
@@ -189,7 +189,7 @@ describe("report-bundle-size-deltas", () => {
         const inheritedBreachFixture = {
             // scene2 is 312 B over its ceiling and identical on both sides: this PR did not touch it.
             current: { scene1: { rawKB: 97.7, rawBytes: 100000 }, scene2: { rawKB: 50.3, rawBytes: 51512 } },
-            master: { scene1: { rawKB: 95.0, rawBytes: 97280 }, scene2: { rawKB: 50.3, rawBytes: 51512 } },
+            master: { scene1: { rawKB: 95.0, rawBytes: 97280, ceilingKB: 100 }, scene2: { rawKB: 50.3, rawBytes: 51512, ceilingKB: 50 } },
             scenes: [
                 { id: 1, slug: "scene1", name: "Scene 1 - BoomBox PBR", maxRawKB: 100 },
                 { id: 2, slug: "scene2", name: "Scene 2 - Sphere", maxRawKB: 50 },
@@ -199,7 +199,7 @@ describe("report-bundle-size-deltas", () => {
         it("reports a scene already over its ceiling that this PR did not grow", () => {
             const comment = runReporter(inheritedBreachFixture).comment ?? "";
 
-            expect(comment).toContain("🛑 **1 scene was already over ceiling on master:** `scene2` (+312 B over its 50.00 KB ceiling)");
+            expect(comment).toContain("🛑 **1 scene was already over ceiling on master:** `scene2` (+312 B over its 50.00 KB baseline ceiling)");
             expect(comment).toContain("This fails the Bundle Size job on every open PR");
             // It is not the author's doing, so it must not be reported as something they caused.
             expect(comment).not.toContain("put over its ceiling by this PR");
@@ -225,10 +225,11 @@ describe("report-bundle-size-deltas", () => {
             // scenes at once, and an uncapped inline list is skimmed past exactly like the build
             // log this section replaces. 12 breached scenes, none of them touched by this PR.
             const breached = Array.from({ length: 12 }, (_, i) => i + 1);
-            const manifest = Object.fromEntries(breached.map((id) => [`scene${id}`, { rawKB: 50.3, rawBytes: 51512 }]));
+            const current = Object.fromEntries(breached.map((id) => [`scene${id}`, { rawKB: 50.3, rawBytes: 51512 }]));
+            const master = Object.fromEntries(breached.map((id) => [`scene${id}`, { rawKB: 50.3, rawBytes: 51512, ceilingKB: 50 }]));
             const result = runReporter({
-                current: manifest,
-                master: manifest,
+                current,
+                master,
                 scenes: breached.map((id) => ({ id, slug: `scene${id}`, name: `Scene ${id}`, maxRawKB: 50 })),
             });
             const comment = result.comment ?? "";
@@ -237,7 +238,7 @@ describe("report-bundle-size-deltas", () => {
             expect(comment).toContain(", and 2 more");
             // The callout names at most HEADROOM_LIST_LIMIT scenes, and the table is capped too.
             const callout = comment.slice(comment.indexOf("🛑"), comment.indexOf("This fails the Bundle Size job"));
-            expect(callout.match(/over its 50\.00 KB ceiling/g) ?? []).toHaveLength(10);
+            expect(callout.match(/over its 50\.00 KB baseline ceiling/g) ?? []).toHaveLength(10);
             const details = comment.slice(comment.indexOf("<details>"), comment.indexOf("</details>"));
             expect(details.match(/⚠️ \d+ B over/g) ?? []).toHaveLength(10);
             expect(details).toContain("12 scenes over ceiling");
@@ -272,13 +273,13 @@ describe("report-bundle-size-deltas", () => {
             const comment =
                 runReporter({
                     current: { scene1: { rawKB: 50.3, rawBytes: 51512 } },
-                    master: { scene1: { rawKB: 50.3, rawBytes: 51500 } },
+                    master: { scene1: { rawKB: 50.3, rawBytes: 51500, ceilingKB: 50 } },
                     scenes: [{ id: 1, slug: "scene1", name: "Scene 1", maxRawKB: 50 }],
                 }).comment ?? "";
 
             // The branch's contribution is reported separately from the total: the author can act
             // on the 12 B they added and cannot act on the 300 B that were already there.
-            expect(comment).toContain("🛑 **1 scene was already over ceiling on master:** `scene1` (+312 B over its 50.00 KB ceiling, 12 B of it added here)");
+            expect(comment).toContain("🛑 **1 scene was already over ceiling on master:** `scene1` (+300 B over its 50.00 KB baseline ceiling, 12 B of it added here)");
             expect(comment).toContain("rebasing will not clear it");
             expect(comment).not.toContain("put over its ceiling by this PR");
         });
@@ -287,11 +288,12 @@ describe("report-bundle-size-deltas", () => {
             // The headroom-only header predates the inherited-breach trigger, which reaches it
             // with nothing moved — so it asserted movement and pointed the author at their own
             // diff directly above a block saying the breach came from master.
-            const identical = { scene1: { rawKB: 50.3, rawBytes: 51512 } };
+            const current = { scene1: { rawKB: 50.3, rawBytes: 51512 } };
+            const master = { scene1: { rawKB: 50.3, rawBytes: 51512, ceilingKB: 50 } };
             const comment =
                 runReporter({
-                    current: identical,
-                    master: identical,
+                    current,
+                    master,
                     scenes: [{ id: 1, slug: "scene1", name: "Scene 1", maxRawKB: 50 }],
                 }).comment ?? "";
 
@@ -304,13 +306,46 @@ describe("report-bundle-size-deltas", () => {
             // author still has a red Bundle Size job and this comment is the only explanation.
             const result = runReporter({
                 current: { scene1: { rawKB: 50.3, rawBytes: 51512 } },
-                master: { scene1: { rawKB: 50.3, rawBytes: 51512 } },
+                master: { scene1: { rawKB: 50.3, rawBytes: 51512, ceilingKB: 50 } },
                 scenes: [{ id: 1, slug: "scene1", name: "Scene 1 - Sphere", maxRawKB: 50 }],
             });
 
             expect(result.stdout).toContain("POST_BUNDLE_COMMENT]true");
             expect(result.comment ?? "").not.toBe("**Bundle Size**: No changes detected.");
             expect(result.comment ?? "").toContain("🛑 **1 scene was already over ceiling on master:**");
+        });
+
+        it("uses the baseline ceiling when a PR tightens the current ceiling (#628)", () => {
+            // Master measured 95 KB under the 100 KB ceiling that applied to it. This PR reclaims
+            // 3 KB but tightens the current ceiling to 90 KB. Comparing master's bytes with the
+            // branch ceiling falsely called this inherited and claimed rebasing could not clear it.
+            const result = runReporter({
+                current: { scene1: { rawKB: 92, rawBytes: 92 * 1024 } },
+                master: { scene1: { rawKB: 95, rawBytes: 95 * 1024, ceilingKB: 100 } },
+                scenes: [{ id: 1, slug: "scene1", name: "Scene 1", maxRawKB: 90 }],
+            });
+            const comment = result.comment ?? "";
+
+            expect(comment).toContain("🚨 **1 scene put over its ceiling by this PR:** `scene1` (+2.0 KB over its 90.00 KB ceiling)");
+            expect(comment).not.toContain("already over ceiling on master");
+            expect(comment).not.toContain("rebasing will not clear it");
+        });
+
+        it("does not infer historical ceiling state when an old baseline has no ceiling", () => {
+            const result = runReporter({
+                current: { scene1: { rawKB: 92, rawBytes: 92 * 1024 } },
+                master: { scene1: { rawKB: 95, rawBytes: 95 * 1024 } },
+                scenes: [{ id: 1, slug: "scene1", name: "Scene 1", maxRawKB: 90 }],
+            });
+            const comment = result.comment ?? "";
+
+            expect(comment).not.toContain("put over its ceiling by this PR");
+            expect(comment).not.toContain("already over ceiling on master");
+            expect(comment).not.toContain("rebasing will not clear it");
+            // A whole-KB delta still posts the ordinary comparison, and the collapsed table can
+            // report the current branch's absolute state without inventing anything about master.
+            expect(comment).toContain("### Decreases");
+            expect(comment).toContain("⚠️ 2.0 KB over");
         });
 
         it("omits the headroom section for scenes that opt out of the ceiling check", () => {
@@ -358,7 +393,7 @@ describe("report-bundle-size-deltas", () => {
         it("posts a headroom-only comment when sub-KB movement pushes a scene over its ceiling", () => {
             const result = runReporter({
                 current: { scene1: { rawKB: 50.3, rawBytes: 51512 } },
-                master: { scene1: { rawKB: 50.0, rawBytes: 51200 } },
+                master: { scene1: { rawKB: 50.0, rawBytes: 51200, ceilingKB: 50 } },
                 scenes: [{ id: 1, slug: "scene1", name: "Scene 1 - Sphere", maxRawKB: 50 }],
             });
 

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -142,10 +142,10 @@ describe("report-bundle-size-deltas", () => {
             expect(comment).toContain("### Ceiling headroom");
             expect(comment).toContain("⚠️ **1 scene this PR moved sits under 1.0 KB of headroom.**");
             expect(comment).toContain("| Scene | Size | Ceiling | Headroom | Δ this PR |");
-            expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.9 KB | 50 KB | **100 B** | +400 B");
+            expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.90 KB | 50.00 KB | **100 B** | +400 B");
             // scene3 is tight too, but this PR did not touch it — it belongs in the collapsed
             // repo-wide list, not in the actionable block.
-            expect(comment).not.toContain("Scene 3 - Grid<br/>`scene3` | 39.6 KB | 40 KB | **460 B**");
+            expect(comment).not.toContain("Scene 3 - Grid<br/>`scene3` | 39.55 KB | 40.00 KB | **460 B**");
         });
 
         it("reports movement the rounded delta table cannot show", () => {
@@ -161,8 +161,8 @@ describe("report-bundle-size-deltas", () => {
 
             expect(comment).toContain("<details>");
             expect(comment).toContain("<summary>Tightest scenes repo-wide — 2 of 3 under 1.0 KB, 1 under 256 B</summary>");
-            expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` ⬅ moved by this PR | 49.9 KB | 50 KB | 100 B |");
-            expect(comment).toContain("Scene 3 - Grid<br/>`scene3` | 39.6 KB | 40 KB | 460 B |");
+            expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` ⬅ moved by this PR | 49.90 KB | 50.00 KB | 100 B |");
+            expect(comment).toContain("Scene 3 - Grid<br/>`scene3` | 39.55 KB | 40.00 KB | 460 B |");
             // Tightest first.
             expect(comment.indexOf("`scene2` ⬅")).toBeLessThan(comment.indexOf("`scene3` |"));
         });
@@ -178,7 +178,7 @@ describe("report-bundle-size-deltas", () => {
                     ],
                 }).comment ?? "";
 
-            expect(comment).toContain("🚨 **1 scene this PR moved now exceeds its ceiling:** `scene2` (+312 B over its 50 KB ceiling)");
+            expect(comment).toContain("🚨 **1 scene this PR moved now exceeds its ceiling:** `scene2` (+312 B over its 50.00 KB ceiling)");
         });
 
         it("omits the headroom section for scenes that opt out of the ceiling check", () => {
@@ -218,7 +218,7 @@ describe("report-bundle-size-deltas", () => {
             expect(comment).not.toContain("### Decreases");
             expect(comment).toContain("### Ceiling headroom");
             expect(comment).toContain("⚠️ **1 scene this PR moved sits under 1.0 KB of headroom.**");
-            expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.9 KB | 50 KB | **100 B** | +400 B");
+            expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.90 KB | 50.00 KB | **100 B** | +400 B");
             // scene1 moved by 100 B too, but it has 2400 B of room — not a reason to warn.
             expect(comment).not.toContain("Scene 1 - BoomBox PBR<br/>`scene1` | 97.7 KB");
         });
@@ -231,7 +231,28 @@ describe("report-bundle-size-deltas", () => {
             });
 
             expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
-            expect(result.comment).toContain("🚨 **1 scene this PR moved now exceeds its ceiling:** `scene1` (+312 B over its 50 KB ceiling)");
+            expect(result.comment).toContain("🚨 **1 scene this PR moved now exceeds its ceiling:** `scene1` (+312 B over its 50.00 KB ceiling)");
+        });
+
+        it("never renders a compliant scene as if it were over its ceiling (precision monotonicity)", () => {
+            // Regression guard for a misread found by rendering the real published baseline rather
+            // than a fixture. `scene117` measures 16948 B against a 16.56 KB ceiling and is 9 B
+            // UNDER it, but the size column rounded to one decimal while the ceiling printed
+            // verbatim from config, giving "16.6 KB" vs "16.56 KB" — a scene that is passing,
+            // displayed as breaching.
+            //
+            // Comparing at two precisions is what breaks it: rounding only preserves order between
+            // values rounded the same way. This asserts the rendered pair, not the formatter, so it
+            // still fails if someone reintroduces the mismatch through a different code path.
+            const result = runReporter({
+                current: { scene117: { rawKB: 16.6, rawBytes: 16948 } },
+                master: { scene117: { rawKB: 16.4, rawBytes: 16800 } },
+                scenes: [{ id: 117, slug: "scene117", name: "Scene 117 — 2D Sprite Picking", maxRawKB: 16.56 }],
+            });
+
+            expect(result.comment).toContain("| 16.55 KB | 16.56 KB |");
+            expect(result.comment).toContain("**9 B**");
+            expect(result.comment).not.toContain("16.6 KB | 16.56 KB");
         });
 
         it("stays silent when tight scenes this PR did not move are the only tight scenes (noise bound — do not remove)", () => {

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -140,7 +140,7 @@ describe("report-bundle-size-deltas", () => {
             const comment = runReporter(headroomFixture).comment ?? "";
 
             expect(comment).toContain("### Ceiling headroom");
-            expect(comment).toContain("⚠️ **1 scene this PR moved sits under 1.0 KB of headroom.**");
+            expect(comment).toContain("⚠️ **1 scene this PR grew now sits under 1.0 KB of headroom.**");
             expect(comment).toContain("| Scene | Size | Ceiling | Headroom | Δ this PR |");
             expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.90 KB | 50.00 KB | **100 B** | +400 B");
             // scene3 is tight too, but this PR did not touch it — it belongs in the collapsed
@@ -178,7 +178,7 @@ describe("report-bundle-size-deltas", () => {
                     ],
                 }).comment ?? "";
 
-            expect(comment).toContain("🚨 **1 scene this PR moved now exceeds its ceiling:** `scene2` (+312 B over its 50.00 KB ceiling)");
+            expect(comment).toContain("🚨 **1 scene this PR grew now exceeds its ceiling:** `scene2` (+312 B over its 50.00 KB ceiling)");
         });
 
         it("omits the headroom section for scenes that opt out of the ceiling check", () => {
@@ -217,7 +217,7 @@ describe("report-bundle-size-deltas", () => {
             expect(comment).not.toContain("### Increases");
             expect(comment).not.toContain("### Decreases");
             expect(comment).toContain("### Ceiling headroom");
-            expect(comment).toContain("⚠️ **1 scene this PR moved sits under 1.0 KB of headroom.**");
+            expect(comment).toContain("⚠️ **1 scene this PR grew now sits under 1.0 KB of headroom.**");
             expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.90 KB | 50.00 KB | **100 B** | +400 B");
             // scene1 moved by 100 B too, but it has 2400 B of room — not a reason to warn.
             expect(comment).not.toContain("Scene 1 - BoomBox PBR<br/>`scene1` | 97.7 KB");
@@ -231,7 +231,7 @@ describe("report-bundle-size-deltas", () => {
             });
 
             expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
-            expect(result.comment).toContain("🚨 **1 scene this PR moved now exceeds its ceiling:** `scene1` (+312 B over its 50.00 KB ceiling)");
+            expect(result.comment).toContain("🚨 **1 scene this PR grew now exceeds its ceiling:** `scene1` (+312 B over its 50.00 KB ceiling)");
         });
 
         it("never renders a compliant scene as if it were over its ceiling (precision monotonicity)", () => {
@@ -322,7 +322,7 @@ describe("report-bundle-size-deltas", () => {
             const comment = runReporter({ current, master, scenes }).comment ?? "";
             const actionable = comment.slice(comment.indexOf("### Ceiling headroom"), comment.indexOf("<details>"));
 
-            expect(comment).toContain("⚠️ **14 scenes this PR moved sit under 1.0 KB of headroom.**");
+            expect(comment).toContain("⚠️ **14 scenes this PR grew now sit under 1.0 KB of headroom.**");
             expect(actionable).toContain("…and 4 more, listed tightest first.");
             // 10 data rows plus the header and separator.
             expect(actionable.split("\n").filter((l) => l.startsWith("| ")).length).toBe(11);

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -178,7 +178,7 @@ describe("report-bundle-size-deltas", () => {
                     ],
                 }).comment ?? "";
 
-            expect(comment).toContain("🚨 **1 scene this PR grew now exceeds its ceiling:** `scene2` (+312 B over its 50.00 KB ceiling)");
+            expect(comment).toContain("🚨 **1 scene put over its ceiling by this PR:** `scene2` (+312 B over its 50.00 KB ceiling)");
         });
 
         // The scenario this whole section exists for. Once master is over a ceiling, the Bundle
@@ -199,10 +199,10 @@ describe("report-bundle-size-deltas", () => {
         it("reports a scene already over its ceiling that this PR did not grow", () => {
             const comment = runReporter(inheritedBreachFixture).comment ?? "";
 
-            expect(comment).toContain("🛑 **1 scene is over ceiling on master, not from this PR:** `scene2` (+312 B over its 50.00 KB ceiling)");
+            expect(comment).toContain("🛑 **1 scene was already over ceiling on master:** `scene2` (+312 B over its 50.00 KB ceiling)");
             expect(comment).toContain("This fails the Bundle Size job on every open PR");
             // It is not the author's doing, so it must not be reported as something they caused.
-            expect(comment).not.toContain("this PR grew now exceeds its ceiling");
+            expect(comment).not.toContain("put over its ceiling by this PR");
         });
 
         it("ranks an over-ceiling scene above every scene still under its ceiling", () => {
@@ -233,7 +233,7 @@ describe("report-bundle-size-deltas", () => {
             });
             const comment = result.comment ?? "";
 
-            expect(comment).toContain("🛑 **12 scenes are over ceiling on master, not from this PR:**");
+            expect(comment).toContain("🛑 **12 scenes were already over ceiling on master:**");
             expect(comment).toContain(", and 2 more");
             // The callout names at most HEADROOM_LIST_LIMIT scenes, and the table is capped too.
             const callout = comment.slice(comment.indexOf("🛑"), comment.indexOf("This fails the Bundle Size job"));
@@ -241,6 +241,62 @@ describe("report-bundle-size-deltas", () => {
             const details = comment.slice(comment.indexOf("<details>"), comment.indexOf("</details>"));
             expect(details.match(/⚠️ \d+ B over/g) ?? []).toHaveLength(10);
             expect(details).toContain("12 scenes over ceiling");
+        });
+
+        // Attribution is a question about the baseline, not about movement. These two fixtures
+        // cover the regions where the two answers diverge — both were rendering false statements.
+        it("attributes a scene this PR adds over its ceiling to this PR, not to master", () => {
+            // A new scene is absent from the baseline, so it has no delta at all. Classifying by
+            // movement called that "inherited" and asserted the scene was already over on master
+            // and that rebasing would not clear it — of a scene that does not exist on master.
+            const comment =
+                runReporter({
+                    current: { scene1: { rawKB: 50.3, rawBytes: 51512 }, scene2: { rawKB: 40, rawBytes: 40960 } },
+                    master: { scene2: { rawKB: 40, rawBytes: 40960 } },
+                    scenes: [
+                        { id: 1, slug: "scene1", name: "Scene 1 - New", maxRawKB: 50 },
+                        { id: 2, slug: "scene2", name: "Scene 2", maxRawKB: 50 },
+                    ],
+                }).comment ?? "";
+
+            expect(comment).toContain("🚨 **1 scene put over its ceiling by this PR:** `scene1` (+312 B over its 50.00 KB ceiling)");
+            expect(comment).not.toContain("already over ceiling on master");
+            expect(comment).not.toContain("rebasing will not clear it");
+        });
+
+        it("keeps a breach inherited when this PR only adds bytes on top of it", () => {
+            // Master is already 300 B over; this branch adds 12 B, which is what a shared-path
+            // change does across many scenes at once. Classifying by movement blamed the author
+            // for the whole 312 B and dropped the note saying rebasing will not help — in the
+            // middle of the repo-wide stall that note exists for.
+            const comment =
+                runReporter({
+                    current: { scene1: { rawKB: 50.3, rawBytes: 51512 } },
+                    master: { scene1: { rawKB: 50.3, rawBytes: 51500 } },
+                    scenes: [{ id: 1, slug: "scene1", name: "Scene 1", maxRawKB: 50 }],
+                }).comment ?? "";
+
+            // The branch's contribution is reported separately from the total: the author can act
+            // on the 12 B they added and cannot act on the 300 B that were already there.
+            expect(comment).toContain("🛑 **1 scene was already over ceiling on master:** `scene1` (+312 B over its 50.00 KB ceiling, 12 B of it added here)");
+            expect(comment).toContain("rebasing will not clear it");
+            expect(comment).not.toContain("put over its ceiling by this PR");
+        });
+
+        it("does not claim movement in the header when the only finding is an inherited breach", () => {
+            // The headroom-only header predates the inherited-breach trigger, which reaches it
+            // with nothing moved — so it asserted movement and pointed the author at their own
+            // diff directly above a block saying the breach came from master.
+            const identical = { scene1: { rawKB: 50.3, rawBytes: 51512 } };
+            const comment =
+                runReporter({
+                    current: identical,
+                    master: identical,
+                    scenes: [{ id: 1, slug: "scene1", name: "Scene 1", maxRawKB: 50 }],
+                }).comment ?? "";
+
+            expect(comment).toContain("No bundle-size changes on this branch — but a scene is over its ceiling on master");
+            expect(comment).not.toContain("this PR moved a scene close to its ceiling");
         });
 
         it("posts a comment for an inherited breach even when this PR moves no bundle bytes", () => {
@@ -254,7 +310,7 @@ describe("report-bundle-size-deltas", () => {
 
             expect(result.stdout).toContain("POST_BUNDLE_COMMENT]true");
             expect(result.comment ?? "").not.toBe("**Bundle Size**: No changes detected.");
-            expect(result.comment ?? "").toContain("🛑 **1 scene is over ceiling on master, not from this PR:**");
+            expect(result.comment ?? "").toContain("🛑 **1 scene was already over ceiling on master:**");
         });
 
         it("omits the headroom section for scenes that opt out of the ceiling check", () => {
@@ -307,7 +363,7 @@ describe("report-bundle-size-deltas", () => {
             });
 
             expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
-            expect(result.comment).toContain("🚨 **1 scene this PR grew now exceeds its ceiling:** `scene1` (+312 B over its 50.00 KB ceiling)");
+            expect(result.comment).toContain("🚨 **1 scene put over its ceiling by this PR:** `scene1` (+312 B over its 50.00 KB ceiling)");
         });
 
         it("never renders a compliant scene as if it were over its ceiling (precision monotonicity)", () => {

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -234,9 +234,18 @@ describe("report-bundle-size-deltas", () => {
             expect(result.comment).toContain("🚨 **1 scene this PR moved now exceeds its ceiling:** `scene1` (+312 B over its 50 KB ceiling)");
         });
 
-        it("stays silent when repo-wide tightness is untouched by the PR", () => {
-            // scene2 is 100 B from its ceiling but this PR did not move it; scene1 moved but has
-            // room to spare. Triggering on repo-wide tightness would put a comment on every PR.
+        it("stays silent when tight scenes this PR did not move are the only tight scenes (noise bound — do not remove)", () => {
+            // This is the guard that keeps the headroom report off every PR, and it is the one
+            // case here that looks redundant from the outside: it asserts an absence, so a
+            // refactor can delete it and every other test still passes. It must not be deleted.
+            //
+            // Roughly half of all scenes sit inside the tight band at any given moment. If the
+            // posting gate ever drops the "this PR moved it" requirement, the report degrades
+            // from an actionable signal into a warning attached to every PR about scenes the
+            // author never touched — which is how a check stops being read at all.
+            //
+            // scene2 is 100 B from its ceiling but is byte-identical to master; scene1 moved
+            // 100 B but has 2400 B of room. Neither is actionable, so nothing should post.
             const result = runReporter({
                 current: {
                     scene1: { rawKB: 97.7, rawBytes: 100000 },

--- a/tests/lite/unit/report-bundle-size-deltas.test.ts
+++ b/tests/lite/unit/report-bundle-size-deltas.test.ts
@@ -94,6 +94,9 @@ describe("report-bundle-size-deltas", () => {
         expect(result.comment).toContain("Scene 2 - Sphere<br/>`scene2` | 40 KB | 46 KB | -6 KB");
         expect(result.comment).not.toContain("scene3");
         expect(result.comment).not.toContain("scene4");
+        // No ceilings are configured in this fixture, so the delta tables are the whole comment
+        // and must stay free of sub-KB precision.
+        expect(result.comment).not.toContain("Ceiling headroom");
         expect(result.comment).not.toMatch(/\d+\.\d+ KB/);
         expect(result.comment).not.toMatch(/bytes?/i);
         expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]true");
@@ -109,5 +112,85 @@ describe("report-bundle-size-deltas", () => {
         expect(result.comment).toBeNull();
         expect(result.stdout).toContain("Master manifest not found; skipping delta report.");
         expect(result.stdout).toContain("##vso[task.setvariable variable=POST_BUNDLE_COMMENT]false");
+    });
+
+    describe("ceiling headroom", () => {
+        // scene1 moves enough to round to a whole KB (so a comment is posted at all) and keeps
+        // plenty of room. scene2 moves by 400 B — invisible in the rounded delta table — and
+        // lands 100 B under its ceiling. scene3 is tight but untouched by this PR.
+        const headroomFixture = {
+            current: {
+                scene1: { rawKB: 97.7, rawBytes: 100000 },
+                scene2: { rawKB: 49.9, rawBytes: 51100 },
+                scene3: { rawKB: 39.6, rawBytes: 40500 },
+            },
+            master: {
+                scene1: { rawKB: 95.0, rawBytes: 97280 },
+                scene2: { rawKB: 49.5, rawBytes: 50700 },
+                scene3: { rawKB: 39.6, rawBytes: 40500 },
+            },
+            scenes: [
+                { id: 1, slug: "scene1", name: "Scene 1 - BoomBox PBR", maxRawKB: 100 },
+                { id: 2, slug: "scene2", name: "Scene 2 - Sphere", maxRawKB: 50 },
+                { id: 3, slug: "scene3", name: "Scene 3 - Grid", maxRawKB: 40 },
+            ],
+        };
+
+        it("emphasises a scene this PR moved that now sits under the tight threshold", () => {
+            const comment = runReporter(headroomFixture).comment ?? "";
+
+            expect(comment).toContain("### Ceiling headroom");
+            expect(comment).toContain("⚠️ **1 scene this PR moved sits under 1.0 KB of headroom.**");
+            expect(comment).toContain("| Scene | Size | Ceiling | Headroom | Δ this PR |");
+            expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` | 49.9 KB | 50 KB | **100 B** | +400 B");
+            // scene3 is tight too, but this PR did not touch it — it belongs in the collapsed
+            // repo-wide list, not in the actionable block.
+            expect(comment).not.toContain("Scene 3 - Grid<br/>`scene3` | 39.6 KB | 40 KB | **460 B**");
+        });
+
+        it("reports movement the rounded delta table cannot show", () => {
+            const comment = runReporter(headroomFixture).comment ?? "";
+
+            // 400 B rounds to a 0 KB change, so scene2 is absent from the delta tables entirely.
+            expect(comment).not.toContain("`scene2` | 50 KB | 50 KB");
+            expect(comment).toContain("+400 B");
+        });
+
+        it("folds the repo-wide picture into a banded details block", () => {
+            const comment = runReporter(headroomFixture).comment ?? "";
+
+            expect(comment).toContain("<details>");
+            expect(comment).toContain("<summary>Tightest scenes repo-wide — 2 of 3 under 1.0 KB, 1 under 256 B</summary>");
+            expect(comment).toContain("Scene 2 - Sphere<br/>`scene2` ⬅ moved by this PR | 49.9 KB | 50 KB | 100 B |");
+            expect(comment).toContain("Scene 3 - Grid<br/>`scene3` | 39.6 KB | 40 KB | 460 B |");
+            // Tightest first.
+            expect(comment.indexOf("`scene2` ⬅")).toBeLessThan(comment.indexOf("`scene3` |"));
+        });
+
+        it("calls out a moved scene that exceeds its ceiling", () => {
+            const comment =
+                runReporter({
+                    current: { scene1: { rawKB: 97.7, rawBytes: 100000 }, scene2: { rawKB: 50.3, rawBytes: 51512 } },
+                    master: { scene1: { rawKB: 95.0, rawBytes: 97280 }, scene2: { rawKB: 49.5, rawBytes: 50700 } },
+                    scenes: [
+                        { id: 1, slug: "scene1", name: "Scene 1 - BoomBox PBR", maxRawKB: 100 },
+                        { id: 2, slug: "scene2", name: "Scene 2 - Sphere", maxRawKB: 50 },
+                    ],
+                }).comment ?? "";
+
+            expect(comment).toContain("🚨 **1 scene this PR moved now exceeds its ceiling:** `scene2` (+312 B over its 50 KB ceiling)");
+        });
+
+        it("omits the headroom section for scenes that opt out of the ceiling check", () => {
+            const comment =
+                runReporter({
+                    current: { scene1: { rawKB: 97.7, rawBytes: 100000 } },
+                    master: { scene1: { rawKB: 95.0, rawBytes: 97280 } },
+                    scenes: [{ id: 1, slug: "scene1", name: "Scene 1", maxRawKB: 100, skipBundleSize: true }],
+                }).comment ?? "";
+
+            expect(comment).toContain("## Bundle Size Changes");
+            expect(comment).not.toContain("Ceiling headroom");
+        });
     });
 });


### PR DESCRIPTION
## Why

Each scene has an absolute ceiling (`maxRawKB` in `scene-config.json`) and the bundle-size check fails a build when a scene exceeds it. In practice those ceilings are **ratchets pinned to whatever each scene last measured, not budgets with slack**. Measured across the 224 scenes on master that have both a tracked manifest and a ceiling:

| Metric | Value |
| --- | --- |
| median headroom | **1251 B** |
| p25 / p10 headroom | 103 B / 56 B |
| under 256 B | 87 scenes (39%) |
| under 1024 B | 104 scenes (46%) |
| under 2048 B | 122 scenes (54%) |

**The failure mode this creates:** two concurrent PRs can each measure *under* a ceiling — each was built against a master that did not contain the other — and breach it together once both land. Azure DevOps builds the **merge commit** for a PR, so once master is over a ceiling, **every subsequent PR's Bundle Size job fails** until the bytes are recovered. That is a repo-wide stall whose only exits are emergency size work or raising a ceiling (which requires explicit approval).

`reportCeilingHeadroom()` already computed this information — its doc comment even anticipates the problem — but it had two gaps:

1. It printed only to a **~42-minute build log that nobody opens**, so the information never reached a human.
2. Its `TIGHT_HEADROOM_BYTES = 256` sat well inside the risk band and said nothing about the ~1 KB range where most near-ceiling scenes actually live.

Separately, the PR comment generator never mentioned ceilings at all.

## What changed

**Reporting only. No ceiling is changed and `scene-config.json` is not touched.**

### 1. Threshold recalibrated: 256 B → 1 KB, with 256 B kept as an inner band

`scripts/bundle-ceiling-headroom.ts` (new) owns the thresholds and the arithmetic, so the build log and the PR comment cannot drift apart.

Justification for 1024 B:

- **It is exactly the granularity below which existing reporting is blind.** The PR delta table rounds to whole KB, so a scene with under 1 KB of headroom can be pushed over by a change the table renders as `0 KB` or `+1 KB`. The author cannot see the risk from the numbers they are shown.
- **It splits the population at the median**, flagging the tight ~46% while staying quiet about the roomy half. 2 KB flags 54% and 4 KB flags 73% — wallpaper nobody reads.

  Re-verified against master after this branch was brought up to date (64 commits, including a 522-line `scene-config.json` churn): 240 scenes with both a size and a ceiling, median headroom **1492 B**, p25 222 B, p10 122 B. **46% still sit under 1 KB** — the same proportion as when the threshold was chosen, so no recalibration was needed. The tightest scene is **2 bytes** from its ceiling.

  **Now confirmed against real measured bytes.** Every figure above was derived from the per-scene manifests committed to git, which each author regenerated at a different time — a staggered, self-reported snapshot rather than one coherent measurement. ADO build `58227` (definition 60, `Babylon Lite Bundle Manifest`) has since measured **all 245 scenes at a single master commit**, and its log is the first true full-repo measurement the repo has ever produced:

  | Band | Tracked-manifest estimate | Real measurement |
  | --- | --- | --- |
  | scenes with size + ceiling | 240 | 241 |
  | median headroom | 1492 B | **1536 B** |
  | under 256 B | 87 (36%) | **71 (29%)** |
  | under 1024 B | 46% | **44%** |
  | under 2048 B | 54% | **54%** |
  | under 4096 B | 73% | **72%** |

  The headline number the threshold rests on — **~46% under 1 KB — holds at 44% against real bytes**, and 1024 B still sits below the median. **No recalibration is needed.** The one figure that moved is the 256 B critical band (87 → 71): the git-tracked manifests were biased slightly *tight*, being older than the code they described. That moves the inner count, not the outer threshold.

  Two incidental confirmations from the same log. First, that build's headroom report — running master's current 256 B threshold — prints `⚠ 71 scene(s) with little headroom`, and my independent reconstruction from the raw per-scene lines arrives at **71**, which cross-validates this PR's `scene${id}` key mapping, `skipBundleSize` opt-out, and fractional-ceiling comparison against a real CI run rather than only against fixtures. Second, that same report lists 10 scenes and then `… and 61 more under 256 B` — the wallpaper failure this PR's hybrid is designed for, visible in production at the *old* threshold. At 1024 B the flagged set becomes 105 scenes while the output stays exactly 10 lines plus a count.

  (Per-scene lines in that log are quantised to 0.1 KB, so individual reconstructed values carry ±51 B; the aggregate percentages and the exact-match on 71 are unaffected. The tightest scene there sits **9 B** below its ceiling.)
- **256 B was not a "quiet" threshold** — it already flagged 87 scenes. It was just an arbitrary point. It survives as the `CRITICAL_HEADROOM_BYTES` count, so the emergency signal stays legible now that the outer band is 4× wider.

Noise stays bounded by the hybrid the code already had: **name the 10 tightest, then count the remainder**. Output length is constant no matter how the flagged set grows.

### 2. Headroom surfaced in the PR comment

`scripts/report-bundle-size-deltas.ts` already loads `scene-config.json`, so `maxRawKB` needed no new plumbing.

- Scenes **this PR moved** that are now tight get an uncollapsed table — the actionable signal.
- Movement is computed from **exact bytes, not the rounded deltas**, precisely because a +400 B change is invisible in the whole-KB table yet is enough to push a 300 B-headroom scene over.
- The repo-wide picture is folded into a `<details>` block with a banded summary.
- A moved scene that is already over its ceiling gets a 🚨 callout.

### 3. Posting gate widened so the report is not inert in its most important case

The comment previously posted only when a **rounded** delta was nonzero. That silenced the whole feature in exactly the scenario it exists to catch: a PR whose only effect is a few hundred bytes produces no delta rows, so `POST_BUNDLE_COMMENT` was false and nothing was posted — even when those bytes had just consumed the last of a scene's headroom. That is the same sub-1-KB blindness the threshold was calibrated against, reintroduced one layer up.

The comment now posts when a rounded delta is nonzero **OR** when this PR moved a scene that now sits in the tight/critical band or over its ceiling. In the second case the comment is **headroom-only** — there are no whole-KB deltas to tabulate.

**Repo-wide tightness deliberately does not trigger a comment.** ~46% of scenes are under 1 KB at any moment, so without the "this PR moved it" requirement every PR would get one and nobody would read them.

### 4. Perf baseline worktree kept in sync with the new helper

Extracting `bundle-ceiling-headroom.ts` out of `bundle-scenes-core.ts` broke the perf job, and CI caught it on this branch:

```
Error: Cannot find module './bundle-ceiling-headroom'
Require stack:
- /home/vsts/work/1/s/.perf-baseline-worktree/scripts/bundle-scenes-core.ts
```

`scripts/build-perf-baseline.ts` checks the baseline ref out into a worktree and then overwrites a **hand-maintained list** of `scripts/` files with the current ones, so the baseline is measured with today's bundle builder rather than a historical one. A newly extracted helper is not on that list, and the baseline ref predates it, so the copy leaves a dangling import.

Only the perf job can see this. Every other consumer builds from a full checkout where the file simply exists — local runs, unit tests, and the Bundle Size job all stayed green while the slowest job in the pipeline was broken.

Fixed by adding the helper to the list, plus a static guard (`tests/lite/unit/perf-baseline-script-closure.test.ts`) that recomputes the import closure of `bundle-scenes-core.ts` and asserts the copy list covers it. Verified both ways: it passes with the fix, and with the fix reverted it fails with

> `build-perf-baseline.ts copies bundle-scenes-core.ts into the baseline worktree but not bundle-ceiling-headroom.ts. ... Add them to the copy list in scripts/build-perf-baseline.ts.`

That turns a 40-minute CI round trip into a 4 ms unit test that names the file to add.

## ⚠️ The bot comment on this PR is stale pre-fix output — read the samples below instead

The `## Bundle Size Changes` comment in the timeline was posted **2026-08-25T22:59:16Z by build
58448**, which ran on `826ab18a` — *before* the direction fix, the cap, and the four attribution
fixes. It is the 16,529-character, 94-rows-all-shrinking artifact analysed later in this
description. **It shows the bugs, not the fix.** Anyone opening this PR sees it first and could
reasonably conclude the feature is broken.

It has not been refreshed because the gate is behaving correctly: this branch changes only
`scripts/` and `tests/`, moves zero bundle bytes, and pushes no scene into the tight band, so the
reporter sets `POST_BUNDLE_COMMENT=false` and neither posts nor edits. Silence is right — but
silence leaves whatever was posted earlier standing.

That is worth naming as a **known limitation of the posting path, and it is pre-existing rather
than introduced here**: any PR that grows a scene, gets a comment, then fixes the growth will keep
displaying the original warning indefinitely. The comment asserts a present state it no longer
measures. Fixing it means editing a previously-posted comment when the gate stops firing, which
requires changing the pipeline's posting step — out of scope for a change explicitly scoped to
reporting only, and it would alter posting behaviour rather than report on it. Filed as a
follow-up in #627, with the repro and the live instance, rather than smuggled into this PR.

The samples below are rendered from the current code against the live published baseline and are
what the fixed reporter emits.

## Sample rendered comments

### A. Rendered from the **current published baseline** (authoritative)

Regenerated after merging master at `c5f8f660`, against the live baseline published by #617
(def-60 build `58458` on `c5f8f660`, **247 scenes**, real `rawBytes`; artifact `last-modified`
23:34:28Z, 16 s before that build finished at 23:34:44Z — i.e. *after* #617 landed, which confirms
that fix is working in production). Every headroom number below
is production data. Only the *movement* is synthetic: `scene267` +150 B, `scene96` +100 B,
`scene1` +4300 B, `scene2` +1200 B, `scene40` −180 B, `scene42` −2000 B, chosen to exercise every
case at once.

Three discriminations worth checking:

- **`scene2` is flagged as over its ceiling** and heads the repo-wide list, labelled `⚠️ 909 B over`.
- **`scene40` shrank by 180 B and is deliberately absent** from the actionable block, even though it
  is one of the tightest scenes in the repo. Only growth consumes headroom.
- **`scene1` grew 4.2 KB and *is* flagged** at 374 B, while a scene growing less can go unflagged —
  the list is ordered by remaining headroom, not by size or delta.

<!-- BEGIN RENDERED SAMPLE -->
## Bundle Size Changes

### Increases

| Package | Current | Master | Change |
|---------|---------|--------|--------|
| Scene 1 — BoomBox PBR<br/>`scene1` | 92 KB | 87 KB | **+5 KB** |
| Scene 2 — Sphere<br/>`scene2` | 47 KB | 46 KB | **+1 KB** |

### Decreases

| Package | Current | Master | Change |
|---------|---------|--------|--------|
| Scene 42 — Physics Clone Pre-Step<br/>`scene42` | 48 KB | 50 KB | -2 KB |

*Sizes rounded to nearest KB. Run `pnpm build:bundle-scenes` locally to verify.*

### Ceiling headroom

🚨 **1 scene this PR grew now exceeds its ceiling:** `scene2` (+909 B over its 45.90 KB ceiling)

⚠️ **3 scenes this PR grew now sit under 1.0 KB of headroom.**

| Scene | Size | Ceiling | Headroom | Δ this PR |
|-------|------|---------|----------|-----------|
| Scene 267 — StandardMaterial Vertex Colors<br/>`scene267` | 41.62 KB | 41.70 KB | **79 B** | +150 B |
| Scene 96 — Sprite uvOffset Parallax<br/>`scene96` | 16.07 KB | 16.20 KB | **135 B** | +100 B |
| Scene 1 — BoomBox PBR<br/>`scene1` | 91.53 KB | 91.90 KB | **374 B** | +4.2 KB |

<details>
<summary>Tightest scenes repo-wide — 1 scene over ceiling, 96 of 243 under 1.0 KB, 4 under 256 B</summary>

| Scene | Size | Ceiling | Headroom |
|-------|------|---------|----------|
| Scene 2 — Sphere<br/>`scene2` ⬅ moved by this PR | 46.79 KB | 45.90 KB | ⚠️ 909 B over |
| Scene 117 — 2D Sprite Picking<br/>`scene117` | 16.55 KB | 16.56 KB | 9 B |
| Scene 267 — StandardMaterial Vertex Colors<br/>`scene267` ⬅ moved by this PR | 41.62 KB | 41.70 KB | 79 B |
| Scene 96 — Sprite uvOffset Parallax<br/>`scene96` ⬅ moved by this PR | 16.07 KB | 16.20 KB | 135 B |
| Scene 100 — Physics Collision Event<br/>`scene100` | 48.97 KB | 49.20 KB | 239 B |
| Scene 231 — StandardMaterial Deform Features<br/>`scene231` | 52.14 KB | 52.40 KB | 264 B |
| Scene 15 — SpotLights + Ground<br/>`scene15` | 45.94 KB | 46.20 KB | 267 B |
| Scene 101 — Physics Trigger Volume<br/>`scene101` | 51.93 KB | 52.20 KB | 280 B |
| Scene 23 — PBR Anisotropy<br/>`scene23` | 76.52 KB | 76.80 KB | 284 B |
| Scene 268 — Orthographic Camera<br/>`scene268` | 44.32 KB | 44.60 KB | 288 B |

</details>

*Headroom is the distance to a scene's `maxRawKB` ceiling in `scene-config.json`. Two PRs can each measure under a ceiling and still breach it together once both land — and because CI builds the merge commit, every later PR's Bundle Size job then fails until the bytes are recovered. If a scene you touched is near zero, consider landing separately.*
<!-- END RENDERED SAMPLE -->

### A2. Inherited breach — the case that was silent until this was caught

`scene2` is over its ceiling on **master** and this PR did not touch it; `scene1` grew 3 KB.
This is the state that fails the Bundle Size job on *every* open PR at once.

<!-- BEGIN INHERITED SAMPLE -->
## Bundle Size Changes

### Increases

| Package | Current | Master | Change |
|---------|---------|--------|--------|
| Scene 1 - BoomBox PBR<br/>`scene1` | 98 KB | 95 KB | **+3 KB** |

*Sizes rounded to nearest KB. Run `pnpm build:bundle-scenes` locally to verify.*

### Ceiling headroom

🛑 **1 scene is over ceiling on master, not from this PR:** `scene2` (+312 B over its 50.00 KB ceiling)

This fails the Bundle Size job on every open PR, including ones that changed no bundle bytes, until the bytes are recovered on master. It is not caused by this branch and rebasing will not clear it.

<details>
<summary>Tightest scenes repo-wide — 0 of 2 under 1.0 KB</summary>

| Scene | Size | Ceiling | Headroom |
|-------|------|---------|----------|
| Scene 2 - Sphere<br/>`scene2` | 50.30 KB | 50.00 KB | ⚠️ 312 B over |
| Scene 1 - BoomBox PBR<br/>`scene1` ⬅ moved by this PR | 97.66 KB | 100.00 KB | 2.3 KB |

</details>

*Headroom is the distance to a scene's `maxRawKB` ceiling in `scene-config.json`. Two PRs can each measure under a ceiling and still breach it together once both land — and because CI builds the merge commit, every later PR's Bundle Size job then fails until the bytes are recovered. If a scene you touched is near zero, consider landing separately.*
<!-- END INHERITED SAMPLE -->


### B. Fixture-based cases

#### Visible delta plus a sub-KB move into the danger zone

`scene1` grows 2.4 KB (visible) and `scene11` grows 40 B (invisible in the delta table — and `scene11` had 44 B of headroom):

---

## Bundle Size Changes

### Increases

| Package | Current | Master | Change |
|---------|---------|--------|--------|
| Scene 1 — BoomBox PBR<br/>`scene1` | 91 KB | 89 KB | **+2 KB** |

*Sizes rounded to nearest KB. Run `pnpm build:bundle-scenes` locally to verify.*

### Ceiling headroom

⚠️ **1 scene this PR grew now sits under 1.0 KB of headroom.**

| Scene | Size | Ceiling | Headroom | Δ this PR |
|-------|------|---------|----------|-----------|
| Scene 11 — Shark GLB<br/>`scene11` | 89.5 KB | 89.5 KB | **4 B** | +40 B |

<details>
<summary>Tightest scenes repo-wide — 104 of 224 under 1.0 KB, 87 under 256 B</summary>

| Scene | Size | Ceiling | Headroom |
|-------|------|---------|----------|
| Scene 117 — 2D Sprite Picking<br/>`scene117` | 16.6 KB | 16.56 KB | 2 B |
| Scene 11 — Shark GLB<br/>`scene11` ⬅ moved by this PR | 89.5 KB | 89.5 KB | 4 B |
| Scene 251 — Animation Mask (Xbot walk, frozen legs)<br/>`scene251` | 90.3 KB | 90.32 KB | 40 B |
| Scene 267 — StandardMaterial Vertex Colors<br/>`scene267` | 43.3 KB | 43.32 KB | 43 B |
| Scene 259 — Emissive Material<br/>`scene259` | 77.7 KB | 77.78 KB | 48 B |
| Scene 12 — PBR Shader Balls<br/>`scene12` | 104.3 KB | 104.36 KB | 49 B |
| Scene 73 — Wheel PBR vs NME Viewports<br/>`scene73` | 142.2 KB | 142.21 KB | 49 B |
| Scene 257 — Negative Node Scale<br/>`scene257` | 80.7 KB | 80.76 KB | 49 B |
| Scene 242 — EmissiveFireflies<br/>`scene242` | 97.9 KB | 97.98 KB | 50 B |
| Scene 260 — Triangle Strip<br/>`scene260` | 80.7 KB | 80.73 KB | 50 B |

</details>

*Headroom is the exact distance to a scene's `maxRawKB` ceiling in `scene-config.json`. Two PRs can each measure under a ceiling and still breach it together once both land — and because CI builds the merge commit, every later PR's Bundle Size job then fails until the bytes are recovered. If a scene you touched is near zero, consider landing separately.*

---

#### Headroom-only — the case that used to post nothing at all

Same `scene11` +40 B, but now it is the PR's *only* size change. Every rounded delta is zero, so before this PR the job set `POST_BUNDLE_COMMENT=false` and the 🚨 was never seen. Now:

---

## Bundle Size Changes

No changes at whole-KB resolution — but this PR moved a scene close to its ceiling.

### Ceiling headroom

⚠️ **1 scene this PR grew now sits under 1.0 KB of headroom.**

| Scene | Size | Ceiling | Headroom | Δ this PR |
|-------|------|---------|----------|-----------|
| Scene 11 — Shark GLB<br/>`scene11` | 89.5 KB | 89.5 KB | **4 B** | +40 B |

<details>
<summary>Tightest scenes repo-wide — 104 of 224 under 1.0 KB, 87 under 256 B</summary>

*(same repo-wide table as above)*

</details>

---

That `scene11` row is the whole point: the delta table shows nothing, yet the scene is 4 bytes from stalling the repo.

## Build behaviour is unchanged

- The absolute ceiling check in `tests/lite/parity/bundle-size.spec.ts` is untouched.
- In `reportCeilingHeadroom()`, only the `over` set can set `process.exitCode = 1`, exactly as before. The tight list is advisory and never fails a build.
- The exit-code path still reads **exact `rawBytes` only**. The shared `measuredBytesOf()` helper does fall back to `rawKB`, but that fallback is used solely by the PR comment, where being approximate costs nothing — deliberately kept out of the path that can fail a build.
- The `skipBundleSize` opt-out is honoured in both places.
- The only behavioural change outside reporting is the posting gate described above, which affects when a comment appears — never whether a build passes.

## Explicitly: no ceilings were changed

`scene-config.json` is not modified by this PR. No `maxRawKB` value moved. No golden reference screenshots changed. `1024` is a **warning** threshold, not a ceiling.

## Validation

- `npx vitest run --project unit tests/lite/unit/bundle-ceiling-headroom.test.ts tests/lite/unit/report-bundle-size-deltas.test.ts tests/lite/unit/perf-baseline-script-closure.test.ts` → **34 passed**
  - `bundle-ceiling-headroom.test.ts`: band boundaries, `rawBytes` vs `rawKB` fallback, tightest-first ordering, and the fractional-ceiling case (92.2 KB = 94412.8 B, so 94413 B must read as over — `Math.round` collapses that to `0` or `-0` depending on where it is applied, both of which read as not-over).
  - `report-bundle-size-deltas.test.ts`: moved-and-tight emphasis, sub-KB movement the delta table cannot show, the banded `<details>` block, the over-ceiling callout, the `skipBundleSize` opt-out, the inherited-breach callout with its ordering, labelling and cap in the repo-wide list, and the gating — all-zero rounded deltas with one scene moved into the tight band must post a headroom-only comment; an inherited breach must post even with identical manifests on both sides; a moved-but-roomy scene alongside untouched repo-wide tightness must not.
- `perf-baseline-script-closure.test.ts`: the copy list covers the import closure, and the entry point itself is on the list (so the closure check cannot pass vacuously).
- **Typecheck**: all six `tsc -p` projects run individually → **0 errors each** on the merge with master `c5f8f660`. (Run separately rather than via `pnpm lint`, whose `&&` chain only proves the last one passed. The two `_toneMappingHelpers` errors previously noted were fixed on master by #615.)
- Master's repo-scanning guards (`artifact-security`, `pipeline-secret-hygiene`, `pipeline-variable-groups-documented`, `pipeline-fail-fast-ordering`) run green with this branch present → **105 passed**. A guard that scans the repo makes every PR an input to every other PR, so file-level disjointness is not sufficient on its own.
- `eslint` → **exit 0**
- `prettier --check` clean on all touched files. (`bundle-scenes-core.ts` retains one pre-existing formatting deviation near line 913, present identically on `origin/master`, deliberately left alone as out of scope.)
- Per GUIDANCE.md: no full suite, no parity, no bundle builds, no perf runs. This change measures nothing, so no manifest regeneration is needed.




---

## CI verification on the merge with master (`96b24f2a`, build 58388) — 12/12 green

Two results worth recording, because both are things only a real CI run can show.

### 1. The perf-baseline copy-list fix is confirmed in the one context that can break it

`Build baseline bundle scenes` checks `origin/master` (`821f239d`) into a detached worktree — a tree that predates `scripts/bundle-ceiling-headroom.ts` — and then copies the current `scripts/` over it. If the extracted helper were missing from the copy list, this is where it would die with `Cannot find module './bundle-ceiling-headroom'`, and nowhere else: every other consumer builds from a full checkout where the file simply exists.

```
Cannot find module   -> 0 occurrences
Resolve baseline ref -> succeeded  (Baseline SHA 821f239d)
Build baseline ...   -> succeeded  (245/245 baseline bundles built)
```

That is the 40-minute integration signal the 4 ms closure test stands in for, observed agreeing with it.

### 2. The headroom section did not render — and the log says why, positively

No bundle-size comment was posted on this PR. That absence on its own is **not** evidence of a pass, so the reporter is written to leave a positive trace either way:

| Case | Log line | Meaning |
|---|---|---|
| Baseline absent | `Master manifest not found; skipping delta report.` | Silence is uninformative |
| Baseline present, nothing moved | `Bundle size comment written to <path>` + full comment echoed | Silence is a real pass |

Build 58388 emitted the **first**:

```
Generate bundle-size delta comment  -> succeeded
  "Master manifest not found; skipping delta report."
Post bundle-size changes to PR      -> skipped   (POST_BUNDLE_COMMENT=false)
```

`lab/public/bundle/master-manifest.json` is absent from master's tree and no pipeline step downloads it, so the baseline the delta half needs does not yet exist anywhere. This is the documented degraded path behaving correctly — the `if (!master)` bail — not a defect in this PR.

**Consequence for reviewers:** the headroom section cannot render end-to-end until the baseline publisher lands (#617). The absolute-headroom half needs only `manifest.json` + `scene-config.json`, but the *movement* half needs a baseline, and movement is the sole reason this comment is not posted on every PR. Bailing without one is deliberate: roughly half of all scenes sit inside the tight band at any moment, so a baseline-free report would warn every PR about scenes it never touched.



---

## End-to-end proof on a real baseline (build 58431, `ec9b682a`) — 12/12 green

#617 landed and its first successful run (def-60 build `58427` on `a173d00a`) published a baseline of
246 scenes with `HTTP 200 {"success":true}`. **Build 58431 on this PR is the first to fetch it**, which
closes the gap flagged above.

Reading the discriminator rather than inferring from the comment's absence:

```
Generate bundle-size delta comment  -> succeeded
  "Bundle size comment written to /home/vsts/work/1/s/test-results/bundle-size-comment.md"
  "**Bundle Size**: No changes detected."
Post bundle-size changes to PR      -> skipped   (POST_BUNDLE_COMMENT=false)

grep -c "Master manifest not found"    -> 0
grep -c "Bundle size comment written" -> 1
```

The bail line is **gone** and the positive trace is **present**, so the baseline was fetched and
compared. This PR is scripts-only and moves no bundle bytes, so `deltas = 0` and
`movedIntoDangerZone = false`, and the gate correctly declines to post. **Silence here is a verified
pass rather than an uninformative absence** — which is precisely the distinction the log lines exist
to make.

What this does and does not prove, stated precisely:

- **Proven:** the baseline fetch, and `collectHeadroomInputs` / `buildHeadroomReport` executing
  against 246 real scenes without throwing — they run unconditionally, before `formatComment`.
  Zero scenes were over ceiling, and nothing spuriously tripped `movedIntoDangerZone`.
- **Not proven by this build:** the rendered headroom markdown inside a *posted* comment, which
  needs a PR that actually moves bundle bytes. Sample A above covers that shape using the real
  baseline locally.

### A misread this surfaced, now fixed (`826ab18a`)

Rendering against real ceilings rather than fixtures exposed a formatting bug that fixtures could not
show, because fixtures used whole-number ceilings. Sizes were rounded to one decimal while ceilings
printed verbatim from `scene-config.json`, where they are authored as free-form decimals:

| | Before | After |
|---|---|---|
| `scene117` (9 B **under** its ceiling) | `16.6 KB` vs `16.56 KB` — reads as **over** | `16.55 KB` vs `16.56 KB` — reads as under |

Rounding only preserves order between values rounded the same way, so comparing at two precisions
could invert the very comparison the table exists to show, contradicting the `9 B` in the row's own
headroom column. A report whose job is to flag scenes near their ceiling must never render a
compliant scene as breaching — that is the one error that sends an author chasing bytes they do not
owe. Both columns now round at a shared precision, which makes the rendered size provably never
exceed the rendered ceiling.

Pinned by a regression test using the real `scene117` numbers, and mutation-checked: reverting the
shared precision fails 6 assertions.



---

## The report caught its own design flaw on its first real run (build 58448)

Build `58448` on `826ab18a` is the **first build to post a bundle-size comment end-to-end**:
`Post bundle-size changes to PR` → `succeeded` (previous runs skipped it for want of a baseline).
`Build baseline bundle scenes` also came back with `Cannot find module` = **0**, a third
confirmation of the perf-baseline copy-list fix.

The posted comment was wrong, in an instructive way. The uncollapsed "scenes this PR moved" block
contained **94 rows — and every one of them had got *smaller***, most by exactly 46 B, picked up
from a size-reducing master merge:

```
⚠️ **94 scenes this PR moved sit under 1.0 KB of headroom.**  <- the bug, as posted
| Scene 267 — StandardMaterial Vertex Colors | 41.48 KB | 41.70 KB | **229 B** | -46 B |
| Scene 100 — Physics Collision Event        | 48.97 KB | 49.20 KB | **239 B** | -46 B |
| Scene 40  — Physics                        | 48.25 KB | 48.50 KB | **261 B** | -46 B |
… 91 more
```

Counted from the posted artifact rather than characterised: of the rows carrying a signed delta,
**94 shrank and 0 grew.** The absoluteness is the diagnostic part, and it is worth more than the
row count. A signal-to-noise problem degrades a list; this *replaced* it — every row was evidence
against the very thing the block was warning about. A partially-wrong list would have suggested a
tuning problem and invited a threshold tweak. A 94/0 split cannot be read as anything but a
predicate that never consulted the sign, which is what it was.

Membership in the moved set was tested with `has()`, which ignores the sign. But **a scene that
shrank gained headroom** — this PR cannot push it over its ceiling, and it was already tight before
being touched. Flagging it points the author at the changes that *helped*.

This is the exact wallpaper failure the threshold design set out to avoid, reproduced by the
section itself the first time it ran on real data. Fixtures could not have caught it: they contained
one or two moved scenes, so `has()` and "grew" were indistinguishable.

Fixed in `c69014bf`:

1. **Direction** — only scenes moved *toward* the ceiling are actionable. Shrinking scenes still
   appear in the collapsed repo-wide list when tight.
2. **Cap** — the uncollapsed block had no limit, so its length was bounded only by how many scenes
   qualified. Now capped at `HEADROOM_LIST_LIMIT` with an overflow count, ordered tightest-first so
   the overflow is always the least urgent tail.

Re-run against the real baseline, reproducing the CI shape (100 scenes shrunk by 46 B, one scene
grown 2.4 KB into the danger zone):

```
### Ceiling headroom

⚠️ **1 scene this PR grew now sits under 1.0 KB of headroom.**

| Scene | Size | Ceiling | Headroom | Δ this PR |
|-------|------|---------|----------|-----------|
| Scene 104 — Physics Character Controller<br/>`scene104` | 102.52 KB | 102.90 KB | **384 B** | +2.3 KB |
```

94 rows of noise → the one scene that actually moved toward its ceiling. Both fixes are
mutation-checked: reverting either fails exactly its own test and nothing else.



## Third design flaw, found the same way (`149d2602`)

Rendering against the live baseline after merging master surfaced a third bug — and it was the
worst of the three, because it made the section silent in **the exact scenario it was built for**.

The other two flaws produced *wrong* output; this one produced **no** output, in the repo-wide-stall
state the whole feature exists to surface — and `condition: always()` on the reporter step guarantees it
runs on exactly those failing builds. The compounding detail is what the author sees: a red Bundle
Size job beside a headroom section listing only healthy scenes. **A section whose presence implies
coverage it does not have is worse than its absence** — the reader stops looking, because something
that looks like the answer is already on screen. Same family as the inverted 94 rows, but an
omission rather than a false positive, and omissions do not look wrong.

`computeSceneHeadroom` splits scenes into `over` and `under`. The `over` set was filtered by
growth, the same way the tight set is:

```ts
const movedAndOver = over.filter((s) => grewBy(s) > 0);   // only what THIS PR grew
```

...and the repo-wide list rendered only `under`. So a scene **already over its ceiling that this
PR did not grow appeared nowhere in the comment.**

That is precisely the repo-wide-stall state described at the top of this PR. Once master is
breached, CI builds the merge commit and the Bundle Size job fails on every open PR — and *none*
of those authors grew the offending scene, so the direction filter removed it from all of their
comments. It is fully reachable, not theoretical: the delta step is

```yaml
- script: npx tsx scripts/report-bundle-size-deltas.ts
  condition: always()
```

so it still runs on exactly those failing builds. It just had nothing to say about the failure.
An author would see a red Bundle Size job next to a headroom section listing only healthy scenes —
worse than no section, because its presence implies it covers ceilings. And since
`movedIntoDangerZone` was also false, a PR that moved no rounded KB got **no comment at all**.

**Fixed three ways:**

1. A distinct `🛑 … over ceiling on master, not from this PR` callout, so the author can tell
   "you did this" from "this was already broken", plus a line saying rebasing will not clear it.
2. Breached scenes now lead the repo-wide list. They were omitted entirely, which headed a
   "tightest scenes" table with something that was not the tightest. They are **labelled**
   (`⚠️ 909 B over`) rather than printed bare, because `computeSceneHeadroom` stores an overage as
   a *positive* number — an unlabelled `909 B` reads as a comfortable margin in a column where
   every other row means the opposite. The summary line names the breach count for the same
   reason: `0 of 2 under 1.0 KB` above a table headed by a breached scene invites the wrong reading.
3. A new `inheritedCeilingBreach` trigger, so the comment posts even when the PR moves no bundle
   bytes — the case with no delta rows by construction.

**Same root cause as the previous two.** No fixture contained a scene over its ceiling that the PR
had not itself moved; `over` was only ever tested together with growth. All three bugs came from
fixtures drawn from the easy region of the input space, agreeing with each other there.

All three fixes are mutation-checked — reverting each one fails the new tests (2, 1 and 1
assertions respectively), and the suite is green when restored.

### Re-validation after merging master (`c5f8f660`)

Master moved a lot (#293 flow-graph, #607 text perf, #610, #616, #617, #618, #619, #621, #622).
Recomputed against the current published baseline, **reporting only — no ceiling was touched**:

| Metric | Earlier baseline | Current baseline (`c5f8f660`) |
|---|---|---|
| scenes compared | 242 | **243** |
| over ceiling | 0 | **0** |
| median headroom | 1597 B | **1825 B** |
| under 256 B | 70 (29%) | **4 (1.6%)** |
| under 1024 B | 108 (44.6%) | **97 (39.9%)** |
| under 2048 B | — | 127 (52.3%) |

**No recalibration.** 1024 B still sits below the median (1825 B) and flags a tight minority
(39.9%); 2048 B would flag the majority and become wallpaper. The `under 256 B` count collapsing
from 70 to 4 is master genuinely getting healthier, and it is a good demonstration of why the
hybrid design was chosen: **the counts moved by a factor of 17 and the rendered output did not
grow by a single row**, because the block is always the 10 tightest plus counts.



---

## Fourth and fifth flaws: the breach callouts were attributing on the wrong question (`5ea1dfb9`)

An independent review pass over the full diff found that the split between the two
breach callouts — 🚨 "caused by this PR" vs 🛑 "inherited from master" — was decided by
asking whether this branch had *moved* the scene. Movement and attribution are different
questions, and they disagree at both edges. I reproduced both before fixing.

**Edge 1 — a scene this PR adds.** A new scene has no baseline entry, so `computeMovedBytes`
skips it and its delta reads as zero. That routed it to the *inherited* callout, which then
stated the scene was already over ceiling on master and that rebasing would not clear it —
about a scene that does not exist on master. Every sentence in that block was false, in the
one case where the author is unambiguously the cause.

**Edge 2 — an inherited breach this PR adds a byte to.** A real inherited breach acquires a
delta the moment the branch grows it by one byte, which is exactly what a shared-path change
does across many scenes at once. That routed it to the *caused* callout, attributing the whole
overage to the author and deleting the "rebasing will not help" note — in the middle of the
repo-wide stall that note exists for.

Fix: classify on the baseline (`masterBytes > ceiling`), which is the question the two callouts
are actually asking. When a scene is over on master *and* the branch added to it, both facts are
now reported rather than one being rounded away:

```
🛑 **1 scene was already over ceiling on master:** `scene1` (+312 B over its 50.00 KB ceiling, 12 B of it added here)
```

The author can act on the 12 B they added and cannot act on the 300 B that were already there;
collapsing those into one number misdirects them either way.

**A sixth, smaller one in the same commit:** the headroom-only header predates the
inherited-breach trigger and so asserted "this PR moved a scene close to its ceiling" on a PR
that moved nothing — directly above a block saying the breach came from master. It now picks
its sentence from the flag that actually fired.

### Rendered — inherited breach that this branch also grew

```markdown
## Bundle Size Changes

No bundle-size changes on this branch — but a scene is over its ceiling on master, which fails this job on every open PR.

### Ceiling headroom

🛑 **1 scene was already over ceiling on master:** `scene1` (+312 B over its 50.00 KB ceiling, 12 B of it added here)

This fails the Bundle Size job on every open PR, including ones that changed no bundle bytes, until the bytes are recovered on master. The breach did not originate on this branch and rebasing will not clear it.

<details>
<summary>Tightest scenes repo-wide — 1 scene over ceiling, 0 of 1 under 1.0 KB</summary>

| Scene | Size | Ceiling | Headroom |
|-------|------|---------|----------|
| Scene 1<br/>`scene1` ⬅ moved by this PR | 50.30 KB | 50.00 KB | ⚠️ 312 B over |

</details>
```

### Same root cause as the first three

Every fixture in this file was drawn from the easy region of the input space, where all the
candidate predicates agree. `over` had only ever been tested *together with* growth, so the
new-scene and already-breached regions were never reached at all. Unanimity across fixtures
felt like coverage while being the same test with different numbers.

Three tests now pin the regions, each mutation-controlled by restoring the movement predicate:
reverting it fails exactly the two attribution edges and nothing else.

### One process note, because it nearly cost the control

My first mutation wrote `grewBy(scene.scene)` — a string where a `SceneHeadroom` was expected.
`Map.get(undefined)` returns `undefined`, so the predicate answered "inherited" for *everything*
and the run produced a plausible-looking 3 failures. It was testing a different program than the
one I meant to revert to. `tsx` strips types without checking them, so vitest alone could not see
it; `tsc -p tests/lite` flags it at the exact column. The rule that follows: **a mutation control
must be typechecked before its result is trusted** — otherwise a mutation that fails to compile
in spirit still runs, and its pass/fail is evidence about something else.

### Validation at `5ea1dfb9`

| Check | Result |
| --- | --- |
| focused unit tests (3 files) | **31 passed** |
| six `tsc -p`, run individually | **0 errors each** |
| `pnpm lint` | **exit 0** |
| prettier on all changed files | **unchanged** |
| `scene-config.json` / `reference/` / `bundle-size.spec.ts` / pipeline YAML | **not in the diff** |


---

## Seventh flaw — a tight scene this PR *added* produced no comment at all

Found by sharpening a question from the delegating session. They reported that `#610` had
landed a new scene and asked what my diff renders for a scene present on one side only. The
answer for the case they asked about was already correct — no fake regression, no throw. But
asking it exposed a neighbouring case that was not.

**A scene that exists only on this branch has no baseline entry**, so `computeMovedBytes`
`continue`s and produces no delta for it. Every movement-based test therefore answers "this PR
did not touch it". The danger-zone callout was built from movement alone, so:

> a PR landing a brand-new scene 400 B under its ceiling produced **no comment whatsoever** —
> no delta rows to post, no flag raised, nothing.

That is silence in the single most actionable case the feature has. The author chose both the
scene's contents *and* its ceiling in the same change, and is the only person able to act
before it merges.

This is the **same movement-as-proxy-for-attribution mistake** already corrected for
over-ceiling scenes in `5ea1dfb9`, left behind in the tight band. Both now ask the baseline:
absent from master means added here.

### What changed

- `isAddedHere(scene)` — `scene.masterBytes == null`; a scene absent from the baseline is this
  branch's, regardless of movement.
- The Δ column renders `new scene` rather than a signed number. `0 B` would read as
  "untouched" — the opposite of why the row exists — and computing a delta against a baseline
  of zero would invent a growth the size of the whole bundle.
- The repo-wide list marks such rows `⬅ added by this PR`.
- Header wording: *"this PR **moved** a scene close to its ceiling"* → *"this PR **put** a
  scene close to its ceiling"*, which is true for both added and grown.

### A pinned test was deliberately reversed

`does not treat a scene absent from master as having grown by its whole size` asserted two
separate claims, and conflating them hid this bug: (1) the delta must never be the scene's
whole size, and (2) the scene must not be flagged at all. Claim 1 is the real invariant and is
kept, now under the name `flags a scene absent from master without inventing a delta the size
of the whole scene`. Claim 2 was the bug.

The discriminator used: **change a pinned behaviour only when it causes a failure of the
feature's purpose, and keep the invariant the test was genuinely written to guard.**

### The bound on the fix

Attribution decides only *whose* a tight scene is; it never decides *whether* a scene is tight.
A second test pins that — `stays silent about a scene this PR added that is nowhere near its
ceiling` — because a callout that fires on healthy scenes trains authors to scroll past the one
that matters. Verified on the live 247-scene baseline: `scene186` at its real 96.7 KB has
3.3 KB of headroom and correctly produces **no comment**; pushed to 400 B it produces the
sample below.

### Mutation controls (both typechecked before being trusted)

| Mutation | `tsc -p tests/lite` | Result |
| --- | --- | --- |
| `movedAndTight` back to `grewBy(s) > 0` only | **0 errors** | fails exactly `flags a scene absent from master…` |
| attribution alone triggers the callout (drop the tight filter) | **0 errors** | fails exactly `stays silent about a scene…` |

An untyped mutation silently becomes a *different program*, and its failure count is evidence
about something else. A first attempt at the second mutation produced **2 tsc errors** and was
discarded rather than read — it would have "passed the control" for the wrong reason.

### Rendered on the live 247-scene baseline

`scene186` present in the current manifest, absent from the published baseline, at 400 B of
headroom:

```markdown
## Bundle Size Changes

No changes at whole-KB resolution — but this PR put a scene close to its ceiling.

### Ceiling headroom

⚠️ **1 scene this PR added or grew now sits under 1.0 KB of headroom.**

| Scene | Size | Ceiling | Headroom | Δ this PR |
|-------|------|---------|----------|-----------|
| Scene 186 — Local Cubemap Blending<br/>`scene186` | 99.61 KB | 100.00 KB | **400 B** | new scene |

<details>
<summary>Tightest scenes repo-wide — 98 of 243 under 1.0 KB, 4 under 256 B</summary>

| Scene | Size | Ceiling | Headroom |
|-------|------|---------|----------|
| Scene 117 — 2D Sprite Picking<br/>`scene117` | 16.55 KB | 16.56 KB | 9 B |
| Scene 267 — StandardMaterial Vertex Colors<br/>`scene267` | 41.48 KB | 41.70 KB | 229 B |
| Scene 96 — Sprite uvOffset Parallax<br/>`scene96` | 15.97 KB | 16.20 KB | 235 B |
| Scene 100 — Physics Collision Event<br/>`scene100` | 48.97 KB | 49.20 KB | 239 B |
| Scene 40 — Physics<br/>`scene40` | 48.25 KB | 48.50 KB | 261 B |
| ... 5 more ...
</details>
```

### Validation at `485797e4`

| Check | Result |
| --- | --- |
| focused unit tests (3 files) | **32 passed** |
| six `tsc -p`, run individually | **0 errors each** |
| `pnpm lint` | **exit 0** |
| prettier on all changed files | **clean** |
| real 247-vs-247 comparison | still `No changes detected` — no new noise |
| `scene-config.json` / `reference/` / `bundle-size.spec.ts` / pipeline YAML | **not in the diff** |

**All seven flaws in this PR were found by rendering against real data or by sharpening a
question about it — none by a fixture.** The single root cause is that every fixture was drawn
from the region of the input space where all candidate predicates agree, and unanimity felt
like coverage while being the same test with different numbers.


---

## Eighth finding — the threshold's own justification had inverted

Prompted by the delegating session flagging a **26-byte median discrepancy** between two independent
reconstructions. Chasing it found that neither number was the one being published, and that the
doc comment justifying `TIGHT_HEADROOM_BYTES` contained an argument that had reversed against
current data.

The comment cited a single dated snapshot (ADO build 58227, n=241) and argued:

> *"The previous value of 256 B was not a 'quiet' threshold — it already flagged 71 scenes"*

Re-measured against the **published baseline artifact** at master `c5f8f660`, using the module's own
`computeSceneHeadroom` / `scenesUnderHeadroom` rather than a reimplementation, so the population
rule is the one the code actually applies:

```
population        243   (over ceiling: 0)
median headroom   1825 B      p25 471 B      p10 360 B
under  256 B        4 scenes ( 2%)     <- comment says 71 (29%)
under 1024 B       97 scenes (40%)     <- comment says 105 (44%)
under 2048 B      127 scenes (52%)     <- comment says 131 (54%)
tightest          scene117 at 9 B      <- unchanged
```

Matches the live build log's `⚠ 97 scene(s) under 1.0 KB of headroom, 4 under 256 B` exactly.

**256 B now flags 4 scenes, not 71.** The conclusion survives — 256 B is still the wrong threshold —
but the stated reason asserted the opposite of the data. That is the same
true-statement-beside-drifted-code failure this PR spent its whole life fixing, sitting in the file
whose comments exist to prevent it.

### The shape of the drift is diagnostic

```
under 1 KB   44% -> 40%       under 256 B   71 scenes -> 4
under 2 KB   54% -> 52%       median      1536 B -> 1825 B
```

The body barely moved; the extreme tail collapsed. That is the signature of a **core-engine deletion
recovering a few hundred bytes across many scenes at once** — it lifts the scenes nearest their
ceilings and leaves the rest alone. It is this report's own subject, observed in the safe direction,
and it is visible in the *baseline* rather than in this branch.

### Why both vintages are kept

Replacing the old snapshot would have been the obvious edit and the wrong one. **A threshold
justified by a single measurement cannot be distinguished from one fitted to it.** 1 KB holding
44% → 40% across two different instruments — a build's own output and a CDN-hosted artifact — while
the tail fell by a factor of seventeen is evidence the number tracks where near-ceiling scenes
actually sit. And the collapse itself is the better disqualification of 256 B: a threshold whose
coverage can fall seventeenfold with nobody touching it is reporting the tail's position, not a
risk level.

Comment-only change. Verified by filtering the diff for non-comment lines — there are none. No
exported value, signature, or behaviour changed.


---

## The ceiling arithmetic is load-bearing — the natural way to write it is wrong

Worth recording because it is why `computeSceneHeadroom` is a shared module with a pinned test
rather than two lines inlined at each call site.

The obvious formulation is `round(maxRawKB * 1024) - measured`: round the ceiling to whole bytes,
then subtract. It is wrong, and it fails in the unsafe direction. A `maxRawKB` of 92.2 is 94412.8
bytes exactly, so a scene at 94413 B is genuinely over by 0.2 B:

```
floor(94412.8 - 94413)  = -1   -> negative -> classified OVER         (correct)
round(94412.8) - 94413  =  0   -> not < 0  -> classified AT ceiling   (breach hidden)
round(94412.8 - 94413)  = -0   -> not < 0  -> classified AT ceiling   (breach hidden)
```

**Both placements of `round` fail**, which is what makes this a family rather than one avoidable
slip. The second is the nastier of the two: `Math.round(-0.2)` is `-0`, which prints as `-0` in a
log and reads as negative to a human, while `-0 < 0` is `false`. The value looks like the breach it
is concealing.

Either way it is a false negative on the one condition that stalls the whole repository.

This is not an exotic corner. Measured across the 243 ceilings the check actually enforces:

```
fractional byte-ceilings                     194  (80%)
where round() and floor() disagree by 1 B     92  (38%)
```

Rounding the ceiling up before subtracting overstates headroom on **more than a third of the
corpus**, every time in the direction that under-reports risk.

This module avoids it by comparing **before** any rounding (`bundle-ceiling-headroom.ts:177`) and
rounding only the displayed magnitude, asymmetrically: `floor` for remaining headroom so it is
never overstated, `Math.ceil` for overage so it is never understated. Both round toward bad news.
Pinned at `bundle-ceiling-headroom.test.ts:48` with the 92.2 KB case in both directions
(94413 over, 94412 under).

**The argument for extraction does not depend on anyone having actually made this mistake.** The
wrong version is the natural one to write, it diverges only within a byte of a ceiling, and 38% of
ceilings are where it would diverge. A defect that narrow survives review and survives every scene
that is comfortably under. It is caught by one pinned test — but only if the arithmetic lives in
one place for that test to pin.

## End-to-end confirmation on a live baseline (build 58493, `8b43afe5`)

Every earlier run of this PR reported `Master manifest not found; skipping delta report.` — the
published baseline artifact did not exist, so the delta half of this feature had never actually
executed in CI. That changed once #617 landed and definition 60 published successfully; this is
the first run of this branch against a real baseline.

```
Resolve baseline ref            Baseline ref: origin/master (no v* tag found)
                                Baseline SHA: c5f8f6604c80370d01661272e4435c7b5aa66d0a
Build baseline bundle scenes    succeeded
Bundle size ceiling checks      243 passed (10.6m)      0 over ceiling
Generate bundle-size delta comment
                                Bundle size comment written to test-results/bundle-size-comment.md
                                **Bundle Size**: No changes detected.
```

**These four readings come from two different jobs, and one of them is red.** `Bundle size ceiling
checks` and `Generate bundle-size delta comment` run inside **Bundle Size**, which succeeded.
`Resolve baseline ref` and `Build baseline bundle scenes` run inside **Performance: Lite vs
Stable**, which *failed* on this same build — at a later BrowserStack step, with `Access to
BrowserStack denied due to incorrect credentials`, a repo-wide credential outage that was failing
every open PR at the time and is unrelated to this branch.

Stated explicitly because the checks list only ever shows the **job**, so cross-referencing it
against the block above looks like a contradiction. It is not: a failed job does not imply its
steps failed, and a passing step does not imply the enclosing job produced usable output.
Containment misleads in both directions, and every result above is a step-level reading taken at
the step.

Two things are worth stating precisely — one because it is easy to read as weaker than it is, the
other because it is easy to read as **stronger**.

**`No changes detected` is a positive result here, not an absent one.** The string is emitted at
`report-bundle-size-deltas.ts:414`, which is only reachable *past* the `if (!master)` early return
at line 494. The two outcomes are mutually exclusive by construction: a run that failed to resolve
a baseline cannot print this line, it prints `Master manifest not found` and returns. So the log
is a trace of the comparison having been performed, rather than the absence of an error from a
comparison that never ran. That distinction is the whole reason the earlier green runs of this
branch were not evidence of anything.

**But that trace is exactly one bit, and it is not the bit that matters most.** Its honest reading
is *"the reporter did not take the bail path"* — nothing more. It says the comparison ran; it says
nothing about whether what the comparison produced was correct. Build 58448 is the proof: it posted
a comment with a clean positive trace and 94 of 94 rows wrong. Had this branch moved no bytes, that
build would have gone green with the same reassuring log line and the defect would have shipped.
The bugs in this PR were found by *reading the output*, not by confirming the machinery moved, and
the discriminator should be quoted that way rather than as evidence of correctness.

**Zero delta is the correct expected value for this PR, and it is falsifiable.** The branch changes
seven files, all under `scripts/` and `tests/`. None is bundled into a scene — `bundle-ceiling-headroom.ts`
is imported by a build script and by the reporter, neither of which ships. A nonzero bundle delta on
this branch would have indicated something was wrong, so the zero is a check that passed, not a
measurement that was skipped.

### Why no headroom section rendered on this PR

This is by design and is worth being explicit about, because "the feature produced no output" and
"the feature is inert" look identical from outside.

The comment is gated on three disjuncts (`report-bundle-size-deltas.ts:508`): a whole-KB delta, a
scene *this PR moved* into the tight band, or an inherited ceiling breach on master. This PR moves
no bytes, so the first two are empty; master has zero scenes over ceiling, so the third is too.
Silence is correct — a reporting-only PR should not attach a table of scenes it never touched.

Deliberately *not* fixed: it would be easy to render the repo-wide tightest-N list unconditionally,
since it needs only the current manifest. That was rejected in the doc comment at line 486 and the
reasoning holds here. Roughly 40% of scenes sit inside the 1 KB band at any moment, so a
baseline-free headroom report would hand every PR in the repo a warning about scenes it had nothing
to do with — which is precisely the wallpaper failure mode part (a) of this task exists to avoid.
The four rendering quadrants (new+roomy, new+tight, new+over, unchanged) were each verified against
the real 247-scene published manifest instead; those results are in the section above.

### Remaining CI state

The three non-green jobs are a repo-wide BrowserStack outage, unrelated to and untouchable by this
change. Confirmed by log string rather than by job name, since the two failures have different
signatures and only one of them names the cause:

```
Performance: Lite vs Stable    Access to BrowserStack denied due to incorrect credentials.
Parity Tests (Cloud Browser)   [browserstack-wait] Timed out after 900s waiting for sessions.
BabylonJS.Babylon-Lite         (umbrella rollup of the two above)
```

The parity signature is *derived* — it never contains the credential string, so grepping parity for
the credentials error finds nothing and would wrongly suggest an unrelated second failure.

**Guardrails at `8b43afe5`:** `scene-config.json`, `reference/`, and `azure-pipelines.yml` are
byte-identical to `origin/master`; branch is 0 behind. No ceiling was read as anything other than
an input.





---

## Phase 3: baseline-owned ceiling attribution (#628)

Rebased onto Phase 2 master commit `286525f8`, whose content-addressed baseline entries carry the `ceilingKB` that applied when their bytes were measured. The reporter now keeps the two time frames separate:

- current/PR headroom uses the branch's `maxRawKB` from `scene-config.json`;
- historical master attribution uses the baseline entry's own `ceilingKB`;
- an older baseline entry without `ceilingKB` has **unknown** historical state. It can still produce ordinary deltas and appear in the current-state table, but it triggers neither "put over by this PR" nor "already over on master" attribution.

That explicitly closes #628 rather than assuming content addressing alone fixes it. The acceptance repro is now a focused test: baseline 95 KB under its historical 100 KB ceiling; PR 92 KB under a newly tightened 90 KB ceiling. The inherited-breach text is absent, and the rendered actionable result is:

```
🚨 **1 scene put over its ceiling by this PR:** `scene1` (+2.0 KB over its 90.00 KB ceiling)
```

For a genuine inherited breach, the callout now reports the baseline overage against the **baseline ceiling**, while the collapsed repo-wide table continues to report the branch's current absolute state.

### Phase 3 validation

- `REUSE_BROWSER=1 pnpm exec vitest run --project unit tests/lite/unit/bundle-ceiling-headroom.test.ts tests/lite/unit/report-bundle-size-deltas.test.ts tests/lite/unit/perf-baseline-script-closure.test.ts` → **34 passed**
- `pnpm run typecheck:tests` → passed (covers `scripts/**/*.ts` and `tests/lite/**/*.ts`)
- focused ESLint on the three affected unit specs → passed
- focused Prettier check on the three Phase 3 files → passed
- live immutable baseline `286525f8…/manifest.json` → **248 entries, 244 with `ceilingKB`**
- guardrails unchanged: `scene-config.json`, `azure-pipelines.yml`, `tests/lite/parity/bundle-size.spec.ts`, and `reference/`

Phase 3 commit: `03afa0aa`.
