### PR TITLE
fix(text): rebuild text bind groups when draw groups reorder

### DIFF
--- a/lab/public/bundle/manifest/scene180.json
+++ b/lab/public/bundle/manifest/scene180.json
@@ -6,5 +6,5 @@
     "scene180-text-shaper-CL-qK3Rv.js",
     "scene180.js"
   ],
-  "rawBytes": 28406
+  "rawBytes": 28377
 }

--- a/packages/babylon-lite/src/text/text-recovery.ts
+++ b/packages/babylon-lite/src/text/text-recovery.ts
@@ -34,8 +34,7 @@ function rebuildTextRendererGpu(renderer: TextRenderer): void {
             usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
         });
         lg.pipeline = null;
-        lg.bindGroups.length = 0;
-        lg.bindGroupAtlasVersions.length = 0;
+        lg.bindGroupCache.length = 0;
         lg.uploadedDataVersion = -1;
         lg.uploadedViewportW = 0;
         lg.uploadedViewportH = 0;

--- a/packages/babylon-lite/src/text/text-renderer.ts
+++ b/packages/babylon-lite/src/text/text-renderer.ts
@@ -11,6 +11,7 @@ import type { SurfaceContext } from "../engine/surface.js";
 import { createEmptyUniformBuffer } from "../resource/gpu-buffers.js";
 import type { TextData } from "./text-data.js";
 import { TEXT_INSTANCE_BYTES } from "./text-data.js";
+import type { CurveSetId } from "./glyph-storage.js";
 import { ensureSharedAtlasGpu } from "./_gpu/text-textures.js";
 import { getOrCreateTextPipeline } from "./_gpu/text-pipeline.js";
 
