### PR TITLE
docs(skills): require a BJS source lookup before naming compat members

### DIFF
--- a/.github/copilot/skills/update-compat-layer.md
+++ b/.github/copilot/skills/update-compat-layer.md
@@ -257,6 +257,28 @@ or newly added there), **never in the compat package**:
   need different backing, reconcile them into the **single** BJS-named class via an
   `@internal` factory (e.g. `AnimationGroup._fromLite(...)`) — never a second public
   type. A divergent name is an API-parity bug even if the methods work.
+- **Confirm every public name against a real BJS source before you write it — always,
+  not just when you feel unsure.** A wrong name is a _confident_ error, so discretionary
+  "grep if in doubt" advice never fires; make the check unconditional for every exported
+  symbol and, above all, for every **method, property or accessor** hanging off an
+  otherwise correctly-named class. And **never name a member after the Lite function it
+  forwards to** — that is how `Bone.resetToRest()` shipped: it forwards to Lite's
+  `clearBoneOverride`, which reads as "reset to rest", while BJS declares only
+  `returnToRest()` — a name already checked into this repo at
+  `lab/lite/src/bjs/scene99.ts`. The Lite call is the implementation; BJS is the name.
+    ```
+    # 1. BJS oracle scenes — always checked in, no install needed
+    git grep -n "<memberName>" -- lab/lite/src/bjs
+    # 2. installed typings — exhaustive, but gitignored and often absent
+    grep -rn "\b<memberName>\b" lab/node_modules/@babylonjs/core
+    ```
+    Read the two results asymmetrically. The oracle scenes are hundreds of real
+    `@babylonjs/core` programs, so a hit **proves the name is real** — but they are a
+    sample, so a miss proves nothing. The typings are exhaustive, so zero hits there
+    **proves the name invented** (open the owning class's `.d.ts` and copy the real one
+    verbatim; add `@babylonjs/loaders` for loader symbols). If the typings aren't
+    installed, the name is **unverified — never "invented"**: keep looking, and never
+    ship a name no source confirmed.
 - Plain class wrappers that hold the Lite object as `_lite` (or `_node`). Mark the
   handle property with an `@internal` JSDoc tag (the repo's
   `babylon-lite/underscore-requires-internal` lint rule requires it).

--- a/.github/copilot/skills/update-compat-layer.md
+++ b/.github/copilot/skills/update-compat-layer.md
@@ -268,17 +268,19 @@ or newly added there), **never in the compat package**:
   `lab/lite/src/bjs/scene99.ts`. The Lite call is the implementation; BJS is the name.
     ```
     # 1. BJS oracle scenes — always checked in, no install needed
-    git grep -n "<memberName>" -- lab/lite/src/bjs
+    git grep -nw "<memberName>" -- lab/lite/src/bjs
     # 2. installed typings — exhaustive, but gitignored and often absent
-    grep -rn "\b<memberName>\b" lab/node_modules/@babylonjs/core
+    grep -Rnw "<memberName>" lab/node_modules/@babylonjs/core
     ```
-    Read the two results asymmetrically. The oracle scenes are hundreds of real
-    `@babylonjs/core` programs, so a hit **proves the name is real** — but they are a
-    sample, so a miss proves nothing. The typings are exhaustive, so zero hits there
-    **proves the name invented** (open the owning class's `.d.ts` and copy the real one
-    verbatim; add `@babylonjs/loaders` for loader symbols). If the typings aren't
-    installed, the name is **unverified — never "invented"**: keep looking, and never
-    ship a name no source confirmed.
+    Keep `-w` in both — whole-word matching stops a near-miss like `returnToRes`
+    counting as a hit on `returnToRest`, and avoids `\b`, which is not portable across
+    grep implementations. Then read the two results asymmetrically. The oracle scenes
+    are hundreds of real `@babylonjs/core` programs, so a hit **proves the name is
+    real** — but they are a sample, so a miss proves nothing. The typings are
+    exhaustive, so zero hits there **proves the name invented** (open the owning class's
+    `.d.ts` and copy the real one verbatim; add `@babylonjs/loaders` for loader
+    symbols). If the typings aren't installed, the name is **unverified — never
+    "invented"**: keep looking, and never ship a name no source confirmed.
 - Plain class wrappers that hold the Lite object as `_lite` (or `_node`). Mark the
   handle property with an `@internal` JSDoc tag (the repo's
   `babylon-lite/underscore-requires-internal` lint rule requires it).


