### PR TITLE
fix(loader): support bufferless glTF accessors

### DIFF
--- a/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-interleave.ts
@@ -89,8 +89,8 @@ export interface GltfVb {
  *  larger than the attribute's tightly-packed element size). */
 export function accessorIsStrided(json: any, idx: number): boolean {
     const a = json.accessors[idx];
-    const bv = json.bufferViews[a.bufferView];
-    const stride: number | undefined = bv.byteStride;
+    const bv = a.bufferView === undefined ? undefined : json.bufferViews[a.bufferView];
+    const stride: number | undefined = bv?.byteStride;
     if (stride === undefined) {
         return false;
     }
@@ -146,11 +146,19 @@ function resolveColorVec4(json: any, binChunk: DataView, idx: number): Float32Ar
     const ct = accessor.componentType;
     const cb = COMP_BYTES[ct] ?? 4;
     const comps = TYPE_SIZES[accessor.type] ?? 4;
+    const out = new F32(accessor.count * 4);
+    if (accessor.bufferView === undefined) {
+        if (comps < 4) {
+            for (let v = 0; v < accessor.count; v++) {
+                out[v * 4 + 3] = 1;
+            }
+        }
+        return out;
+    }
     const bv = json.bufferViews[accessor.bufferView];
     const stride = bv.byteStride ?? comps * cb;
     const inv = ct === UNSIGNED_BYTE ? 1 / 255 : ct === UNSIGNED_SHORT ? 1 / 65535 : 1;
     const base = (bv.byteOffset ?? 0) + (accessor.byteOffset ?? 0);
-    const out = new F32(accessor.count * 4);
     for (let v = 0; v < accessor.count; v++) {
         const row = base + v * stride;
         for (let c = 0; c < 4; c++) {

--- a/packages/babylon-lite/src/loader-gltf/gltf-uv-denorm.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-uv-denorm.ts
@@ -17,6 +17,9 @@ const COMP_BYTES: Record<number, number> = { [UNSIGNED_BYTE]: 1, [UNSIGNED_SHORT
 
 export function resolveUvVec2(json: any, binChunk: DataView, idx: number): Float32Array {
     const accessor = json.accessors[idx];
+    if (accessor.bufferView === undefined) {
+        return new F32(accessor.count * 2);
+    }
     const ct = accessor.componentType;
     const cb = COMP_BYTES[ct] ?? 4;
     const bv = json.bufferViews[accessor.bufferView];

--- a/tests/lite/unit/gltf-interleave.test.ts
+++ b/tests/lite/unit/gltf-interleave.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect } from "vitest";
 import { accessorIsStrided, buildInterleavedPartial, installLazyCpu, computeAabbStrided } from "../../../packages/babylon-lite/src/loader-gltf/gltf-interleave.js";
 
 const FLOAT = 5126;
+const UNSIGNED_BYTE = 5121;
+
+interface TestAccessor {
+    bufferView?: number;
+    byteOffset?: number;
+    componentType: number;
+    count: number;
+    type: string;
+    normalized?: boolean;
+}
 
 /** Build a minimal glTF JSON + binary chunk with POSITION+NORMAL interleaved in
  *  one stride-24 bufferView (offset 0 and 12), plus a tight TEXCOORD_0 bufferView. */
@@ -16,12 +26,13 @@ function makeInterleavedAsset() {
     new Float32Array(buf, interleaved.byteLength, uvs.length).set(uvs);
     const binChunk = new DataView(buf);
 
+    const accessors: TestAccessor[] = [
+        { bufferView: 0, byteOffset: 0, componentType: FLOAT, count: verts, type: "VEC3" }, // POSITION
+        { bufferView: 0, byteOffset: 12, componentType: FLOAT, count: verts, type: "VEC3" }, // NORMAL
+        { bufferView: 1, byteOffset: 0, componentType: FLOAT, count: verts, type: "VEC2" }, // TEXCOORD_0
+    ];
     const json = {
-        accessors: [
-            { bufferView: 0, byteOffset: 0, componentType: FLOAT, count: verts, type: "VEC3" }, // POSITION
-            { bufferView: 0, byteOffset: 12, componentType: FLOAT, count: verts, type: "VEC3" }, // NORMAL
-            { bufferView: 1, byteOffset: 0, componentType: FLOAT, count: verts, type: "VEC2" }, // TEXCOORD_0
-        ],
+        accessors,
         bufferViews: [
             { buffer: 0, byteOffset: 0, byteLength: interleaved.byteLength, byteStride: 24 },
             { buffer: 0, byteOffset: interleaved.byteLength, byteLength: uvs.byteLength }, // tight, no stride
@@ -37,6 +48,18 @@ describe("gltf-interleave", () => {
         expect(accessorIsStrided(json, 0)).toBe(true); // POSITION (stride 24 ≠ 12)
         expect(accessorIsStrided(json, 1)).toBe(true); // NORMAL (stride 24 ≠ 12)
         expect(accessorIsStrided(json, 2)).toBe(false); // TEXCOORD_0 (no byteStride)
+    });
+
+    it("treats a zero-initialized accessor without a bufferView as tight", () => {
+        expect(
+            accessorIsStrided(
+                {
+                    accessors: [{ componentType: FLOAT, count: 2, type: "VEC3" }],
+                    bufferViews: [],
+                },
+                0
+            )
+        ).toBe(false);
     });
 
     it("leaves strided POSITION/NORMAL CPU fields null (lazy) but records the GPU layout", async () => {
@@ -115,5 +138,27 @@ describe("gltf-interleave", () => {
         const { json, binChunk } = makeInterleavedAsset();
         const tightOnly = { attributes: { TEXCOORD_0: 2 } };
         expect(await buildInterleavedPartial(json, binChunk, tightOnly, new Float32Array(16) as never, 0)).toBeUndefined();
+    });
+
+    it("materializes zero-initialized colors when another attribute is interleaved", async () => {
+        const { json, binChunk, primitive } = makeInterleavedAsset();
+        const colorIndex = json.accessors.length;
+        json.accessors.push({ componentType: FLOAT, count: 2, type: "VEC4" });
+        (primitive.attributes as Record<string, number>).COLOR_0 = colorIndex;
+
+        const partial = (await buildInterleavedPartial(json, binChunk, primitive, new Float32Array(16) as never, 0))!;
+
+        expect(Array.from(partial._colors!)).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it("materializes zero-initialized normalized UVs when another attribute is interleaved", async () => {
+        const { json, binChunk, primitive } = makeInterleavedAsset();
+        const uvIndex = json.accessors.length;
+        json.accessors.push({ componentType: UNSIGNED_BYTE, count: 2, type: "VEC2", normalized: true });
+        (primitive.attributes as Record<string, number>).TEXCOORD_0 = uvIndex;
+
+        const partial = (await buildInterleavedPartial(json, binChunk, primitive, new Float32Array(16) as never, 0))!;
+
+        expect(Array.from(partial._uvs!)).toEqual([0, 0, 0, 0]);
     });
 });

--- a/tests/lite/unit/gltf-interleave.test.ts
+++ b/tests/lite/unit/gltf-interleave.test.ts
@@ -143,12 +143,12 @@ describe("gltf-interleave", () => {
     it("materializes zero-initialized colors when another attribute is interleaved", async () => {
         const { json, binChunk, primitive } = makeInterleavedAsset();
         const colorIndex = json.accessors.length;
-        json.accessors.push({ componentType: FLOAT, count: 2, type: "VEC4" });
+        json.accessors.push({ componentType: FLOAT, count: 2, type: "VEC3" });
         (primitive.attributes as Record<string, number>).COLOR_0 = colorIndex;
 
         const partial = (await buildInterleavedPartial(json, binChunk, primitive, new Float32Array(16) as never, 0))!;
 
-        expect(Array.from(partial._colors!)).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+        expect(Array.from(partial._colors!)).toEqual([0, 0, 0, 1, 0, 0, 0, 1]);
     });
 
     it("materializes zero-initialized normalized UVs when another attribute is interleaved", async () => {


### PR DESCRIPTION
## Summary
- treat glTF accessors without a `bufferView` as non-strided instead of dereferencing an absent buffer view
- materialize zero-initialized interleaved-path color and normalized UV data as required by the glTF accessor schema
- preserve VEC3 color expansion with alpha `1`
- add regression coverage for striding detection, colors, and normalized integer UVs

## Validation
- on untouched `master`, all three regression cases fail with `undefined.byteStride`
- Khronos glTF 2.0 `accessor.schema.json` states that when `bufferView` is undefined, the accessor **MUST** initialize with zeros
- `REUSE_BROWSER=1 corepack pnpm exec vitest run --project unit tests/lite/unit/gltf-interleave.test.ts` — 9 passed
- `corepack pnpm run lint`
- `REUSE_BROWSER=1 corepack pnpm build:lib`
- filtered bundle builds and ceiling tests for interleaved scenes 210, 245, 246, and 258; all remain under their configured ceilings