### PR TITLE
fix(compat): record the Lite sync watermark as a marker, not git metadata

### DIFF
--- a/.github/copilot/skills/update-compat-layer.md
+++ b/.github/copilot/skills/update-compat-layer.md
@@ -139,14 +139,17 @@ Task 3 gap implementable.
 ## Task 1 — React to upstream BJS/Lite diffs
 
 1. **Find Lite changes since the previous sync.** Read `LAST_LITE_SHA` from the
-   `Last synced Lite commit` marker in `COMPAT-STATUS.md`, and record the Lite
-   `master` HEAD you are syncing against as `NEW_LITE_SHA`. Capture `NEW_LITE_SHA`
-   **before you commit anything**, or it will point at your own work:
+   `Last synced Lite commit` marker, and capture the commit you are syncing from as
+   `NEW_LITE_SHA`. Take it from `HEAD` **before you make any commits**, or it will
+   point at your own work instead of the Lite history you reviewed:
 
     ```
-    git rev-parse origin/master                 # -> NEW_LITE_SHA
-    git log --oneline LAST_LITE_SHA..NEW_LITE_SHA -- packages/babylon-lite/src
-    git diff --stat LAST_LITE_SHA..NEW_LITE_SHA -- packages/babylon-lite/src/index.ts
+    LAST_LITE_SHA=$(grep -m1 '^- \*\*Last synced Lite commit:' \
+      packages/babylon-lite-compat/COMPAT-STATUS.md | grep -oE '[0-9a-f]{40}')
+    NEW_LITE_SHA=$(git rev-parse HEAD)
+
+    git log --oneline $LAST_LITE_SHA..$NEW_LITE_SHA -- packages/babylon-lite/src
+    git diff --stat $LAST_LITE_SHA..$NEW_LITE_SHA -- packages/babylon-lite/src/index.ts
     ```
 
     New public exports in `index.ts` are new Lite capabilities — cross-reference them

--- a/.github/copilot/skills/update-compat-layer.md
+++ b/.github/copilot/skills/update-compat-layer.md
@@ -148,6 +148,10 @@ Task 3 gap implementable.
       packages/babylon-lite-compat/COMPAT-STATUS.md | grep -oE '[0-9a-f]{40}')
     NEW_LITE_SHA=$(git rev-parse HEAD)
 
+    # The marker must be present and resolvable before it is used as a range end.
+    test -n "$LAST_LITE_SHA" && git cat-file -e "$LAST_LITE_SHA^{commit}" 2>/dev/null \
+      || { echo "Last synced Lite commit marker missing or unresolvable"; exit 1; }
+
     git log --oneline $LAST_LITE_SHA..$NEW_LITE_SHA -- packages/babylon-lite/src
     git diff --stat $LAST_LITE_SHA..$NEW_LITE_SHA -- packages/babylon-lite/src/index.ts
     ```
@@ -157,6 +161,12 @@ Task 3 gap implementable.
     trigger:** if a new Lite capability clears a blocker on a previously-skipped lab
     scene, drive that scene to parity. If no new Lite capability lands, Task 2 stays
     dormant.
+
+    **If that check fails, stop the sync and report it.** Do not guess a starting
+    point and do not carry on without one. An empty `LAST_LITE_SHA` leaves the range
+    as `..$NEW_LITE_SHA`, which git reads as `HEAD..HEAD` and answers with silence and
+    exit code 0 — so every Lite change since the last sync would be skipped with
+    nothing at all to show it happened.
 
     Do **not** derive this watermark from the history of `COMPAT-STATUS.md` itself.
     It is recorded as a marker _inside_ that file precisely so that editing the file

--- a/.github/copilot/skills/update-compat-layer.md
+++ b/.github/copilot/skills/update-compat-layer.md
@@ -92,7 +92,7 @@ The single source of truth for all three is
 
 | Task | Goal                             | Tracked in `COMPAT-STATUS.md` by                                  |
 | ---- | -------------------------------- | ----------------------------------------------------------------- |
-| 1    | Upstream diffs                   | the `Last synced BJS commit` + `Last sync date` markers           |
+| 1    | Upstream diffs                   | the two `Last synced ...` SHAs + the `Last sync date` marker      |
 | 2    | Lab-scene coverage (conditional) | the **Lab scene coverage** section (working list + blocker table) |
 | 3    | API parity                       | the per-area **status matrix** (a row per core/loaders symbol)    |
 
@@ -138,18 +138,27 @@ Task 3 gap implementable.
 
 ## Task 1 — React to upstream BJS/Lite diffs
 
-1. **Find Lite changes since the previous sync.** Get `LAST_STATUS_COMMIT`, then
-   review Lite source changes since it:
+1. **Find Lite changes since the previous sync.** Read `LAST_LITE_SHA` from the
+   `Last synced Lite commit` marker in `COMPAT-STATUS.md`, and record the Lite
+   `master` HEAD you are syncing against as `NEW_LITE_SHA`. Capture `NEW_LITE_SHA`
+   **before you commit anything**, or it will point at your own work:
+
     ```
