### PR TITLE
fix(gizmo): remove ineffective async event cancellation

### DIFF
--- a/lab/public/bundle/manifest/scene221.json
+++ b/lab/public/bundle/manifest/scene221.json
@@ -1,11 +1,11 @@
 {
   "rawKB": 98,
-  "rawBytes": 100394,
+  "rawBytes": 100343,
   "gzipKB": 37.7,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene221-shader-renderable-DyYBbZ62.js",
-    "scene221-standard-renderable-CrbWO8pQ.js",
+    "scene221-shader-renderable-BES3lbdk.js",
+    "scene221-standard-renderable-D11Q9XJh.js",
     "scene221-swapchain-overlay-ilhN4El_.js",
     "scene221-ubo-layout-DJjxxUdh.js",
     "scene221.js"

--- a/lab/public/bundle/manifest/scene222.json
+++ b/lab/public/bundle/manifest/scene222.json
@@ -1,16 +1,16 @@
 {
   "rawKB": 111,
-  "rawBytes": 113677,
+  "rawBytes": 113623,
   "gzipKB": 42.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
     "scene222-gpu-pool-CHlSfwGp.js",
     "scene222-shader-pipeline-cache-B3SDpvaR.js",
-    "scene222-shader-renderable-D0hxLeGX.js",
-    "scene222-standard-renderable-BV7mypE8.js",
+    "scene222-shader-renderable-uBosVW42.js",
+    "scene222-standard-renderable-CG0gJmbS.js",
     "scene222-swapchain-overlay-ilhN4El_.js",
     "scene222-ubo-layout-Cs5YvLYZ.js",
-    "scene222-uniform-copy-batch-CpNHi2tt.js",
+    "scene222-uniform-copy-batch-BOIYQmYI.js",
     "scene222.js"
   ]
 }

--- a/lab/public/bundle/manifest/scene223.json
+++ b/lab/public/bundle/manifest/scene223.json
@@ -1,10 +1,10 @@
 {
   "rawKB": 64.8,
-  "rawBytes": 66393,
+  "rawBytes": 66394,
   "gzipKB": 24.9,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene223-standard-renderable-BdyYiXDh.js",
+    "scene223-standard-renderable-CNv3s2Ph.js",
     "scene223-swapchain-overlay-ilhN4El_.js",
     "scene223.js"
   ]

--- a/lab/public/bundle/manifest/scene224.json
+++ b/lab/public/bundle/manifest/scene224.json
@@ -1,10 +1,10 @@
 {
   "rawKB": 78.4,
-  "rawBytes": 80307,
-  "gzipKB": 29.7,
+  "rawBytes": 80258,
+  "gzipKB": 29.6,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene224-standard-renderable-ClEbx_lC.js",
+    "scene224-standard-renderable-BNQYiB_w.js",
     "scene224-swapchain-overlay-ilhN4El_.js",
     "scene224.js"
   ]

--- a/lab/public/bundle/manifest/scene49.json
+++ b/lab/public/bundle/manifest/scene49.json
@@ -1,10 +1,10 @@
 {
   "rawKB": 88.8,
-  "rawBytes": 90955,
-  "gzipKB": 34.2,
+  "rawBytes": 90909,
+  "gzipKB": 34.1,
   "ignoredRawKB": 0,
   "runtimeChunks": [
-    "scene49-standard-renderable-BymvFUPC.js",
+    "scene49-standard-renderable-Cp4gxZL1.js",
     "scene49-swapchain-overlay-ilhN4El_.js",
     "scene49-ubo-layout-DJjxxUdh.js",
     "scene49.js"

--- a/packages/babylon-lite/src/gizmo/pointer-drag.ts
+++ b/packages/babylon-lite/src/gizmo/pointer-drag.ts
@@ -278,8 +278,8 @@ function installDispatcher(layer: UtilityLayer, canvas: HTMLCanvasElement): Disp
         }
     };
 
-    // Capture phase so we beat arc-rotate-controls (which uses bubble phase)
-    // for events that hit a gizmo collider.
+    // Capture phase marks the async pick as pending before the bubble-phase
+    // camera controls decide how to handle this gesture.
     canvas.addEventListener("pointerdown", onPointerDown, { capture: true });
     canvas.addEventListener("pointermove", onPointerMove, { capture: true });
     canvas.addEventListener("pointerup", onPointerUp, { capture: true });
@@ -349,9 +349,6 @@ async function handlePointerDown(state: DispatcherState, event: PointerEvent): P
         return;
     }
 
-    // Stop the camera controls from grabbing this gesture.
-    event.stopImmediatePropagation();
-    event.preventDefault();
     if ("setPointerCapture" in state.canvas) {
         try {
             state.canvas.setPointerCapture(event.pointerId);


### PR DESCRIPTION
## Summary
- remove `stopImmediatePropagation()` and `preventDefault()` calls that ran only after asynchronous GPU picking completed
- clarify that the capture listener synchronously marks the pick as pending before camera controls handle the gesture
- refresh the affected gizmo scene bundle manifests without raising any ceiling

This addresses the report in https://forum.babylonjs.com/t/lite-picking-inside-an-event-handler/63998.

## Validation
- `pnpm exec eslint packages\babylon-lite\src\gizmo\pointer-drag.ts`
- `pnpm exec tsc -p packages\babylon-lite\tsconfig.json --noEmit`
- `pnpm build:lib && pnpm exec tsx scripts\build-bundle-scenes.ts --scenes scene49,scene221,scene222,scene223,scene224`

No unit, parity, or visual tests were run locally, as requested.