### PR TITLE
feat(shader): add async pipeline compilation

### DIFF
--- a/docs/lite/architecture/53-async-shader-pipeline-compilation.md
+++ b/docs/lite/architecture/53-async-shader-pipeline-compilation.md
@@ -1,0 +1,130 @@
+# Module: Async ShaderMaterial Pipeline Compilation
+
+> Package path: `packages/babylon-lite/src/material/shader/`
+
+## Purpose
+
+This opt-in prepares ShaderMaterial render pipelines before `FrameGraph.build()` or before a caller-defined readiness boundary. It moves WebGPU pipeline compilation off the first synchronous `Renderable.bind()` without changing pixels, pipeline keys, descriptors, or the synchronous fallback. Standard, PBR, NodeMaterial, geometry-material, post-process, and effect pipelines are outside this module.
+
+## Public API Surface
+
+```ts
+type ShaderMaterialPipelineLayout = "mesh" | "thin-instances" | "thin-instances-color";
+
+function enableAsyncShaderPipelineCompilation(engine: EngineContext): void;
+
+function prepareShaderMaterialPipeline(engine: EngineContext, material: ShaderMaterial, layout: ShaderMaterialPipelineLayout, target: RenderTarget | RenderTask): Promise<void>;
+
+function prepareShaderMaterialPipelineForTask(task: RenderTask, material: ShaderMaterial, layout: ShaderMaterialPipelineLayout): Promise<void>;
+```
+
+`enableAsyncShaderPipelineCompilation` is idempotent. It must be called before ShaderMaterial renderables are built when automatic scene-registration preparation is desired. `prepareShaderMaterialPipeline` and `prepareShaderMaterialPipelineForTask` are explicit preparation queries and do not require a renderable or a prior `addMesh`.
+
+The layout values mean:
+
+- `mesh`: the vertex buffers declared by `ShaderMaterial.attributes`.
+- `thin-instances`: those mesh buffers plus four instance-rate `float32x4` matrix rows at consecutive shader locations.
+- `thin-instances-color`: the thin-instance matrix layout plus one instance-rate `float32x4` color.
+
+No public API accepts a `GPUDevice`, `GPURenderPipelineDescriptor`, shader module, pipeline layout, or vertex-buffer descriptor.
+
+## Internal Architecture
+
+`shader-pipeline.ts` remains the single owner of ShaderMaterial pipeline identity and construction. Async preparation invokes the unchanged synchronous builder against a transient capture device that delegates shader-module creation to the real device and intercepts only `createRenderPipeline(descriptor)`. The placeholder pipeline is removed from the completed cache synchronously, before control can yield, and the captured descriptor is submitted to the real device through `createRenderPipelineAsync`.
+
+This guarantees that both paths derive the same variant key, shader modules, final cache key, and complete `GPURenderPipelineDescriptor` without adding a branch or descriptor abstraction to the ordinary first-bind path. Both publish the result into the same `ShaderPipelineBindings.pipelines` map.
+
+Automatic thin-instance registration records the mesh plus its logical matrix-only or matrix-and-color layout in the parent ShaderMaterial builder before the lazy thin module is loaded. Preparation resolves that logical layout inside the opt-in module. Explicit preparation uses the same resolver. Scenes that do not import the enabler retain none of the registrar branch, explicit resolver, or descriptor-capture code.
+
+Each bindings object may lazily own an internal pending-pipeline map. It is allocated only when async preparation is used. One promise is retained per final pipeline key. Concurrent requests for the same key await that promise. The entry is removed on fulfillment or rejection. A synchronous bind remains available throughout; if it wins a race, its pipeline remains authoritative in the shared completed cache.
+
+Automatic scene-registration preparation is best-effort. Rejections are reported through `console.error` and do not abort frame-graph construction or scene registration; the first bind then uses the unchanged synchronous path. Explicit preparation APIs reject so callers that define their own readiness boundary can handle the failure directly.
+
+The ShaderMaterial renderable module exposes an install-only registrar setter. The enabler installs one callback globally and owns a `WeakMap` per enabled engine. Ordinary renderables are keyed by renderable identity; thin-instance recipes are keyed by mesh identity so the lazy thin module needs no feature hook. Rollup removes the registrar and all calls when the enabler is absent.
+
+Recipes retain only `ShaderMaterial` plus the already-computed logical pipeline additions. Preparation always resolves current-device bindings at execution time. It therefore cannot reuse a bind-group layout, pipeline layout, module, or pipeline map from a lost device.
+
+Before preparation, the opt-in module retargets an installed cross-material cache to the current GPU device. It then resolves bindings and modules normally. The ordinary synchronous path remains byte-equivalent for scenes that do not import the feature.
+
+## Pipeline Configuration
+
+The prepared descriptor is exactly the descriptor used by synchronous ShaderMaterial rendering:
+
+- vertex entry point: `mainVertex`;
+- optional fragment entry point: `mainFragment`;
+- group 0: scene bind-group layout;
+- group 1: ShaderMaterial bind-group layout;
+- topology and culling: material values;
+- color format and blend: target and material values;
+- depth/stencil format, comparison, writes, bias, and stencil: target and material values;
+- sample count and alpha-to-coverage: target signature plus the installed material resolver.
+
+Depth-only targets omit the fragment stage unless `depthOnlyFragment` is set. A `RenderTask` supplies its retained `_targetSignature`, including a separate depth target's format and comparison. A `RenderTarget` signature is derived from its descriptor's color format, depth format, depth comparison, and sample count. Callers using a task with a separate depth attachment must pass the `RenderTask`, not only its color target.
+
+## Shader Logic
+
+No fragment or vertex math changes. For thin instances, the owner appends these inputs after the material's declared attributes:
+
+```wgsl
+world0: vec4<f32>
+world1: vec4<f32>
+world2: vec4<f32>
+world3: vec4<f32>
+instanceColor: vec4<f32> // only for thin-instances-color
+```
+
+Their shader locations begin at `material.attributes.length`. Matrix data uses one instance-rate buffer with stride 64 and offsets 0, 16, 32, and 48. Color uses a second instance-rate buffer with stride 16 and offset 0.
+
+## State Machine / Lifecycle
+
+1. The caller optionally enables automatic preparation on the engine.
+2. Opaque, transparent, and thin ShaderMaterial renderable creation registers logical recipes through the installed module-local callback.
+3. Scene registration builds deferred scene content and awaits every top-level task `_preload`.
+4. The preparation hook materializes pending RenderTask meshes and shadow task states, then traverses top-level tasks plus internal `_task`, `_tasks`, and `_staticTasks` owners.
+5. Each ShaderMaterial recipe is prepared for each RenderTask signature. Duplicate final keys share one pending promise.
+6. Scene registration awaits all preparation, then calls `FrameGraph.build()`; normal binding finds completed pipelines.
+7. Runtime-only renderables or signatures not prepared beforehand use the unchanged synchronous fallback.
+
+PCF and ESM expose one internal RenderTask through their shadow state. CSM exposes a composite `_task` and its cascade `_tasks`; the opt-in CSM static cache additionally exposes `_staticTasks`. Shadow states are materialized only when the scene owns the top-level `shadow` task.
+
+After device loss, recipes remain logical. Current-device bindings and the current-device cross-material cache are resolved only when preparation runs. No old-device binding is authoritative.
+
+## Babylon.js Equivalence Map
+
+Babylon.js may compile render pipelines asynchronously before first use. Lite exposes the same scheduling capability only for ShaderMaterial and retains Lite's existing material-owned descriptor, cache, and synchronous bind behavior. This module changes when compilation occurs, not the pipeline state or shader result.
+
+## Dependencies
+
+- `scene/scene-core.ts`: awaited preparation boundary after task preloads and before frame-graph build.
+- `frame-graph/render-task.ts`: exact task signature and pending-mesh resolution.
+- `frame-graph/shadow-inputs.ts`: registered shadow caster sets.
+- `material/shader/shader-pipeline.ts`: synchronous descriptor/key construction and completed/pending caches.
+- `material/shader/shader-pipeline-cache.ts`: device-relative cross-material caches.
+- `material/shader/shader-renderable.ts`: opaque and transparent recipe feeds.
+- `material/shader/shader-thin-instance.ts`: thin layout selection and recipe feed.
+
+## Test Specification
+
+Focused tests must prove:
+
+1. the feature is inert until enabled;
+2. opaque, transparent, thin matrix-only, and thin color recipes prepare the same key and descriptor consumed by synchronous bind;
+3. duplicate recipes and duplicate tasks call `createRenderPipelineAsync` once per final key;
+4. rejection removes the pending entry and a later synchronous bind still creates its pipeline;
+5. registration awaits preparation after task preloads and before `FrameGraph.build()`;
+6. explicit preparation works before any renderable or `addMesh` exists;
+7. RenderTarget and RenderTask target signatures select the intended color, depth, comparison, and sample state;
+8. PCF, ESM, default CSM, and cached CSM internal tasks are traversed, including `_tasks` and `_staticTasks`;
+9. plain registration does not materialize unused shadow states;
+10. after switching to a second GPUDevice, both plain and cross-material-cache paths allocate new bindings/modules/pipelines and never read the first device's GPU objects;
+11. Standard, PBR, NodeMaterial, geometry, post-process, and effect pipeline creation counts are unchanged.
+
+## File Manifest
+
+- `packages/babylon-lite/src/material/shader/enable-async-shader-pipeline-compilation.ts`
+- `packages/babylon-lite/src/material/shader/shader-pipeline.ts`
+- `packages/babylon-lite/src/material/shader/shader-pipeline-cache.ts`
+- `packages/babylon-lite/src/material/shader/shader-renderable.ts`
+- `packages/babylon-lite/src/material/shader/shader-thin-instance.ts`
+- `packages/babylon-lite/src/scene/scene-core.ts`
+- `packages/babylon-lite/src/index.ts`

