### PR TITLE
fix(ci): harden BrowserStack artifact publication

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -96,6 +96,8 @@ The cloud parity config connects to remote Chrome **directly over CDP**
 so specs shard across `CIWORKERS` parallel cloud browsers. The local Vite dev
 server is exposed to the remote browser through a BrowserStack Local tunnel
 started by the config's `globalSetup` (`config/browserstack-local-tunnel.ts`).
+Both BrowserStack Playwright configs explicitly disable tracing, including
+retry tracing, because BrowserStack connection metadata can embed credentials.
 
 ```sh
 pnpm build:bundle-scenes
@@ -491,8 +493,8 @@ Both cloud test suites (perf and parity) produce:
 - **JUnit XML** — consumed by Azure DevOps `PublishTestResults@2` and
   displayed in the pipeline's **Tests** tab with pass/fail counts, durations,
   and error messages
-- **HTML report** — interactive Playwright report with error details,
-  screenshots, and traces
+- **HTML report** — interactive Playwright report with error details and
+  screenshots; tracing is disabled for BrowserStack runs
 
 Report locations after a run:
 
@@ -508,8 +510,14 @@ pnpm exec playwright show-report test-results/parity-report
 pnpm exec playwright show-report test-results/perf-report
 ```
 
-In CI, test artifacts (including the HTML report) are uploaded as pipeline
-artifacts on every run and can be downloaded from the build summary.
+In CI, BrowserStack reports and JUnit files are sanitized and independently
+verified before publication. The fail-closed scan requires both BrowserStack
+credentials, checks raw and URL-encoded forms in every file and nested ZIP, and
+sets `ArtifactsSafe=true` only after verification succeeds. Azure test-result
+publication and failed-test CDN report uploads are gated on that variable. The
+CDN allowlist contains only `test-results/parity-report` and
+`test-results/perf-report`; raw Playwright artifact/trace directories are never
+uploaded.
 
 ---
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -316,6 +316,9 @@ stages:
             timeoutInMinutes: 120
             pool:
                 vmImage: "ubuntu-latest"
+            variables:
+                ArtifactsSafe: "false"
+                ReportUploaded: "false"
             steps:
                 - checkout: self
                   fetchDepth: 0
@@ -408,23 +411,34 @@ stages:
                       BROWSERSTACK_USERNAME: "$(BROWSERSTACK_USERNAME)"
                       BROWSERSTACK_ACCESS_KEY: "$(BROWSERSTACK_ACCESS_KEY)"
 
-                - task: PublishTestResults@2
+                # Only the JUnit file and explicit HTML report allowlist may be
+                # published. Raw Playwright output/trace directories stay private.
+                - script: |
+                      set -euo pipefail
+                      npx tsx scripts/redact-secrets.ts sanitize test-results/perf-junit.xml test-results/perf-report
+                      npx tsx scripts/redact-secrets.ts verify test-results/perf-junit.xml test-results/perf-report
+                      echo "##vso[task.setvariable variable=ArtifactsSafe]true"
                   condition: always()
+                  displayName: "Sanitize and verify publishable perf artifacts"
+                  env:
+                      BROWSERSTACK_USERNAME: "$(BROWSERSTACK_USERNAME)"
+                      BROWSERSTACK_ACCESS_KEY: "$(BROWSERSTACK_ACCESS_KEY)"
+
+                - task: PublishTestResults@2
+                  condition: and(always(), eq(variables['ArtifactsSafe'], 'true'))
                   inputs:
                       testResultsFormat: "JUnit"
-                      testResultsFiles: "**/test-results/perf-junit.xml"
+                      testResultsFiles: "test-results/perf-junit.xml"
                       mergeTestResults: true
                       testRunTitle: "Perf Regression"
+                      publishRunAttachments: false
                   continueOnError: true
-
                 - script: npx tsx scripts/report-test-results.ts test-results/perf-junit.xml
-                  condition: always()
+                  condition: and(always(), eq(variables['ArtifactsSafe'], 'true'))
                   continueOnError: true
                   displayName: "Report test results"
-
                 - template: config/templates/upload-test-report.yml
                   parameters:
-                      reportDir: $(System.DefaultWorkingDirectory)/test-results/perf-report
                       reportType: perf
 
           # ──────────────────────────────────────────────────────────────
@@ -435,6 +449,9 @@ stages:
             timeoutInMinutes: 180
             pool:
                 vmImage: "ubuntu-latest"
+            variables:
+                ArtifactsSafe: "false"
+                ReportUploaded: "false"
             steps:
                 - checkout: self
 
@@ -474,34 +491,34 @@ stages:
                       BSTACK_SESSIONS_REQUIRED: "2"
                       BSTACK_LOCAL_IDENTIFIER: "bstack-lite-parity-$(Build.BuildId)"
 
