### PR TITLE
fix: retry transient runtime initialization failures

### DIFF
--- a/packages/babylon-lite/src/mesh/csg2.ts
+++ b/packages/babylon-lite/src/mesh/csg2.ts
@@ -79,6 +79,9 @@ async function getRuntimeAsync(): Promise<Csg2Runtime> {
         csg2Runtime = runtime;
         return runtime;
     })();
+    void csg2RuntimePromise.catch(() => {
+        csg2RuntimePromise = null;
+    });
 
     return csg2RuntimePromise;
 }

--- a/packages/babylon-lite/src/navigation/navigation.ts
+++ b/packages/babylon-lite/src/navigation/navigation.ts
@@ -150,6 +150,9 @@ async function _ensureRecast(locateFile?: (url: string) => string): Promise<{ co
                 _coreModule = core;
                 _generatorsModule = gens;
             })();
+            void _initPromise.catch(() => {
+                _initPromise = null;
+            });
         }
         await _initPromise;
     }


### PR DESCRIPTION
## Summary
- clear the cached Recast initialization promise after rejection so navigation setup can retry
- clear the cached Manifold initialization promise after rejection so CSG2 setup can retry
- preserve successful runtime caching and concurrent initialization sharing

## Validation
- bundled the production `navigation.ts` source with controlled Recast aliases: untouched `master` repeats the first rejection; this change initializes successfully on the second call and records two attempts
- bundled the production `csg2.ts` source with controlled Manifold aliases: untouched `master` repeats the first rejection; this change initializes successfully on the second call and records two attempts
- `REUSE_BROWSER=1 corepack pnpm exec vitest run --project unit tests/lite/unit/navigation.test.ts` — 27 passed
- `corepack pnpm run lint`
- `REUSE_BROWSER=1 corepack pnpm build:lib`
- filtered bundle builds for scenes 91 and 170–175; all remain under their configured ceilings