### PR TITLE
fix(pbr): preload self-shadow caster shader variant

### DIFF
--- a/lab/public/bundle/manifest/scene111.json
+++ b/lab/public/bundle/manifest/scene111.json
@@ -18,7 +18,7 @@
     "scene111-node-registry-BsyPCLL6.js",
     "scene111-node-renderable-Dw7ix7rM.js",
     "scene111-node-shadow-C3rYL0xt.js",
-    "scene111-pbr-renderable-DEvmH18Q.js",
+    "scene111-pbr-renderable-Btzk5XcQ.js",
     "scene111-pbr-shadow-fragment-CFzpdZcF.js",
     "scene111-shader-composer-Ce54ihvR.js",
     "scene111-shadow-fragment-core-Dbe1xNkt.js",
@@ -29,5 +29,5 @@
     "scene111-vertex-output-C7G5u6Y0.js",
     "scene111.js"
   ],
-  "rawBytes": 132260
+  "rawBytes": 132263
 }

--- a/lab/public/bundle/manifest/scene215.json
+++ b/lab/public/bundle/manifest/scene215.json
@@ -6,11 +6,11 @@
     "scene215-material-view-Dua1bl7W.js",
     "scene215-multilight-wgsl-CQJbxr3k.js",
     "scene215-no-color-view-DFQStqrM.js",
-    "scene215-pbr-renderable-4o_DccKk.js",
+    "scene215-pbr-renderable-MD-Psn4-.js",
     "scene215-pbr-shadow-fragment-HtMfYaoO.js",
     "scene215-shadow-task-BM34zMuF.js",
     "scene215-singlelight-directional-wgsl-C_O-myb1.js",
     "scene215.js"
   ],
-  "rawBytes": 81044
+  "rawBytes": 81047
 }

