### PR TITLE
feat(particle): export createParticleSystem from the package entry

### DIFF
--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -730,7 +730,7 @@ export { buildNodeParticleSetWithFlowMaps } from "./particle/node/npe-flow-map.j
 export { buildNodeParticleSetWithNoiseTextures } from "./particle/node/npe-noise.js";
 export { buildNodeParticleSetWithTextureUpdates } from "./particle/node/npe-texture-updates.js";
 export type { ParticleSystem } from "./particle/particle-system.js";
-export { animateParticleSystem, startParticleSystem, stopParticleSystem } from "./particle/particle-system.js";
+export { animateParticleSystem, createParticleSystem, startParticleSystem, stopParticleSystem } from "./particle/particle-system.js";
 export type { RegisterNodeParticleOptions } from "./particle/particle-scene.js";
 export { registerNodeParticleSet } from "./particle/particle-scene.js";
 export { createParticleBillboard, syncParticleBillboard } from "./particle/particle-billboard.js";


### PR DESCRIPTION
`particle/particle-system.js` exports four functions; the barrel re-exports three:

```ts
// packages/babylon-lite/src/index.ts
export { animateParticleSystem, startParticleSystem, stopParticleSystem } from "./particle/particle-system.js";
//       ^ missing: createParticleSystem — the constructor the other three take as their argument
```

The `ParticleSystem` type is exported, and the rendering half (`createParticleBillboard`, `syncParticleBillboard`) is public, so the imperative particle path is reachable in every respect except the call that begins it. One name added to an existing re-export line; no implementation change.

Found while porting a WebGPU procedural space game onto Lite — we had deferred two emitters after reading `index.d.ts` and concluding Lite offered only Node Particle graphs.