-                # Scrub BrowserStack credentials from the report/JUnit artifacts
-                # before they are published/uploaded. The CDP wsEndpoint embeds the
-                # access key and can surface in Playwright error output.
-                - script: npx tsx scripts/redact-secrets.ts test-results
+                # Only the JUnit file and explicit HTML report allowlist may be
+                # published. Raw Playwright output/trace directories stay private.
+                - script: |
+                      set -euo pipefail
+                      npx tsx scripts/redact-secrets.ts sanitize test-results/parity-junit.xml test-results/parity-report
+                      npx tsx scripts/redact-secrets.ts verify test-results/parity-junit.xml test-results/parity-report
+                      echo "##vso[task.setvariable variable=ArtifactsSafe]true"
                   condition: always()
-                  continueOnError: true
-                  displayName: "Redact secrets from test artifacts"
+                  displayName: "Sanitize and verify publishable parity artifacts"
                   env:
                       BROWSERSTACK_USERNAME: "$(BROWSERSTACK_USERNAME)"
                       BROWSERSTACK_ACCESS_KEY: "$(BROWSERSTACK_ACCESS_KEY)"
 
                 - task: PublishTestResults@2
-                  condition: always()
+                  condition: and(always(), eq(variables['ArtifactsSafe'], 'true'))
                   inputs:
                       testResultsFormat: "JUnit"
-                      testResultsFiles: "**/test-results/parity-junit.xml"
+                      testResultsFiles: "test-results/parity-junit.xml"
                       mergeTestResults: true
                       testRunTitle: "Parity (Cloud)"
+                      publishRunAttachments: false
                   continueOnError: true
-
                 - script: npx tsx scripts/report-test-results.ts test-results/parity-junit.xml
-                  condition: always()
+                  condition: and(always(), eq(variables['ArtifactsSafe'], 'true'))
                   continueOnError: true
                   displayName: "Report test results"
-
                 - template: config/templates/upload-test-report.yml
                   parameters:
-                      reportDir: $(System.DefaultWorkingDirectory)/test-results/parity-report
                       reportType: parity
 
           # ──────────────────────────────────────────────────────────────

