### PR TITLE
fix(loader): retry transient decoder failures

### DIFF
--- a/packages/babylon-lite/src/loader-gltf/draco-decode.ts
+++ b/packages/babylon-lite/src/loader-gltf/draco-decode.ts
@@ -52,7 +52,7 @@ function loadDracoScript(): Promise<DracoFactory> {
     if (scriptLoadPromise) {
         return scriptLoadPromise;
     }
-    const promise = new Promise<DracoFactory>((resolve, reject) => {
+    scriptLoadPromise = new Promise<DracoFactory>((resolve, reject) => {
         const existing = (globalThis as { DracoDecoderModule?: DracoFactory }).DracoDecoderModule;
         if (existing) {
             resolve(existing);
@@ -81,30 +81,24 @@ function loadDracoScript(): Promise<DracoFactory> {
         script.onerror = () => fail("Failed to load draco_decoder.js from " + script.src);
         document.head.appendChild(script);
     });
-    scriptLoadPromise = promise;
-    void promise.catch(() => {
-        if (scriptLoadPromise === promise) {
-            scriptLoadPromise = null;
-        }
+    void scriptLoadPromise.catch(() => {
+        scriptLoadPromise = null;
     });
-    return promise;
+    return scriptLoadPromise;
 }
 
 async function getDracoModule(): Promise<DracoModule> {
     if (modulePromise) {
         return modulePromise;
     }
-    const promise = (async () => {
+    modulePromise = (async () => {
         const factory = await loadDracoScript();
         return factory({ locateFile: (f: string) => dracoBaseUrl + f });
     })();
-    modulePromise = promise;
-    void promise.catch(() => {
-        if (modulePromise === promise) {
-            modulePromise = null;
-        }
+    void modulePromise.catch(() => {
+        modulePromise = null;
     });
-    return promise;
+    return modulePromise;
 }
 
 /**

--- a/packages/babylon-lite/src/loader-gltf/draco-decode.ts
+++ b/packages/babylon-lite/src/loader-gltf/draco-decode.ts
@@ -52,7 +52,7 @@ function loadDracoScript(): Promise<DracoFactory> {
     if (scriptLoadPromise) {
         return scriptLoadPromise;
     }
-    scriptLoadPromise = new Promise<DracoFactory>((resolve, reject) => {
+    const promise = new Promise<DracoFactory>((resolve, reject) => {
         const existing = (globalThis as { DracoDecoderModule?: DracoFactory }).DracoDecoderModule;
         if (existing) {
             resolve(existing);
@@ -60,29 +60,51 @@ function loadDracoScript(): Promise<DracoFactory> {
         }
         const script = document.createElement("script");
         script.src = dracoBaseUrl + "draco_decoder.js";
+        const cleanup = (): void => {
+            script.onload = null;
+            script.onerror = null;
+            script.remove();
+        };
+        const fail = (message: string): void => {
+            cleanup();
+            reject(new Error(message));
+        };
         script.onload = () => {
             const factory = (globalThis as { DracoDecoderModule?: DracoFactory }).DracoDecoderModule;
             if (!factory) {
-                reject(new Error("draco_decoder.js loaded but DracoDecoderModule is undefined"));
+                fail("draco_decoder.js loaded but DracoDecoderModule is undefined");
             } else {
+                cleanup();
                 resolve(factory);
             }
         };
-        script.onerror = () => reject(new Error("Failed to load draco_decoder.js from " + script.src));
+        script.onerror = () => fail("Failed to load draco_decoder.js from " + script.src);
         document.head.appendChild(script);
     });
-    return scriptLoadPromise;
+    scriptLoadPromise = promise;
+    void promise.catch(() => {
+        if (scriptLoadPromise === promise) {
+            scriptLoadPromise = null;
+        }
+    });
+    return promise;
 }
 
 async function getDracoModule(): Promise<DracoModule> {
     if (modulePromise) {
         return modulePromise;
     }
-    modulePromise = (async () => {
+    const promise = (async () => {
         const factory = await loadDracoScript();
         return factory({ locateFile: (f: string) => dracoBaseUrl + f });
     })();
-    return modulePromise;
+    modulePromise = promise;
+    void promise.catch(() => {
+        if (modulePromise === promise) {
+            modulePromise = null;
+        }
+    });
+    return promise;
 }
 
 /**

--- a/packages/babylon-lite/src/loader-gltf/meshopt-decode.ts
+++ b/packages/babylon-lite/src/loader-gltf/meshopt-decode.ts
@@ -29,7 +29,7 @@ function loadMeshoptScript(): Promise<MeshoptDecoderModule> {
     if (scriptLoadPromise) {
         return scriptLoadPromise;
     }
-    scriptLoadPromise = new Promise<MeshoptDecoderModule>((resolve, reject) => {
+    const promise = new Promise<MeshoptDecoderModule>((resolve, reject) => {
         const existing = (globalThis as { MeshoptDecoder?: MeshoptDecoderModule }).MeshoptDecoder;
         if (existing) {
             resolve(existing);
@@ -37,18 +37,34 @@ function loadMeshoptScript(): Promise<MeshoptDecoderModule> {
         }
         const script = document.createElement("script");
         script.src = meshoptBaseUrl + "meshopt_decoder.js";
+        const cleanup = (): void => {
+            script.onload = null;
+            script.onerror = null;
+            script.remove();
+        };
+        const fail = (message: string): void => {
+            cleanup();
+            reject(new Error(message));
+        };
         script.onload = () => {
             const mod = (globalThis as { MeshoptDecoder?: MeshoptDecoderModule }).MeshoptDecoder;
             if (!mod) {
-                reject(new Error("meshopt_decoder.js loaded but MeshoptDecoder is undefined"));
+                fail("meshopt_decoder.js loaded but MeshoptDecoder is undefined");
             } else {
+                cleanup();
                 resolve(mod);
             }
         };
-        script.onerror = () => reject(new Error("Failed to load meshopt_decoder.js from " + script.src));
+        script.onerror = () => fail("Failed to load meshopt_decoder.js from " + script.src);
         document.head.appendChild(script);
     });
-    return scriptLoadPromise;
+    scriptLoadPromise = promise;
+    void promise.catch(() => {
+        if (scriptLoadPromise === promise) {
+            scriptLoadPromise = null;
+        }
+    });
+    return promise;
 }
 
 /** Resolve the ready meshopt decoder module (WASM instantiated). */

--- a/packages/babylon-lite/src/loader-gltf/meshopt-decode.ts
+++ b/packages/babylon-lite/src/loader-gltf/meshopt-decode.ts
@@ -29,7 +29,7 @@ function loadMeshoptScript(): Promise<MeshoptDecoderModule> {
     if (scriptLoadPromise) {
         return scriptLoadPromise;
     }
-    const promise = new Promise<MeshoptDecoderModule>((resolve, reject) => {
+    scriptLoadPromise = new Promise<MeshoptDecoderModule>((resolve, reject) => {
         const existing = (globalThis as { MeshoptDecoder?: MeshoptDecoderModule }).MeshoptDecoder;
         if (existing) {
             resolve(existing);
@@ -58,13 +58,10 @@ function loadMeshoptScript(): Promise<MeshoptDecoderModule> {
         script.onerror = () => fail("Failed to load meshopt_decoder.js from " + script.src);
         document.head.appendChild(script);
     });
-    scriptLoadPromise = promise;
-    void promise.catch(() => {
-        if (scriptLoadPromise === promise) {
-            scriptLoadPromise = null;
-        }
+    void scriptLoadPromise.catch(() => {
+        scriptLoadPromise = null;
     });
-    return promise;
+    return scriptLoadPromise;
 }
 
 /** Resolve the ready meshopt decoder module (WASM instantiated). */

--- a/tests/lite/unit/lazy-loader-retry.test.ts
+++ b/tests/lite/unit/lazy-loader-retry.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface ScriptMock {
+    src: string;
+    onload?: () => void;
+    onerror?: () => void;
+    remove(): void;
+}
+
+function installScriptDocument(onAppend: (script: ScriptMock) => void): void {
+    vi.stubGlobal("document", {
+        createElement: () => ({ src: "", async: false, remove: vi.fn() }),
+        head: { appendChild: onAppend },
+    });
+}
+
+afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+});
+
+describe("lazy decoder retries", () => {
+    it("retries meshopt script loading after a transient failure", async () => {
+        const scripts: ScriptMock[] = [];
+        let fail = true;
+        installScriptDocument((script) => {
+            scripts.push(script);
+            queueMicrotask(() => {
+                if (fail) {
+                    script.onerror?.();
+                } else {
+                    vi.stubGlobal("MeshoptDecoder", { ready: Promise.resolve(), decodeGltfBuffer: () => undefined });
+                    script.onload?.();
+                }
+            });
+        });
+        const decoder = await import("../../../packages/babylon-lite/src/loader-gltf/meshopt-decode.js");
+
+        await expect(decoder.getMeshoptDecoder()).rejects.toThrow("Failed to load");
+        fail = false;
+        decoder.setMeshoptBaseUrl("/retry");
+
+        await expect(decoder.getMeshoptDecoder()).resolves.toBeDefined();
+        expect(scripts).toHaveLength(2);
+        expect(scripts[1]!.src).toBe("/retry/meshopt_decoder.js");
+        expect(scripts.every((script) => vi.mocked(script.remove).mock.calls.length === 1)).toBe(true);
+    });
+
+    it("retries both Draco script and module initialization failures", async () => {
+        const scripts: ScriptMock[] = [];
+        let failScript = true;
+        let factoryCalls = 0;
+        const heap = new ArrayBuffer(16);
+        const factory = vi.fn(async () => {
+            factoryCalls++;
+            if (factoryCalls === 1) {
+                throw new Error("transient wasm failure");
+            }
+            return {
+                Decoder: class {
+                    public DecodeBufferToMesh() {
+                        return { ok: () => true, error_msg: () => "" };
+                    }
+                    public GetTrianglesUInt32Array(): void {}
+                    public GetAttributeByUniqueId(): undefined {
+                        return undefined;
+                    }
+                    public GetAttributeDataArrayForAllPoints(): boolean {
+                        return true;
+                    }
+                },
+                DecoderBuffer: class {
+                    public Init(): void {}
+                },
+                Mesh: class {
+                    public num_faces(): number {
+                        return 0;
+                    }
+                    public num_points(): number {
+                        return 0;
+                    }
+                },
+                destroy: () => undefined,
+                HEAPF32: new Float32Array(heap),
+                HEAPU32: new Uint32Array(heap),
+                HEAP32: new Int32Array(heap),
+                DT_FLOAT32: 0,
+                DT_INT32: 1,
+                _malloc: () => 0,
+                _free: () => undefined,
+            };
+        });
+        installScriptDocument((script) => {
+            scripts.push(script);
+            queueMicrotask(() => {
+                if (failScript) {
+                    script.onerror?.();
+                } else {
+                    vi.stubGlobal("DracoDecoderModule", factory);
+                    script.onload?.();
+                }
+            });
+        });
+        const decoder = await import("../../../packages/babylon-lite/src/loader-gltf/draco-decode.js");
+        const decode = () => decoder.decodeDracoPrimitive(new Uint8Array(), {}, {});
+
+        await expect(decode()).rejects.toThrow("Failed to load");
+        failScript = false;
+        decoder.setDracoBaseUrl("/retry");
+        await expect(decode()).rejects.toThrow("transient wasm failure");
+        await expect(decode()).resolves.toMatchObject({ _vertexCount: 0, _indexCount: 0 });
+        expect(scripts).toHaveLength(2);
+        expect(scripts[1]!.src).toBe("/retry/draco_decoder.js");
+        expect(scripts.every((script) => vi.mocked(script.remove).mock.calls.length === 1)).toBe(true);
+        expect(factory).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/lite/unit/meshopt-decode.test.ts
+++ b/tests/lite/unit/meshopt-decode.test.ts
@@ -11,6 +11,7 @@ describe("meshopt decoder loading", () => {
             src: "",
             onload: null as (() => void) | null,
             onerror: null as (() => void) | null,
+            remove: vi.fn(),
         };
         const decoder = {
             ready: Promise.resolve(),


### PR DESCRIPTION
## Summary
- clear failed Draco and Meshopt script-load caches so transient network failures can be retried
- clear failed Draco module initialization caches so transient WASM failures can recover
- remove completed/failed injected scripts and their handlers
- add regression coverage for script and module retry paths

## Validation
- `REUSE_BROWSER=1 corepack pnpm exec vitest run --project unit tests/lite/unit/lazy-loader-retry.test.ts tests/lite/unit/meshopt-decode.test.ts`
- `corepack pnpm exec eslint packages/babylon-lite/src/loader-gltf/draco-decode.ts packages/babylon-lite/src/loader-gltf/meshopt-decode.ts tests/lite/unit/lazy-loader-retry.test.ts tests/lite/unit/meshopt-decode.test.ts`
- `corepack pnpm exec tsc -p packages/babylon-lite/tsconfig.json --noEmit`
- `REUSE_BROWSER=1 corepack pnpm build:lib`
- `REUSE_BROWSER=1 corepack pnpm exec playwright test tests/lite/parity/bundle-size.spec.ts --grep "Scene 211"` — 89.9 KB raw / 90.2 KB ceiling

`corepack pnpm run lint` also reaches two unrelated existing `master` type errors in `clustered-light.test.ts` and `pbr-lightmap.test.ts` concerning `_toneMappingHelpers`; the changed files and library source typecheck pass.