### PR TITLE
docs(post-process): correct the shader outline to match the helper

### DIFF
--- a/docs/lite/architecture/29-post-process.md
+++ b/docs/lite/architecture/29-post-process.md
@@ -228,21 +228,25 @@ fn postProcessVertex(@builtin(vertex_index) vertexIndex: u32) -> PostProcessVert
     let p = positions[vertexIndex];
     var out: PostProcessVertexOutput;
     out.position = vec4f(p, 0.0, 1.0);
-    out.uv = p * 0.5 + vec2f(0.5, 0.5);
+    // V is flipped: clip space is +Y up, texture space is +Y down.
+    out.uv = vec2f(p.x * 0.5 + 0.5, 0.5 - p.y * 0.5);
     return out;
 }
 
 @group(0) @binding(0) var sourceSampler: sampler;
 @group(0) @binding(1) var sourceTextureSampler: texture_2d<f32>;
 
-fn readPostProcessSource(position: vec2f) -> vec4f {
-    let dims = vec2f(textureDimensions(sourceTextureSampler));
-    let uv = (floor(position) + vec2f(0.5)) / dims;
-    return textureSampleLevel(sourceTextureSampler, sourceSampler, clamp(uv, vec2f(0.0), vec2f(1.0)), 0.0);
+fn samplePostProcessSource(uv: vec2f) -> vec4f {
+    return textureSample(sourceTextureSampler, sourceSampler, uv);
 }
 
-fn samplePostProcessSource(uv: vec2f) -> vec4f {
-    return textureSampleLevel(sourceTextureSampler, sourceSampler, clamp(uv, vec2f(0.0), vec2f(1.0)), 0.0);
+// Texel-snapped read. Takes a NORMALIZED uv, like samplePostProcessSource —
+// not a pixel coordinate — and clamps to the texel centres so a snapped fetch
+// cannot bleed outside the source.
+fn readPostProcessSource(uv: vec2f) -> vec4f {
+    let dims = vec2f(textureDimensions(sourceTextureSampler));
+    let p = clamp(floor(uv * dims) + vec2f(0.5), vec2f(0.5), dims - vec2f(0.5));
+    return textureSampleLevel(sourceTextureSampler, sourceSampler, p / dims, 0);
 }
 
 // user fragmentWGSL must define:


### PR DESCRIPTION
Docs only — no code change.

The WGSL outline under "Shader Logic" in `docs/lite/architecture/29-post-process.md` has drifted from the strings `frame-graph/post-process-task.ts` actually deploys. Three differences, each of which sends someone writing a custom `applyPostProcess` wrong:

| | Page said | `post-process-task.ts` does |
|---|---|---|
| vertex `uv` | `p * 0.5 + vec2f(0.5, 0.5)` | `vec2f(p.x*0.5+0.5, 0.5-p.y*0.5)` — V flipped |
| `readPostProcessSource` | takes `position: vec2f`, a **pixel** coordinate, `floor(position)` | takes `uv: vec2f`, a **normalized** uv, `floor(uv*dims)`, clamped to texel centres |
| `samplePostProcessSource` | `textureSampleLevel(..., clamp(uv, 0, 1), 0.0)` | plain `textureSample(sourceTextureSampler, sourceSampler, uv)` |

The middle one is the one that bites: same function name, opposite parameter meaning, and no compile error — an effect written from the page samples a single texel near the origin instead of the intended one.

The page is otherwise accurate, so this only replaces the three snippets with the shipped text and adds two short comments (why V is flipped, and that `readPostProcessSource` takes a uv).

### Verification

Extracted each of the three constructs from the source and from the page, stripped comments, collapsed whitespace (WGSL is whitespace-insensitive) and compared:

```
MATCH  vertex uv
MATCH  samplePostProcessSource
MATCH  readPostProcessSource
```

No source, test, or bundle output is touched, so no manifest or ceiling impact.