-    git log -1 --format=%H -- packages/babylon-lite-compat/COMPAT-STATUS.md
-    git log --oneline LAST_STATUS_COMMIT..HEAD -- packages/babylon-lite/src
-    git diff --stat LAST_STATUS_COMMIT..HEAD -- packages/babylon-lite/src/index.ts
+    git rev-parse origin/master                 # -> NEW_LITE_SHA
+    git log --oneline LAST_LITE_SHA..NEW_LITE_SHA -- packages/babylon-lite/src
+    git diff --stat LAST_LITE_SHA..NEW_LITE_SHA -- packages/babylon-lite/src/index.ts
     ```
+
     New public exports in `index.ts` are new Lite capabilities — cross-reference them
     against `🔧`/`⚡`/`❌` rows (they may now be upgradable). **This is the Task 2
     trigger:** if a new Lite capability clears a blocker on a previously-skipped lab
     scene, drive that scene to parity. If no new Lite capability lands, Task 2 stays
     dormant.
+
+    Do **not** derive this watermark from the history of `COMPAT-STATUS.md` itself.
+    It is recorded as a marker _inside_ that file precisely so that editing the file
+    is harmless — a status-row correction must never move the watermark.
+
 2. **Find BJS core/loaders changes since `LAST_BJS_SHA`** (the `Last synced BJS
 commit` in `COMPAT-STATUS.md`): - Latest master HEAD → `https://api.github.com/repos/BabylonJS/Babylon.js/commits/master`
    (record as `NEW_BJS_SHA`). - Compare → `https://api.github.com/repos/BabylonJS/Babylon.js/compare/LAST_BJS_SHA...master`