--- a/lab/public/bundle/manifest/scene159.json
+++ b/lab/public/bundle/manifest/scene159.json
@@ -3,7 +3,7 @@
   "gzipKB": 15.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene159-shader-renderable-DMhxbN_m.js",
+    "scene159-shader-renderable-kT4HP2KK.js",
     "scene159.js"
   ],
   "rawBytes": 40056

--- a/lab/public/bundle/manifest/scene160.json
+++ b/lab/public/bundle/manifest/scene160.json
@@ -3,7 +3,7 @@
   "gzipKB": 16.2,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene160-shader-renderable-C9JhN4YW.js",
+    "scene160-shader-renderable-BqzK03PK.js",
     "scene160.js"
   ],
   "rawBytes": 41991

--- a/lab/public/bundle/manifest/scene161.json
+++ b/lab/public/bundle/manifest/scene161.json
@@ -3,7 +3,7 @@
   "gzipKB": 15.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene161-shader-renderable-CTnKIz_2.js",
+    "scene161-shader-renderable-D3b6O3Ym.js",
     "scene161.js"
   ],
   "rawBytes": 40590

--- a/lab/public/bundle/manifest/scene162.json
+++ b/lab/public/bundle/manifest/scene162.json
@@ -3,7 +3,7 @@
   "gzipKB": 15.5,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene162-shader-renderable-5gp8AY_p.js",
+    "scene162-shader-renderable-yU4yim81.js",
     "scene162.js"
   ],
   "rawBytes": 40075

--- a/lab/public/bundle/manifest/scene163.json
+++ b/lab/public/bundle/manifest/scene163.json
@@ -3,7 +3,7 @@
   "gzipKB": 15.4,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene163-shader-renderable-yOhayoau.js",
+    "scene163-shader-renderable-BxwvYkxM.js",
     "scene163.js"
   ],
   "rawBytes": 39765

--- a/lab/public/bundle/manifest/scene165.json
+++ b/lab/public/bundle/manifest/scene165.json
@@ -3,7 +3,7 @@
   "gzipKB": 17.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene165-shader-renderable-9gnA-KV2.js",
+    "scene165-shader-renderable-BbBJT7cB.js",
     "scene165-shader-thin-instance-BeAUIeBi.js",
     "scene165-thin-instance-gpu-DwdFRT5G.js",
     "scene165.js"

--- a/lab/public/bundle/manifest/scene274.json
+++ b/lab/public/bundle/manifest/scene274.json
@@ -5,8 +5,8 @@
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene274-shader-pipeline-cache-BSncalml.js",
-    "scene274-shader-renderable-DwwVsZBc.js",
-    "scene274-uniform-copy-batch-DXXW-xkV.js",
+    "scene274-shader-renderable-BJ2YjS0d.js",
+    "scene274-uniform-copy-batch-DHcsWD0d.js",
     "scene274.js"
   ]
 }

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -292,6 +292,12 @@ export {
 } from "./material/shader/shader-material.js";
 export { enableShaderUniformRangeUpdates } from "./material/shader/shader-uniform-range.js";
 export { enableShaderMaterialUniformCaching } from "./material/shader/enable-shader-material-uniform-caching.js";
+export {
+    enableAsyncShaderPipelineCompilation,
+    prepareShaderMaterialPipeline,
+    prepareShaderMaterialPipelineForTask,
+} from "./material/shader/enable-async-shader-pipeline-compilation.js";
+export type { ShaderMaterialPipelineLayout } from "./material/shader/enable-async-shader-pipeline-compilation.js";
 export { createShaderNoColorMaterialView } from "./material/shader/no-color-view.js";
 export { createShaderNormalMaterialView } from "./material/shader/normal-view.js";
 export type { ShaderNormalViewConfig } from "./material/shader/normal-view.js";