@@ -125,9 +126,14 @@ interface LayerGpu {
     instanceBuf: GPUBuffer;
     instanceCap: number;
     pipeline: GPURenderPipeline | null;
-    /** Per-draw-group bind groups; rebuilt when atlas grows. */
+    /** Per-draw-group bind groups; rebuilt when atlas grows. Indexed by draw-group index,
+     *  which is NOT stable: `data._groups` is spliced when a group empties and rebuilt in
+     *  map-insertion order by `applyReset`. `bindGroupCurveSetIds` records which curve set
+     *  each cached entry was built for so a reordered group cannot inherit another curve
+     *  set's atlas textures. */
     bindGroups: GPUBindGroup[];
     bindGroupAtlasVersions: number[];
+    bindGroupCurveSetIds: CurveSetId[];
     uploadedDataVersion: number;
     uploadedViewportW: number;
     uploadedViewportH: number;
@@ -192,6 +198,7 @@ function ensureLayerGpu(rr: TextRenderer, layer: TextLayer): LayerGpu {
         pipeline: null,
         bindGroups: [],
         bindGroupAtlasVersions: [],
+        bindGroupCurveSetIds: [],
         uploadedDataVersion: -1,
         uploadedViewportW: 0,
         uploadedViewportH: 0,
@@ -236,7 +243,8 @@ function uploadLayer(rr: TextRenderer, lg: LayerGpu, bindGroupLayout: GPUBindGro
         const { rebuilt, gpu: atlasGpu } = ensureSharedAtlasGpu(device, g.curveSet.atlas);
         const current = lg.bindGroups[i];
         const currentVer = lg.bindGroupAtlasVersions[i] ?? -1;
-        if (!current || rebuilt || currentVer !== atlasGpu.uploadedVersion) {
+        const currentCurveSetId = lg.bindGroupCurveSetIds[i];
+        if (!current || rebuilt || currentVer !== atlasGpu.uploadedVersion || currentCurveSetId !== g.curveSetId) {
             lg.bindGroups[i] = device.createBindGroup({
                 label: "text-renderer-bg0-" + g.curveSetId,
                 layout: bindGroupLayout,
@@ -247,6 +255,7 @@ function uploadLayer(rr: TextRenderer, lg: LayerGpu, bindGroupLayout: GPUBindGro
                 ],
             });
             lg.bindGroupAtlasVersions[i] = atlasGpu.uploadedVersion;
+            lg.bindGroupCurveSetIds[i] = g.curveSetId;
             // Bundle baked the old bind group; force a re-record.
             lg.renderBundle = null;
         }
@@ -254,6 +263,7 @@ function uploadLayer(rr: TextRenderer, lg: LayerGpu, bindGroupLayout: GPUBindGro
     if (lg.bindGroups.length > data._groups.length) {
         lg.bindGroups.length = data._groups.length;
         lg.bindGroupAtlasVersions.length = data._groups.length;
+        lg.bindGroupCurveSetIds.length = data._groups.length;
         lg.renderBundle = null;
     }
 
@@ -374,6 +384,7 @@ function textRendererUpdate(rr: TextRenderer): void {
             // Pipeline change → bind groups must be rebuilt against new bindGroupLayout.
             lg.bindGroups.length = 0;
             lg.bindGroupAtlasVersions.length = 0;
+            lg.bindGroupCurveSetIds.length = 0;
             // Bundle baked the old pipeline; force a re-record.
             lg.renderBundle = null;
         }

--- a/packages/babylon-lite/src/text/text-renderer.ts
+++ b/packages/babylon-lite/src/text/text-renderer.ts
@@ -119,6 +119,15 @@ export interface TextRenderer extends RenderingContext {
     _visibleBundles: GPURenderBundle[];
 }
 
+/** @internal One cached bind group plus the inputs it was built from. Bundling the three
+ *  together makes the cache self-describing: an entry can never disagree with its own
+ *  invalidation keys, and there is a single array to write, truncate, and clear. */
+interface BindGroupCacheEntry {
+    bindGroup: GPUBindGroup;
+    atlasVersion: number;
+    curveSetId: CurveSetId;
+}
+
 /** @internal Per-layer GPU resources owned by the renderer. */
 interface LayerGpu {
     layer: TextLayer;
@@ -126,14 +135,12 @@ interface LayerGpu {
     instanceBuf: GPUBuffer;
     instanceCap: number;
     pipeline: GPURenderPipeline | null;
-    /** Per-draw-group bind groups; rebuilt when atlas grows. Indexed by draw-group index,
-     *  which is NOT stable: `data._groups` is spliced when a group empties and rebuilt in
-     *  map-insertion order by `applyReset`. `bindGroupCurveSetIds` records which curve set
-     *  each cached entry was built for so a reordered group cannot inherit another curve
-     *  set's atlas textures. */
-    bindGroups: GPUBindGroup[];
-    bindGroupAtlasVersions: number[];
-    bindGroupCurveSetIds: CurveSetId[];
+    /** Per-draw-group bind groups; rebuilt when the atlas grows or the curve set at an index
+     *  changes. Indexed by draw-group index, which is NOT stable: `data._groups` is spliced
+     *  when a group empties and rebuilt in map-insertion order by `applyReset`. Each entry
+     *  therefore carries the curve set it was built for, so a reordered group cannot inherit
+     *  another curve set's atlas textures. */
+    bindGroupCache: BindGroupCacheEntry[];
     uploadedDataVersion: number;
     uploadedViewportW: number;
     uploadedViewportH: number;
@@ -196,9 +203,7 @@ function ensureLayerGpu(rr: TextRenderer, layer: TextLayer): LayerGpu {
         }),
         instanceCap: cap,
         pipeline: null,
-        bindGroups: [],
-        bindGroupAtlasVersions: [],
-        bindGroupCurveSetIds: [],
+        bindGroupCache: [],
         uploadedDataVersion: -1,
         uploadedViewportW: 0,
         uploadedViewportH: 0,
@@ -241,29 +246,27 @@ function uploadLayer(rr: TextRenderer, lg: LayerGpu, bindGroupLayout: GPUBindGro
     for (let i = 0; i < data._groups.length; i++) {
         const g = data._groups[i]!;
         const { rebuilt, gpu: atlasGpu } = ensureSharedAtlasGpu(device, g.curveSet.atlas);
-        const current = lg.bindGroups[i];
-        const currentVer = lg.bindGroupAtlasVersions[i] ?? -1;
-        const currentCurveSetId = lg.bindGroupCurveSetIds[i];
-        if (!current || rebuilt || currentVer !== atlasGpu.uploadedVersion || currentCurveSetId !== g.curveSetId) {
-            lg.bindGroups[i] = device.createBindGroup({
-                label: "text-renderer-bg0-" + g.curveSetId,
-                layout: bindGroupLayout,
-                entries: [
-                    { binding: 0, resource: { buffer: lg.textU } },
-                    { binding: 1, resource: atlasGpu.curveTex.createView() },
-                    { binding: 2, resource: atlasGpu.bandTex.createView() },
-                ],
-            });
-            lg.bindGroupAtlasVersions[i] = atlasGpu.uploadedVersion;
-            lg.bindGroupCurveSetIds[i] = g.curveSetId;
+        const cached = lg.bindGroupCache[i];
+        if (!cached || rebuilt || cached.atlasVersion !== atlasGpu.uploadedVersion || cached.curveSetId !== g.curveSetId) {
+            lg.bindGroupCache[i] = {
+                bindGroup: device.createBindGroup({
+                    label: "text-renderer-bg0-" + g.curveSetId,
+                    layout: bindGroupLayout,
+                    entries: [
+                        { binding: 0, resource: { buffer: lg.textU } },
+                        { binding: 1, resource: atlasGpu.curveTex.createView() },
+                        { binding: 2, resource: atlasGpu.bandTex.createView() },
+                    ],
+                }),
+                atlasVersion: atlasGpu.uploadedVersion,
+                curveSetId: g.curveSetId,
+            };
             // Bundle baked the old bind group; force a re-record.
             lg.renderBundle = null;
         }
     }
-    if (lg.bindGroups.length > data._groups.length) {
-        lg.bindGroups.length = data._groups.length;
-        lg.bindGroupAtlasVersions.length = data._groups.length;
-        lg.bindGroupCurveSetIds.length = data._groups.length;
+    if (lg.bindGroupCache.length > data._groups.length) {
+        lg.bindGroupCache.length = data._groups.length;
         lg.renderBundle = null;
     }
 
@@ -382,9 +385,7 @@ function textRendererUpdate(rr: TextRenderer): void {
         if (lg.pipeline !== pipeline) {
             lg.pipeline = pipeline;
             // Pipeline change → bind groups must be rebuilt against new bindGroupLayout.
-            lg.bindGroups.length = 0;
-            lg.bindGroupAtlasVersions.length = 0;
-            lg.bindGroupCurveSetIds.length = 0;
+            lg.bindGroupCache.length = 0;
             // Bundle baked the old pipeline; force a re-record.
             lg.renderBundle = null;
         }
@@ -451,7 +452,7 @@ function textRendererRecord(rr: TextRenderer): number {
             let groupDraws = 0;
             for (let i = 0; i < data._groups.length; i++) {
                 const g = data._groups[i]!;
-                const bg = lg.bindGroups[i];
+                const bg = lg.bindGroupCache[i]?.bindGroup;
                 if (g.slotCount === 0 || !bg) {
                     continue;
                 }

--- a/tests/lite/unit/device-lost-renderer-recovery.test.ts
+++ b/tests/lite/unit/device-lost-renderer-recovery.test.ts
@@ -12,6 +12,7 @@ import { rebuildRegisteredSpriteRenderers } from "../../../packages/babylon-lite
 import type { GlyphCurves } from "../../../packages/babylon-lite/src/text/glyph-storage";
 import { createGlyphStorage } from "../../../packages/babylon-lite/src/text/glyph-storage";
 import { createTextData } from "../../../packages/babylon-lite/src/text/text-data";
+import { updateTextData } from "../../../packages/babylon-lite/src/text/text-data";
 import { createTextLayer, createTextRenderer, registerTextRenderer } from "../../../packages/babylon-lite/src/text/text-renderer";
 import { rebuildRegisteredTextRenderers } from "../../../packages/babylon-lite/src/text/text-recovery";
 
@@ -234,5 +235,34 @@ describe("TextRenderer device-lost recovery", () => {
         expect(layer.coverageGamma).toBe(2);
         expect(renderer._clear).toBe(false);
         expect(other.touched).toBe(false);
+    });
+
+    it("leaves the per-draw-group bind-group cache consistent when the group list shrank before recovery", async () => {
+        const engine = makeEngine(makeDevice());
+        const storage = createGlyphStorage(
+            new Map([
+                ["a", new Map([[1, glyph()]])],
+                ["b", new Map([[1, glyph()]])],
+            ])
+        );
+        const runA = { curveSet: "a", glyphs: [{ glyphId: 1, x: 0, y: 0 }], pixelsPerFontUnit: 1 };
+        const runB = { curveSet: "b", glyphs: [{ glyphId: 1, x: 8, y: 0 }], pixelsPerFontUnit: 1 };
+        const data = createTextData(storage, [runA, runB]);
+        const layer = createTextLayer(data);
+        const renderer = createTextRenderer(engine, { layers: [layer] });
+        registerTextRenderer(renderer);
+        renderer._update();
+
+        expect(renderer._layerGpu.get(layer)!.bindGroupCache.map((e) => e.curveSetId)).toEqual(["a", "b"]);
+
+        // Drop a curve set *before* recovery runs, so the rebuild — not a later `_update()` —
+        // is what has to reconcile the cache with the shorter group list. Truncation in
+        // `uploadLayer` only shrinks a cache that is longer than the group list, so an entry
+        // the rebuild failed to discard would never be trimmed back out.
+        updateTextData(data, { update: "reset", runs: [runB] });
+        engine._device = makeDevice().device;
+        await rebuildRegisteredTextRenderers(engine);
+
+        expect(renderer._layerGpu.get(layer)!.bindGroupCache.map((e) => e.curveSetId)).toEqual(["b"]);
     });
 });

--- a/tests/lite/unit/text-renderer-bind-group-cache.test.ts
+++ b/tests/lite/unit/text-renderer-bind-group-cache.test.ts
@@ -126,23 +126,22 @@ function expectBindGroupsMatchGroups(rr: TextRenderer, layer: TextLayer): void {
     const lg = layerGpu(rr, layer);
     const groups = layer.data._groups;
 
-    // The three per-group arrays are parallel: same length, written and truncated together.
-    expect(lg.bindGroups.length).toBe(groups.length);
-    expect(lg.bindGroupAtlasVersions.length).toBe(groups.length);
-    expect(lg.bindGroupCurveSetIds.length).toBe(groups.length);
+    // One entry per draw group — the cache is truncated with the group list.
+    expect(lg.bindGroupCache.length).toBe(groups.length);
 
     for (let i = 0; i < groups.length; i++) {
         const g = groups[i]!;
         const gpu = g.curveSet.atlas.gpu;
         expect(gpu).not.toBeNull();
 
-        const bg = lg.bindGroups[i] as unknown as MockBindGroup;
+        const entry = lg.bindGroupCache[i]!;
+        const bg = entry.bindGroup as unknown as MockBindGroup;
         const curveView = bg.__entries.find((e) => e.binding === 1)!.resource as MockTextureView;
         const bandView = bg.__entries.find((e) => e.binding === 2)!.resource as MockTextureView;
 
         expect(curveView.__texture).toBe(gpu!.curveTex);
         expect(bandView.__texture).toBe(gpu!.bandTex);
-        expect(lg.bindGroupCurveSetIds[i]).toBe(g.curveSetId);
+        expect(entry.curveSetId).toBe(g.curveSetId);
     }
 }
 
@@ -202,7 +201,7 @@ describe("text renderer bind-group cache", () => {
         const rr = createTextRenderer(surface, { layers: [layer] });
 
         rr._update();
-        expect(layerGpu(rr, layer).bindGroups.length).toBe(2);
+        expect(layerGpu(rr, layer).bindGroupCache.length).toBe(2);
 
         updateTextData(data, { update: "reset", runs: [run("g", 10)] });
         rr._update();

--- a/tests/lite/unit/text-renderer-bind-group-cache.test.ts
+++ b/tests/lite/unit/text-renderer-bind-group-cache.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Text renderer per-draw-group bind-group cache.
+ *
+ * `LayerGpu.bindGroups` is keyed by draw-group *index*, but `TextData._groups` is not
+ * index-stable: `applyReset` rebuilds it in curve-set-first-seen order (reusing the group
+ * objects), and `dropEmptyGroup` splices. A cache entry must therefore be invalidated when
+ * the group at that index switches to a different curve set — otherwise a run draws while
+ * sampling another curve set's atlas textures, which renders correctly-positioned but
+ * wrong-shaped glyphs.
+ *
+ * The atlas-version guard alone cannot catch this: every curve set owns its own
+ * `SharedAtlas` (see `makeCurveSet`), and those independent version counters routinely
+ * hold the same integer, so a reorder produces no version change. These tests assert on
+ * the actual textures bound per group rather than on version numbers.
+ *
+ * Pure CPU — the GPU device is mocked. Real text draws are covered by the parity scenes.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { GlyphCurves } from "../../../packages/babylon-lite/src/text/glyph-storage";
+import { createGlyphStorage } from "../../../packages/babylon-lite/src/text/glyph-storage";
+import type { GlyphRun } from "../../../packages/babylon-lite/src/text/text-data";
+import { createTextData, updateTextData } from "../../../packages/babylon-lite/src/text/text-data";
+import type { TextLayer, TextRenderer } from "../../../packages/babylon-lite/src/text/text-renderer";
+import { createTextLayer, createTextRenderer } from "../../../packages/babylon-lite/src/text/text-renderer";
+import type { SurfaceContext } from "../../../packages/babylon-lite/src/engine/surface";
+
+// ── Mock GPU device ───────────────────────────────────────────────
+// Only the calls the text renderer makes during `_update()` are implemented. Textures and
+// their views carry a back-reference so a bind group can be traced to the atlas it samples.
+
+type MockTexture = { label: string; __id: number; createView: () => MockTextureView; destroy: () => void };
+type MockTextureView = { __texture: MockTexture };
+type MockBindGroup = { label: string; __entries: { binding: number; resource: unknown }[] };
+
+function createMockDevice() {
+    let nextTextureId = 0;
+    const counters = { bindGroupsCreated: 0, texturesCreated: 0 };
+
+    const device = {
+        createBuffer: vi.fn((desc: { label?: string; size: number }) => ({
+            label: desc.label ?? "",
+            getMappedRange: () => new ArrayBuffer(desc.size),
+            unmap: vi.fn(),
+            destroy: vi.fn(),
+        })),
+        createTexture: vi.fn((desc: { label?: string }): MockTexture => {
+            counters.texturesCreated++;
+            const tex: MockTexture = {
+                label: desc.label ?? "",
+                __id: nextTextureId++,
+                createView: () => ({ __texture: tex }),
+                destroy: vi.fn(),
+            };
+            return tex;
+        }),
+        createBindGroup: vi.fn((desc: { label?: string; entries: { binding: number; resource: unknown }[] }): MockBindGroup => {
+            counters.bindGroupsCreated++;
+            return { label: desc.label ?? "", __entries: desc.entries };
+        }),
+        createBindGroupLayout: vi.fn(() => ({})),
+        createPipelineLayout: vi.fn(() => ({})),
+        createShaderModule: vi.fn(() => ({})),
+        createRenderPipeline: vi.fn(() => ({})),
+        queue: { writeBuffer: vi.fn(), writeTexture: vi.fn() },
+    };
+
+    return { device, counters };
+}
+
+/** A surface backed by the mock device. Each call builds a fresh device so the text
+ *  pipeline cache (keyed by device) does not leak between tests. */
+function createMockSurface() {
+    const { device, counters } = createMockDevice();
+    const engine = { _device: device };
+    const surface = {
+        engine,
+        canvas: { width: 800, height: 600 },
+        format: "bgra8unorm",
+    } as unknown as SurfaceContext;
+    return { surface, counters };
+}
+
+// ── Text fixtures ─────────────────────────────────────────────────
+
+function makeGlyph(glyphId: number): GlyphCurves {
+    return {
+        glyphId,
+        curves: [
+            { p0x: 0, p0y: 0, p1x: 50, p1y: 100, p2x: 100, p2y: 0 },
+            { p0x: 100, p0y: 0, p1x: 50, p1y: -20, p2x: 0, p2y: 0 },
+        ],
+        bounds: { xMin: 0, yMin: -20, xMax: 100, yMax: 100 },
+    };
+}
+
+/** Two curve sets, each with its own `SharedAtlas`. */
+function makeStorage() {
+    const curves = (ids: number[]) => new Map<number, GlyphCurves>(ids.map((id) => [id, makeGlyph(id)]));
+    return createGlyphStorage(
+        new Map([
+            ["f", curves([1, 2, 3])],
+            ["g", curves([1, 2, 3])],
+        ])
+    );
+}
+
+function run(curveSet: string, x: number, glyphIds: number[] = [1, 2]): GlyphRun {
+    return {
+        curveSet,
+        glyphs: glyphIds.map((glyphId, i) => ({ glyphId, x: x + i, y: 0 })),
+        pixelsPerFontUnit: 1,
+    };
+}
+
+// ── Assertions ────────────────────────────────────────────────────
+
+function layerGpu(rr: TextRenderer, layer: TextLayer) {
+    const lg = rr._layerGpu.get(layer);
+    expect(lg).toBeDefined();
+    return lg!;
+}
+
+/** Every cached bind group must sample the atlas of the group that now sits at its index. */
+function expectBindGroupsMatchGroups(rr: TextRenderer, layer: TextLayer): void {
+    const lg = layerGpu(rr, layer);
+    const groups = layer.data._groups;
+
+    // The three per-group arrays are parallel: same length, written and truncated together.
+    expect(lg.bindGroups.length).toBe(groups.length);
+    expect(lg.bindGroupAtlasVersions.length).toBe(groups.length);
+    expect(lg.bindGroupCurveSetIds.length).toBe(groups.length);
+
+    for (let i = 0; i < groups.length; i++) {
+        const g = groups[i]!;
+        const gpu = g.curveSet.atlas.gpu;
+        expect(gpu).not.toBeNull();
+
+        const bg = lg.bindGroups[i] as unknown as MockBindGroup;
+        const curveView = bg.__entries.find((e) => e.binding === 1)!.resource as MockTextureView;
+        const bandView = bg.__entries.find((e) => e.binding === 2)!.resource as MockTextureView;
+
+        expect(curveView.__texture).toBe(gpu!.curveTex);
+        expect(bandView.__texture).toBe(gpu!.bandTex);
+        expect(lg.bindGroupCurveSetIds[i]).toBe(g.curveSetId);
+    }
+}
+
+describe("text renderer bind-group cache", () => {
+    it("rebinds the correct atlas after a reset reorders draw groups", () => {
+        const { surface } = createMockSurface();
+        const storage = makeStorage();
+        const data = createTextData(storage, [run("f", 0), run("g", 10)]);
+        const layer = createTextLayer(data);
+        const rr = createTextRenderer(surface, { layers: [layer] });
+
+        rr._update();
+
+        expect(data._groups.map((g) => g.curveSetId)).toEqual(["f", "g"]);
+        expectBindGroupsMatchGroups(rr, layer);
+
+        const atlasF = storage._curveSets.get("f")!.atlas;
+        const atlasG = storage._curveSets.get("g")!.atlas;
+        // Independent atlases whose version counters collide — the reason an atlas-version
+        // check alone cannot detect the reorder below.
+        expect(atlasF.gpu!.uploadedVersion).toBe(atlasG.gpu!.uploadedVersion);
+        expect(atlasF.gpu!.curveTex).not.toBe(atlasG.gpu!.curveTex);
+
+        // Same curve sets, same group count, reversed order → `applyReset` swaps the two
+        // group objects in `_groups` without changing its length.
+        updateTextData(data, { update: "reset", runs: [run("g", 10), run("f", 0)] });
+        expect(data._groups.map((g) => g.curveSetId)).toEqual(["g", "f"]);
+
+        rr._update();
+
+        expectBindGroupsMatchGroups(rr, layer);
+    });
+
+    it("does not recreate bind groups when nothing changed", () => {
+        const { surface, counters } = createMockSurface();
+        const storage = makeStorage();
+        const data = createTextData(storage, [run("f", 0), run("g", 10)]);
+        const layer = createTextLayer(data);
+        const rr = createTextRenderer(surface, { layers: [layer] });
+
+        rr._update();
+        const afterFirst = counters.bindGroupsCreated;
+        expect(afterFirst).toBe(2);
+
+        rr._update();
+        rr._update();
+
+        expect(counters.bindGroupsCreated).toBe(afterFirst);
+        expectBindGroupsMatchGroups(rr, layer);
+    });
+
+    it("truncates the per-group cache when a curve set disappears", () => {
+        const { surface } = createMockSurface();
+        const storage = makeStorage();
+        const data = createTextData(storage, [run("f", 0), run("g", 10)]);
+        const layer = createTextLayer(data);
+        const rr = createTextRenderer(surface, { layers: [layer] });
+
+        rr._update();
+        expect(layerGpu(rr, layer).bindGroups.length).toBe(2);
+
+        updateTextData(data, { update: "reset", runs: [run("g", 10)] });
+        rr._update();
+
+        expect(data._groups.map((g) => g.curveSetId)).toEqual(["g"]);
+        expectBindGroupsMatchGroups(rr, layer);
+    });
+});


### PR DESCRIPTION
## Problem

With Babylon outline (Slug) text rendering, a large bold heading in Word Online renders correctly for a moment after load and then garbles into stroke slivers — glyphs in the right positions with the wrong outlines.

## Root cause

`LayerGpu`'s bind-group cache is keyed by draw-group **index**, but `TextData._groups` is not index-stable:

- `applyReset` rebuilds `_groups` in curve-set-first-seen order, reusing the group objects, so the array can reorder without changing length.
- `dropEmptyGroup` splices, shifting later groups down.

The only staleness guard was an atlas-version comparison. Every curve set owns its own `SharedAtlas` (see `makeCurveSet`), so those version counters are independent and routinely hold the same integer. A reorder therefore produced no version change and no rebuild, and the group at index `i` drew while sampling a *different* curve set's curve/band textures.

`text-renderable.ts` already handles this correctly by caching `bindGroup` on the group object itself; the renderer's index-keyed cache was the outlier. Per-group storage isn't an option here because `LayerGpu` is per-layer and a `TextData` can in principle be shared across layers.

## Fix

Track the curve set each cached bind group was built for, and rebuild the entry when it no longer matches the group at that index.

The cache is a single `bindGroupCache: BindGroupCacheEntry[]`, where each entry holds its bind group next to the `atlasVersion` and `curveSetId` it was built from. It started as three parallel arrays (`bindGroups` / `bindGroupAtlasVersions` / `bindGroupCurveSetIds`) kept in agreement by convention across four write sites; review feedback on that asymmetry prompted the collapse into one array. An entry can no longer disagree with its own invalidation keys, and there is a single array to write, truncate, and clear.

Worth noting for reviewers: the reported failure mode behind that feedback — `text-recovery.ts` leaving a stale key after a device-lost rebuild — is not actually reachable, because recovery sets `lg.pipeline = null` and the pipeline-change branch in `textRendererUpdate` already clears the cache before `uploadLayer` runs. The structural fix was taken for the fragility, not the bug.

## Tests

New `tests/lite/unit/text-renderer-bind-group-cache.test.ts` (mocked GPU device, pure CPU) covers:

- **Reorder** — two curve sets, reset with the run order reversed; asserts each cached bind group samples the atlas textures of the group now at its index. Fails without the fix.
- **Shrink** — a curve set disappears; asserts the cache truncates with the group list and stays correct. Fails without the fix.
- **No churn** — repeated steady-state `_update()` calls create no additional bind groups, so the new condition doesn't invalidate every frame. Passes with and without the fix.

The reorder test also asserts that the two atlases' `uploadedVersion` values are equal, documenting why the version guard alone could never catch this.

`tests/lite/unit/device-lost-renderer-recovery.test.ts` gains a case for a group list that shrank before the rebuild ran.

## Bundle size

The single-array cache is **smaller than the code it fixes, and smaller than baseline**. scene180 raw bytes:

| | raw bytes | vs. pre-fix master |
| --- | --- | --- |
| pre-fix master | 28,406 | — |
| three parallel arrays | 28,584 | +178 |
| single `bindGroupCache` | **28,377** | **−29** |

`lab/public/bundle/manifest/scene180.json` regenerated accordingly.

## Validation

- `pnpm test:unit` — 198 files / 1507 tests pass; text + device-lost suites re-run against the final shape.
- Regression guard re-verified: removing the curve-set comparison fails the reorder and shrink tests while "no churn" still passes.
- `eslint`, `prettier`, and `tsc` clean on the changed source and test files.
- Verified live in a local Word Online build with outline rendering forced on: garbling reproduced on the unpatched build, clean with the fix at load, after scrolling away and back, and at 130% zoom.
- Consuming build regression (`@babylonjs/lite` upgrade in 1JS): 36/36 canvases pixel-identical (MAD 0.00000) against the pre-upgrade build.