@@ -435,8 +444,8 @@ Lite change unblocked a scene. Do not finish until:
 - [ ] **(Task 3)** The **Supported APIs at a glance** table in
       `packages/babylon-lite-compat/README.md` still reflects the matrix (any changed
       area's roll-up + note updated).
-- [ ] **(Task 1)** `Last synced BJS commit` / `Last sync date` updated to
-      `NEW_BJS_SHA` / today.
+- [ ] **(Task 1)** `Last synced BJS commit`, `Last synced Lite commit` and
+      `Last sync date` updated to `NEW_BJS_SHA` / `NEW_LITE_SHA` / today.
 - [ ] Tests, both typechecks, ESLint, and Prettier all pass.
 
 If any box is unchecked, the run is not done.
@@ -460,8 +469,9 @@ Update the part each task touched:
    section — move newly-working scenes into the working list (bump the count) and
    revise/remove blocker rows. When nothing was unblocked, the existing "Task 2 status"
    line already says so — leave it alone rather than adding a note saying it again.
-3. **(Task 1)** Set `Last synced BJS commit` to `NEW_BJS_SHA` and `Last sync date` to
-   today; update `Lite compat package version` if it changed.
+3. **(Task 1)** Set `Last synced BJS commit` to `NEW_BJS_SHA`, `Last synced Lite commit`
+   to `NEW_LITE_SHA`, and `Last sync date` to today; update `Lite compat package version`
+   if it changed.
 
 Then **sync the README summary** (`packages/babylon-lite-compat/README.md`,
 **Supported APIs at a glance**): a per-_feature-area_ roll-up (one `✅`/`⚡`/`❌` per
@@ -506,7 +516,8 @@ and ships to npm, so add no per-symbol rows and no internal-doc links.
 - **When Task 2 fires, land the scene — don't just unblock it:** drive it to MAD ≈ 0
   and into the working list (expect a chain of several gaps). If nothing was
   unblocked, zero scene work is correct.
-- Summarise at the end, per task: **(Task 1)** changes acted on + `NEW_BJS_SHA`;
+- Summarise at the end, per task: **(Task 1)** changes acted on, plus `NEW_BJS_SHA`
+  and `NEW_LITE_SHA`;
   **(Task 2)** which scene(s) landed at MAD ≈ 0 + new count (or "none unblocked");
   **(Task 3)** which floor outcome you hit, the (now-empty) ledger size, any
   tree-shakeable Lite additions with bundle-diff proof, and the test/lint results.

--- a/packages/babylon-lite-compat/COMPAT-STATUS.md
+++ b/packages/babylon-lite-compat/COMPAT-STATUS.md
@@ -4,17 +4,24 @@ This file tracks the support status of each Babylon.js (BJS) feature area in the
 `@babylonjs/lite-compat` package. It is the single source of truth consulted and
 updated by the `update-compat-layer` skill.
 
-<!-- The two markers below are machine-read by the update-compat-layer skill.
-     Do not rename them. Update the SHA after re-syncing against BJS master. -->
+<!-- The three markers below are machine-read by the update-compat-layer skill.
+     Do not rename them. Update both SHAs and the date at the end of every sync. -->
 
 - **Last synced BJS commit:** `82d305cbb2603e16e9795fd311690ac96a358501`
+- **Last synced Lite commit:** `6b71be8339a0cacaf9c82271a77c62b387b5c1e8`
 - **Last sync date:** 2026-08-24
 - **Lite compat package version:** 0.0.1
 
 > The "Last synced BJS commit" is the `BabylonJS/Babylon.js` `master` HEAD that the
-> compat surface was last reconciled against. The skill diffs BJS history since
-> this SHA (and Lite history since the last commit that touched this file) to find
-> new work, then updates the SHA.
+> compat surface was last reconciled against; the "Last synced Lite commit" is the
+> `BabylonJS/Babylon-Lite` `master` HEAD at that same moment. The skill diffs both
+> histories forward from these SHAs to find new work, then updates them.
+
+> **Why the Lite watermark is a field.** It used to be inferred from _the commit that
+> last modified this file_, which made every edit here load-bearing: correcting a
+> single status row also advanced the watermark, silently skipping any Lite change in
+> between, with nothing to report the gap. Recording it explicitly makes this an
+> ordinary document again — edit it freely; only the marker moves the watermark.
 
 **Scope:** the compat layer (and the `update-compat-layer` skill that maintains it)
 covers **only the public API of `@babylonjs/core` and `@babylonjs/loaders`**. The
@@ -29,8 +36,9 @@ for reader context but are not part of the audited surface.
 The `update-compat-layer` skill advances the compat layer on three fronts; this
 file is the live status record for each:
 
-1. **Upstream sync (Task 1 — diffs).** The `Last synced BJS commit` / `Last sync
-date` markers above record the `BabylonJS/Babylon.js` `master` HEAD the surface
+1. **Upstream sync (Task 1 — diffs).** The `Last synced BJS commit`,
+   `Last synced Lite commit` and `Last sync date` markers above record the
+   `BabylonJS/Babylon.js` and `BabylonJS/Babylon-Lite` `master` HEADs the surface
    was last reconciled against.
 2. **Lab-scene coverage (Task 2).** The [Lab scene coverage](#lab-scene-coverage)
    section records which Babylon.js oracle scenes render at parity through the

--- a/packages/babylon-lite-compat/COMPAT-STATUS.md
+++ b/packages/babylon-lite-compat/COMPAT-STATUS.md
@@ -4,8 +4,11 @@ This file tracks the support status of each Babylon.js (BJS) feature area in the
 `@babylonjs/lite-compat` package. It is the single source of truth consulted and
 updated by the `update-compat-layer` skill.
 
-<!-- The three markers below are machine-read by the update-compat-layer skill.
-     Do not rename them. Update both SHAs and the date at the end of every sync. -->
+<!-- `Last synced BJS commit`, `Last synced Lite commit` and `Last sync date` are the
+     sync markers: machine-read by the update-compat-layer skill, and all three are
+     rewritten at the end of every sync. Do not rename them.
+     `Lite compat package version` is NOT a sync marker -- it tracks the published
+     package and changes only when that version changes. -->
 
 - **Last synced BJS commit:** `82d305cbb2603e16e9795fd311690ac96a358501`
 - **Last synced Lite commit:** `6b71be8339a0cacaf9c82271a77c62b387b5c1e8`

--- a/packages/babylon-lite-compat/CONTRIBUTING.md
+++ b/packages/babylon-lite-compat/CONTRIBUTING.md
@@ -26,9 +26,11 @@ the skill, the pipeline, the README table — reads from or updates it.
 
 It tracks three things:
 
-1. **Upstream sync markers.** `Last synced BJS commit` + `Last sync date` record
-   the `BabylonJS/Babylon.js` `master` HEAD the surface was last reconciled
-   against. These markers are **machine-read** by the skill — do not rename them.
+1. **Upstream sync markers.** `Last synced BJS commit` records the
+   `BabylonJS/Babylon.js` `master` HEAD the surface was last reconciled against,
+   `Last synced Lite commit` records the Babylon Lite commit it was reconciled
+   against, and `Last sync date` records when. All three are **machine-read** by
+   the skill — do not rename them, and rewrite all three at the end of every sync.
 2. **Lab-scene coverage.** The _Lab scene coverage_ section lists which oracle
    scenes render at pixel parity (MAD ≈ 0) through the compat layer, and the
    blocker for the rest.
@@ -48,11 +50,11 @@ It tracks three things:
 [`.github/copilot/skills/update-compat-layer.md`](../../.github/copilot/skills/update-compat-layer.md)
 is the skill that advances the layer. Every run makes progress on three fronts:
 
-| Task                                      | Goal                                                                   | Tracked in `COMPAT-STATUS.md` by                        |
-| ----------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------- |
-| **1 — Upstream diffs**                    | React to what changed in Babylon.js + Babylon Lite since the last sync | the `Last synced BJS commit` / `Last sync date` markers |
-| **2 — Lab-scene coverage** (required win) | Land **at least one** more oracle scene at MAD ≈ 0                     | the _Lab scene coverage_ section                        |
-| **3 — API parity**                        | Add/upgrade core + loaders symbols (real impl or honest stub)          | the per-area status matrix                              |
+| Task                                      | Goal                                                                   | Tracked in `COMPAT-STATUS.md` by                                                    |
+| ----------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **1 — Upstream diffs**                    | React to what changed in Babylon.js + Babylon Lite since the last sync | the `Last synced BJS commit` / `Last synced Lite commit` / `Last sync date` markers |
+| **2 — Lab-scene coverage** (required win) | Land **at least one** more oracle scene at MAD ≈ 0                     | the _Lab scene coverage_ section                                                    |
+| **3 — API parity**                        | Add/upgrade core + loaders symbols (real impl or honest stub)          | the per-area status matrix                                                          |
 
 Task 2 is the headline deliverable of every run: a run that ships zero new working
 scenes is considered incomplete.


### PR DESCRIPTION
## The problem

`COMPAT-STATUS.md` carries two sync watermarks, stored in two very different ways:

| Watermark | How it was stored |
| --- | --- |
| BJS | a field **in** the file — `Last synced BJS commit` |
| Lite | inferred **about** the file — `git log -1 --format=%H -- packages/babylon-lite-compat/COMPAT-STATUS.md` |

That asymmetry makes ordinary edits to this file secretly load-bearing. Correcting one status row — or moving a scene into the _Working_ list — also advances the Lite watermark, so the next sync silently skips every Lite change in between, with nothing to report the gap.

## Why it surfaced now

Because any edit has that side effect, the compat-sync agent is instructed never to touch this file outside a general sync.

That rule collides head-on with `packages/babylon-lite-compat/CONTRIBUTING.md`:

> Only flip `compatParity` to `true` once the compat render matches the native Lite port at MAD ≈ 0, and add the scene to the _Working_ list in `COMPAT-STATUS.md`.

In #614 the two rules deadlocked. @deltakosh asked three times for the Working list and count to be updated alongside the `compatParity` flip that PR makes; the agent declined three times, correctly citing the watermark. Both sides were right — the design was wrong.

## The change

Make the Lite watermark symmetric with the BJS one.

- **`COMPAT-STATUS.md`** — add a `Last synced Lite commit` marker, seeded with `6b71be8339a0cacaf9c82271a77c62b387b5c1e8`. That is the commit that last modified this file, i.e. precisely where the inferred watermark points today, so **no Lite history is skipped or re-examined** across the switch. Also documents why the marker exists, so the git-metadata version doesn't come back.
- **`update-compat-layer.md`** — Task 1 now reads that marker, and captures the Lite `master` HEAD it is syncing against as `NEW_LITE_SHA` *before* committing anything (otherwise it would point at the agent's own work). `NEW_LITE_SHA` is added to the completion checklist and the write-up step.

## Result

This file becomes an ordinary document again: edit it freely, and only the marker moves the watermark. The `compatParity` / Working-list convention in CONTRIBUTING.md can then be followed without a hidden cost.

Docs and prompt only — no source, test or build changes.
