### PR TITLE
ci: raise Node heap limit to fix intermittent playground build OOM

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,8 @@
 public-hoist-pattern[]=*playwright*
+
+; Raise the V8 heap limit for every Node process pnpm spawns. The playground's `vite build`
+; (`pnpm build:playground`) peaks above the ~2 GB default heap on the hosted CI agents and dies with
+; `FatalProcessOutOfMemory` (exit 134). The failure is nondeterministic — it landed on roughly a third
+; of runs, including the release pipeline, where it aborted the playground site deploy after the npm
+; packages had already published. 8192 matches the Babylon.js monorepo.
+node-options=--max-old-space-size=8192


### PR DESCRIPTION
## Problem

The playground's `vite build` intermittently dies with `FatalProcessOutOfMemory` (exit 134) on the hosted CI agents:

```
<--- Last few GCs --->
...
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

It's nondeterministic — it hit roughly a third of recent runs across **PR #535, #536, and #537**, so it isn't caused by any one change. It also hit the **release pipeline** (build 57568), where it aborted the playground site deploy at task 21 of 25 — after the npm packages had already published.

The build genuinely needs the memory: `main-*.js` alone is ~4.2 MB minified with a ~16 MB sourcemap, and Monaco contributes a long tail of language chunks. The hosted agents give Node a ~2 GB default heap, which it sits right at the edge of.

## Fix

Set `node-options` in `.npmrc`:

```
node-options=--max-old-space-size=8192
```

pnpm applies this to every Node process it spawns, so it covers the playground build without threading `NODE_OPTIONS` through individual pipeline steps or per-script `cross-env` wrappers. `8192` matches what the Babylon.js monorepo already uses.

## Verification

Heap limit for a pnpm-spawned Node, before and after:

```
pnpm exec node -e "console.log(require('v8').getHeapStatistics().heap_size_limit/1024/1024)"
```

| | heap limit |
| --- | --- |
| bare `node` | 4144 MB |
| `pnpm exec node` (after this change) | 8240 MB |

`pnpm build:playground` still succeeds (`✓ built in 27.53s`).

Since the failure is intermittent rather than deterministic, this can't be proven by a single green run — but the flag directly removes the ceiling that was being hit.