--- a/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-renderable.ts
@@ -83,12 +83,15 @@ export async function buildPbrRenderables(scene: SceneContext, meshes: Mesh[], e
         const lr = writeMeshLightSelection(mesh, scene.lights);
         const affectedCount = lr > 0 ? 1 : -lr;
         hasAnyAffectedLight ||= affectedCount > 0;
-        if (affectedCount === 1 && !(mesh.receiveShadows && hasSomeShadows)) {
+        if (affectedCount === 1) {
             needsSingleLightPath = true;
             const type = getPackedSingleLightType(scene.lights, lr - 1);
             if (!singleLightTypes.includes(type)) {
                 singleLightTypes.push(type);
             }
+            // A mono-light shadow receiver uses the multi-light path in the main pass,
+            // but its no-color caster override disables receiving and falls back to single-light.
+            needsMultiLightPath ||= mesh.receiveShadows && hasSomeShadows;
         } else if (affectedCount > 0) {
             needsMultiLightPath = true;
         }

--- a/tests/lite/unit/pbr-shadow-caster-receiver.test.ts
+++ b/tests/lite/unit/pbr-shadow-caster-receiver.test.ts
@@ -62,7 +62,7 @@ const shadowSignature = {
     _colorFormat: null,
     _depthStencilFormat: "depth32float",
     _sampleCount: 1,
-} as RenderTargetSignature;
+} as unknown as RenderTargetSignature;
 
 describe("PBR shadow caster-receiver shader variants", () => {
     it("declares the single-light uniform type used by the no-color shadow pass", async () => {
@@ -76,7 +76,7 @@ describe("PBR shadow caster-receiver shader variants", () => {
             _depthTexture: { createView: vi.fn(() => ({}) as GPUTextureView) },
             _depthSampler: {} as GPUSampler,
             _shadowUBO: {} as GPUBuffer,
-        } as ShadowGenerator;
+        } as unknown as ShadowGenerator;
         scene.lights.push(light);
 
         const material = createPbrMaterial();

--- a/tests/lite/unit/pbr-shadow-caster-receiver.test.ts
+++ b/tests/lite/unit/pbr-shadow-caster-receiver.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine.js";
+import type { RenderTargetSignature } from "../../../packages/babylon-lite/src/engine/render-target.js";
+import { createDirectionalLight } from "../../../packages/babylon-lite/src/light/directional-light.js";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh.js";
+import { createPbrNoColorMaterialView } from "../../../packages/babylon-lite/src/material/pbr/no-color-view.js";
+import { createPbrMaterial } from "../../../packages/babylon-lite/src/material/pbr/pbr-material.js";
+import { clearPbrPipelineCache } from "../../../packages/babylon-lite/src/material/pbr/pbr-pipeline.js";
+import { buildPbrRenderables } from "../../../packages/babylon-lite/src/material/pbr/pbr-renderable.js";
+import { clearSceneBGLCache } from "../../../packages/babylon-lite/src/render/scene-helpers.js";
+import { createSceneContext } from "../../../packages/babylon-lite/src/scene/scene.js";
+import type { ShadowGenerator } from "../../../packages/babylon-lite/src/shadow/shadow-generator.js";
+
+function makeEngine(): { engine: EngineContext; createShaderModule: ReturnType<typeof vi.fn> } {
+    const createShaderModule = vi.fn((descriptor: GPUShaderModuleDescriptor) => descriptor as unknown as GPUShaderModule);
+    const device = {
+        createBindGroupLayout: vi.fn((descriptor: GPUBindGroupLayoutDescriptor) => descriptor as unknown as GPUBindGroupLayout),
+        createPipelineLayout: vi.fn((descriptor: GPUPipelineLayoutDescriptor) => descriptor as unknown as GPUPipelineLayout),
+        createShaderModule,
+        createRenderPipeline: vi.fn((descriptor: GPURenderPipelineDescriptor) => descriptor as unknown as GPURenderPipeline),
+        createBindGroup: vi.fn((descriptor: GPUBindGroupDescriptor) => descriptor as unknown as GPUBindGroup),
+        createSampler: vi.fn((descriptor: GPUSamplerDescriptor) => descriptor as unknown as GPUSampler),
+        createTexture: vi.fn(() => {
+            return {
+                createView: vi.fn(() => ({}) as GPUTextureView),
+                destroy: vi.fn(),
+            } as unknown as GPUTexture;
+        }),
+        createBuffer: vi.fn((descriptor: GPUBufferDescriptor) => {
+            const storage = new ArrayBuffer(Number(descriptor.size));
+            return {
+                destroy: vi.fn(),
+                getMappedRange: vi.fn(() => storage),
+                unmap: vi.fn(),
+            } as unknown as GPUBuffer;
+        }),
+        queue: {
+            writeBuffer: vi.fn(),
+            writeTexture: vi.fn(),
+        },
+    } as unknown as GPUDevice;
+    const engine = { _device: device, _disposables: [] } as unknown as EngineContext;
+    Object.assign(engine, { engine });
+    return { engine, createShaderModule };
+}
+
+function makeMesh(material: Mesh["material"]): Mesh {
+    const worldMatrix = new Float32Array(16);
+    worldMatrix[0] = worldMatrix[5] = worldMatrix[10] = worldMatrix[15] = 1;
+    return {
+        material,
+        receiveShadows: true,
+        morphTargets: null,
+        worldMatrix,
+        worldMatrixVersion: 1,
+        _gpu: {},
+    } as unknown as Mesh;
+}
+
+const shadowSignature = {
+    _colorFormat: null,
+    _depthStencilFormat: "depth32float",
+    _sampleCount: 1,
+} as RenderTargetSignature;
+
+describe("PBR shadow caster-receiver shader variants", () => {
+    it("declares the single-light uniform type used by the no-color shadow pass", async () => {
+        clearPbrPipelineCache();
+        clearSceneBGLCache();
+        const { engine, createShaderModule } = makeEngine();
+        const scene = createSceneContext(engine, { defaultRenderTask: false });
+        const light = createDirectionalLight([0, -1, 0]);
+        light.shadowGenerator = {
+            _shadowType: "pcf",
+            _depthTexture: { createView: vi.fn(() => ({}) as GPUTextureView) },
+            _depthSampler: {} as GPUSampler,
+            _shadowUBO: {} as GPUBuffer,
+        } as ShadowGenerator;
+        scene.lights.push(light);
+
+        const material = createPbrMaterial();
+        const mesh = makeMesh(material);
+        scene._groups.set(material._buildGroup, [mesh]);
+        const { rebuildSingle } = await buildPbrRenderables(scene, [mesh], undefined);
+
+        const shadowRenderable = rebuildSingle(scene, mesh, createPbrNoColorMaterialView(material));
+        shadowRenderable.bind(engine, shadowSignature);
+
+        const fragmentWgsl = createShaderModule.mock.calls
+            .map((call) => (call[0] as GPUShaderModuleDescriptor).code)
+            .find((code) => code.includes("var<uniform> lights: lightsUniforms"));
+        expect(fragmentWgsl).toContain("struct lightsUniforms");
+    });
+});


### PR DESCRIPTION
## Summary
- preload the single-light PBR shader variant when a mono-light mesh also receives shadows
- keep the multi-light receiver variant available for the main pass
- add a regression covering the no-color caster override and refresh affected bundle manifests

## Validation
- `pnpm exec vitest run --project unit tests/lite/unit/pbr-shadow-caster-receiver.test.ts tests/lite/unit/alpha-to-coverage.test.ts`
- `pnpm exec playwright test tests/lite/parity/scenes/scene111-light-selection.spec.ts tests/lite/parity/scenes/scene215-cascaded-shadows-pbr.spec.ts`
- filtered bundle build for `scene111,scene215` (both below ceilings; +3 bytes each)
- scoped ESLint and tests TypeScript typecheck
- Opus review: PRISTINE

`pnpm run lint` reaches an unrelated pre-existing type error in `lab/lite/src/bjs/scene275.ts`: `TextRenderer.writeToDepthBuffer` is not defined on the current type.

Forum report: https://forum.babylonjs.com/t/lite-shader-error-because-of-self-shadowing/63966