### PR DESCRIPTION
## Problem

`.github/copilot/skills/update-compat-layer.md` states the "match the Babylon.js API exactly" rule **twice** — once in the wrapper-conventions list (*"**Never invent a divergent name** … A divergent name is an API-parity bug even if the methods work"*) and again in the Guardrails summary (*"**Exact API parity:** … A divergent public name is a parity bug"*).

It still didn't hold. In #609 the compat-sync agent shipped:

```ts
public resetToRest(): void {
    clearBoneOverride(this._skeleton._lite, this._lite);
}
```

Babylon.js declares `returnToRest()`, not `resetToRest()`:

- `@babylonjs/core` declares `returnToRest(): void;` in **both** `Bones/bone.pure.d.ts` and `Bones/skeleton.d.ts`.
- `resetToRest` appears nowhere in `@babylonjs/core`, and nowhere in `BabylonJS/Babylon.js`.
- **The correct name was already checked into this repo**: `lab/lite/src/bjs/scene99.ts:38` calls `skeleton.returnToRest();`.

@deltakosh caught it reviewing #609 (*"Rename `Bone.resetToRest()` to `returnToRest()`"*). The same PR shows the failure mode a second time: `Bone.setEnabled(value)` forwards to Lite's `setBoneVisible(...)`, a Lite-semantics name carrying the wrong Babylon.js meaning.

## Root cause

The member was named after **the Lite function it forwards to** rather than the Babylon.js surface it mirrors — `clearBoneOverride` reads semantically as "reset to rest".

Two concrete weaknesses let that through, and neither is a lack of emphasis:

1. **No verification action.** Both statements say what the outcome must be and what not to do, but neither says *look the name up*. The neighbouring defaults rule does prescribe an action ("read both signatures"); the parity rule doesn't. That asymmetry is the gap.
2. **Only type-level examples.** Both illustrations are class names (`AnimationGroup`, `Mesh`) — obvious, and rarely wrong. The case that actually failed is a **method** on a correctly-named class, which no example covered.

A third restatement would add length to an already ~31 KB file without changing behaviour. The value is in adding an *action* and a *method-level example*.

## Change

One new bullet in "Implementation patterns", directly after the existing parity bullet. That bullet and the Guardrails restatement are left untouched.

It does three things:

- **Makes the check unconditional.** A wrong name is a *confident* error, so discretionary "grep if in doubt" guidance never fires — the author doesn't feel unsure. The lookup therefore applies to every exported symbol and every public member, and especially to methods, properties and accessors hanging off an otherwise correctly-named class.
- **Names the anti-pattern.** Never name a compat member after the Lite function it forwards to, using `resetToRest` / `clearBoneOverride` → `returnToRest` as the worked example.
- **Layers two sources, with the correct logic on each:**

| Source | Hit | Miss |
| --- | --- | --- |
| BJS oracle scenes (`lab/lite/src/bjs`) — checked in, no install needed | **proves the name is real** | proves nothing — a sample, not the API |
| Installed typings (`lab/node_modules/@babylonjs/*`) — exhaustive, but `node_modules/` is gitignored | name confirmed | **proves the name invented** — but only when the typings are actually present |

If the typings aren't installed the result is **unverified — never "invented"**. Getting that asymmetry wrong would be worse than no rule at all: against an absent directory *every* name greps to zero hits, so a flat "zero hits ⇒ invented" instruction would hand the agent false confidence in the name it just made up. The bullet closes with the clamp: never ship a name no source confirmed.

The oracle corpus is searched first because it is always available — all 237 files under `lab/lite/src/bjs` import `@babylonjs/core`, and the skill already refers to them as "BJS oracle scene(s)". Ordering enforces the logic structurally instead of merely asserting it.

## Scope

- One file: `.github/copilot/skills/update-compat-layer.md` (+22 lines, no deletions).
- **No code changes.** The `resetToRest` rename belongs to #609, not here.
- Docs-only, so no tests were run or added. `prettier --check` passes on the file, which the root `format:check` script covers via its `**/*.md` glob.