--- a/packages/babylon-lite/src/material/shader/enable-async-shader-pipeline-compilation.ts
+++ b/packages/babylon-lite/src/material/shader/enable-async-shader-pipeline-compilation.ts
@@ -23,11 +23,14 @@ interface PrepareRecipe {
 let _recipesByEngine: WeakMap<EngineContext, WeakMap<object, PrepareRecipe>> | null = null;
 
 function isRenderTask(value: unknown): value is RenderTask {
-    return typeof value === "object" && value !== null && "_renderables" in value && "_targetSignature" in value;
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+    return "_renderables" in value && "_targetSignature" in value;
 }
 
 function nestedTasks(value: unknown): readonly unknown[] {
-    if (typeof value !== "object" || value === null) {
+    if (!value || typeof value !== "object") {
         return [];
     }
     const state = value as { _task?: unknown; _tasks?: readonly unknown[]; _staticTasks?: readonly unknown[] };
@@ -89,8 +92,9 @@ async function prepareScene(engine: EngineContext, scene: SceneContext, recipes:
         }
         _resolvePendingMeshes(candidate, candidate.scene);
         const renderables = candidate._renderables.length || candidate._config.autoMirror === false ? candidate._renderables : candidate.scene._renderables;
+        const sceneRenderables = renderables === candidate.scene._renderables ? null : new Set(candidate.scene._renderables);
         for (const renderable of renderables) {
-            const recipe = recipes.get(renderable) ?? (renderable.mesh && candidate.scene._renderables.includes(renderable) ? recipes.get(renderable.mesh) : undefined);
+            const recipe = recipes.get(renderable) ?? (renderable.mesh && (!sceneRenderables || sceneRenderables.has(renderable)) ? recipes.get(renderable.mesh) : undefined);
             if (recipe) {
                 const bindings = currentBindings(engine, recipe.material);
                 const resolvedLayout = resolveLayout(recipe.material, bindings, recipe.layout);

--- a/packages/babylon-lite/src/material/shader/enable-async-shader-pipeline-compilation.ts
+++ b/packages/babylon-lite/src/material/shader/enable-async-shader-pipeline-compilation.ts
@@ -1,0 +1,264 @@
+import type { EngineContext } from "../../engine/engine.js";
+import type { RenderTarget, RenderTargetSignature } from "../../engine/render-target.js";
+import { targetSignatureKey } from "../../engine/render-target.js";
+import type { RenderTask } from "../../frame-graph/render-task.js";
+import { _resolvePendingMeshes } from "../../frame-graph/render-task.js";
+import type { Renderable } from "../../render/renderable.js";
+import { _getShadowTaskCasterMeshes } from "../../frame-graph/shadow-inputs.js";
+import type { SceneContext } from "../../scene/scene-core.js";
+import { _installAsyncShaderPipelinePreparation } from "../../scene/scene-core.js";
+import { retargetShaderPipelineCache } from "./shader-pipeline-cache.js";
+import { _resolveShaderPipelineVariantKey, getOrCreateShaderPipeline, getOrCreateShaderPipelineBindings, type ShaderPipelineBindings } from "./shader-pipeline.js";
+import type { ShaderMaterial } from "./shader-material.js";
+import { _installAsyncShaderPipelineRegistrar } from "./shader-renderable.js";
+
+/** Logical vertex-input layout for a ShaderMaterial pipeline. */
+export type ShaderMaterialPipelineLayout = "mesh" | "thin-instances" | "thin-instances-color";
+
+interface PrepareRecipe {
+    readonly material: ShaderMaterial;
+    readonly layout: ShaderMaterialPipelineLayout;
+}
+
+let _recipesByEngine: WeakMap<EngineContext, WeakMap<object, PrepareRecipe>> | null = null;
+
+function isRenderTask(value: unknown): value is RenderTask {
+    return typeof value === "object" && value !== null && "_renderables" in value && "_targetSignature" in value;
+}
+
+function nestedTasks(value: unknown): readonly unknown[] {
+    if (typeof value !== "object" || value === null) {
+        return [];
+    }
+    const state = value as { _task?: unknown; _tasks?: readonly unknown[]; _staticTasks?: readonly unknown[] };
+    return [state._task, ...(state._tasks ?? []), ...(state._staticTasks ?? [])];
+}
+
+/**
+ * Opt in to preparing ShaderMaterial render pipelines during scene registration.
+ * The default synchronous pipeline path remains installed and is used for signatures
+ * or renderables introduced after registration.
+ */
+export function enableAsyncShaderPipelineCompilation(engine: EngineContext): void {
+    if (_recipesByEngine?.has(engine)) {
+        return;
+    }
+    if (!_recipesByEngine) {
+        _recipesByEngine = new WeakMap();
+        _installAsyncShaderPipelineRegistrar(_registerAsyncShaderPipelineRecipe);
+        _installAsyncShaderPipelinePreparation(_prepareAsyncShaderPipelinesForScene);
+    }
+    const recipes = new WeakMap<object, PrepareRecipe>();
+    _recipesByEngine.set(engine, recipes);
+}
+
+/** @internal Register a logical pipeline recipe from a ShaderMaterial renderable builder. */
+export function _registerAsyncShaderPipelineRecipe(scene: SceneContext, material: ShaderMaterial, key: Renderable | object, layout: ShaderMaterialPipelineLayout = "mesh"): void {
+    _recipesByEngine?.get(scene.surface.engine)?.set(key, { material, layout });
+}
+
+/** @internal Run the installed engine's automatic preparation for one scene. */
+export function _prepareAsyncShaderPipelinesForScene(scene: SceneContext): Promise<void> {
+    const recipes = _recipesByEngine?.get(scene.surface.engine);
+    return recipes ? prepareScene(scene.surface.engine, scene, recipes) : Promise.resolve();
+}
+
+async function prepareScene(engine: EngineContext, scene: SceneContext, recipes: WeakMap<object, PrepareRecipe>): Promise<void> {
+    const tasks: unknown[] = [...scene._frameGraph._tasks];
+    if (scene._frameGraph._tasks.some((task) => task.name === "shadow")) {
+        for (const light of scene.lights) {
+            const generator = light.shadowGenerator;
+            const casterMeshes = generator ? _getShadowTaskCasterMeshes(generator) : undefined;
+            if (generator?._ensureShadowTaskState && casterMeshes && !generator._preloadPending) {
+                tasks.push(generator._ensureShadowTaskState(engine, scene, casterMeshes));
+            }
+        }
+    }
+
+    const seen = new Set<unknown>();
+    const preparations: Promise<void>[] = [];
+    while (tasks.length) {
+        const candidate = tasks.pop();
+        if (!candidate || seen.has(candidate)) {
+            continue;
+        }
+        seen.add(candidate);
+        tasks.push(...nestedTasks(candidate));
+        if (!isRenderTask(candidate)) {
+            continue;
+        }
+        _resolvePendingMeshes(candidate, candidate.scene);
+        const renderables = candidate._renderables.length || candidate._config.autoMirror === false ? candidate._renderables : candidate.scene._renderables;
+        for (const renderable of renderables) {
+            const recipe = recipes.get(renderable) ?? (renderable.mesh && candidate.scene._renderables.includes(renderable) ? recipes.get(renderable.mesh) : undefined);
+            if (recipe) {
+                const bindings = currentBindings(engine, recipe.material);
+                const resolvedLayout = resolveLayout(recipe.material, bindings, recipe.layout);
+                preparations.push(
+                    prepareShaderPipeline(
+                        engine,
+                        candidate._targetSignature,
+                        recipe.material,
+                        bindings,
+                        resolvedLayout.variantKey,
+                        resolvedLayout.vertexBuffers,
+                        resolvedLayout.instanceAttrs
+                    )
+                );
+            }
+        }
+    }
+    const failures = new Set<unknown>();
+    for (const result of await Promise.allSettled(preparations)) {
+        if (result.status === "rejected") {
+            failures.add(result.reason);
+        }
+    }
+    for (const failure of failures) {
+        console.error("Async ShaderMaterial pipeline preparation failed; the synchronous first-bind fallback remains available.", failure);
+    }
+}
+
+/** Prepare one ShaderMaterial pipeline for a known Lite target before its first draw. */
+export async function prepareShaderMaterialPipeline(
+    engine: EngineContext,
+    material: ShaderMaterial,
+    layout: ShaderMaterialPipelineLayout,
+    target: RenderTarget | RenderTask
+): Promise<void> {
+    const signature = isRenderTask(target) ? target._targetSignature : renderTargetSignature(target);
+    const bindings = currentBindings(engine, material);
+    const resolvedLayout = resolveLayout(material, bindings, layout);
+    await prepareShaderPipeline(engine, signature, material, bindings, resolvedLayout.variantKey, resolvedLayout.vertexBuffers, resolvedLayout.instanceAttrs);
+}
+
+/** Prepare one ShaderMaterial pipeline for a RenderTask using the task's exact attachment signature. */
+export function prepareShaderMaterialPipelineForTask(task: RenderTask, material: ShaderMaterial, layout: ShaderMaterialPipelineLayout): Promise<void> {
+    return prepareShaderMaterialPipeline(task.engine, material, layout, task);
+}
+
+function currentBindings(engine: EngineContext, material: ShaderMaterial): ShaderPipelineBindings {
+    retargetShaderPipelineCache(material, engine._device);
+    return getOrCreateShaderPipelineBindings(engine, material);
+}
+
+async function prepareShaderPipeline(
+    engine: EngineContext,
+    signature: RenderTargetSignature,
+    material: ShaderMaterial,
+    bindings: ShaderPipelineBindings,
+    variantKey: string,
+    vertexBuffers: readonly GPUVertexBufferLayout[],
+    instanceAttrs: string
+): Promise<void> {
+    const simpleKey = `${targetSignatureKey(signature)}${_resolveShaderPipelineVariantKey(signature, material, variantKey)}`;
+    if (bindings.pipelines.has(simpleKey)) {
+        return;
+    }
+    const simplePending = bindings._P?.get(simpleKey);
+    if (simplePending) {
+        await simplePending;
+        return;
+    }
+
+    const device = engine._device;
+    const placeholder = {} as GPURenderPipeline;
+    let descriptor: GPURenderPipelineDescriptor | undefined;
+    const captureDevice = {
+        createShaderModule(moduleDescriptor: GPUShaderModuleDescriptor): GPUShaderModule {
+            return device.createShaderModule(moduleDescriptor);
+        },
+        createRenderPipeline(pipelineDescriptor: GPURenderPipelineDescriptor): GPURenderPipeline {
+            descriptor = pipelineDescriptor;
+            return placeholder;
+        },
+    } as GPUDevice;
+    const captured = getOrCreateShaderPipeline({ _device: captureDevice } as EngineContext, signature, material, bindings, variantKey, vertexBuffers, instanceAttrs);
+    if (captured !== placeholder) {
+        return;
+    }
+
+    let key: string | undefined;
+    for (const [candidate, pipeline] of bindings.pipelines) {
+        if (pipeline === placeholder) {
+            key = candidate;
+            bindings.pipelines.delete(candidate);
+            break;
+        }
+    }
+    if (!key || !descriptor) {
+        throw new Error("Async ShaderMaterial pipeline preparation could not capture the synchronous descriptor.");
+    }
+
+    const pending = bindings._P?.get(key);
+    if (pending) {
+        await pending;
+        return;
+    }
+    const pendingPipelines = bindings._P ?? (bindings._P = new Map());
+    const creation = device.createRenderPipelineAsync(descriptor).then((pipeline) => {
+        const winner = bindings.pipelines.get(key);
+        if (winner) {
+            return winner;
+        }
+        bindings.pipelines.set(key, pipeline);
+        return pipeline;
+    });
+    pendingPipelines.set(key, creation);
+    try {
+        await creation;
+    } finally {
+        if (pendingPipelines.get(key) === creation) {
+            pendingPipelines.delete(key);
+        }
+    }
+}
+
+function resolveLayout(
+    material: ShaderMaterial,
+    bindings: ShaderPipelineBindings,
+    layout: ShaderMaterialPipelineLayout
+): { readonly variantKey: string; readonly vertexBuffers: readonly GPUVertexBufferLayout[]; readonly instanceAttrs: string } {
+    if (layout === "mesh") {
+        return { variantKey: "", vertexBuffers: bindings.vertexBuffers, instanceAttrs: "" };
+    }
+    const hasColor = layout === "thin-instances-color";
+    const baseLocation = material.attributes.length;
+    const instanceLayouts: GPUVertexBufferLayout[] = [
+        {
+            arrayStride: 64,
+            stepMode: "instance",
+            attributes: [
+                { shaderLocation: baseLocation, offset: 0, format: "float32x4" },
+                { shaderLocation: baseLocation + 1, offset: 16, format: "float32x4" },
+                { shaderLocation: baseLocation + 2, offset: 32, format: "float32x4" },
+                { shaderLocation: baseLocation + 3, offset: 48, format: "float32x4" },
+            ],
+        },
+    ];
+    let instanceAttrs = `@location(${baseLocation}) world0: vec4<f32>,
+@location(${baseLocation + 1}) world1: vec4<f32>,
+@location(${baseLocation + 2}) world2: vec4<f32>,
+@location(${baseLocation + 3}) world3: vec4<f32>,
+`;
+    if (hasColor) {
+        instanceLayouts.push({
+            arrayStride: 16,
+            stepMode: "instance",
+            attributes: [{ shaderLocation: baseLocation + 4, offset: 0, format: "float32x4" }],
+        });
+        instanceAttrs += `@location(${baseLocation + 4}) instanceColor: vec4<f32>,
+`;
+    }
+    return { variantKey: "" + +hasColor, vertexBuffers: [...bindings.vertexBuffers, ...instanceLayouts], instanceAttrs };
+}
+
+function renderTargetSignature(target: RenderTarget): RenderTargetSignature {
+    const descriptor = target._descriptor;
+    return {
+        _colorFormat: descriptor.format,
+        _depthStencilFormat: descriptor.dFormat,
+        _depthCompare: descriptor._depthCompare,
+        _sampleCount: descriptor.samples,
+    };
+}

--- a/packages/babylon-lite/src/material/shader/shader-pipeline-cache.ts
+++ b/packages/babylon-lite/src/material/shader/shader-pipeline-cache.ts
@@ -37,6 +37,14 @@ export function clearShaderPipelineCache(): void {
     _generation++;
 }
 
+/** @internal Move an installed cross-material cache to the current GPU device before async preparation. */
+export function retargetShaderPipelineCache(material: ShaderMaterial, device: GPUDevice): void {
+    const state = material as CacheMaterial;
+    if (state._shaderPipelineCache) {
+        state._shaderPipelineCache = getDeviceCache(device);
+    }
+}
+
 function getDeviceCache(device: GPUDevice): DeviceCache {
     _deviceCaches ??= new WeakMap();
     let cache = _deviceCaches.get(device);

--- a/packages/babylon-lite/src/material/shader/shader-pipeline.ts
+++ b/packages/babylon-lite/src/material/shader/shader-pipeline.ts
@@ -27,6 +27,8 @@ export interface ShaderPipelineBindings {
     readonly customSpec: UboSpec | null;
     readonly vertexBuffers: readonly GPUVertexBufferLayout[];
     readonly pipelines: Map<string, GPURenderPipeline>;
+    /** @internal Async creations in flight, allocated only by the opt-in preparer. */
+    _P?: Map<string, Promise<GPURenderPipeline>>;
     /** @internal */
     readonly _pipelineLayout: GPUPipelineLayout;
 }
@@ -199,6 +201,12 @@ export function getOrCreateShaderPipeline(
     });
     bindings.pipelines.set(key, pipeline);
     return pipeline;
+}
+
+/** @internal Resolve only the variant suffix needed for pre-module async deduplication. */
+export function _resolveShaderPipelineVariantKey(sig: RenderTargetSignature, material: ShaderMaterial, variantKey: string): string {
+    const alphaToCoverageResolver = _getAlphaToCoverageResolver();
+    return sig._sampleCount > 1 && !!alphaToCoverageResolver?.(material) ? `${variantKey}:a2c` : variantKey;
 }
 
 function toUboField(decl: ShaderUniformDecl): UboField {

--- a/packages/babylon-lite/src/material/shader/shader-renderable.ts
+++ b/packages/babylon-lite/src/material/shader/shader-renderable.ts
@@ -150,6 +150,15 @@ export async function buildShaderGroup(scene: SceneContext, meshes: Mesh[]): Pro
     if (!meshes.some((m) => !!m.thinInstances)) {
         return buildPlain(scene, meshes);
     }
+    if (_asyncPipelineRegistrar) {
+        for (const mesh of meshes) {
+            if (mesh.thinInstances) {
+                const material = mesh.material as ShaderMaterial;
+                const hasColor = !!mesh.thinInstances.colors && material._tic != 0;
+                _asyncPipelineRegistrar(scene, material, mesh, hasColor ? "thin-instances-color" : "thin-instances");
+            }
+        }
+    }
     const mod = await import("./shader-thin-instance.js");
     const cull = meshes.some((m) => !!m.thinInstances?._gpuCullingEnabled) ? await import("../../mesh/thin-instance-cull-binding.js") : undefined;
     return mod.buildShaderRenderablesWithInstancing(
@@ -165,6 +174,14 @@ export async function buildShaderGroup(scene: SceneContext, meshes: Mesh[]): Pro
         getUniformBatch,
         cull
     );
+}
+
+export type ShaderAsyncPipelineRegistrar = (scene: SceneContext, material: ShaderMaterial, key: Renderable | Mesh, layout?: "thin-instances" | "thin-instances-color") => void;
+
+let _asyncPipelineRegistrar: ShaderAsyncPipelineRegistrar | null = null;
+/** @internal Install the optional async ShaderMaterial recipe registrar. */
+export function _installAsyncShaderPipelineRegistrar(register: ShaderAsyncPipelineRegistrar): void {
+    _asyncPipelineRegistrar = register;
 }
 
 function buildSingleShaderRenderable(scene: SceneContext, mesh: Mesh, material: ShaderMaterial, isOverride: boolean, getUniformBatch?: UniformBatchFactory): Renderable {
@@ -261,6 +278,7 @@ function createOpaqueRenderable(
             };
         },
     };
+    _asyncPipelineRegistrar?.(scene, material, r);
     return r;
 }
 
@@ -309,6 +327,7 @@ function createTransparentRenderable(scene: SceneContext, material: ShaderMateri
             };
         },
     };
