### PR TITLE
chore(deps): pin glTF interface to 9.22.0

### DIFF
--- a/lab/package.json
+++ b/lab/package.json
@@ -22,7 +22,7 @@
         "@recast-navigation/wasm": "0.43.1",
         "@vitejs/plugin-basic-ssl": "^2.1.0",
         "@webgpu/types": "^0.1.71",
-        "babylonjs-gltf2interface": "^9.19.0",
+        "babylonjs-gltf2interface": "latest",
         "manifold-3d": "3.5.1",
         "typescript": "^6.0.3",
         "vite": "^6.4.3"

--- a/lab/package.json
+++ b/lab/package.json
@@ -22,7 +22,7 @@
         "@recast-navigation/wasm": "0.43.1",
         "@vitejs/plugin-basic-ssl": "^2.1.0",
         "@webgpu/types": "^0.1.71",
-        "babylonjs-gltf2interface": "latest",
+        "babylonjs-gltf2interface": "9.22.0",
         "manifold-3d": "3.5.1",
         "typescript": "^6.0.3",
         "vite": "^6.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 1.3.13
       '@babylonjs/loaders':
         specifier: ^9.19.0
-        version: 9.19.0(@babylonjs/core@9.19.0)(babylonjs-gltf2interface@9.19.0)
+        version: 9.19.0(@babylonjs/core@9.19.0)(babylonjs-gltf2interface@9.22.1)
       '@babylonjs/materials':
         specifier: ^9.19.0
         version: 9.19.0(@babylonjs/core@9.19.0)
@@ -154,8 +154,8 @@ importers:
         specifier: ^0.1.71
         version: 0.1.71
       babylonjs-gltf2interface:
-        specifier: ^9.19.0
-        version: 9.19.0
+        specifier: latest
+        version: 9.22.1
       manifold-3d:
         specifier: 3.5.1
         version: 3.5.1(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0(@types/node@26.1.1))(esbuild-wasm@0.27.7)
@@ -1824,8 +1824,8 @@ packages:
       react-native-b4a:
         optional: true
 
-  babylonjs-gltf2interface@9.19.0:
-    resolution: {integrity: sha512-VyXEf5QKcE5XaHfUVUmzjqyUro89zZaDjBxRXtbUuc4suHNrBfqOHecfCRvD3PaHtdtN+ZF8A4g1n06Pi70Rlw==}
+  babylonjs-gltf2interface@9.22.1:
+    resolution: {integrity: sha512-RfOiN+gTHOlf7Uj+HHZM9jqFnofo4sAUPyEe69A9UHw6794b4ySHYb59K+wW8Id6QN7jkPWNTg7Up1WYArtzOg==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -4377,10 +4377,10 @@ snapshots:
     dependencies:
       '@types/emscripten': 1.41.5
 
-  '@babylonjs/loaders@9.19.0(@babylonjs/core@9.19.0)(babylonjs-gltf2interface@9.19.0)':
+  '@babylonjs/loaders@9.19.0(@babylonjs/core@9.19.0)(babylonjs-gltf2interface@9.22.1)':
     dependencies:
       '@babylonjs/core': 9.19.0
-      babylonjs-gltf2interface: 9.19.0
+      babylonjs-gltf2interface: 9.22.1
 
   '@babylonjs/materials@9.19.0(@babylonjs/core@9.19.0)':
     dependencies:
@@ -5696,7 +5696,7 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babylonjs-gltf2interface@9.19.0: {}
+  babylonjs-gltf2interface@9.22.1: {}
 
   balanced-match@4.0.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 1.3.13
       '@babylonjs/loaders':
         specifier: ^9.19.0
-        version: 9.19.0(@babylonjs/core@9.19.0)(babylonjs-gltf2interface@9.22.1)
+        version: 9.19.0(@babylonjs/core@9.19.0)(babylonjs-gltf2interface@9.22.0)
       '@babylonjs/materials':
         specifier: ^9.19.0
         version: 9.19.0(@babylonjs/core@9.19.0)
@@ -154,8 +154,8 @@ importers:
         specifier: ^0.1.71
         version: 0.1.71
       babylonjs-gltf2interface:
-        specifier: latest
-        version: 9.22.1
+        specifier: 9.22.0
+        version: 9.22.0
       manifold-3d:
         specifier: 3.5.1
         version: 3.5.1(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0(@types/node@26.1.1))(esbuild-wasm@0.27.7)
@@ -1824,8 +1824,8 @@ packages:
       react-native-b4a:
         optional: true
 
-  babylonjs-gltf2interface@9.22.1:
-    resolution: {integrity: sha512-RfOiN+gTHOlf7Uj+HHZM9jqFnofo4sAUPyEe69A9UHw6794b4ySHYb59K+wW8Id6QN7jkPWNTg7Up1WYArtzOg==}
+  babylonjs-gltf2interface@9.22.0:
+    resolution: {integrity: sha512-6YSn6Ehy45Tila36MEH4/Q+60j3yv1NUJOlcaIji07VPd6RliloRz9QJ+eWcGe1dn5ckPcCtG8GOmgdS/Zx6Jw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -4377,10 +4377,10 @@ snapshots:
     dependencies:
       '@types/emscripten': 1.41.5
 
-  '@babylonjs/loaders@9.19.0(@babylonjs/core@9.19.0)(babylonjs-gltf2interface@9.22.1)':
+  '@babylonjs/loaders@9.19.0(@babylonjs/core@9.19.0)(babylonjs-gltf2interface@9.22.0)':
     dependencies:
       '@babylonjs/core': 9.19.0
-      babylonjs-gltf2interface: 9.22.1
+      babylonjs-gltf2interface: 9.22.0
 
   '@babylonjs/materials@9.19.0(@babylonjs/core@9.19.0)':
     dependencies:
@@ -5696,7 +5696,7 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babylonjs-gltf2interface@9.22.1: {}
+  babylonjs-gltf2interface@9.22.0: {}
 
   balanced-match@4.0.4: {}
 


### PR DESCRIPTION
## Summary
- pin `babylonjs-gltf2interface` to version 9.22.0
- refresh the lockfile and `@babylonjs/loaders` peer resolution

## Validation
- `pnpm typecheck:lab`