--- a/config/playwright.parity-cloud.config.ts
+++ b/config/playwright.parity-cloud.config.ts
@@ -59,8 +59,8 @@ export default defineConfig({
     use: {
         headless: true,
         viewport: { width: 1280, height: 720 },
-        // Keep traces off: the BrowserStack wsEndpoint embeds the access key and
-        // could otherwise be captured in published trace artifacts.
+        // Keep all tracing, including retry tracing, off: the BrowserStack
+        // wsEndpoint embeds credentials that traces can capture.
         trace: "off",
         ...(useBrowserStack
             ? { connectOptions: { wsEndpoint: buildBrowserStackEndpoint() } }

--- a/config/playwright.perf-cloud.config.ts
+++ b/config/playwright.perf-cloud.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
         channel: "chrome",
         headless: true,
         viewport: { width: 1280, height: 720 },
+        // Explicitly disable all tracing, including retry tracing, because
+        // BrowserStack connection metadata can contain credentials.
+        trace: "off",
         launchOptions: {
             args: ["--force-color-profile=srgb", "--enable-precise-memory-info", "--enable-unsafe-webgpu"],
         },

--- a/config/templates/upload-test-report.yml
+++ b/config/templates/upload-test-report.yml
@@ -1,8 +1,9 @@
-# Reusable step template: upload Playwright HTML report and post link to PR
+# Reusable step template: upload an allowlisted Playwright HTML report and post
+# its link to the PR. Raw Playwright output and trace directories are never
+# accepted by this template.
 #
 # Parameters:
-#   reportDir     — path to the HTML report folder (e.g. test-results/perf-report)
-#   reportType    — label used in the deploy path and PR comment (e.g. perf, parity, unit)
+#   reportType — allowlisted report/deploy name (perf or parity)
 #
 # Required pipeline variables:
 #   BabylonJS-Deployment variable group: DEPLOYMENT_SERVER, DEPLOY_TOKEN
@@ -11,39 +12,40 @@
 #   BabylonBotPAT — GitHub PAT service connection for PR comments
 
 parameters:
-    - name: reportDir
-      type: string
     - name: reportType
       type: string
+      values:
+          - parity
+          - perf
 
 steps:
     - script: |
-          REPORT_DIR="${{ parameters.reportDir }}"
+          set -euo pipefail
+          REPORT_DIR="$(System.DefaultWorkingDirectory)/test-results/${{ parameters.reportType }}-report"
+          ARCHIVE="$(Build.SourcesDirectory)/_test_report.zip"
+          trap 'rm -f "$ARCHIVE"' EXIT
 
           if ! test -d "$REPORT_DIR"; then
-            echo "No report directory found at $REPORT_DIR, skipping upload"
-            exit 0
+            echo "Allowlisted report directory is unavailable; refusing upload."
+            exit 1
           fi
 
           cd "$REPORT_DIR"
-          zip -r $(Build.SourcesDirectory)/_test_report.zip *
-          cd $(Build.SourcesDirectory)
+          zip -q -r "$ARCHIVE" .
+          cd "$(Build.SourcesDirectory)"
 
-          curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+          curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD)" -X POST \
             -H "Content-Type: multipart/form-data" \
             -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
             -F "path=lite/$(Build.BuildNumber)/testResults/${{ parameters.reportType }}" \
             -F "storageAccount=$(STORAGE_ACCOUNT)" \
-            -F "zip=@_test_report.zip"
-
-          rm -f _test_report.zip
-      condition: failed()
-      continueOnError: true
+            -F "zip=@$ARCHIVE"
+          echo "##vso[task.setvariable variable=ReportUploaded]true"
+      condition: and(failed(), eq(variables['ArtifactsSafe'], 'true'))
       displayName: "Upload ${{ parameters.reportType }} test report"
 
     - task: GitHubComment@0
-      condition: failed()
-      continueOnError: true
+      condition: and(failed(), eq(variables['ArtifactsSafe'], 'true'), eq(variables['ReportUploaded'], 'true'))
       displayName: "Post ${{ parameters.reportType }} report link to PR"
       inputs:
           gitHubConnection: "BabylonBotPAT"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-tsdoc": "^0.5.2",
+        "fflate": "^0.8.3",
         "globals": "^17.11.0",
         "miniray": "^0.3.1",
         "node-web-audio-api": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       eslint-plugin-tsdoc:
         specifier: ^0.5.2
         version: 0.5.2(eslint@10.8.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       globals:
         specifier: ^17.11.0
         version: 17.11.0

--- a/scripts/redact-secrets.ts
+++ b/scripts/redact-secrets.ts
@@ -1,98 +1,350 @@
 /**
- * redact-secrets.ts — Scrub BrowserStack credentials from test artifacts.
+ * Sanitizes and verifies BrowserStack test artifacts before publication.
  *
- * The parity-cloud Playwright config connects over a CDP wsEndpoint that embeds
- * BROWSERSTACK_ACCESS_KEY (and username). On failures, Playwright can echo that
- * endpoint into the JUnit XML and HTML report that the ParityCloud job publishes
- * and uploads — which would leak the access key in build artifacts. This script
- * walks the given paths and replaces every occurrence of the credentials (both
- * raw and URL-encoded, since the wsEndpoint is URL-encoded) with "***".
+ * Every file is inspected as bytes, and ZIP files (including nested ZIPs such
+ * as Playwright trace.zip files) are unpacked in memory, sanitized, and rebuilt.
+ * Unsupported archives, unreadable paths, symbolic links, missing credentials,
+ * and residual raw or URL-encoded credentials fail closed.
  *
  * Usage:
- *   tsx scripts/redact-secrets.ts <path> [<path> ...]
- *
- * No-op when BROWSERSTACK_ACCESS_KEY / BROWSERSTACK_USERNAME are unset, or when a
- * path does not exist (so it is always safe to run with `condition: always()`).
+ *   tsx scripts/redact-secrets.ts sanitize <path> [<path> ...]
+ *   tsx scripts/redact-secrets.ts verify <path> [<path> ...]
  */
-import { readdirSync, readFileSync, statSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, lstatSync, readdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { basename, dirname, join } from "path";
+import { pathToFileURL } from "url";
+import { unzipSync, zipSync } from "fflate";
 
-// Only scrub text-based report artifacts; skip binaries (screenshots, traces).
-const TEXT_EXTENSIONS = new Set([".xml", ".html", ".htm", ".json", ".txt", ".log", ".js", ".md", ".css"]);
+const MASK_BYTE = "*".charCodeAt(0);
+const MAX_ARCHIVE_DEPTH = 8;
+const MAX_ARCHIVE_ENTRIES = 10_000;
+const MAX_UNCOMPRESSED_ARCHIVE_BYTES = 512 * 1024 * 1024;
+const UNSUPPORTED_ARCHIVE_EXTENSIONS = [".7z", ".br", ".bz2", ".gz", ".rar", ".tar", ".tgz", ".xz"];
 
-function collectSecrets(): string[] {
-    const secrets: string[] = [];
-    for (const name of ["BROWSERSTACK_ACCESS_KEY", "BROWSERSTACK_USERNAME"]) {
-        const value = process.env[name];
-        if (value && value.length >= 4) {
-            secrets.push(value);
-            const encoded = encodeURIComponent(value);
-            if (encoded !== value) {
-                secrets.push(encoded);
+export interface BrowserStackCredentials {
+    username: string;
+    accessKey: string;
+}
+
+export interface ArtifactSecurityStats {
+    filesInspected: number;
+    archivesInspected: number;
+    redactions: number;
+}
+
+type Mode = "sanitize" | "verify";
+
+interface ProcessResult {
+    data: Buffer;
+    changed: boolean;
+}
+
+interface ArchiveBudget {
+    entriesRemaining: number;
+    bytesRemaining: number;
+}
+
+class ArtifactSecurityError extends Error {}
+
+function encodedVariants(value: string): string[] {
+    const variants = new Set<string>([value]);
+    let encoded = value;
+    for (let depth = 0; depth < 3; depth++) {
+        encoded = encodeURIComponent(encoded);
+        variants.add(encoded);
+        variants.add(encoded.replace(/%[0-9A-F]{2}/g, (match) => match.toLowerCase()));
+    }
+    variants.add(new URLSearchParams({ value }).toString().slice("value=".length));
+    return [...variants];
+}
+
+function credentialVariants(credentials: BrowserStackCredentials): string[] {
+    if (!credentials.username || !credentials.accessKey || credentials.username === "$(BROWSERSTACK_USERNAME)" || credentials.accessKey === "$(BROWSERSTACK_ACCESS_KEY)") {
+        throw new ArtifactSecurityError("Required BrowserStack credentials are unavailable; artifacts cannot be declared safe.");
+    }
+    return [...new Set([...encodedVariants(credentials.accessKey), ...encodedVariants(credentials.username)])].sort((a, b) => b.length - a.length);
+}
+
+export function browserStackCredentialsFromEnvironment(env: NodeJS.ProcessEnv = process.env): BrowserStackCredentials {
+    return {
+        username: env.BROWSERSTACK_USERNAME ?? "",
+        accessKey: env.BROWSERSTACK_ACCESS_KEY ?? "",
+    };
+}
+
+function replaceAllBytes(input: Buffer, patterns: readonly Buffer[]): { data: Buffer; replacements: number } {
+    let output = input;
+    let replacements = 0;
+
+    for (const pattern of patterns) {
+        let offset = 0;
+        while (offset <= output.length - pattern.length) {
+            const index = output.indexOf(pattern, offset);
+            if (index === -1) {
+                break;
+            }
+            if (output === input) {
+                output = Buffer.from(input);
+            }
+            output.fill(MASK_BYTE, index, index + pattern.length);
+            replacements++;
+            offset = index + pattern.length;
+        }
+    }
+
+    return { data: output, replacements };
+}
+
+function containsCredential(input: Buffer, patterns: readonly Buffer[]): boolean {
+    return patterns.some((pattern) => input.indexOf(pattern) !== -1);
+}
+
+function replaceAllText(input: string, variants: readonly string[]): { value: string; replacements: number } {
+    let value = input;
+    let replacements = 0;
+    for (const variant of variants) {
+        if (!value.includes(variant)) {
+            continue;
+        }
+        const parts = value.split(variant);
+        replacements += parts.length - 1;
+        value = parts.join("*".repeat(variant.length));
+    }
+    return { value, replacements };
+}
+
+function isZip(data: Buffer, name: string): boolean {
+    const signature = data.length >= 4 ? data.subarray(0, 4).toString("hex") : "";
+    return name.toLowerCase().endsWith(".zip") || signature === "504b0304" || signature === "504b0506" || signature === "504b0708";
+}
+
+function isUnsupportedArchive(name: string): boolean {
+    const lower = name.toLowerCase();
+    return UNSUPPORTED_ARCHIVE_EXTENSIONS.some((extension) => lower.endsWith(extension));
+}
+
+function validateZipEntryName(name: string): void {
+    const normalized = name.replace(/\\/g, "/");
+    if (normalized.includes("\0") || normalized.startsWith("/") || normalized.split("/").includes("..")) {
+        throw new ArtifactSecurityError("A compressed artifact contains an unsafe entry and cannot be published.");
+    }
+}
+
+function processZip(
+    input: Buffer,
+    mode: Mode,
+    bytePatterns: readonly Buffer[],
+    textPatterns: readonly string[],
+    stats: ArtifactSecurityStats,
+    budget: ArchiveBudget,
+    depth: number
+): ProcessResult {
+    if (depth > MAX_ARCHIVE_DEPTH) {
+        throw new ArtifactSecurityError("A compressed artifact exceeds the supported nesting depth.");
+    }
+
+    let entries: Record<string, Uint8Array>;
+    try {
+        entries = unzipSync(input, {
+            filter: (entry) => {
+                if (!Number.isSafeInteger(entry.originalSize) || entry.originalSize < 0 || budget.entriesRemaining === 0 || entry.originalSize > budget.bytesRemaining) {
+                    throw new ArtifactSecurityError("A compressed artifact exceeds the safe inspection budget.");
+                }
+                budget.entriesRemaining--;
+                budget.bytesRemaining -= entry.originalSize;
+                return true;
+            },
+        });
+    } catch (error) {
+        if (error instanceof ArtifactSecurityError) {
+            throw error;
+        }
+        throw new ArtifactSecurityError("A compressed artifact could not be inspected.");
+    }
+
+    const names = Object.keys(entries);
+    stats.archivesInspected++;
+    const rebuilt: Record<string, Uint8Array> = {};
+    for (const name of names) {
+        validateZipEntryName(name);
+        const sanitizedName = replaceAllText(name, textPatterns);
+        if (mode === "verify" && sanitizedName.replacements > 0) {
+            throw new ArtifactSecurityError("BrowserStack credentials remain in a publishable artifact.");
+        }
+        stats.redactions += sanitizedName.replacements;
+
+        const entry = entries[name];
+        if (!entry) {
+            throw new ArtifactSecurityError("A compressed artifact entry could not be inspected.");
+        }
+        const processed = processBuffer(Buffer.from(entry), sanitizedName.value, mode, bytePatterns, textPatterns, stats, budget, depth);
+        if (rebuilt[sanitizedName.value]) {
+            throw new ArtifactSecurityError("Artifact sanitization produced conflicting archive entries.");
+        }
+        rebuilt[sanitizedName.value] = processed.data;
+    }
+
+    if (mode === "verify") {
+        if (containsCredential(input, bytePatterns)) {
+            throw new ArtifactSecurityError("BrowserStack credentials remain in a publishable artifact.");
+        }
+        return { data: input, changed: false };
+    }
+
+    try {
+        return { data: Buffer.from(zipSync(rebuilt)), changed: true };
+    } catch {
+        throw new ArtifactSecurityError("A compressed artifact could not be rebuilt safely.");
+    }
+}
+
+function processBuffer(
+    input: Buffer,
+    name: string,
+    mode: Mode,
+    bytePatterns: readonly Buffer[],
+    textPatterns: readonly string[],
+    stats: ArtifactSecurityStats,
+    budget: ArchiveBudget,
+    depth = 0
+): ProcessResult {
+    stats.filesInspected++;
+    if (isZip(input, name)) {
+        return processZip(input, mode, bytePatterns, textPatterns, stats, budget, depth + 1);
+    }
+    if (isUnsupportedArchive(name)) {
+        throw new ArtifactSecurityError("A compressed artifact type is unsupported and cannot be published.");
+    }
+
+    if (mode === "verify") {
+        if (containsCredential(input, bytePatterns)) {
+            throw new ArtifactSecurityError("BrowserStack credentials remain in a publishable artifact.");
+        }
+        return { data: input, changed: false };
+    }
+
+    const result = replaceAllBytes(input, bytePatterns);
+    stats.redactions += result.replacements;
+    return { data: result.data, changed: result.replacements > 0 };
+}
+
+function processPath(
+    target: string,
+    mode: Mode,
+    bytePatterns: readonly Buffer[],
+    textPatterns: readonly string[],
+    stats: ArtifactSecurityStats,
+    budget: ArchiveBudget,
+    renameTarget: boolean
+): string {
+    let metadata: ReturnType<typeof lstatSync>;
+    try {
+        metadata = lstatSync(target);
+    } catch {
+        throw new ArtifactSecurityError("A required artifact path could not be inspected.");
+    }
+    if (metadata.isSymbolicLink()) {
+        throw new ArtifactSecurityError("Symbolic links are not allowed in publishable artifacts.");
+    }
+
+    if (metadata.isDirectory()) {
+        let entries: string[];
+        try {
+            entries = readdirSync(target);
+        } catch {
+            throw new ArtifactSecurityError("An artifact directory could not be inspected.");
+        }
+        for (const entry of entries) {
+            processPath(join(target, entry), mode, bytePatterns, textPatterns, stats, budget, true);
+        }
+    } else if (metadata.isFile()) {
+        let data: Buffer;
+        try {
+            data = readFileSync(target);
+        } catch {
+            throw new ArtifactSecurityError("An artifact file could not be inspected.");
+        }
+        const processed = processBuffer(data, basename(target), mode, bytePatterns, textPatterns, stats, budget);
+        if (mode === "sanitize" && processed.changed) {
+            try {
+                writeFileSync(target, processed.data);
+            } catch {
+                throw new ArtifactSecurityError("A sanitized artifact could not be written.");
             }
         }
+    } else {
+        throw new ArtifactSecurityError("A publishable artifact is not a regular file or directory.");
     }
-    // De-dupe and sort longest-first so overlapping values are fully masked.
-    return [...new Set(secrets)].sort((a, b) => b.length - a.length);
-}
 
-function escapeRegExp(s: string): string {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function redactFile(filePath: string, patterns: RegExp[]): void {
-    let content: string;
-    try {
-        content = readFileSync(filePath, "utf-8");
-    } catch {
-        return; // unreadable / binary — skip
+    const sanitizedName = replaceAllText(basename(target), textPatterns);
+    if (mode === "verify" && sanitizedName.replacements > 0) {
+        throw new ArtifactSecurityError("BrowserStack credentials remain in a publishable artifact.");
     }
-    let redacted = content;
-    for (const pattern of patterns) {
-        redacted = redacted.replace(pattern, "***");
-    }
-    if (redacted !== content) {
-        writeFileSync(filePath, redacted);
-        console.log(`[redact-secrets] Redacted ${filePath}`);
-    }
-}
-
-function walk(target: string, patterns: RegExp[]): void {
-    let stats;
-    try {
-        stats = statSync(target);
-    } catch {
-        return; // path does not exist — safe no-op
-    }
-    if (stats.isDirectory()) {
-        for (const entry of readdirSync(target)) {
-            walk(join(target, entry), patterns);
+    stats.redactions += sanitizedName.replacements;
+    if (mode === "sanitize" && renameTarget && sanitizedName.value !== basename(target)) {
+        const renamed = join(dirname(target), sanitizedName.value);
+        if (existsSync(renamed)) {
+            throw new ArtifactSecurityError("Artifact sanitization produced conflicting file names.");
         }
-        return;
+        try {
+            renameSync(target, renamed);
+        } catch {
+            throw new ArtifactSecurityError("A sanitized artifact could not be renamed safely.");
+        }
+        return renamed;
     }
-    const dot = target.lastIndexOf(".");
-    const ext = dot >= 0 ? target.slice(dot).toLowerCase() : "";
-    if (TEXT_EXTENSIONS.has(ext)) {
-        redactFile(target, patterns);
+    if (mode === "sanitize" && !renameTarget && sanitizedName.replacements > 0) {
+        throw new ArtifactSecurityError("A requested artifact path contains a BrowserStack credential and cannot be renamed safely.");
     }
+    return target;
+}
+
+function processArtifacts(paths: readonly string[], credentials: BrowserStackCredentials, mode: Mode): ArtifactSecurityStats {
+    if (paths.length === 0) {
+        throw new ArtifactSecurityError("At least one artifact path is required.");
+    }
+
+    const textPatterns = credentialVariants(credentials);
+    const bytePatterns = textPatterns.map((pattern) => Buffer.from(pattern));
+    const stats: ArtifactSecurityStats = { filesInspected: 0, archivesInspected: 0, redactions: 0 };
+    const budget: ArchiveBudget = { entriesRemaining: MAX_ARCHIVE_ENTRIES, bytesRemaining: MAX_UNCOMPRESSED_ARCHIVE_BYTES };
+    for (const artifactPath of paths) {
+        processPath(artifactPath, mode, bytePatterns, textPatterns, stats, budget, false);
+    }
+    return stats;
+}
+
+export function sanitizeArtifacts(paths: readonly string[], credentials: BrowserStackCredentials): ArtifactSecurityStats {
+    return processArtifacts(paths, credentials, "sanitize");
+}
+
+export function verifyArtifacts(paths: readonly string[], credentials: BrowserStackCredentials): ArtifactSecurityStats {
+    return processArtifacts(paths, credentials, "verify");
 }
 
 function main(): void {
-    const paths = process.argv.slice(2);
-    if (paths.length === 0) {
-        console.error("[redact-secrets] Usage: tsx scripts/redact-secrets.ts <path> [<path> ...]");
+    const [mode, ...paths] = process.argv.slice(2);
+    if (mode !== "sanitize" && mode !== "verify") {
+        console.error("[artifact-security] Usage: tsx scripts/redact-secrets.ts <sanitize|verify> <path> [<path> ...]");
         process.exit(1);
     }
-    const secrets = collectSecrets();
-    if (secrets.length === 0) {
-        console.log("[redact-secrets] No BrowserStack credentials in env — nothing to redact.");
-        return;
+
+    try {
+        const stats = processArtifacts(paths, browserStackCredentialsFromEnvironment(), mode);
+        if (mode === "sanitize") {
+            console.log(
+                `[artifact-security] Sanitized ${stats.redactions} credential occurrence(s) across ${stats.filesInspected} file(s), including ${stats.archivesInspected} ZIP archive(s).`
+            );
+        } else {
+            console.log(`[artifact-security] Verified ${stats.filesInspected} file(s), including ${stats.archivesInspected} ZIP archive(s).`);
+        }
+    } catch (error) {
+        const message = error instanceof ArtifactSecurityError ? error.message : "Artifact security processing failed unexpectedly.";
+        console.error(`[artifact-security] ${message}`);
+        process.exit(1);
     }
-    const patterns = secrets.map((s) => new RegExp(escapeRegExp(s), "g"));
-    for (const p of paths) {
-        walk(p, patterns);
-    }
-    console.log("[redact-secrets] Done.");
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/tests/lite/unit/artifact-security.test.ts
+++ b/tests/lite/unit/artifact-security.test.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from "crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { spawnSync } from "child_process";
+import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { browserStackCredentialsFromEnvironment, sanitizeArtifacts, type BrowserStackCredentials, verifyArtifacts } from "../../../scripts/redact-secrets";
+
+const repoRoot = resolve(__dirname, "../../..");
+const scriptPath = resolve(repoRoot, "scripts/redact-secrets.ts");
+const tsxPath = resolve(repoRoot, "node_modules/tsx/dist/cli.mjs");
+const tempDirs: string[] = [];
+
+function createTempDir(): string {
+    const directory = mkdtempSync(join(tmpdir(), "artifact-security-"));
+    tempDirs.push(directory);
+    return directory;
+}
+
+function syntheticCredentials(): BrowserStackCredentials {
+    const id = randomUUID();
+    return {
+        username: `ci-user-${id}@example.invalid`,
+        accessKey: `synthetic-${id}+/=`,
+    };
+}
+
+afterEach(() => {
+    for (const directory of tempDirs.splice(0)) {
+        rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+describe("BrowserStack artifact security", () => {
+    it("sanitizes raw credentials in nested artifacts", () => {
+        const directory = createTempDir();
+        const nested = join(directory, "report", "data");
+        mkdirSync(nested, { recursive: true });
+        const credentials = syntheticCredentials();
+        const artifact = join(nested, "failure.json");
+        writeFileSync(artifact, JSON.stringify({ endpoint: credentials.accessKey, owner: credentials.username }));
+
+        const stats = sanitizeArtifacts([directory], credentials);
+        verifyArtifacts([directory], credentials);
+
+        const content = readFileSync(artifact, "utf8");
+        expect(content).not.toContain(credentials.accessKey);
+        expect(content).not.toContain(credentials.username);
+        expect(stats.redactions).toBeGreaterThanOrEqual(2);
+    });
+
+    it("sanitizes URL-encoded and repeatedly encoded credentials", () => {
+        const directory = createTempDir();
+        const credentials = syntheticCredentials();
+        const artifact = join(directory, "report.html");
+        const encodedUsername = encodeURIComponent(credentials.username);
+        const nestedAccessKey = encodeURIComponent(encodeURIComponent(credentials.accessKey));
+        writeFileSync(artifact, `${encodedUsername}\n${nestedAccessKey}`);
+
+        sanitizeArtifacts([artifact], credentials);
+        verifyArtifacts([artifact], credentials);
+
+        const content = readFileSync(artifact, "utf8");
+        expect(content).not.toContain(encodedUsername);
+        expect(content).not.toContain(nestedAccessKey);
+    });
+
+    it("recursively sanitizes credentials inside ZIP artifacts", () => {
+        const directory = createTempDir();
+        const credentials = syntheticCredentials();
+        const tracePath = join(directory, "trace.zip");
+        const nestedZip = zipSync({
+            "nested.txt": strToU8(encodeURIComponent(credentials.username)),
+        });
+        writeFileSync(
+            tracePath,
+            zipSync({
+                [`resources/${credentials.username}.txt`]: strToU8(credentials.accessKey),
+                "nested.zip": nestedZip,
+            })
+        );
+
+        const stats = sanitizeArtifacts([tracePath], credentials);
+        verifyArtifacts([tracePath], credentials);
+
+        const outer = unzipSync(readFileSync(tracePath));
+        expect(Object.keys(outer).join("\n")).not.toContain(credentials.username);
+        expect(strFromU8(outer["resources/".concat("*".repeat(credentials.username.length), ".txt")] ?? new Uint8Array())).not.toContain(credentials.accessKey);
+        const nested = unzipSync(outer["nested.zip"] ?? new Uint8Array());
+        expect(strFromU8(nested["nested.txt"] ?? new Uint8Array())).not.toContain(encodeURIComponent(credentials.username));
+        expect(stats.archivesInspected).toBe(2);
+    });
+
+    it.each([
+        ["raw", (credentials: BrowserStackCredentials) => credentials.accessKey],
+        ["URL-encoded", (credentials: BrowserStackCredentials) => encodeURIComponent(credentials.username)],
+    ])("verification rejects %s credentials before sanitization", (_label, secretValue) => {
+        const directory = createTempDir();
+        const credentials = syntheticCredentials();
+        const artifact = join(directory, "report.txt");
+        writeFileSync(artifact, secretValue(credentials));
+
+        expect(() => verifyArtifacts([artifact], credentials)).toThrow("BrowserStack credentials remain");
+    });
+
+    it("leaves clean artifacts unchanged and verifies them", () => {
+        const directory = createTempDir();
+        const credentials = syntheticCredentials();
+        const artifact = join(directory, "clean.bin");
+        const clean = Buffer.from([0, 1, 2, 3, 255, 10, 13]);
+        writeFileSync(artifact, clean);
+
+        const stats = sanitizeArtifacts([artifact], credentials);
+        verifyArtifacts([artifact], credentials);
+
+        expect(readFileSync(artifact)).toEqual(clean);
+        expect(stats.redactions).toBe(0);
+    });
+
+    it("fails closed when credentials or artifacts are unavailable", () => {
+        const directory = createTempDir();
+        const artifact = join(directory, "report.txt");
+        writeFileSync(artifact, "clean");
+
+        expect(() => sanitizeArtifacts([artifact], browserStackCredentialsFromEnvironment({}))).toThrow("credentials are unavailable");
+        expect(() =>
+            sanitizeArtifacts(
+                [artifact],
+                browserStackCredentialsFromEnvironment({
+                    BROWSERSTACK_USERNAME: "$(BROWSERSTACK_USERNAME)",
+                    BROWSERSTACK_ACCESS_KEY: "$(BROWSERSTACK_ACCESS_KEY)",
+                })
+            )
+        ).toThrow("credentials are unavailable");
+        expect(() => verifyArtifacts([join(directory, "missing")], syntheticCredentials())).toThrow("could not be inspected");
+    });
+
+    it("does not print credentials or matching artifact contents on failure", () => {
+        const directory = createTempDir();
+        const credentials = syntheticCredentials();
+        const artifact = join(directory, "report.txt");
+        const matchingContent = `private-content-${credentials.accessKey}`;
+        writeFileSync(artifact, matchingContent);
+
+        const result = spawnSync(process.execPath, [tsxPath, scriptPath, "verify", artifact], {
+            cwd: repoRoot,
+            encoding: "utf8",
+            env: {
+                ...process.env,
+                BROWSERSTACK_USERNAME: credentials.username,
+                BROWSERSTACK_ACCESS_KEY: credentials.accessKey,
+            },
+        });
+        const output = `${result.stdout}${result.stderr}`;
+
+        expect(result.status).toBe(1);
+        expect(output).not.toContain(credentials.username);
+        expect(output).not.toContain(credentials.accessKey);
+        expect(output).not.toContain(matchingContent);
+    });
+});
+
+describe("BrowserStack pipeline publication gates", () => {
+    const pipeline = readFileSync(resolve(repoRoot, "azure-pipelines.yml"), "utf8");
+    const uploadTemplate = readFileSync(resolve(repoRoot, "config/templates/upload-test-report.yml"), "utf8");
+    const parityConfig = readFileSync(resolve(repoRoot, "config/playwright.parity-cloud.config.ts"), "utf8");
+    const perfConfig = readFileSync(resolve(repoRoot, "config/playwright.perf-cloud.config.ts"), "utf8");
+
+    it("explicitly disables tracing in every BrowserStack Playwright config", () => {
+        expect(parityConfig).toContain('trace: "off"');
+        expect(perfConfig).toContain('trace: "off"');
+    });
+
+    it("sets ArtifactsSafe only after sanitize and verify commands", () => {
+        const safetySteps = [...pipeline.matchAll(/npx tsx scripts\/redact-secrets\.ts sanitize[\s\S]*?##vso\[task\.setvariable variable=ArtifactsSafe\]true/g)];
+        expect(safetySteps).toHaveLength(2);
+        expect(pipeline.match(/ArtifactsSafe: "false"/g)).toHaveLength(2);
+        for (const step of safetySteps) {
+            expect(step[0]).toContain("redact-secrets.ts verify");
+            expect(step[0]).not.toContain("continueOnError");
+        }
+    });
+
+    it("gates BrowserStack result publication and allowlists only report directories", () => {
+        for (const suite of ["perf", "parity"]) {
+            expect(pipeline).toMatch(
+                new RegExp(
+                    `PublishTestResults@2\\s+condition: and\\(always\\(\\), eq\\(variables\\['ArtifactsSafe'\\], 'true'\\)\\)[\\s\\S]*?${suite}-junit\\.xml[\\s\\S]*?publishRunAttachments: false`
+                )
+            );
+        }
+        expect(uploadTemplate).toContain("condition: and(failed(), eq(variables['ArtifactsSafe'], 'true'))");
+        expect(uploadTemplate).toContain("test-results/${{ parameters.reportType }}-report");
+        expect(uploadTemplate).not.toContain("reportDir");
+        expect(uploadTemplate).not.toContain("-artifacts");
+    });
+});


### PR DESCRIPTION
## Summary
- explicitly disable Playwright tracing for both BrowserStack suites, including retries
- sanitize and independently verify only allowlisted JUnit/HTML report outputs, recursively inspecting nested ZIPs and rejecting uninspectable artifacts
- gate Azure test results, report processing, and failure-report CDN uploads on `ArtifactsSafe=true`; disable JUnit run attachments so raw Playwright artifacts cannot bypass the allowlist
- add focused coverage for raw, URL-encoded, nested, ZIP-contained, missing, and clean credential cases

## Validation
- `REUSE_BROWSER=1 pnpm exec vitest run --project unit tests/lite/unit/artifact-security.test.ts tests/lite/unit/pipeline-secret-hygiene.test.ts`
- focused ESLint, Prettier, and TypeScript checks for changed files

## Operational follow-up
- rotate the BrowserStack access key that may have been exposed
- purge existing public snapshot-CDN report/trace artifacts that may contain the old credentials