+    _asyncPipelineRegistrar?.(scene, material, r);
     return r;
 }
 

--- a/packages/babylon-lite/src/scene/scene-core.ts
+++ b/packages/babylon-lite/src/scene/scene-core.ts
@@ -540,6 +540,12 @@ export async function buildScene(scene: SceneContext): Promise<void> {
     await ctx._rebuildHook?.(ctx);
 }
 
+let _prepareShaderPipelines: ((scene: SceneContext) => Promise<void>) | null = null;
+/** @internal Install the optional async ShaderMaterial preparation boundary. */
+export function _installAsyncShaderPipelinePreparation(prepare: (scene: SceneContext) => Promise<void>): void {
+    _prepareShaderPipelines = prepare;
+}
+
 /**
  * Register a scene with the engine. Builds deferred work, sorts renderables by order,
  * and adds the scene to its bound surface's render list in overlay order. The scene is
@@ -557,6 +563,9 @@ export async function registerScene(scene: SceneContext): Promise<void> {
     // Promise.all treats tasks without a preload hook as already resolved.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     await Promise.all(ctx._frameGraph._tasks.map((task) => task._preload?.()));
+    if (_prepareShaderPipelines) {
+        await _prepareShaderPipelines(ctx);
+    }
     ctx._frameGraph.build();
     if (surface._renderingContexts[0]) {
         const overlay = await import("./swapchain-overlay.js");
@@ -582,6 +591,9 @@ export async function registerSceneWithShadowSupport(scene: SceneContext): Promi
     // Promise.all treats tasks without a preload hook as already resolved.
     // eslint-disable-next-line @typescript-eslint/await-thenable
     await Promise.all(ctx._frameGraph._tasks.map((task) => task._preload?.()));
+    if (_prepareShaderPipelines) {
+        await _prepareShaderPipelines(ctx);
+    }
     ctx._frameGraph.build();
     if (surface._renderingContexts[0]) {
         const overlay = await import("./swapchain-overlay.js");

--- a/tests/lite/unit/async-shader-pipeline-compilation.test.ts
+++ b/tests/lite/unit/async-shader-pipeline-compilation.test.ts
@@ -258,6 +258,33 @@ describe("async ShaderMaterial pipeline compilation", () => {
         expect(createRenderPipeline).not.toHaveBeenCalled();
     });
 
+    it("does not apply a mesh-keyed thin recipe to an explicit override renderable", async () => {
+        const { engine, createRenderPipelineAsync } = makeEngine();
+        const material = makeMaterial();
+        const mesh = { material, thinInstances: { count: 1, matrices: new Float32Array(16) } } as unknown as Mesh;
+        const main = { mesh } as Renderable;
+        const override = { mesh } as Renderable;
+        const scene = {
+            surface: { engine },
+            _renderables: [main],
+            lights: [],
+        } as unknown as SceneContext;
+        const task = {
+            scene,
+            _renderables: [override],
+            _pendingMeshes: [],
+            _targetSignature: signature,
+            _config: { autoMirror: false },
+        } as unknown as RenderTask;
+        Object.assign(scene, { _frameGraph: { _tasks: [task] } });
+
+        enableAsyncShaderPipelineCompilation(engine);
+        _registerAsyncShaderPipelineRecipe(scene, material, mesh, "thin-instances");
+        await _prepareAsyncShaderPipelinesForScene(scene);
+
+        expect(createRenderPipelineAsync).not.toHaveBeenCalled();
+    });
+
     it("traverses shadow task, cascade, and static-cache render tasks", async () => {
         clearSceneBGLCache();
         const { engine, createRenderPipelineAsync } = makeEngine();
@@ -353,6 +380,7 @@ describe("async ShaderMaterial pipeline compilation", () => {
             lights: [],
         } as unknown as SceneContext;
         Object.assign(scene, { surface: { engine } });
+        Object.assign(task, { scene });
 
         enableAsyncShaderPipelineCompilation(engine);
         _registerAsyncShaderPipelineRecipe(scene, material, renderable);

--- a/tests/lite/unit/async-shader-pipeline-compilation.test.ts
+++ b/tests/lite/unit/async-shader-pipeline-compilation.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import { createRenderTarget, type RenderTargetSignature } from "../../../packages/babylon-lite/src/engine/render-target";
+import type { RenderTask } from "../../../packages/babylon-lite/src/frame-graph/render-task";
+import { setShadowTaskCasterMeshes } from "../../../packages/babylon-lite/src/frame-graph/shadow-inputs";
+import {
+    _prepareAsyncShaderPipelinesForScene,
+    _registerAsyncShaderPipelineRecipe,
+    enableAsyncShaderPipelineCompilation,
+    prepareShaderMaterialPipeline,
+    prepareShaderMaterialPipelineForTask,
+} from "../../../packages/babylon-lite/src/material/shader/enable-async-shader-pipeline-compilation";
+import { createShaderMaterial } from "../../../packages/babylon-lite/src/material/shader/shader-material";
+import { clearShaderPipelineCache, enableShaderPipelineCache } from "../../../packages/babylon-lite/src/material/shader/shader-pipeline-cache";
+import { getOrCreateShaderPipeline, getOrCreateShaderPipelineBindings } from "../../../packages/babylon-lite/src/material/shader/shader-pipeline";
+import { buildShaderRenderablesWithInstancing } from "../../../packages/babylon-lite/src/material/shader/shader-thin-instance";
+import type { ShaderPacket } from "../../../packages/babylon-lite/src/material/shader/shader-renderable";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
+import { clearSceneBGLCache } from "../../../packages/babylon-lite/src/render/scene-helpers";
+import type { Renderable } from "../../../packages/babylon-lite/src/render/renderable";
+import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
+import type { ShadowGenerator } from "../../../packages/babylon-lite/src/shadow/shadow-generator";
+
+const gpuGlobals = globalThis as Omit<typeof globalThis, "GPUShaderStage"> & {
+    GPUShaderStage?: { VERTEX: number; FRAGMENT: number };
+};
+gpuGlobals.GPUShaderStage ??= { VERTEX: 0x1, FRAGMENT: 0x2 } as unknown as GPUShaderStage;
+
+function makeEngine(createAsync?: (descriptor: GPURenderPipelineDescriptor) => Promise<GPURenderPipeline>) {
+    const createBindGroupLayout = vi.fn((descriptor: GPUBindGroupLayoutDescriptor) => descriptor as unknown as GPUBindGroupLayout);
+    const createPipelineLayout = vi.fn((descriptor: GPUPipelineLayoutDescriptor) => descriptor as unknown as GPUPipelineLayout);
+    const createShaderModule = vi.fn((descriptor: GPUShaderModuleDescriptor) => descriptor as unknown as GPUShaderModule);
+    const createRenderPipeline = vi.fn((descriptor: GPURenderPipelineDescriptor) => descriptor as unknown as GPURenderPipeline);
+    const createRenderPipelineAsync = vi.fn(createAsync ?? (async (descriptor: GPURenderPipelineDescriptor) => descriptor as unknown as GPURenderPipeline));
+    const device = {
+        createBindGroupLayout,
+        createPipelineLayout,
+        createShaderModule,
+        createRenderPipeline,
+        createRenderPipelineAsync,
+    } as unknown as GPUDevice;
+    const engine = { _device: device } as unknown as EngineContext;
+    return { engine, createShaderModule, createRenderPipeline, createRenderPipelineAsync };
+}
+
+function makeMaterial() {
+    return createShaderMaterial({
+        vertexSource: "@vertex fn mainVertex(input: VertexInput) -> @builtin(position) vec4f { return vec4f(input.position, 1); }",
+        fragmentSource: "@fragment fn mainFragment() -> @location(0) vec4f { return vec4f(1); }",
+        attributes: ["position"],
+    });
+}
+
+const signature = {
+    _colorFormat: "rgba8unorm",
+    _depthStencilFormat: "depth24plus",
+    _sampleCount: 1,
+} as RenderTargetSignature;
+
+function targetTask(engine?: EngineContext): RenderTask {
+    return { _renderables: [], _targetSignature: signature, engine } as unknown as RenderTask;
+}
+
+function layoutArgs(layout: "mesh" | "thin-instances" | "thin-instances-color", bindings: ReturnType<typeof getOrCreateShaderPipelineBindings>) {
+    if (layout === "mesh") {
+        return { variantKey: "", vertexBuffers: bindings.vertexBuffers, instanceAttrs: "" };
+    }
+    const hasColor = layout === "thin-instances-color";
+    const instanceLayouts: GPUVertexBufferLayout[] = [
+        {
+            arrayStride: 64,
+            stepMode: "instance",
+            attributes: [
+                { shaderLocation: 1, offset: 0, format: "float32x4" },
+                { shaderLocation: 2, offset: 16, format: "float32x4" },
+                { shaderLocation: 3, offset: 32, format: "float32x4" },
+                { shaderLocation: 4, offset: 48, format: "float32x4" },
+            ],
+        },
+    ];
+    let instanceAttrs = `@location(1) world0: vec4<f32>,
+@location(2) world1: vec4<f32>,
+@location(3) world2: vec4<f32>,
+@location(4) world3: vec4<f32>,
+`;
+    if (hasColor) {
+        instanceLayouts.push({
+            arrayStride: 16,
+            stepMode: "instance",
+            attributes: [{ shaderLocation: 5, offset: 0, format: "float32x4" }],
+        });
+        instanceAttrs += `@location(5) instanceColor: vec4<f32>,
+`;
+    }
+    return { variantKey: "" + +hasColor, vertexBuffers: [...bindings.vertexBuffers, ...instanceLayouts], instanceAttrs };
+}
+
+describe("async ShaderMaterial pipeline compilation", () => {
+    it("is inert until enabled and enabling is idempotent", async () => {
+        const { engine, createRenderPipelineAsync } = makeEngine();
+        const material = makeMaterial();
+        const renderable = {} as Renderable;
+        const scene = {
+            surface: { engine },
+            _frameGraph: { _tasks: [] },
+            _renderables: [],
+            lights: [],
+        } as unknown as SceneContext;
+
+        _registerAsyncShaderPipelineRecipe(scene, material, renderable);
+        await _prepareAsyncShaderPipelinesForScene(scene);
+        expect(createRenderPipelineAsync).not.toHaveBeenCalled();
+
+        enableAsyncShaderPipelineCompilation(engine);
+        enableAsyncShaderPipelineCompilation(engine);
+        const task = {
+            scene,
+            _renderables: [renderable],
+            _pendingMeshes: [],
+            _targetSignature: signature,
+            _config: { autoMirror: false },
+        } as unknown as RenderTask;
+        scene._frameGraph._tasks.push(task);
+        _registerAsyncShaderPipelineRecipe(scene, material, renderable);
+        await _prepareAsyncShaderPipelinesForScene(scene);
+
+        expect(createRenderPipelineAsync).toHaveBeenCalledOnce();
+    });
+
+    it("deduplicates concurrent preparation before creating shader modules", async () => {
+        clearSceneBGLCache();
+        let resolveCreation!: (pipeline: GPURenderPipeline) => void;
+        const creation = new Promise<GPURenderPipeline>((resolve) => (resolveCreation = resolve));
+        const { engine, createShaderModule, createRenderPipelineAsync } = makeEngine(() => creation);
+        const material = makeMaterial();
+        const task = targetTask(engine);
+
+        const first = prepareShaderMaterialPipeline(engine, material, "mesh", task);
+        const second = prepareShaderMaterialPipeline(engine, material, "mesh", task);
+
+        expect(createShaderModule).toHaveBeenCalledTimes(2);
+        expect(createRenderPipelineAsync).toHaveBeenCalledTimes(1);
+
+        resolveCreation({} as GPURenderPipeline);
+        await Promise.all([first, second]);
+    });
+
+    it("deduplicates concurrent preparation with the cross-material cache", async () => {
+        clearShaderPipelineCache();
+        clearSceneBGLCache();
+        let resolveCreation!: (pipeline: GPURenderPipeline) => void;
+        const creation = new Promise<GPURenderPipeline>((resolve) => (resolveCreation = resolve));
+        const { engine, createShaderModule, createRenderPipelineAsync } = makeEngine(() => creation);
+        const material = makeMaterial();
+        enableShaderPipelineCache(engine, [{ material }]);
+        const task = targetTask(engine);
+
+        const first = prepareShaderMaterialPipeline(engine, material, "mesh", task);
+        const second = prepareShaderMaterialPipeline(engine, material, "mesh", task);
+
+        expect(createShaderModule).toHaveBeenCalledTimes(2);
+        expect(createRenderPipelineAsync).toHaveBeenCalledTimes(1);
+
+        resolveCreation({} as GPURenderPipeline);
+        await Promise.all([first, second]);
+    });
+
+    it.each(["mesh", "thin-instances", "thin-instances-color"] as const)("uses the prepared key and synchronous descriptor for the %s layout", async (layoutName) => {
+        clearSceneBGLCache();
+        const prepared = makeEngine();
+        const material = makeMaterial();
+        const task = targetTask(prepared.engine);
+
+        await prepareShaderMaterialPipeline(prepared.engine, material, layoutName, task);
+        const bindings = getOrCreateShaderPipelineBindings(prepared.engine, material);
+        const layout = layoutArgs(layoutName, bindings);
+        const pipeline = getOrCreateShaderPipeline(prepared.engine, signature, material, bindings, layout.variantKey, layout.vertexBuffers, layout.instanceAttrs);
+        const asyncPipeline = await prepared.createRenderPipelineAsync.mock.results[0]!.value;
+
+        expect(pipeline).toBe(asyncPipeline);
+        expect(prepared.createRenderPipeline).not.toHaveBeenCalled();
+
+        clearSceneBGLCache();
+        const synchronous = makeEngine();
+        const syncMaterial = makeMaterial();
+        const syncBindings = getOrCreateShaderPipelineBindings(synchronous.engine, syncMaterial);
+        const syncLayout = layoutArgs(layoutName, syncBindings);
+        getOrCreateShaderPipeline(synchronous.engine, signature, syncMaterial, syncBindings, syncLayout.variantKey, syncLayout.vertexBuffers, syncLayout.instanceAttrs);
+
+        expect(prepared.createRenderPipelineAsync.mock.calls[0]![0]).toEqual(synchronous.createRenderPipeline.mock.calls[0]![0]);
+    });
+
+    it("uses RenderTarget attachment state and the task convenience API", async () => {
+        clearSceneBGLCache();
+        const { engine, createRenderPipelineAsync } = makeEngine();
+        const material = makeMaterial();
+        const target = createRenderTarget({
+            format: "rgba16float",
+            dFormat: "depth32float",
+            _depthCompare: "less-equal",
+            samples: 4,
+            size: { width: 64, height: 64 },
+        });
+
+        await prepareShaderMaterialPipeline(engine, material, "mesh", target);
+        const descriptor = createRenderPipelineAsync.mock.calls[0]![0];
+
+        expect(descriptor.fragment?.targets).toEqual([{ format: "rgba16float" }]);
+        expect(descriptor.depthStencil).toMatchObject({ format: "depth32float", depthCompare: "less-equal" });
+        expect(descriptor.multisample).toEqual({ count: 4 });
+
+        const second = makeEngine();
+        await prepareShaderMaterialPipelineForTask(targetTask(second.engine), makeMaterial(), "mesh");
+        expect(second.createRenderPipelineAsync).toHaveBeenCalledOnce();
+    });
+
+    it.each([false, true])("matches the actual thin-instance renderable layout when color is %s", async (hasColor) => {
+        clearSceneBGLCache();
+        const { engine, createRenderPipeline } = makeEngine();
+        const material = makeMaterial();
+        const mesh = {
+            material,
+            thinInstances: {
+                count: 1,
+                matrices: new Float32Array(16),
+                colors: hasColor ? new Float32Array(4) : undefined,
+            },
+            worldMatrix: new Float32Array(16),
+            _gpu: { indexCount: 3 },
+        } as unknown as Mesh;
+        const scene = { surface: { engine }, _renderables: [], lights: [] } as unknown as SceneContext;
+        enableAsyncShaderPipelineCompilation(engine);
+        const result = buildShaderRenderablesWithInstancing(
+            scene,
+            [mesh],
+            () => ({ renderables: [], rebuildSingle: () => undefined as never }),
+            (_scene, _material, _spec, packetMesh) => ({ mesh: packetMesh, _bindGroup: {} }) as unknown as ShaderPacket,
+            () => undefined,
+            () => undefined,
+            () => ({}) as GPUBuffer,
+            getOrCreateShaderPipeline,
+            getOrCreateShaderPipelineBindings
+        );
+        _registerAsyncShaderPipelineRecipe(scene, material, mesh, hasColor ? "thin-instances-color" : "thin-instances");
+
+        const task = {
+            scene,
+            _renderables: result.renderables,
+            _pendingMeshes: [],
+            _targetSignature: signature,
+            _config: { autoMirror: false },
+        } as unknown as RenderTask;
+        Object.assign(scene, { _frameGraph: { _tasks: [task] }, _renderables: result.renderables });
+        await _prepareAsyncShaderPipelinesForScene(scene);
+        result.renderables[0]!.bind(engine, signature);
+
+        expect(createRenderPipeline).not.toHaveBeenCalled();
+    });
+
+    it("traverses shadow task, cascade, and static-cache render tasks", async () => {
+        clearSceneBGLCache();
+        const { engine, createRenderPipelineAsync } = makeEngine();
+        const material = makeMaterial();
+        const renderables = [{}, {}, {}] as Renderable[];
+        const scene = {
+            surface: { engine },
+            _renderables: [],
+            lights: [],
+        } as unknown as SceneContext;
+        const formats = ["rgba8unorm", "bgra8unorm", "rgba16float"] as const;
+        const nested = renderables.map(
+            (renderable, index) =>
+                ({
+                    scene,
+                    _renderables: [renderable],
+                    _pendingMeshes: [],
+                    _targetSignature: { ...signature, _colorFormat: formats[index]! },
+                    _config: { autoMirror: false },
+                }) as unknown as RenderTask
+        );
+        const ensureState = vi.fn(() => ({ _task: nested[0], _tasks: [nested[1]], _staticTasks: [nested[2]] }));
+        const generator = { _ensureShadowTaskState: ensureState } as unknown as ShadowGenerator;
+        setShadowTaskCasterMeshes(generator, [{} as Mesh]);
+        generator._preloadPending = undefined;
+        Object.assign(scene, {
+            _frameGraph: { _tasks: [{ name: "shadow" }] },
+            lights: [{ shadowGenerator: generator }],
+        });
+
+        enableAsyncShaderPipelineCompilation(engine);
+        for (const renderable of renderables) {
+            _registerAsyncShaderPipelineRecipe(scene, material, renderable);
+        }
+        await _prepareAsyncShaderPipelinesForScene(scene);
+
+        expect(ensureState).toHaveBeenCalledOnce();
+        expect(createRenderPipelineAsync).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not materialize shadow state without the scene shadow task", async () => {
+        const { engine } = makeEngine();
+        const ensureState = vi.fn();
+        const generator = { _ensureShadowTaskState: ensureState } as unknown as ShadowGenerator;
+        setShadowTaskCasterMeshes(generator, [{} as Mesh]);
+        generator._preloadPending = undefined;
+        const scene = {
+            surface: { engine },
+            _frameGraph: { _tasks: [{ name: "scene" }] },
+            _renderables: [],
+            lights: [{ shadowGenerator: generator }],
+        } as unknown as SceneContext;
+
+        enableAsyncShaderPipelineCompilation(engine);
+        await _prepareAsyncShaderPipelinesForScene(scene);
+
+        expect(ensureState).not.toHaveBeenCalled();
+    });
+
+    it("cleans up a rejected preparation and preserves the synchronous fallback", async () => {
+        clearSceneBGLCache();
+        const failure = new Error("pipeline validation failed");
+        const { engine, createRenderPipeline, createRenderPipelineAsync } = makeEngine(() => Promise.reject(failure));
+        const material = makeMaterial();
+        const task = targetTask(engine);
+
+        await expect(prepareShaderMaterialPipeline(engine, material, "mesh", task)).rejects.toBe(failure);
+        const bindings = getOrCreateShaderPipelineBindings(engine, material);
+        expect(bindings._P?.size).toBe(0);
+
+        const pipeline = getOrCreateShaderPipeline(engine, signature, material, bindings);
+        expect(pipeline).toBeDefined();
+        expect(createRenderPipelineAsync).toHaveBeenCalledOnce();
+        expect(createRenderPipeline).toHaveBeenCalledOnce();
+    });
+
+    it("keeps automatic scene preparation best-effort when async creation rejects", async () => {
+        clearSceneBGLCache();
+        const error = vi.spyOn(console, "error").mockImplementation(() => {});
+        const failure = new Error("pipeline validation failed");
+        const { engine, createRenderPipeline } = makeEngine(() => Promise.reject(failure));
+        const material = makeMaterial();
+        const renderable = {} as Renderable;
+        const task = {
+            _renderables: [renderable],
+            _pendingMeshes: [],
+            _targetSignature: signature,
+            _config: { autoMirror: false },
+        } as unknown as RenderTask;
+        const scene = {
+            _frameGraph: { _tasks: [task] },
+            _renderables: [renderable],
+            lights: [],
+        } as unknown as SceneContext;
+        Object.assign(scene, { surface: { engine } });
+
+        enableAsyncShaderPipelineCompilation(engine);
+        _registerAsyncShaderPipelineRecipe(scene, material, renderable);
+        await expect(_prepareAsyncShaderPipelinesForScene(scene)).resolves.toBeUndefined();
+
+        expect(error).toHaveBeenCalledWith(expect.stringContaining("synchronous first-bind fallback"), failure);
+        getOrCreateShaderPipeline(engine, signature, material, getOrCreateShaderPipelineBindings(engine, material));
+        expect(createRenderPipeline).toHaveBeenCalledOnce();
+        error.mockRestore();
+    });
+
+    it.each([
+        ["plain", false],
+        ["cross-material cache", true],
+    ] as const)("rebuilds %s bindings, modules, and pipelines after a device switch", async (_name, cached) => {
+        clearShaderPipelineCache();
+        clearSceneBGLCache();
+        const first = makeEngine();
+        const second = makeEngine();
+        const material = makeMaterial();
+        if (cached) {
+            enableShaderPipelineCache(first.engine, [{ material }]);
+        }
+
+        await prepareShaderMaterialPipeline(first.engine, material, "mesh", targetTask(first.engine));
+        const firstBindings = getOrCreateShaderPipelineBindings(first.engine, material);
+        await prepareShaderMaterialPipeline(second.engine, material, "mesh", targetTask(second.engine));
+        const secondBindings = getOrCreateShaderPipelineBindings(second.engine, material);
+
+        expect(secondBindings).not.toBe(firstBindings);
+        expect(first.createShaderModule).toHaveBeenCalledTimes(2);
+        expect(second.createShaderModule).toHaveBeenCalledTimes(2);
+        expect(first.createRenderPipelineAsync).toHaveBeenCalledOnce();
+        expect(second.createRenderPipelineAsync).toHaveBeenCalledOnce();
+    });
+});

--- a/tests/lite/unit/rendering-context-registration.test.ts
+++ b/tests/lite/unit/rendering-context-registration.test.ts
@@ -10,6 +10,7 @@ import {
 import { addTaskAtStart } from "../../../packages/babylon-lite/src/frame-graph/frame-graph-actions";
 import type { Task } from "../../../packages/babylon-lite/src/frame-graph/task";
 import { addToScene, createSceneContext, disposeScene, registerScene, unregisterScene, type SceneContext } from "../../../packages/babylon-lite/src/scene/scene";
+import { _installAsyncShaderPipelinePreparation } from "../../../packages/babylon-lite/src/scene/scene-core";
 import type { Material } from "../../../packages/babylon-lite/src/material/material";
 import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
 import type { MeshGroupBuilder, Renderable } from "../../../packages/babylon-lite/src/render/renderable";
@@ -210,5 +211,25 @@ describe("registerScene / unregisterScene", () => {
         await registerScene(scene);
 
         expect(recorded).toBe(true);
+    });
+
+    it("awaits async shader preparation after task preloads and before frame-graph build", async () => {
+        const engine = makeMockEngine();
+        const scene = createSceneContext(engine);
+        const order: string[] = [];
+        const task = scene._frameGraph._tasks[0]!;
+        task._preload = async () => {
+            order.push("preload");
+        };
+        _installAsyncShaderPipelinePreparation(async () => {
+            order.push("prepare");
+        });
+        vi.spyOn(scene._frameGraph, "build").mockImplementation(() => {
+            order.push("build");
+        });
+
+        await registerScene(scene);
+
+        expect(order).toEqual(["preload", "prepare", "build"]);
     });
 });


### PR DESCRIPTION
## Summary
- add opt-in asynchronous ShaderMaterial pipeline preparation before frame-graph build
- preserve the synchronous first-bind fallback and device-aware cache behavior
- cover key/descriptor identity, shared-cache deduplication, thin instances, RenderTarget signatures, shadows, and device changes
- keep affected inactive scene runtime byte counts unchanged

## Validation
- Opus review: PRISTINE
- focused unit tests: 22 passed
- public API build tests: 5 passed
- full lint and TypeScript checks
- filtered bundle checks: scene159, scene160, scene161, scene162, scene163, scene165, scene274
- bundle manifest validation: 237 scenes checked