### PR TITLE
Extend Havok query and trigger APIs

### DIFF
--- a/docs/lite/architecture/42-physics.md
+++ b/docs/lite/architecture/42-physics.md
@@ -197,8 +197,8 @@ steps matches the animation and sprite managers.
   `onPhysicsTrigger` previously returned `void`; callers that ignore its return value
   need no runtime changes, while callers can now retain the disposer to unsubscribe.
 - **Queries** (`havok-queries.ts`): `physicsRaycast`, `shapeCast`, `shapeProximity`.
-  Shape casts accept `ignoreBodies` so callers can sweep a body's own shape without
-  immediately hitting that body.
+  Shape casts accept one `ignoreBody`, matching Havok's single optional ignored body
+  ID, so callers can sweep a body's own shape without immediately hitting that body.
 - **Heightfield** (`havok-heightfield.ts`): `createHeightFieldShape`.
 - **Character controller** (`character-controller.ts`): kinematic cast-and-slide
   movement; `moveWithCollisions` uses `worldStepSeconds(world)` (the world's step, or

--- a/docs/lite/architecture/42-physics.md
+++ b/docs/lite/architecture/42-physics.md
@@ -192,13 +192,17 @@ steps matches the animation and sprite managers.
 
 - **Collision events** (`havok-collision.ts`): `setPhysicsBodyCollisionEventsEnabled`
   + `onPhysicsCollision` register an after-step drain on `world._afterStep`.
-- **Triggers** (`havok-trigger.ts`): `setPhysicsShapeIsTrigger` + `onPhysicsTrigger`.
+- **Triggers** (`havok-trigger.ts`): `setPhysicsShapeIsTrigger`, `onPhysicsTrigger`,
+  and body-aware `onPhysicsTriggerBodies`; both subscriptions return a disposer.
 - **Queries** (`havok-queries.ts`): `physicsRaycast`, `shapeCast`, `shapeProximity`.
+  Shape casts accept `ignoreBodies` so callers can sweep a body's own shape without
+  immediately hitting that body.
 - **Heightfield** (`havok-heightfield.ts`): `createHeightFieldShape`.
 - **Character controller** (`character-controller.ts`): kinematic cast-and-slide
   movement; `moveWithCollisions` uses `worldStepSeconds(world)` (the world's step, or
   the scene's per-frame delta when no fixed step is set) to convert a requested
-  displacement into a velocity.
+  displacement into a velocity. `getPhysicsCharacterControllerBody` exposes the
+  backing body for queries and event matching.
 - **Floating origin** (`havok-floating-origin.ts`): `enableHavokFloatingOrigin`
   opts a world into multi-region simulation for Large World Rendering
   (see [35-large-world-rendering.md](35-large-world-rendering.md)).

--- a/docs/lite/architecture/42-physics.md
+++ b/docs/lite/architecture/42-physics.md
@@ -194,6 +194,8 @@ steps matches the animation and sprite managers.
   + `onPhysicsCollision` register an after-step drain on `world._afterStep`.
 - **Triggers** (`havok-trigger.ts`): `setPhysicsShapeIsTrigger`, `onPhysicsTrigger`,
   and body-aware `onPhysicsTriggerBodies`; both subscriptions return a disposer.
+  `onPhysicsTrigger` previously returned `void`; callers that ignore its return value
+  need no runtime changes, while callers can now retain the disposer to unsubscribe.
 - **Queries** (`havok-queries.ts`): `physicsRaycast`, `shapeCast`, `shapeProximity`.
   Shape casts accept `ignoreBodies` so callers can sweep a body's own shape without
   immediately hitting that body.

--- a/packages/babylon-lite/package.json
+++ b/packages/babylon-lite/package.json
@@ -26,6 +26,7 @@
     },
     "devDependencies": {
         "@ampproject/remapping": "^2.3.0",
+        "@babylonjs/havok": "^1.3.14",
         "@types/webxr": "^0.5.24",
         "@webgpu/types": "^0.1.71",
         "typescript": "^6.0.3",

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -935,11 +935,17 @@ export { shapeProximity, shapeCast, physicsRaycast } from "./physics/havok-queri
 export type { ShapeProximityQuery, ShapeCastQuery, ShapeProximityResult, ShapeCastResult, RaycastQuery, RaycastResult } from "./physics/havok-queries.js";
 export { setPhysicsBodyCollisionEventsEnabled, onPhysicsCollision } from "./physics/havok-collision.js";
 export type { PhysicsCollisionInfo } from "./physics/havok-collision.js";
-export { setPhysicsShapeIsTrigger, onPhysicsTrigger } from "./physics/havok-trigger.js";
-export type { PhysicsTriggerInfo } from "./physics/havok-trigger.js";
+export { setPhysicsShapeIsTrigger, onPhysicsTrigger, onPhysicsTriggerBodies } from "./physics/havok-trigger.js";
+export type { PhysicsTriggerBodyInfo, PhysicsTriggerInfo } from "./physics/havok-trigger.js";
 export { createPhysicsViewer, showPhysicsBody, showPhysicsConstraint, hidePhysicsBody, disposePhysicsViewer } from "./physics/physics-viewer.js";
 export type { PhysicsViewer, PhysicsViewerOptions, PhysicsConstraintDebug } from "./physics/physics-viewer.js";
-export { createPhysicsCharacterController, PhysicsCharacterController, CharacterSupportedState, CharacterCollisionObservable } from "./physics/character-controller.js";
+export {
+    createPhysicsCharacterController,
+    getPhysicsCharacterControllerBody,
+    PhysicsCharacterController,
+    CharacterSupportedState,
+    CharacterCollisionObservable,
+} from "./physics/character-controller.js";
 export type { PhysicsCharacterControllerOptions, CharacterSurfaceInfo, CharacterCollisionEvent } from "./physics/character-controller.js";
 
 // ─── Navigation (Recast V2) ──────────────────────────────────────────

--- a/packages/babylon-lite/src/physics/character-controller.ts
+++ b/packages/babylon-lite/src/physics/character-controller.ts
@@ -364,6 +364,11 @@ export class PhysicsCharacterController {
         return this._position;
     }
 
+    /** Get the Havok body backing this character controller. */
+    public getBody(): PhysicsBody {
+        return this._body;
+    }
+
     /** Teleport the character to a new position, clearing any swept motion. */
     public setPosition(position: Vec3): void {
         vcopy(this._position, position);
@@ -1400,4 +1405,9 @@ function matToArray(m: Mat4): number[] {
  */
 export function createPhysicsCharacterController(world: PhysicsWorld, position: Vec3, options: PhysicsCharacterControllerOptions): PhysicsCharacterController {
     return new PhysicsCharacterController(world, position, options);
+}
+
+/** Return the Havok body backing a character controller. */
+export function getPhysicsCharacterControllerBody(controller: PhysicsCharacterController): PhysicsBody {
+    return controller.getBody();
 }

--- a/packages/babylon-lite/src/physics/havok-queries.ts
+++ b/packages/babylon-lite/src/physics/havok-queries.ts
@@ -53,6 +53,8 @@ export interface ShapeCastQuery {
     endPosition: Vec3;
     /** Whether trigger volumes count as hits. Default `false`. */
     shouldHitTriggers?: boolean;
+    /** Bodies to exclude, such as the body whose own shape is being swept. */
+    ignoreBodies?: readonly PhysicsBody[];
 }
 
 /** Result of a {@link shapeProximity} query. */
@@ -180,7 +182,8 @@ export function shapeCast(world: PhysicsWorld, query: ShapeCastQuery): ShapeCast
     const hknp = world._hknp;
     const collector = getCollector(world);
     const { rotation: r, startPosition: s, endPosition: e } = query;
-    const hkQuery = [query.shape._hkShape, [r.x, r.y, r.z, r.w], [s.x, s.y, s.z], [e.x, e.y, e.z], query.shouldHitTriggers ?? false, ignoreNone()];
+    const ignoredBodies = query.ignoreBodies?.length ? query.ignoreBodies.map((body) => body._hkBody[0]) : ignoreNone();
+    const hkQuery = [query.shape._hkShape, [r.x, r.y, r.z, r.w], [s.x, s.y, s.z], [e.x, e.y, e.z], query.shouldHitTriggers ?? false, ignoredBodies];
     hknp.HP_World_ShapeCastWithCollector(world._hkWorld, collector, hkQuery);
 
     if (hknp.HP_QueryCollector_GetNumHits(collector)[1] > 0) {

--- a/packages/babylon-lite/src/physics/havok-queries.ts
+++ b/packages/babylon-lite/src/physics/havok-queries.ts
@@ -24,6 +24,7 @@
  * ```
  */
 
+import type { ShapeCastInput as HavokShapeCastInput } from "@babylonjs/havok";
 import type { Quat, Vec3 } from "../math/types.js";
 import type { PhysicsBody, PhysicsShape, PhysicsWorld } from "./havok.js";
 
@@ -53,8 +54,8 @@ export interface ShapeCastQuery {
     endPosition: Vec3;
     /** Whether trigger volumes count as hits. Default `false`. */
     shouldHitTriggers?: boolean;
-    /** Bodies to exclude, such as the body whose own shape is being swept. */
-    ignoreBodies?: readonly PhysicsBody[];
+    /** Body to exclude, such as the body whose own shape is being swept. */
+    ignoreBody?: PhysicsBody;
 }
 
 /** Result of a {@link shapeProximity} query. */
@@ -118,8 +119,8 @@ export interface RaycastResult {
 /** Ignore-none body filter handle: a single zero body id. Lazily built — a
  *  module-level `BigInt(0)` call is a module-init side effect that would defeat
  *  the package's `sideEffects: false` contract. */
-let _ignoreNone: bigint[] | null = null;
-function ignoreNone(): bigint[] {
+let _ignoreNone: [bigint] | null = null;
+function ignoreNone(): [bigint] {
     return (_ignoreNone ??= [BigInt(0)]);
 }
 
@@ -182,8 +183,8 @@ export function shapeCast(world: PhysicsWorld, query: ShapeCastQuery): ShapeCast
     const hknp = world._hknp;
     const collector = getCollector(world);
     const { rotation: r, startPosition: s, endPosition: e } = query;
-    const ignoredBodies = query.ignoreBodies?.length ? query.ignoreBodies.map((body) => body._hkBody[0]) : ignoreNone();
-    const hkQuery = [query.shape._hkShape, [r.x, r.y, r.z, r.w], [s.x, s.y, s.z], [e.x, e.y, e.z], query.shouldHitTriggers ?? false, ignoredBodies];
+    const ignoredBody: [bigint] = query.ignoreBody ? [BigInt(query.ignoreBody._hkBody[0])] : ignoreNone();
+    const hkQuery: HavokShapeCastInput = [query.shape._hkShape, [r.x, r.y, r.z, r.w], [s.x, s.y, s.z], [e.x, e.y, e.z], query.shouldHitTriggers ?? false, ignoredBody];
     hknp.HP_World_ShapeCastWithCollector(world._hkWorld, collector, hkQuery);
 
     if (hknp.HP_QueryCollector_GetNumHits(collector)[1] > 0) {

--- a/packages/babylon-lite/src/physics/havok-trigger.ts
+++ b/packages/babylon-lite/src/physics/havok-trigger.ts
@@ -24,12 +24,25 @@
  */
 
 import { onPhysicsAfterStep } from "./havok.js";
-import type { PhysicsShape, PhysicsWorld } from "./havok.js";
+import type { PhysicsBody, PhysicsShape, PhysicsWorld } from "./havok.js";
+
+type PhysicsTriggerType = PhysicsTriggerInfo["type"];
+
+const TRIGGER_ENTERED = 8;
+const TRIGGER_EXITED = 16;
 
 /** A single trigger-volume event reported by Havok after a physics step. */
 export interface PhysicsTriggerInfo {
     /** `ENTERED` when a body enters the trigger volume, `EXITED` when it leaves. */
     type: "ENTERED" | "EXITED";
+}
+
+/** Trigger event including the two participating bodies. */
+export interface PhysicsTriggerBodyInfo extends PhysicsTriggerInfo {
+    /** First body reported by Havok, or `null` if it is no longer tracked. */
+    bodyA: PhysicsBody | null;
+    /** Second body reported by Havok, or `null` if it is no longer tracked. */
+    bodyB: PhysicsBody | null;
 }
 
 /**
@@ -54,26 +67,59 @@ export function setPhysicsShapeIsTrigger(world: PhysicsWorld, shape: PhysicsShap
  * {@link setPhysicsShapeIsTrigger} first, otherwise the stream is empty.
  * @param world - The physics world to listen on.
  * @param cb - Callback invoked with each {@link PhysicsTriggerInfo} as it is read.
+ * @returns A disposer that removes the callback.
  */
-export function onPhysicsTrigger(world: PhysicsWorld, cb: (info: PhysicsTriggerInfo) => void): void {
-    const hknp = world._hknp;
-    // Native Havok trigger event types: 8 = ENTERED, 16 = EXITED. The Havok `EventType` enum
-    // only enumerates the collision types, so the trigger values are matched literally (mirroring
-    // Babylon.js' `_nativeTriggerCollisionValueToCollisionType`). Unknown values are skipped.
-    const TRIGGER_ENTERED = 8;
-    const TRIGGER_EXITED = 16;
+export function onPhysicsTrigger(world: PhysicsWorld, cb: (info: PhysicsTriggerInfo) => void): () => void {
+    return registerTriggerDrain(world, () => drainTriggerEvents(world, (type) => cb({ type })));
+}
 
-    onPhysicsAfterStep(world, () => {
-        let addr = hknp.HP_World_GetTriggerEvents(world._hkWorld)[1];
-        while (addr) {
-            const intBuf = new Int32Array(hknp.HEAPU8.buffer, addr);
-            const type = intBuf[0];
-            if (type === TRIGGER_ENTERED) {
-                cb({ type: "ENTERED" });
-            } else if (type === TRIGGER_EXITED) {
-                cb({ type: "EXITED" });
-            }
-            addr = hknp.HP_World_GetNextTriggerEvent(world._hkWorld, addr);
+/**
+ * Register a trigger callback that also resolves both participating Havok bodies.
+ *
+ * A body is `null` when the native event references a body that has already been removed from
+ * the world's tracked body list.
+ * @param world - The physics world to listen on.
+ * @param cb - Callback invoked with each body-aware trigger event.
+ * @returns A disposer that removes the callback.
+ */
+export function onPhysicsTriggerBodies(world: PhysicsWorld, cb: (info: PhysicsTriggerBodyInfo) => void): () => void {
+    return registerTriggerDrain(world, () =>
+        drainTriggerEvents(world, (type, bodyAId, bodyBId) => {
+            cb({ type, bodyA: findBodyById(world, bodyAId), bodyB: findBodyById(world, bodyBId) });
+        })
+    );
+}
+
+function drainTriggerEvents(world: PhysicsWorld, cb: (type: PhysicsTriggerType, bodyAId: number, bodyBId: number) => void): void {
+    const hknp = world._hknp;
+    let address = hknp.HP_World_GetTriggerEvents(world._hkWorld)[1];
+    while (address) {
+        const event = new Int32Array(hknp.HEAPU8.buffer, address);
+        const type = event[0] === TRIGGER_ENTERED ? "ENTERED" : event[0] === TRIGGER_EXITED ? "EXITED" : null;
+        if (type) {
+            cb(type, event[2]!, event[6]!);
         }
-    });
+        address = hknp.HP_World_GetNextTriggerEvent(world._hkWorld, address);
+    }
+}
+
+function registerTriggerDrain(world: PhysicsWorld, drain: () => void): () => void {
+    onPhysicsAfterStep(world, drain);
+    return () => {
+        const callbacks = world._afterStep;
+        const index = callbacks?.indexOf(drain) ?? -1;
+        if (index >= 0) {
+            callbacks!.splice(index, 1);
+        }
+    };
+}
+
+function findBodyById(world: PhysicsWorld, bodyId: number): PhysicsBody | null {
+    for (const body of world._bodies) {
+        const nativeId = body._hkBody[0];
+        if (nativeId === bodyId || (typeof nativeId === "bigint" && nativeId === BigInt(bodyId))) {
+            return body;
+        }
+    }
+    return null;
 }

--- a/packages/babylon-lite/src/physics/havok.ts
+++ b/packages/babylon-lite/src/physics/havok.ts
@@ -343,7 +343,7 @@ function _stepWorld(world: PhysicsWorld, deltaMs: number): void {
     // Babylon.js, where physics is advanced inside `scene.animate()` (before render) and
     // post-step scene logic runs in `onAfterRenderObservable`.
     if (world._afterStep) {
-        const cbs = world._afterStep;
+        const cbs = world._afterStep.slice();
         for (let i = 0; i < cbs.length; i++) {
             cbs[i]!(dt);
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@ampproject/remapping':
         specifier: ^2.3.0
         version: 2.3.0
+      '@babylonjs/havok':
+        specifier: ^1.3.14
+        version: 1.3.14
       '@types/webxr':
         specifier: ^0.5.24
         version: 0.5.24

--- a/tests/lite/unit/character-controller-shape-options.test.ts
+++ b/tests/lite/unit/character-controller-shape-options.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { PhysicsCharacterController, type PhysicsCharacterControllerOptions } from "../../../packages/babylon-lite/src/physics/character-controller";
+import {
+    getPhysicsCharacterControllerBody,
+    PhysicsCharacterController,
+    type PhysicsCharacterControllerOptions,
+} from "../../../packages/babylon-lite/src/physics/character-controller";
 import type { Vec3 } from "../../../packages/babylon-lite/src/math/types";
 import type { PhysicsBody, PhysicsShape, PhysicsWorld } from "../../../packages/babylon-lite/src/physics/havok";
 
@@ -58,6 +62,13 @@ function makeController(): {
 }
 
 describe("PhysicsCharacterController.setShapeOptions", () => {
+    it("exposes its backing body for physics queries", () => {
+        const { cc, body } = makeController();
+
+        expect(cc.getBody()).toBe(body);
+        expect(getPhysicsCharacterControllerBody(cc)).toBe(body);
+    });
+
     it("rebuilds the capsule and preserves the world-space foot position by default", () => {
         const { cc, createCapsule, setBodyShape, releaseShape, setNodePosition, oldShape, body } = makeController();
         const options = { capsuleHeight: 1.2, capsuleRadius: 0.4 };

--- a/tests/lite/unit/physics-havok-queries.test.ts
+++ b/tests/lite/unit/physics-havok-queries.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PhysicsBody, PhysicsShape, PhysicsWorld } from "../../../packages/babylon-lite/src";
+import { shapeCast } from "../../../packages/babylon-lite/src/physics/havok-queries";
+
+function castQuery(shape: PhysicsShape, ignoreBodies?: readonly PhysicsBody[]) {
+    return {
+        shape,
+        rotation: { x: 0, y: 0, z: 0, w: 1 },
+        startPosition: { x: 1, y: 2, z: 3 },
+        endPosition: { x: 4, y: 5, z: 6 },
+        ignoreBodies,
+    };
+}
+
+describe("Havok shape queries", () => {
+    it("passes ignored body ids to shape casts", () => {
+        const cast = vi.fn();
+        const hknp = {
+            HP_QueryCollector_Create: vi.fn(() => [0, "collector"]),
+            HP_World_ShapeCastWithCollector: cast,
+            HP_QueryCollector_GetNumHits: vi.fn(() => [0, 0]),
+        };
+        const ignoredBodies = [{ _hkBody: [42n] }, { _hkBody: [84n] }] as PhysicsBody[];
+        const world = { _hknp: hknp, _hkWorld: "world" } as unknown as PhysicsWorld;
+        const shape = { _hkShape: "shape" } as PhysicsShape;
+
+        shapeCast(world, castQuery(shape, ignoredBodies));
+
+        expect(cast).toHaveBeenCalledWith("world", "collector", ["shape", [0, 0, 0, 1], [1, 2, 3], [4, 5, 6], false, [42n, 84n]]);
+    });
+
+    it("keeps Havok's sentinel when no bodies are ignored", () => {
+        const cast = vi.fn();
+        const world = {
+            _hknp: {
+                HP_QueryCollector_Create: vi.fn(() => [0, "collector"]),
+                HP_World_ShapeCastWithCollector: cast,
+                HP_QueryCollector_GetNumHits: vi.fn(() => [0, 0]),
+            },
+            _hkWorld: "world",
+        } as unknown as PhysicsWorld;
+        const shape = { _hkShape: "shape" } as PhysicsShape;
+
+        shapeCast(world, castQuery(shape));
+
+        expect(cast.mock.calls[0]![2][5]).toEqual([0n]);
+    });
+});

--- a/tests/lite/unit/physics-havok-queries.test.ts
+++ b/tests/lite/unit/physics-havok-queries.test.ts
@@ -1,32 +1,32 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PhysicsBody, PhysicsShape, PhysicsWorld } from "../../../packages/babylon-lite/src";
-import { shapeCast } from "../../../packages/babylon-lite/src/physics/havok-queries";
+import { shapeCast, type ShapeCastQuery } from "../../../packages/babylon-lite/src/physics/havok-queries";
 
-function castQuery(shape: PhysicsShape, ignoreBodies?: readonly PhysicsBody[]) {
+function castQuery(shape: PhysicsShape, ignoreBody?: PhysicsBody): ShapeCastQuery {
     return {
         shape,
         rotation: { x: 0, y: 0, z: 0, w: 1 },
         startPosition: { x: 1, y: 2, z: 3 },
         endPosition: { x: 4, y: 5, z: 6 },
-        ignoreBodies,
+        ignoreBody,
     };
 }
 
 describe("Havok shape queries", () => {
-    it("passes ignored body ids to shape casts", () => {
+    it("passes one ignored body id using Havok's body-id tuple", () => {
         const cast = vi.fn();
         const hknp = {
             HP_QueryCollector_Create: vi.fn(() => [0, "collector"]),
             HP_World_ShapeCastWithCollector: cast,
             HP_QueryCollector_GetNumHits: vi.fn(() => [0, 0]),
         };
-        const ignoredBodies = [{ _hkBody: [42n] }, { _hkBody: [84n] }] as PhysicsBody[];
+        const ignoredBody = { _hkBody: [42n] } as PhysicsBody;
         const world = { _hknp: hknp, _hkWorld: "world" } as unknown as PhysicsWorld;
         const shape = { _hkShape: "shape" } as PhysicsShape;
 
-        shapeCast(world, castQuery(shape, ignoredBodies));
+        shapeCast(world, castQuery(shape, ignoredBody));
 
-        expect(cast).toHaveBeenCalledWith("world", "collector", ["shape", [0, 0, 0, 1], [1, 2, 3], [4, 5, 6], false, [42n, 84n]]);
+        expect(cast).toHaveBeenCalledWith("world", "collector", ["shape", [0, 0, 0, 1], [1, 2, 3], [4, 5, 6], false, [42n]]);
     });
 
     it("keeps Havok's sentinel when no bodies are ignored", () => {

--- a/tests/lite/unit/physics-trigger.test.ts
+++ b/tests/lite/unit/physics-trigger.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { PhysicsBody, PhysicsWorld } from "../../../packages/babylon-lite/src/physics/havok";
+import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
+import { createHavokWorld, onPhysicsAfterStep, type PhysicsBody, type PhysicsWorld } from "../../../packages/babylon-lite/src/physics/havok";
 import { onPhysicsTrigger, onPhysicsTriggerBodies } from "../../../packages/babylon-lite/src/physics/havok-trigger";
 
 function makeWorld(events: ReadonlyArray<{ type: number; bodyA: number; bodyB: number }>, bodies: PhysicsBody[] = []) {
@@ -62,5 +63,28 @@ describe("Havok trigger events", () => {
             { type: "ENTERED", bodyA, bodyB },
             { type: "EXITED", bodyA, bodyB: null },
         ]);
+    });
+
+    it("does not skip later after-step callbacks when a trigger subscription disposes itself", () => {
+        const triggerWorld = makeWorld([{ type: 8, bodyA: 1, bodyB: 2 }]);
+        const hknp = Object.assign(triggerWorld._hknp, {
+            HP_World_Create: vi.fn(() => [0, {}]),
+            HP_World_SetGravity: vi.fn(),
+            HP_World_Step: vi.fn(),
+        });
+        const scene = { _beforeRender: [], fixedDeltaMs: 0, surface: { engine: { _currentDelta: 16 } } } as unknown as SceneContext;
+        const world = createHavokWorld(scene, hknp);
+        const calls: string[] = [];
+        let dispose = (): void => undefined;
+        dispose = onPhysicsTrigger(world, () => {
+            calls.push("trigger");
+            dispose();
+        });
+        onPhysicsAfterStep(world, () => calls.push("other"));
+
+        scene._beforeRender[0]!(16);
+
+        expect(calls).toEqual(["trigger", "other"]);
+        expect(world._afterStep).toHaveLength(1);
     });
 });

--- a/tests/lite/unit/physics-trigger.test.ts
+++ b/tests/lite/unit/physics-trigger.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PhysicsBody, PhysicsWorld } from "../../../packages/babylon-lite/src/physics/havok";
+import { onPhysicsTrigger, onPhysicsTriggerBodies } from "../../../packages/babylon-lite/src/physics/havok-trigger";
+
+function makeWorld(events: ReadonlyArray<{ type: number; bodyA: number; bodyB: number }>, bodies: PhysicsBody[] = []) {
+    const memory = new ArrayBuffer(256);
+    const addresses = events.map((event, index) => {
+        const address = 16 + index * 32;
+        const data = new Int32Array(memory, address, 8);
+        data[0] = event.type;
+        data[2] = event.bodyA;
+        data[6] = event.bodyB;
+        return address;
+    });
+    const next = new Map(addresses.map((address, index) => [address, addresses[index + 1] ?? 0]));
+    return {
+        _hknp: {
+            HEAPU8: new Uint8Array(memory),
+            HP_World_GetTriggerEvents: vi.fn(() => [0, addresses[0] ?? 0]),
+            HP_World_GetNextTriggerEvent: vi.fn((_world, address: number) => next.get(address) ?? 0),
+        },
+        _hkWorld: {},
+        _bodies: bodies,
+        _afterStep: [],
+    } as unknown as PhysicsWorld;
+}
+
+describe("Havok trigger events", () => {
+    it("reports entered and exited events, skips unknown events, and supports disposal", () => {
+        const world = makeWorld([
+            { type: 8, bodyA: 1, bodyB: 2 },
+            { type: 99, bodyA: 3, bodyB: 4 },
+            { type: 16, bodyA: 5, bodyB: 6 },
+        ]);
+        const received = vi.fn();
+
+        const dispose = onPhysicsTrigger(world, received);
+        world._afterStep![0]!(1 / 60);
+
+        expect(received.mock.calls.map(([event]) => event)).toEqual([{ type: "ENTERED" }, { type: "EXITED" }]);
+        dispose();
+        dispose();
+        expect(world._afterStep).toHaveLength(0);
+    });
+
+    it("resolves participating bodies and returns null for bodies no longer tracked", () => {
+        const bodyA = { _hkBody: [101n] } as PhysicsBody;
+        const bodyB = { _hkBody: [202] } as PhysicsBody;
+        const world = makeWorld(
+            [
+                { type: 8, bodyA: 101, bodyB: 202 },
+                { type: 16, bodyA: 101, bodyB: 303 },
+            ],
+            [bodyA, bodyB]
+        );
+        const received = vi.fn();
+
+        onPhysicsTriggerBodies(world, received);
+        world._afterStep![0]!(1 / 60);
+
+        expect(received.mock.calls.map(([event]) => event)).toEqual([
+            { type: "ENTERED", bodyA, bodyB },
+            { type: "EXITED", bodyA, bodyB: null },
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

- allow Havok shape casts to exclude selected bodies, including a character controller's own backing body
- expose the backing body through both the character-controller instance and functional API
- add body-aware trigger events while preserving the lightweight existing trigger callback
- return disposers from trigger subscriptions so callers can unregister post-step drains
- document the new query and trigger capabilities

## Validation

- `pnpm lint`
- focused Havok unit tests: 3 files / 7 tests passed
- full unit suite: 256 files passed, 1 skipped / 2,872 tests passed, 9 skipped
- `pnpm build`
- build and tree-shaking suite: 7 files / 33 tests passed

## Breaking change

BREAKING CHANGE: `onPhysicsTrigger` now returns an unsubscribe disposer instead of `void`. Existing callers that ignore the return value continue to work; callers can retain it to remove the post-step subscription.
