### PR TITLE
Improve shared runtime utilities

### DIFF
--- a/docs/lite/architecture/26-material-plugin.md
+++ b/docs/lite/architecture/26-material-plugin.md
@@ -194,10 +194,13 @@ scene's refresh state. The Standard bind builders pass the owning scene into the
 plugin extension, so one material shared by multiple scenes resolves each
 scene's distinct UBO; disposing either scene cannot invalidate the other's
 binding. Static plugins retain the registration-time upload. Re-baking a
-material queues every affected mesh for a same-frame material-swap rebuild, so
-new bind groups reference the replacement UBO before the old buffer is retired
-after in-flight GPU work drains. Disposing the scene destroys all of its
-remaining plugin UBOs and releases the material references held by the bridge.
+material queues every affected mesh for a material-swap rebuild. The old UBO's
+release is attached to those renderables' existing disposer packets, so it
+remains valid while the swap queue is blocked by an asynchronous runtime build.
+Only after every affected replacement bind group has been committed is the old
+buffer retired behind a subsequent GPU fence. Disposing the scene destroys all
+of its remaining plugin UBOs and releases the material references held by the
+bridge.
 
 The decisive benefit: this route adds no `_writeUbo` hook or plugin UBO loop to
 the Standard renderable. The pre-existing `StdExt._bind` / `_textures` loops in
@@ -273,7 +276,7 @@ and grayscale is a linear reduction, the result stays pixel-identical.
 - Unit coverage verifies independent dynamic refresh state across two scenes,
   scene-disposal cleanup, shared-material scene isolation, lazy plugin-free
   feature detection, and replacement-UBO rebinding/retirement when a Standard
-  material is baked again.
+  material is baked again while the material-swap queue is blocked.
 - Bundle-size: `bundle-size.spec.ts` guards the generic scene-context propagation
   and verifies the plugin implementation remains absent from plugin-free scene
   graphs.

--- a/docs/lite/architecture/26-material-plugin.md
+++ b/docs/lite/architecture/26-material-plugin.md
@@ -196,11 +196,12 @@ scene's distinct UBO; disposing either scene cannot invalidate the other's
 binding. Static plugins retain the registration-time upload. Re-baking a
 material queues every affected mesh for a material-swap rebuild. The old UBO's
 release is attached to those renderables' existing disposer packets. Async
-runtime builds expose the packet they temporarily remove from
-`scene._meshDisposables`, so a re-bake during that window can attach to the same
-pending teardown. The old buffer therefore remains valid while the swap queue is
-blocked. Only after every affected replacement bind group has been committed is
-the old buffer retired behind a subsequent GPU fence. Disposing the scene
+per-mesh and full-group rebuilds expose the packets they temporarily remove from
+`scene._meshDisposables`, so a re-bake during either window can attach to the
+same pending teardown. The old buffer therefore remains valid while the swap
+queue or an async group build is blocked. Only after every affected replacement
+bind group has been committed is the old buffer retired behind a subsequent GPU
+fence. Disposing the scene
 destroys all of its remaining plugin UBOs and releases the material references
 held by the bridge.
 
@@ -279,7 +280,8 @@ and grayscale is a linear reduction, the result stays pixel-identical.
   scene-disposal cleanup, shared-material scene isolation, lazy plugin-free
   feature detection, and replacement-UBO rebinding/retirement when a Standard
   material is baked again while the material-swap queue is blocked, including
-  the async-build window where `_meshDisposables` temporarily has no packet.
+  per-mesh and full-group async-build windows where `_meshDisposables`
+  temporarily has no packet.
 - Bundle-size: `bundle-size.spec.ts` guards the generic scene-context propagation
   and verifies the plugin implementation remains absent from plugin-free scene
   graphs.

--- a/docs/lite/architecture/26-material-plugin.md
+++ b/docs/lite/architecture/26-material-plugin.md
@@ -195,12 +195,14 @@ plugin extension, so one material shared by multiple scenes resolves each
 scene's distinct UBO; disposing either scene cannot invalidate the other's
 binding. Static plugins retain the registration-time upload. Re-baking a
 material queues every affected mesh for a material-swap rebuild. The old UBO's
-release is attached to those renderables' existing disposer packets, so it
-remains valid while the swap queue is blocked by an asynchronous runtime build.
-Only after every affected replacement bind group has been committed is the old
-buffer retired behind a subsequent GPU fence. Disposing the scene destroys all
-of its remaining plugin UBOs and releases the material references held by the
-bridge.
+release is attached to those renderables' existing disposer packets. Async
+runtime builds expose the packet they temporarily remove from
+`scene._meshDisposables`, so a re-bake during that window can attach to the same
+pending teardown. The old buffer therefore remains valid while the swap queue is
+blocked. Only after every affected replacement bind group has been committed is
+the old buffer retired behind a subsequent GPU fence. Disposing the scene
+destroys all of its remaining plugin UBOs and releases the material references
+held by the bridge.
 
 The decisive benefit: this route adds no `_writeUbo` hook or plugin UBO loop to
 the Standard renderable. The pre-existing `StdExt._bind` / `_textures` loops in
@@ -276,7 +278,8 @@ and grayscale is a linear reduction, the result stays pixel-identical.
 - Unit coverage verifies independent dynamic refresh state across two scenes,
   scene-disposal cleanup, shared-material scene isolation, lazy plugin-free
   feature detection, and replacement-UBO rebinding/retirement when a Standard
-  material is baked again while the material-swap queue is blocked.
+  material is baked again while the material-swap queue is blocked, including
+  the async-build window where `_meshDisposables` temporarily has no packet.
 - Bundle-size: `bundle-size.spec.ts` guards the generic scene-context propagation
   and verifies the plugin implementation remains absent from plugin-free scene
   graphs.

--- a/docs/lite/architecture/26-material-plugin.md
+++ b/docs/lite/architecture/26-material-plugin.md
@@ -54,6 +54,7 @@ export interface MaterialPlugin {
     readonly name: string;
     priority?: number; // lower runs first; default 500
     isEnabled?: boolean; // default true when attached
+    dynamic?: boolean; // refresh Standard-material UBO values every frame
     defines?: Record<string, boolean | number>;
     getCustomCode?(shaderType: "vertex" | "fragment"): Partial<Record<MaterialPluginPoint, string>> | null;
     getUniforms?(): { ubo?: PluginUboField[] };
@@ -71,8 +72,8 @@ interface Material {
 
 Public exports (`index.ts`): `MaterialPlugin`, `MaterialPluginPoint`,
 `PluginUboField`, `PluginSamplerDecl`, `PluginTextureBinding` (all `export type`),
-plus the runtime function `enableMaterialPlugins(scene)` — the explicit opt-in
-entry point.
+plus the runtime functions `enableMaterialPlugins(scene)` and
+`bakeStdPluginMaterial(material, engine)`.
 
 ## Opt-in entry point — `enableMaterialPlugins(scene)`
 
@@ -101,6 +102,8 @@ standardGroupBuilder`, so PBR materials are never touched), walks `scene.meshes`
    This is required because Standard's `_computeStandardMaterialFeatures` is not
    ext-extensible, so the index must be baked in before the build reads it. PBR
    needs no walk — its `detect` hook encodes the index during feature computation.
+   Standard materials created after this walk can be registered explicitly with
+   `bakeStdPluginMaterial(material, engine)`.
 
 Because none of this lives in a shared module, removing the call (or never adding
 it) leaves every byte of the PBR/Standard core untouched.
@@ -181,10 +184,13 @@ material UBO, so the bridge:
   mesh UBO. `buildPluginFragment(plugins, idx, /*forStandard*/ true)` emits a
   dedicated `var<uniform> pluginUbo : pluginUboUniforms;` fragment binding (struct
   declared in `_helperFunctions`) instead of appending `_uboFields` to the mesh
-  UBO. The bridge builds that `GPUBuffer` once per signature at registration time
-  (uniform values are constant for a given signature) and pushes its bind entry
+  UBO. The bridge builds one `GPUBuffer` per material, so materials with the same
+  shader signature can retain different uniform values, and pushes its bind entry
   from `StdExt._bind` — **before** the texture entries, matching the binding
   declaration order — followed by `bindPluginTextures`.
+
+Standard plugins marked `dynamic: true` have their per-material UBO values
+rewritten before every frame. Static plugins retain the registration-time upload.
 
 The decisive benefit: this route touches **zero shared standard code**. The
 pre-existing `StdExt._bind` / `_textures` loops in `standard-pipeline.ts` /

--- a/docs/lite/architecture/26-material-plugin.md
+++ b/docs/lite/architecture/26-material-plugin.md
@@ -73,7 +73,7 @@ interface Material {
 Public exports (`index.ts`): `MaterialPlugin`, `MaterialPluginPoint`,
 `PluginUboField`, `PluginSamplerDecl`, `PluginTextureBinding` (all `export type`),
 plus the runtime functions `enableMaterialPlugins(scene)` and
-`bakeStdPluginMaterial(material, engine)`.
+`bakeStdPluginMaterial(material, scene)`.
 
 ## Opt-in entry point — `enableMaterialPlugins(scene)`
 
@@ -103,7 +103,7 @@ standardGroupBuilder`, so PBR materials are never touched), walks `scene.meshes`
    ext-extensible, so the index must be baked in before the build reads it. PBR
    needs no walk — its `detect` hook encodes the index during feature computation.
    Standard materials created after this walk can be registered explicitly with
-   `bakeStdPluginMaterial(material, engine)`.
+   `bakeStdPluginMaterial(material, scene)`.
 
 Because none of this lives in a shared module, removing the call (or never adding
 it) leaves every byte of the PBR/Standard core untouched.
@@ -190,7 +190,12 @@ material UBO, so the bridge:
   declaration order — followed by `bindPluginTextures`.
 
 Standard plugins marked `dynamic: true` have their per-material UBO values
-rewritten before every frame. Static plugins retain the registration-time upload.
+rewritten before every frame. Dynamic tracking and UBO ownership are scoped to
+the enabling scene, so enabling a second scene does not replace the first
+scene's refresh state. Static plugins retain the registration-time upload.
+Re-baking a material retires its previous UBO after in-flight GPU work drains;
+disposing the scene destroys all of its remaining plugin UBOs and releases the
+material references held by the bridge.
 
 The decisive benefit: this route touches **zero shared standard code**. The
 pre-existing `StdExt._bind` / `_textures` loops in `standard-pipeline.ts` /
@@ -233,10 +238,11 @@ and grayscale is a linear reduction, the result stays pixel-identical.
 3. Per mesh: detect (PBR) / pre-baked features (Standard) assign the signature index
    → compose builds WGSL with the plugin fragment → pipeline/bind groups created →
    UBO + textures bound.
-4. **Toggle:** set `plugin.isEnabled`, then (because `_renderFeatures` is cached)
-   set `material._renderFeatures = undefined`, call `enableMaterialPlugins(scene)`
-   again to re-bake, and `rebuildMaterial(scene, material)`. The new signature
-   index yields a fresh pipeline.
+4. **Toggle:** set `plugin.isEnabled`, call `bakeStdPluginMaterial(material,
+scene)`, then `rebuildMaterial(scene, material)`. The new signature index
+   yields a fresh pipeline and the replaced plugin UBO is retired safely.
+5. **Dispose:** `disposeScene(scene)` destroys every remaining Standard plugin
+   UBO owned by that scene and drops its per-material refresh state.
 
 ## Babylon.js Equivalence Map
 
@@ -259,6 +265,9 @@ and grayscale is a linear reduction, the result stays pixel-identical.
 - Scene 217 (`scene217-material-plugin`): a PBR sphere **and** a Standard box, each
   with the BlackAndWhite plugin enabled, validated against a BJS golden using an
   equivalent `MaterialPluginBase` BlackAndWhite plugin. MAD ≤ `scene-config.maxMad`.
+- Unit coverage verifies independent dynamic refresh state across two scenes,
+  scene-disposal cleanup, and old-UBO retirement when a Standard material is
+  baked again.
 - Bundle-size: every pre-existing (plugin-free) scene stays **byte-identical** to
   master — `bundle-size.spec.ts` reports no "increased vs master" for any scene
   except (newly added) scene217. Because plugin code is only reachable through

--- a/docs/lite/architecture/26-material-plugin.md
+++ b/docs/lite/architecture/26-material-plugin.md
@@ -10,15 +10,12 @@ existing **PBR** or **Standard** material while keeping the full built-in
 lighting / IBL / shadow pipeline. Plugins are plain-data objects (GUIDANCE §4b′),
 attached per-instance via `material.plugins = [plugin]`.
 
-**Hard guarantee: plugin-free scenes are BYTE-IDENTICAL to a build without the
-plugin system.** No shared/core file (renderables, group builders, flags,
-pipelines) carries any plugin-specific code. Plugin support is an **explicit
-opt-in**: the application imports and calls `enableMaterialPlugins(scene)` (after
-creating materials/meshes, before `registerScene`). That single call is the _only_
-thing that pulls the plugin bridges into a scene's module graph. A scene that
-never calls it produces the exact same bytes as master — verified by content-hash
-equality of every runtime chunk. The plugin's WGSL ships in the user's scene
-module, not the engine.
+Plugin support is an **explicit opt-in**: the application imports and calls
+`enableMaterialPlugins(scene)` (after creating materials/meshes, before
+`registerScene`). That call is the only thing that pulls the plugin bridges and
+their WGSL into a scene's module graph. Shared Standard binding infrastructure
+only propagates its existing owning `SceneContext` through the generic extension
+hook, allowing opt-in state to remain truly scene-local.
 
 ## Public API Surface
 
@@ -103,10 +100,11 @@ standardGroupBuilder`, so PBR materials are never touched), walks `scene.meshes`
    ext-extensible, so the index must be baked in before the build reads it. PBR
    needs no walk — its `detect` hook encodes the index during feature computation.
    Standard materials created after this walk can be registered explicitly with
-   `bakeStdPluginMaterial(material, scene)`.
+   `bakeStdPluginMaterial(material, scene)`. Materials without plugins are left
+   untouched, so their normal lazy feature detection remains live until build.
 
-Because none of this lives in a shared module, removing the call (or never adding
-it) leaves every byte of the PBR/Standard core untouched.
+The plugin implementation remains outside the always-loaded PBR/Standard graph;
+only the generic Standard binding hook carries scene ownership context.
 
 ## Injection-point → Lite slot mapping
 
@@ -192,18 +190,21 @@ material UBO, so the bridge:
 Standard plugins marked `dynamic: true` have their per-material UBO values
 rewritten before every frame. Dynamic tracking and UBO ownership are scoped to
 the enabling scene, so enabling a second scene does not replace the first
-scene's refresh state. Static plugins retain the registration-time upload.
-Re-baking a material retires its previous UBO after in-flight GPU work drains;
-disposing the scene destroys all of its remaining plugin UBOs and releases the
-material references held by the bridge.
+scene's refresh state. The Standard bind builders pass the owning scene into the
+plugin extension, so one material shared by multiple scenes resolves each
+scene's distinct UBO; disposing either scene cannot invalidate the other's
+binding. Static plugins retain the registration-time upload. Re-baking a
+material queues every affected mesh for a same-frame material-swap rebuild, so
+new bind groups reference the replacement UBO before the old buffer is retired
+after in-flight GPU work drains. Disposing the scene destroys all of its
+remaining plugin UBOs and releases the material references held by the bridge.
 
-The decisive benefit: this route touches **zero shared standard code**. The
-pre-existing `StdExt._bind` / `_textures` loops in `standard-pipeline.ts` /
-`collect-std-bound-textures.ts` and the `_frag` loop in `standard-renderable.ts`
-carry the plugin for free. `standard-renderable.ts`, `standard-group-builder.ts`,
-and `standard-flags.ts` are byte-identical to master (no `_writeUbo` hook, no UBO
-write loop, no gated import). WGSL access to a Standard plugin uniform is
-`pluginUbo.<field>` (PBR access is `material.<field>`).
+The decisive benefit: this route adds no `_writeUbo` hook or plugin UBO loop to
+the Standard renderable. The pre-existing `StdExt._bind` / `_textures` loops in
+`standard-pipeline.ts` / `collect-std-bound-textures.ts` and the `_frag` loop in
+`standard-renderable.ts` carry the plugin; the bind hook receives the owning
+scene so scene-local UBO state can be selected. WGSL access to a Standard plugin
+uniform is `pluginUbo.<field>` (PBR access is `material.<field>`).
 
 ## Pipeline Configuration / Cache Keying
 
@@ -238,9 +239,13 @@ and grayscale is a linear reduction, the result stays pixel-identical.
 3. Per mesh: detect (PBR) / pre-baked features (Standard) assign the signature index
    → compose builds WGSL with the plugin fragment → pipeline/bind groups created →
    UBO + textures bound.
-4. **Toggle:** set `plugin.isEnabled`, call `bakeStdPluginMaterial(material,
-scene)`, then `rebuildMaterial(scene, material)`. The new signature index
-   yields a fresh pipeline and the replaced plugin UBO is retired safely.
+4. **Toggle/re-bake:** set `plugin.isEnabled`, then call
+   `bakeStdPluginMaterial(material, scene)`. The new signature index yields a
+   fresh pipeline; affected bindings are rebuilt through the scene's material
+   swap queue, and the replaced plugin UBO is retired safely. Removing the last
+   plugin clears the cached Standard features only when that scene actually had
+   an existing plugin state; plugin-free materials are never eagerly cached by
+   `enableMaterialPlugins`.
 5. **Dispose:** `disposeScene(scene)` destroys every remaining Standard plugin
    UBO owned by that scene and drops its per-material refresh state.
 
@@ -266,13 +271,12 @@ scene)`, then `rebuildMaterial(scene, material)`. The new signature index
   with the BlackAndWhite plugin enabled, validated against a BJS golden using an
   equivalent `MaterialPluginBase` BlackAndWhite plugin. MAD ≤ `scene-config.maxMad`.
 - Unit coverage verifies independent dynamic refresh state across two scenes,
-  scene-disposal cleanup, and old-UBO retirement when a Standard material is
-  baked again.
-- Bundle-size: every pre-existing (plugin-free) scene stays **byte-identical** to
-  master — `bundle-size.spec.ts` reports no "increased vs master" for any scene
-  except (newly added) scene217. Because plugin code is only reachable through
-  `enableMaterialPlugins`, the shared PBR/Standard chunks keep identical content
-  hashes.
+  scene-disposal cleanup, shared-material scene isolation, lazy plugin-free
+  feature detection, and replacement-UBO rebinding/retirement when a Standard
+  material is baked again.
+- Bundle-size: `bundle-size.spec.ts` guards the generic scene-context propagation
+  and verifies the plugin implementation remains absent from plugin-free scene
+  graphs.
 
 ## File Manifest
 
@@ -283,8 +287,8 @@ scene)`, then `rebuildMaterial(scene, material)`. The new signature index
 - `material/plugin/pbr-plugin-bridge.ts` — PBR `PbrExt`.
 - `material/plugin/std-plugin-bridge.ts` — Standard `StdExt` + self-managed UBO.
 - `material/plugin/enable-material-plugins.ts` — the opt-in entry point.
-- Edits (all plugin-graph-only or type-only): `material/material.ts` (`plugins?`
-  type-only field, erased from JS), `index.ts` (exports). **No shared/core
-  PBR/Standard runtime file is modified** — `standard-renderable.ts`,
-  `standard-group-builder.ts`, `standard-flags.ts`, and `pbr-renderable.ts` are
-  diff-free vs master.
+- Shared Standard binding edits: `standard-flags.ts`, `standard-pipeline.ts`,
+  `standard-renderable.ts`, `standard-geometry-renderable.ts`, and
+  `fragments/std-uv-transform-fragment.ts` propagate `SceneContext` through the
+  generic bind hook. No shared plugin state or plugin-specific binding loop is
+  added.

--- a/packages/babylon-lite/src/frame-graph/depth-pyramid.ts
+++ b/packages/babylon-lite/src/frame-graph/depth-pyramid.ts
@@ -44,13 +44,27 @@ struct V{@builtin(position)p:vec4f};
 @vertex fn vs(@builtin(vertex_index)i:u32)->V{let p=array<vec2f,3>(vec2f(-1,-1),vec2f(3,-1),vec2f(-1,3))[i];return V(vec4f(p,0,1));}
 @fragment fn fs(@builtin(position)fc:vec4f)->@location(0)f32{
   let c=vec2<i32>(fc.xy)*2;
-  let d=vec2<i32>(textureDimensions(src))-vec2<i32>(1,1);
+  let sd=vec2<i32>(textureDimensions(src));
+  let d=sd-vec2<i32>(1,1);
   let x1=min(c.x+1,d.x); let y1=min(c.y+1,d.y);
   let a=textureLoad(src,vec2<i32>(c.x,c.y),0).r;
   let b=textureLoad(src,vec2<i32>(x1,c.y),0).r;
   let e=textureLoad(src,vec2<i32>(c.x,y1),0).r;
   let f=textureLoad(src,vec2<i32>(x1,y1),0).r;
-  return ${op}(${op}(a,b),${op}(e,f));
+  var r=${op}(${op}(a,b),${op}(e,f));
+  let dd=max(sd/vec2<i32>(2,2),vec2<i32>(1,1));
+  let extraX=(sd.x&1)==1&&i32(fc.x)==dd.x-1;
+  let extraY=(sd.y&1)==1&&i32(fc.y)==dd.y-1;
+  if(extraX){
+    let x2=min(c.x+2,d.x);
+    r=${op}(r,${op}(textureLoad(src,vec2<i32>(x2,c.y),0).r,textureLoad(src,vec2<i32>(x2,y1),0).r));
+  }
+  if(extraY){
+    let y2=min(c.y+2,d.y);
+    r=${op}(r,${op}(textureLoad(src,vec2<i32>(c.x,y2),0).r,textureLoad(src,vec2<i32>(x1,y2),0).r));
+    if(extraX){r=${op}(r,textureLoad(src,vec2<i32>(min(c.x+2,d.x),y2),0).r);}
+  }
+  return r;
 }`;
 }
 

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -246,7 +246,7 @@ export { createLineSystemData, createLineSystem, createLines, updateLineSystem }
 export type { LineSystemData, LineSystemDataOptions, LineSystemOptions, LinesOptions, LineSystemUpdateOptions } from "./mesh/create-line-system.js";
 export { createDashedLines, updateDashedLines } from "./mesh/create-dashed-lines.js";
 export type { DashedLinesOptions, DashedLinesUpdateOptions } from "./mesh/create-dashed-lines.js";
-export { getMeshGeometry } from "./mesh/get-mesh-geometry.js";
+export { getMeshGeometry, getMeshTriangles } from "./mesh/get-mesh-geometry.js";
 export { createBoxData } from "./mesh/create-box.js";
 export type { BoxData } from "./mesh/create-box.js";
 export { createSphereData } from "./mesh/create-sphere.js";
@@ -391,6 +391,7 @@ export { AcesToneMapping } from "./material/pbr/pbr-aces-wgsl.js";
 export { NeutralToneMapping } from "./material/pbr/pbr-neutral-wgsl.js";
 export type { MaterialPlugin, MaterialPluginPoint, PluginUboField, PluginSamplerDecl, PluginTextureBinding } from "./material/plugin/material-plugin.js";
 export { enableMaterialPlugins } from "./material/plugin/enable-material-plugins.js";
+export { bakeStdPluginMaterial } from "./material/plugin/std-plugin-bridge.js";
 export { enableMaterialStencil } from "./material/enable-material-stencil.js";
 export { getAlphaToCoverage, setAlphaToCoverage } from "./render/alpha-to-coverage.js";
 export type { AlphaToCoverageTarget } from "./render/alpha-to-coverage.js";

--- a/packages/babylon-lite/src/loader-hdr/load-hdr.ts
+++ b/packages/babylon-lite/src/loader-hdr/load-hdr.ts
@@ -29,6 +29,8 @@ export interface HdrLoadOptions {
     faceSize?: number;
     /** When true, render the HDR cubemap as the skybox background. */
     useCubemapSkybox?: boolean;
+    /** When true, skip the background skybox renderable entirely. */
+    skipSkybox?: boolean;
     /** When true, skip the ground plane. */
     skipGround?: boolean;
     /** Skybox size matching BJS createDefaultEnvironment skyboxSize option. */
@@ -93,10 +95,11 @@ export async function loadHdrEnvironment(scene: SceneContext, url: string, optio
     // exposure/contrast at build time into their per-mesh UBO). Backgrounds cost nothing here:
     // each builder stamps its own rebuild descriptor onto the renderable it returns.
     const useHdr = !!options?.useCubemapSkybox;
+    const skipSkybox = !!options?.skipSkybox;
     const skipGround = !!options?.skipGround;
     engine._dlr?.h(scene, url, faceSize);
     scene._deferredBuilders.push(async () => {
-        if (useHdr && textures.specularCubeView) {
+        if (useHdr && !skipSkybox && textures.specularCubeView) {
             let autoSkyboxSize = options?.skyboxSize;
             let rootPosition = options?.skyboxPosition;
             if (autoSkyboxSize === undefined || rootPosition === undefined) {
@@ -109,11 +112,11 @@ export async function loadHdrEnvironment(scene: SceneContext, url: string, optio
             const { buildHdrSkyboxRenderable } = await import("../material/pbr/background-hdr-skybox.js");
             scene._renderables.push(await buildHdrSkyboxRenderable(scene, textures, autoSkyboxSize / 2, rootPosition, primaryColor));
         }
-        if (!useHdr || !skipGround) {
+        if ((!useHdr && !skipSkybox) || !skipGround) {
             const primaryColor = scene.environmentPrimaryColor ?? [0.08697355964132344, 0.08697355964132344, 0.2122208331110881];
             const { computeSceneSize } = await import("../material/pbr/scene-size.js");
             const { groundSize, skyboxSize: autoSkyboxSize, rootPosition } = computeSceneSize(scene, options?.skyboxSize);
-            if (!useHdr) {
+            if (!useHdr && !skipSkybox) {
                 const { buildSolidSkyboxRenderable } = await import("../material/pbr/background-solid-skybox.js");
                 scene._renderables.push(buildSolidSkyboxRenderable(scene, textures, autoSkyboxSize / 2, rootPosition, primaryColor));
             }

--- a/packages/babylon-lite/src/material/plugin/enable-material-plugins.ts
+++ b/packages/babylon-lite/src/material/plugin/enable-material-plugins.ts
@@ -28,7 +28,6 @@
  */
 
 import type { SceneContext } from "../../scene/scene.js";
-import { onBeforeRender } from "../../scene/scene-core.js";
 import { _registerPbrExt } from "../pbr/pbr-flags.js";
 import { _registerStdExt } from "../standard/standard-flags.js";
 import { registerPbrPlugins } from "./pbr-plugin-bridge.js";
@@ -51,5 +50,7 @@ export function enableMaterialPlugins(scene: SceneContext): void {
     registerPbrPlugins(_registerPbrExt);
     const engine = scene.surface.engine;
     registerStdPlugins(scene.meshes, engine, _registerStdExt);
-    onBeforeRender(scene, () => refreshStdPluginUbos(engine));
+    // Public onBeforeRender() callbacks use unshift(), so appending keeps the upload
+    // after plugin-value mutations regardless of whether they register before or after us.
+    scene._beforeRender.push(() => refreshStdPluginUbos(engine));
 }

--- a/packages/babylon-lite/src/material/plugin/enable-material-plugins.ts
+++ b/packages/babylon-lite/src/material/plugin/enable-material-plugins.ts
@@ -31,7 +31,7 @@ import type { SceneContext } from "../../scene/scene.js";
 import { _registerPbrExt } from "../pbr/pbr-flags.js";
 import { _registerStdExt } from "../standard/standard-flags.js";
 import { registerPbrPlugins } from "./pbr-plugin-bridge.js";
-import { refreshStdPluginUbos, registerStdPlugins } from "./std-plugin-bridge.js";
+import { registerStdPlugins } from "./std-plugin-bridge.js";
 
 /**
  * Enable material-plugin support for `scene`.
@@ -48,9 +48,12 @@ import { refreshStdPluginUbos, registerStdPlugins } from "./std-plugin-bridge.js
  */
 export function enableMaterialPlugins(scene: SceneContext): void {
     registerPbrPlugins(_registerPbrExt);
-    const engine = scene.surface.engine;
-    registerStdPlugins(scene.meshes, engine, _registerStdExt);
+    const refresh = registerStdPlugins(scene, _registerStdExt);
     // Public onBeforeRender() callbacks use unshift(), so appending keeps the upload
     // after plugin-value mutations regardless of whether they register before or after us.
-    scene._beforeRender.push(() => refreshStdPluginUbos(engine));
+    const previous = scene._beforeRender.indexOf(refresh);
+    if (previous >= 0) {
+        scene._beforeRender.splice(previous, 1);
+    }
+    scene._beforeRender.push(refresh);
 }

--- a/packages/babylon-lite/src/material/plugin/enable-material-plugins.ts
+++ b/packages/babylon-lite/src/material/plugin/enable-material-plugins.ts
@@ -6,12 +6,9 @@
  * always-fetched engine graph references the plugin bridges. A scene only pulls
  * in plugin code when the application imports and calls `enableMaterialPlugins`.
  *
- * This is what keeps plugin-free scenes BYTE-IDENTICAL to a build without the
- * plugin system at all: the shared PBR/Standard renderable and group-builder
- * modules carry zero plugin-specific code; they merely walk their generic
- * extension registries. `enableMaterialPlugins` registers the plugin bridges
- * into those global registries, and the pre-existing hook loops invoke them with
- * no shared-code changes.
+ * Shared PBR/Standard renderables carry no plugin implementation; they merely
+ * walk generic extension registries and pass their owning scene to binding hooks.
+ * `enableMaterialPlugins` registers the plugin bridges into those registries.
  *
  * Contract: call AFTER creating materials/meshes and adding them to the scene,
  * and BEFORE `registerScene(scene)`. Attach plugins via

--- a/packages/babylon-lite/src/material/plugin/enable-material-plugins.ts
+++ b/packages/babylon-lite/src/material/plugin/enable-material-plugins.ts
@@ -28,10 +28,11 @@
  */
 
 import type { SceneContext } from "../../scene/scene.js";
+import { onBeforeRender } from "../../scene/scene-core.js";
 import { _registerPbrExt } from "../pbr/pbr-flags.js";
 import { _registerStdExt } from "../standard/standard-flags.js";
 import { registerPbrPlugins } from "./pbr-plugin-bridge.js";
-import { registerStdPlugins } from "./std-plugin-bridge.js";
+import { refreshStdPluginUbos, registerStdPlugins } from "./std-plugin-bridge.js";
 
 /**
  * Enable material-plugin support for `scene`.
@@ -48,5 +49,7 @@ import { registerStdPlugins } from "./std-plugin-bridge.js";
  */
 export function enableMaterialPlugins(scene: SceneContext): void {
     registerPbrPlugins(_registerPbrExt);
-    registerStdPlugins(scene.meshes, scene.surface.engine, _registerStdExt);
+    const engine = scene.surface.engine;
+    registerStdPlugins(scene.meshes, engine, _registerStdExt);
+    onBeforeRender(scene, () => refreshStdPluginUbos(engine));
 }

--- a/packages/babylon-lite/src/material/plugin/material-plugin.ts
+++ b/packages/babylon-lite/src/material/plugin/material-plugin.ts
@@ -74,6 +74,9 @@ export interface MaterialPlugin {
     /** Default true when attached. A disabled plugin contributes no shader code
      *  but still changes the pipeline cache key (so toggling forces a rebuild). */
     isEnabled?: boolean;
+    /** Re-upload this plugin's Standard-material UBO values before every rendered frame.
+     *  PBR plugin values already follow the material UBO's versioned update path. */
+    dynamic?: boolean;
     /** Static defines folded into the pipeline cache key (and available to the
      *  plugin when it builds its custom code). */
     defines?: Record<string, boolean | number>;

--- a/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
+++ b/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
@@ -79,6 +79,39 @@ function _releaseMaterialState(scene: SceneContext, state: MaterialPluginState):
     }
 }
 
+function _releaseMaterialStateAfterBindings(scene: SceneContext, mat: StandardMaterialProps, state: MaterialPluginState): void {
+    if (!state._uboBuffer || !scene._built) {
+        _releaseMaterialState(scene, state);
+        return;
+    }
+    const activeDisposers: (() => void)[][] = [];
+    for (const mesh of scene.meshes) {
+        if (mesh.material && getMaterialSource(mesh.material) === mat) {
+            const disposers = scene._meshDisposables.get(mesh);
+            if (disposers) {
+                activeDisposers.push(disposers);
+            }
+        }
+    }
+    if (activeDisposers.length === 0) {
+        _releaseMaterialState(scene, state);
+        return;
+    }
+    let remaining = activeDisposers.length;
+    for (const disposers of activeDisposers) {
+        let completed = false;
+        disposers.push(() => {
+            if (completed) {
+                return;
+            }
+            completed = true;
+            if (--remaining === 0) {
+                _releaseMaterialState(scene, state);
+            }
+        });
+    }
+}
+
 function _clearSceneMaterials(scene: SceneContext, state: ScenePluginState): void {
     for (const materialState of state._materials.values()) {
         _releaseMaterialState(scene, materialState);
@@ -194,7 +227,7 @@ export function bakeStdPluginMaterial(mat: StandardMaterialProps | null | undefi
     if (!mat.plugins?.length) {
         if (old) {
             existingSceneState!._materials.delete(mat);
-            _releaseMaterialState(scene, old);
+            _releaseMaterialStateAfterBindings(scene, mat, old);
             mat._renderFeatures = undefined;
             _queueBindingRebuild(scene, mat);
         }
@@ -219,7 +252,7 @@ export function bakeStdPluginMaterial(mat: StandardMaterialProps | null | undefi
     };
     if (old) {
         mat._renderFeatures = undefined;
-        _releaseMaterialState(scene, old);
+        _releaseMaterialStateAfterBindings(scene, mat, old);
     }
     sceneState._materials.set(mat, state);
     mat._renderFeatures = { features: _computeStandardMaterialFeatures(mat) | (idx << PLUGIN_INDEX_SHIFT) };

--- a/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
+++ b/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
@@ -16,10 +16,11 @@
  */
 
 import type { EngineContext } from "../../engine/engine.js";
+import { retireGpuResources } from "../../engine/gpu-resource-retirement.js";
 import type { StdExt } from "../standard/standard-flags.js";
 import type { StandardMaterialProps } from "../standard/standard-material.js";
 import { _computeStandardMaterialFeatures, getStandardGroupBuilder } from "../standard/standard-material.js";
-import type { Mesh } from "../../mesh/mesh.js";
+import type { SceneContext } from "../../scene/scene.js";
 import type { ShaderFragment, UboSpec } from "../../shader/fragment-types.js";
 import { createUniformBuffer } from "../../resource/gpu-buffers.js";
 import type { MaterialPlugin } from "./material-plugin.js";
@@ -41,17 +42,16 @@ interface MaterialPluginState {
     readonly _engine: EngineContext;
 }
 
+interface ScenePluginState {
+    readonly _materials: Map<StandardMaterialProps, MaterialPluginState>;
+    readonly _refresh: (deltaMs: number) => void;
+}
+
 let _sigToIndex: Map<string, number> | null = null;
 let _indexToEntry: Map<number, PluginEntry> | null = null;
-let _materialStates: Map<StandardMaterialProps, MaterialPluginState> | null = null;
+let _sceneStates: WeakMap<SceneContext, ScenePluginState> | null = null;
+let _materialStates: WeakMap<StandardMaterialProps, Map<EngineContext, MaterialPluginState[]>> | null = null;
 let _counter = 0;
-
-function _resetState(): void {
-    _sigToIndex = new Map();
-    _indexToEntry = new Map();
-    _materialStates = new Map();
-    _counter = 0;
-}
 
 function _indexFor(plugins: readonly MaterialPlugin[]): number {
     const sig = pluginSignature(plugins);
@@ -66,6 +66,75 @@ function _indexFor(plugins: readonly MaterialPlugin[]): number {
     return idx;
 }
 
+function _bindingState(mat: StandardMaterialProps, engine: EngineContext | undefined): MaterialPluginState | undefined {
+    if (!engine) {
+        return;
+    }
+    const states = _materialStates?.get(mat)?.get(engine);
+    return states?.[states.length - 1];
+}
+
+function _trackBindingState(mat: StandardMaterialProps, state: MaterialPluginState): void {
+    const byEngine = (_materialStates ??= new WeakMap()).get(mat) ?? new Map<EngineContext, MaterialPluginState[]>();
+    const states = byEngine.get(state._engine) ?? [];
+    states.push(state);
+    byEngine.set(state._engine, states);
+    _materialStates.set(mat, byEngine);
+}
+
+function _untrackBindingState(mat: StandardMaterialProps, state: MaterialPluginState): void {
+    const byEngine = _materialStates?.get(mat);
+    const states = byEngine?.get(state._engine);
+    if (!states) {
+        return;
+    }
+    const index = states.indexOf(state);
+    if (index >= 0) {
+        states.splice(index, 1);
+    }
+    if (states.length === 0) {
+        byEngine!.delete(state._engine);
+    }
+}
+
+function _releaseMaterialState(scene: SceneContext, mat: StandardMaterialProps, state: MaterialPluginState): void {
+    _untrackBindingState(mat, state);
+    if (!state._uboBuffer) {
+        return;
+    }
+    if (scene._z || !scene._built) {
+        state._uboBuffer.destroy();
+    } else {
+        const buffer = state._uboBuffer;
+        retireGpuResources(state._engine, () => buffer.destroy());
+    }
+}
+
+function _clearSceneMaterials(scene: SceneContext, state: ScenePluginState): void {
+    for (const [mat, materialState] of state._materials) {
+        _releaseMaterialState(scene, mat, materialState);
+    }
+    state._materials.clear();
+}
+
+function _sceneState(scene: SceneContext): ScenePluginState {
+    const states = (_sceneStates ??= new WeakMap());
+    let state = states.get(scene);
+    if (!state) {
+        const created: ScenePluginState = {
+            _materials: new Map(),
+            _refresh: () => refreshStdPluginUbos(scene),
+        };
+        states.set(scene, created);
+        scene._disposables.push(() => {
+            _clearSceneMaterials(scene, created);
+            states.delete(scene);
+        });
+        state = created;
+    }
+    return state;
+}
+
 const stdPluginExt: StdExt = {
     _id: "plugin",
     _phase: "mesh",
@@ -74,14 +143,14 @@ const stdPluginExt: StdExt = {
         const idx = (features >>> PLUGIN_INDEX_SHIFT) & PLUGIN_INDEX_MASK;
         return _indexToEntry?.get(idx)?._fragment ?? { _id: "plugin-0" };
     },
-    _bind(mat: StandardMaterialProps, entries: GPUBindGroupEntry[], b: number): number {
+    _bind(mat: StandardMaterialProps, entries: GPUBindGroupEntry[], b: number, _mesh, engine): number {
         const plugins = (mat as StandardMaterialProps & { plugins?: MaterialPlugin[] }).plugins;
         if (!plugins?.length) {
             return b;
         }
         // The self-managed UBO is declared first in the plugin fragment's
         // bindings (before any textures), so it must be bound first here too.
-        const state = _materialStates?.get(mat);
+        const state = _bindingState(mat, engine);
         if (state?._uboBuffer) {
             entries.push({ binding: b++, resource: { buffer: state._uboBuffer } });
         }
@@ -102,20 +171,22 @@ const stdPluginExt: StdExt = {
  *  into each Standard plugin material's cached feature set. Called from
  *  `enableMaterialPlugins` only.
  *
- *  `meshes` may contain non-Standard (e.g. PBR) materials — those are skipped via
+ *  `scene.meshes` may contain non-Standard (e.g. PBR) materials — those are skipped via
  *  the `_buildGroup` discriminator so their `_renderFeatures` is left untouched
  *  for the PBR build's own `detect`-based feature computation. */
-export function registerStdPlugins(meshes: readonly Mesh[], engine: EngineContext, register: (ext: StdExt) => void): void {
-    _resetState();
+export function registerStdPlugins(scene: SceneContext, register: (ext: StdExt) => void): (deltaMs: number) => void {
     register(stdPluginExt);
+    const state = _sceneState(scene);
+    _clearSceneMaterials(scene, state);
     const materials = new Set<StandardMaterialProps>();
-    for (const m of meshes) {
+    for (const m of scene.meshes) {
         const mat = m.material as StandardMaterialProps | null;
         if (mat && !materials.has(mat)) {
             materials.add(mat);
-            bakeStdPluginMaterial(mat, engine);
+            bakeStdPluginMaterial(mat, scene);
         }
     }
+    return state._refresh;
 }
 
 /**
@@ -124,8 +195,18 @@ export function registerStdPlugins(meshes: readonly Mesh[], engine: EngineContex
  * Call this after assigning plugins to a Standard material created after
  * {@link registerStdPlugins} has walked the scene, and before its mesh first renders.
  */
-export function bakeStdPluginMaterial(mat: StandardMaterialProps | null | undefined, engine: EngineContext): void {
-    if (!mat?.plugins?.length || mat._buildGroup !== getStandardGroupBuilder()) {
+export function bakeStdPluginMaterial(mat: StandardMaterialProps | null | undefined, scene: SceneContext): void {
+    if (!mat || mat._buildGroup !== getStandardGroupBuilder()) {
+        return;
+    }
+    const sceneState = _sceneState(scene);
+    const old = sceneState._materials.get(mat);
+    if (!mat.plugins?.length) {
+        if (old) {
+            sceneState._materials.delete(mat);
+            _releaseMaterialState(scene, mat, old);
+        }
+        mat._renderFeatures = { features: _computeStandardMaterialFeatures(mat) };
         return;
     }
     const plugins = mat.plugins;
@@ -135,27 +216,33 @@ export function bakeStdPluginMaterial(mat: StandardMaterialProps | null | undefi
     if (uboSpec && uboSpec._totalBytes > 0) {
         const data = new Float32Array(uboSpec._totalBytes / 4);
         writePluginUbo(plugins, data, uboSpec._offsets);
-        uboBuffer = createUniformBuffer(engine, data, "plugin-ubo");
+        uboBuffer = createUniformBuffer(scene.surface.engine, data, "plugin-ubo");
     }
-    (_materialStates ??= new Map()).set(mat, {
+    const state: MaterialPluginState = {
         _plugins: plugins,
         _uboBuffer: uboBuffer,
         _uboSpec: uboSpec,
         _dynamic: enabledPlugins(plugins).some((plugin) => plugin.dynamic === true),
-        _engine: engine,
-    });
+        _engine: scene.surface.engine,
+    };
+    if (old) {
+        _releaseMaterialState(scene, mat, old);
+    }
+    sceneState._materials.set(mat, state);
+    _trackBindingState(mat, state);
     mat._renderFeatures = { features: _computeStandardMaterialFeatures(mat) | (idx << PLUGIN_INDEX_SHIFT) };
 }
 
 let _uboScratch: Float32Array | null = null;
 
-/** Re-upload dynamic Standard plugin UBO values for one engine. */
-export function refreshStdPluginUbos(engine: EngineContext): void {
-    if (!_materialStates) {
+/** Re-upload dynamic Standard plugin UBO values for one scene. */
+export function refreshStdPluginUbos(scene: SceneContext): void {
+    const sceneState = _sceneStates?.get(scene);
+    if (!sceneState) {
         return;
     }
-    for (const state of _materialStates.values()) {
-        if (!state._dynamic || state._engine !== engine || !state._uboBuffer || !state._uboSpec) {
+    for (const state of sceneState._materials.values()) {
+        if (!state._dynamic || !state._uboBuffer || !state._uboSpec) {
             continue;
         }
         const floats = state._uboSpec._totalBytes / 4;
@@ -165,6 +252,6 @@ export function refreshStdPluginUbos(engine: EngineContext): void {
             _uboScratch.fill(0, 0, floats);
         }
         writePluginUbo(state._plugins, _uboScratch, state._uboSpec._offsets);
-        engine._device.queue.writeBuffer(state._uboBuffer, 0, _uboScratch.buffer, 0, state._uboSpec._totalBytes);
+        state._engine._device.queue.writeBuffer(state._uboBuffer, 0, _uboScratch.buffer, 0, state._uboSpec._totalBytes);
     }
 }

--- a/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
+++ b/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
@@ -20,7 +20,7 @@ import type { StdExt } from "../standard/standard-flags.js";
 import type { StandardMaterialProps } from "../standard/standard-material.js";
 import { _computeStandardMaterialFeatures, getStandardGroupBuilder } from "../standard/standard-material.js";
 import type { Mesh } from "../../mesh/mesh.js";
-import type { ShaderFragment } from "../../shader/fragment-types.js";
+import type { ShaderFragment, UboSpec } from "../../shader/fragment-types.js";
 import { createUniformBuffer } from "../../resource/gpu-buffers.js";
 import type { MaterialPlugin } from "./material-plugin.js";
 import { bindPluginTextures, buildPluginFragment, enabledPlugins, pluginSignature, writePluginUbo } from "./plugin-bridge-shared.js";
@@ -29,23 +29,31 @@ const PLUGIN_INDEX_SHIFT = 24;
 const PLUGIN_INDEX_MASK = 0x7f;
 
 interface PluginEntry {
-    readonly _plugins: readonly MaterialPlugin[];
     readonly _fragment: ShaderFragment;
-    /** Self-managed plugin uniform buffer, or null when the plugins declare no uniforms. */
+    readonly _uboSpec: UboSpec | null;
+}
+
+interface MaterialPluginState {
+    readonly _plugins: readonly MaterialPlugin[];
     readonly _uboBuffer: GPUBuffer | null;
+    readonly _uboSpec: UboSpec | null;
+    readonly _dynamic: boolean;
+    readonly _engine: EngineContext;
 }
 
 let _sigToIndex: Map<string, number> | null = null;
 let _indexToEntry: Map<number, PluginEntry> | null = null;
+let _materialStates: Map<StandardMaterialProps, MaterialPluginState> | null = null;
 let _counter = 0;
 
 function _resetState(): void {
     _sigToIndex = new Map();
     _indexToEntry = new Map();
+    _materialStates = new Map();
     _counter = 0;
 }
 
-function _indexFor(plugins: readonly MaterialPlugin[], engine: EngineContext): number {
+function _indexFor(plugins: readonly MaterialPlugin[]): number {
     const sig = pluginSignature(plugins);
     const map = (_sigToIndex ??= new Map());
     let idx = map.get(sig);
@@ -53,24 +61,9 @@ function _indexFor(plugins: readonly MaterialPlugin[], engine: EngineContext): n
         idx = ++_counter;
         map.set(sig, idx);
         const built = buildPluginFragment(plugins, idx, true);
-        // Build the self-managed plugin UBO once per signature. Uniform values
-        // come from the plugins themselves (constant for a given signature), so
-        // the buffer is filled at registration time and shared by every material
-        // carrying that signature.
-        let uboBuffer: GPUBuffer | null = null;
-        if (built._stdUboSpec && built._stdUboSpec._totalBytes > 0) {
-            const data = new Float32Array(built._stdUboSpec._totalBytes / 4);
-            writePluginUbo(plugins, data, built._stdUboSpec._offsets);
-            uboBuffer = createUniformBuffer(engine, data, "plugin-ubo");
-        }
-        (_indexToEntry ??= new Map()).set(idx, { _plugins: plugins, _fragment: built._fragment, _uboBuffer: uboBuffer });
+        (_indexToEntry ??= new Map()).set(idx, { _fragment: built._fragment, _uboSpec: built._stdUboSpec });
     }
     return idx;
-}
-
-function _entryFor(plugins: readonly MaterialPlugin[]): PluginEntry | undefined {
-    const idx = _sigToIndex?.get(pluginSignature(plugins));
-    return idx ? _indexToEntry?.get(idx) : undefined;
 }
 
 const stdPluginExt: StdExt = {
@@ -88,9 +81,9 @@ const stdPluginExt: StdExt = {
         }
         // The self-managed UBO is declared first in the plugin fragment's
         // bindings (before any textures), so it must be bound first here too.
-        const entry = _entryFor(plugins);
-        if (entry?._uboBuffer) {
-            entries.push({ binding: b++, resource: { buffer: entry._uboBuffer } });
+        const state = _materialStates?.get(mat);
+        if (state?._uboBuffer) {
+            entries.push({ binding: b++, resource: { buffer: state._uboBuffer } });
         }
         return bindPluginTextures(plugins, entries, b);
     },
@@ -115,11 +108,63 @@ const stdPluginExt: StdExt = {
 export function registerStdPlugins(meshes: readonly Mesh[], engine: EngineContext, register: (ext: StdExt) => void): void {
     _resetState();
     register(stdPluginExt);
+    const materials = new Set<StandardMaterialProps>();
     for (const m of meshes) {
-        const mat = m.material as (StandardMaterialProps & { plugins?: MaterialPlugin[]; _renderFeatures?: { features: number }; _buildGroup?: unknown }) | null;
-        if (mat?.plugins?.length && mat._buildGroup === getStandardGroupBuilder()) {
-            const idx = _indexFor(mat.plugins, engine);
-            mat._renderFeatures = { features: _computeStandardMaterialFeatures(mat) | (idx << PLUGIN_INDEX_SHIFT) };
+        const mat = m.material as StandardMaterialProps | null;
+        if (mat && !materials.has(mat)) {
+            materials.add(mat);
+            bakeStdPluginMaterial(mat, engine);
         }
+    }
+}
+
+/**
+ * Bake a Standard material's plugin signature and per-material uniform buffer.
+ *
+ * Call this after assigning plugins to a Standard material created after
+ * {@link registerStdPlugins} has walked the scene, and before its mesh first renders.
+ */
+export function bakeStdPluginMaterial(mat: StandardMaterialProps | null | undefined, engine: EngineContext): void {
+    if (!mat?.plugins?.length || mat._buildGroup !== getStandardGroupBuilder()) {
+        return;
+    }
+    const plugins = mat.plugins;
+    const idx = _indexFor(plugins);
+    const uboSpec = _indexToEntry?.get(idx)?._uboSpec ?? null;
+    let uboBuffer: GPUBuffer | null = null;
+    if (uboSpec && uboSpec._totalBytes > 0) {
+        const data = new Float32Array(uboSpec._totalBytes / 4);
+        writePluginUbo(plugins, data, uboSpec._offsets);
+        uboBuffer = createUniformBuffer(engine, data, "plugin-ubo");
+    }
+    (_materialStates ??= new Map()).set(mat, {
+        _plugins: plugins,
+        _uboBuffer: uboBuffer,
+        _uboSpec: uboSpec,
+        _dynamic: enabledPlugins(plugins).some((plugin) => plugin.dynamic === true),
+        _engine: engine,
+    });
+    mat._renderFeatures = { features: _computeStandardMaterialFeatures(mat) | (idx << PLUGIN_INDEX_SHIFT) };
+}
+
+let _uboScratch: Float32Array | null = null;
+
+/** Re-upload dynamic Standard plugin UBO values for one engine. */
+export function refreshStdPluginUbos(engine: EngineContext): void {
+    if (!_materialStates) {
+        return;
+    }
+    for (const state of _materialStates.values()) {
+        if (!state._dynamic || state._engine !== engine || !state._uboBuffer || !state._uboSpec) {
+            continue;
+        }
+        const floats = state._uboSpec._totalBytes / 4;
+        if (!_uboScratch || _uboScratch.length < floats) {
+            _uboScratch = new Float32Array(floats);
+        } else {
+            _uboScratch.fill(0, 0, floats);
+        }
+        writePluginUbo(state._plugins, _uboScratch, state._uboSpec._offsets);
+        engine._device.queue.writeBuffer(state._uboBuffer, 0, _uboScratch.buffer, 0, state._uboSpec._totalBytes);
     }
 }

--- a/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
+++ b/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
@@ -87,7 +87,7 @@ function _releaseMaterialStateAfterBindings(scene: SceneContext, mat: StandardMa
     const activeDisposers: (() => void)[][] = [];
     for (const mesh of scene.meshes) {
         if (mesh.material && getMaterialSource(mesh.material) === mat) {
-            const disposers = scene._meshDisposables.get(mesh);
+            const disposers = scene._runtimeBuilds?.pendingDisposers(mesh) ?? scene._meshDisposables.get(mesh);
             if (disposers) {
                 activeDisposers.push(disposers);
             }

--- a/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
+++ b/packages/babylon-lite/src/material/plugin/std-plugin-bridge.ts
@@ -11,8 +11,8 @@
  *     rebuild on any plugin change, and
  *   - delivers plugin uniforms through a SELF-MANAGED uniform buffer declared as
  *     a fragment binding and bound via the pre-existing `StdExt._bind` loop. This
- *     keeps every shared standard-material module byte-identical to a plugin-free
- *     build (no `_writeUbo` hook, no extra UBO loop in the renderable).
+ *     avoids an `_writeUbo` hook or extra plugin UBO loop in the renderable; the
+ *     generic bind hook only carries the owning scene for lifetime-safe lookup.
  */
 
 import type { EngineContext } from "../../engine/engine.js";
@@ -20,7 +20,9 @@ import { retireGpuResources } from "../../engine/gpu-resource-retirement.js";
 import type { StdExt } from "../standard/standard-flags.js";
 import type { StandardMaterialProps } from "../standard/standard-material.js";
 import { _computeStandardMaterialFeatures, getStandardGroupBuilder } from "../standard/standard-material.js";
+import { getMaterialSource } from "../material-view.js";
 import type { SceneContext } from "../../scene/scene.js";
+import { enqueueMaterialSwap } from "../../scene/mesh-scene-registry.js";
 import type { ShaderFragment, UboSpec } from "../../shader/fragment-types.js";
 import { createUniformBuffer } from "../../resource/gpu-buffers.js";
 import type { MaterialPlugin } from "./material-plugin.js";
@@ -50,7 +52,6 @@ interface ScenePluginState {
 let _sigToIndex: Map<string, number> | null = null;
 let _indexToEntry: Map<number, PluginEntry> | null = null;
 let _sceneStates: WeakMap<SceneContext, ScenePluginState> | null = null;
-let _materialStates: WeakMap<StandardMaterialProps, Map<EngineContext, MaterialPluginState[]>> | null = null;
 let _counter = 0;
 
 function _indexFor(plugins: readonly MaterialPlugin[]): number {
@@ -66,39 +67,7 @@ function _indexFor(plugins: readonly MaterialPlugin[]): number {
     return idx;
 }
 
-function _bindingState(mat: StandardMaterialProps, engine: EngineContext | undefined): MaterialPluginState | undefined {
-    if (!engine) {
-        return;
-    }
-    const states = _materialStates?.get(mat)?.get(engine);
-    return states?.[states.length - 1];
-}
-
-function _trackBindingState(mat: StandardMaterialProps, state: MaterialPluginState): void {
-    const byEngine = (_materialStates ??= new WeakMap()).get(mat) ?? new Map<EngineContext, MaterialPluginState[]>();
-    const states = byEngine.get(state._engine) ?? [];
-    states.push(state);
-    byEngine.set(state._engine, states);
-    _materialStates.set(mat, byEngine);
-}
-
-function _untrackBindingState(mat: StandardMaterialProps, state: MaterialPluginState): void {
-    const byEngine = _materialStates?.get(mat);
-    const states = byEngine?.get(state._engine);
-    if (!states) {
-        return;
-    }
-    const index = states.indexOf(state);
-    if (index >= 0) {
-        states.splice(index, 1);
-    }
-    if (states.length === 0) {
-        byEngine!.delete(state._engine);
-    }
-}
-
-function _releaseMaterialState(scene: SceneContext, mat: StandardMaterialProps, state: MaterialPluginState): void {
-    _untrackBindingState(mat, state);
+function _releaseMaterialState(scene: SceneContext, state: MaterialPluginState): void {
     if (!state._uboBuffer) {
         return;
     }
@@ -111,10 +80,21 @@ function _releaseMaterialState(scene: SceneContext, mat: StandardMaterialProps, 
 }
 
 function _clearSceneMaterials(scene: SceneContext, state: ScenePluginState): void {
-    for (const [mat, materialState] of state._materials) {
-        _releaseMaterialState(scene, mat, materialState);
+    for (const materialState of state._materials.values()) {
+        _releaseMaterialState(scene, materialState);
     }
     state._materials.clear();
+}
+
+function _queueBindingRebuild(scene: SceneContext, mat: StandardMaterialProps): void {
+    if (!scene._built) {
+        return;
+    }
+    for (const mesh of scene.meshes) {
+        if (mesh.material && getMaterialSource(mesh.material) === mat) {
+            enqueueMaterialSwap(scene, mesh);
+        }
+    }
 }
 
 function _sceneState(scene: SceneContext): ScenePluginState {
@@ -143,14 +123,15 @@ const stdPluginExt: StdExt = {
         const idx = (features >>> PLUGIN_INDEX_SHIFT) & PLUGIN_INDEX_MASK;
         return _indexToEntry?.get(idx)?._fragment ?? { _id: "plugin-0" };
     },
-    _bind(mat: StandardMaterialProps, entries: GPUBindGroupEntry[], b: number, _mesh, engine): number {
-        const plugins = (mat as StandardMaterialProps & { plugins?: MaterialPlugin[] }).plugins;
+    _bind(mat: StandardMaterialProps, entries: GPUBindGroupEntry[], b: number, _mesh, scene): number {
+        const source = getMaterialSource(mat) as StandardMaterialProps;
+        const plugins = source.plugins;
         if (!plugins?.length) {
             return b;
         }
         // The self-managed UBO is declared first in the plugin fragment's
         // bindings (before any textures), so it must be bound first here too.
-        const state = _bindingState(mat, engine);
+        const state = scene ? _sceneStates?.get(scene)?._materials.get(source) : undefined;
         if (state?._uboBuffer) {
             entries.push({ binding: b++, resource: { buffer: state._uboBuffer } });
         }
@@ -177,12 +158,21 @@ const stdPluginExt: StdExt = {
 export function registerStdPlugins(scene: SceneContext, register: (ext: StdExt) => void): (deltaMs: number) => void {
     register(stdPluginExt);
     const state = _sceneState(scene);
-    _clearSceneMaterials(scene, state);
     const materials = new Set<StandardMaterialProps>();
     for (const m of scene.meshes) {
         const mat = m.material as StandardMaterialProps | null;
-        if (mat && !materials.has(mat)) {
+        if (mat?._buildGroup === getStandardGroupBuilder()) {
             materials.add(mat);
+        }
+    }
+    for (const [mat, materialState] of state._materials) {
+        if (!materials.has(mat)) {
+            state._materials.delete(mat);
+            _releaseMaterialState(scene, materialState);
+        }
+    }
+    for (const mat of materials) {
+        if (mat.plugins?.length || state._materials.has(mat)) {
             bakeStdPluginMaterial(mat, scene);
         }
     }
@@ -199,16 +189,18 @@ export function bakeStdPluginMaterial(mat: StandardMaterialProps | null | undefi
     if (!mat || mat._buildGroup !== getStandardGroupBuilder()) {
         return;
     }
-    const sceneState = _sceneState(scene);
-    const old = sceneState._materials.get(mat);
+    const existingSceneState = _sceneStates?.get(scene);
+    const old = existingSceneState?._materials.get(mat);
     if (!mat.plugins?.length) {
         if (old) {
-            sceneState._materials.delete(mat);
-            _releaseMaterialState(scene, mat, old);
+            existingSceneState!._materials.delete(mat);
+            _releaseMaterialState(scene, old);
+            mat._renderFeatures = undefined;
+            _queueBindingRebuild(scene, mat);
         }
-        mat._renderFeatures = { features: _computeStandardMaterialFeatures(mat) };
         return;
     }
+    const sceneState = existingSceneState ?? _sceneState(scene);
     const plugins = mat.plugins;
     const idx = _indexFor(plugins);
     const uboSpec = _indexToEntry?.get(idx)?._uboSpec ?? null;
@@ -226,11 +218,12 @@ export function bakeStdPluginMaterial(mat: StandardMaterialProps | null | undefi
         _engine: scene.surface.engine,
     };
     if (old) {
-        _releaseMaterialState(scene, mat, old);
+        mat._renderFeatures = undefined;
+        _releaseMaterialState(scene, old);
     }
     sceneState._materials.set(mat, state);
-    _trackBindingState(mat, state);
     mat._renderFeatures = { features: _computeStandardMaterialFeatures(mat) | (idx << PLUGIN_INDEX_SHIFT) };
+    _queueBindingRebuild(scene, mat);
 }
 
 let _uboScratch: Float32Array | null = null;

--- a/packages/babylon-lite/src/material/standard/fragments/std-uv-transform-fragment.ts
+++ b/packages/babylon-lite/src/material/standard/fragments/std-uv-transform-fragment.ts
@@ -153,10 +153,11 @@ export const stdUvTransformExt: StdExt = {
     _feature: STD_HAS_UV_TRANSFORM,
     _meshFeatures: (_meshFeatures, material) => (material?._hasUvTx ? STD_HAS_UV_TRANSFORM : 0),
     _frag: createStdUvTransformFragment,
-    _bind(material, entries, binding, _mesh, engine) {
-        if (!engine) {
-            throw new Error("Standard UV transform _bind requires the engine argument from the Standard bind-group builder");
+    _bind(material, entries, binding, _mesh, scene) {
+        if (!scene) {
+            throw new Error("Standard UV transform _bind requires the scene argument from the Standard bind-group builder");
         }
+        const engine = scene.surface.engine;
         const data = new Float32Array(FLOATS_PER_CHANNEL * CHANNEL_COUNT);
         writeUvTransformData(data, material);
         const buffer = createUniformBuffer(engine, data);

--- a/packages/babylon-lite/src/material/standard/standard-flags.ts
+++ b/packages/babylon-lite/src/material/standard/standard-flags.ts
@@ -1,7 +1,7 @@
 import type { ShaderFragment } from "../../shader/fragment-types.js";
 import type { Texture2D } from "../../texture/texture-2d.js";
 import type { Mesh } from "../../mesh/mesh.js";
-import type { EngineContext } from "../../engine/engine.js";
+import type { SceneContext } from "../../scene/scene-core.js";
 import type { StandardMaterialProps } from "./standard-material.js";
 
 // ─── Feature Flags ──────────────────────────────────────────────────
@@ -75,7 +75,7 @@ export interface StdExt {
     /** @internal */
     _frag(features: number, meshFeatures?: number, shadowLights?: ShadowLightSlotLite[]): ShaderFragment;
     /** @internal Push group-1 bind entries starting at binding `b`; return new b. */
-    _bind?(mat: StandardMaterialProps, entries: GPUBindGroupEntry[], b: number, mesh?: Mesh, engine?: EngineContext): number;
+    _bind?(mat: StandardMaterialProps, entries: GPUBindGroupEntry[], b: number, mesh?: Mesh, scene?: SceneContext): number;
     /** @internal Bind feature-owned vertex buffers and return the next slot. */
     _bindVertexBuffers?(mesh: Mesh, pass: GPURenderPassEncoder | GPURenderBundleEncoder, slot: number): number;
     /** @internal Enumerate textures for acquire/release. */

--- a/packages/babylon-lite/src/material/standard/standard-geometry-renderable.ts
+++ b/packages/babylon-lite/src/material/standard/standard-geometry-renderable.ts
@@ -219,9 +219,9 @@ export function buildStandardGeometryRenderable(scene: SceneContext, mesh: Mesh,
     }
     const skeletonVelocity =
         skeletonVelocityFactory && mesh.skeleton
-            ? skeletonVelocityFactory(engine, mesh.skeleton, (texture) => _createGeometryMeshBindGroup(engine, view, res, mesh, meshUBO, texture))
+            ? skeletonVelocityFactory(engine, mesh.skeleton, (texture) => _createGeometryMeshBindGroup(scene, view, res, mesh, meshUBO, texture))
             : null;
-    let meshBindGroup = skeletonVelocity?._bindGroup ?? _createGeometryMeshBindGroup(engine, view, res, mesh, meshUBO, null);
+    let meshBindGroup = skeletonVelocity?._bindGroup ?? _createGeometryMeshBindGroup(scene, view, res, mesh, meshUBO, null);
     let velocityReady = false;
 
     // Acquire all textures the standard shader references so the GPU-pool
@@ -525,13 +525,14 @@ function _ensureViewResources(
 }
 
 function _createGeometryMeshBindGroup(
-    engine: EngineContext,
+    scene: SceneContext,
     view: StandardGeometryMaterialView,
     res: StandardGeometryViewResources,
     mesh: Mesh,
     meshUBO: GPUBuffer,
     previousBoneTexture: GPUTexture | null
 ): GPUBindGroup {
+    const engine = scene.surface.engine;
     const source = view.source as StandardMaterialProps;
     const features = res._features;
     let nextBinding = 0;
@@ -552,7 +553,7 @@ function _createGeometryMeshBindGroup(
     }
     for (const used of res._extFragments) {
         if (used._ext._bind) {
-            nextBinding = used._ext._bind(source, entries, nextBinding, mesh, engine);
+            nextBinding = used._ext._bind(source, entries, nextBinding, mesh, scene);
         }
     }
     // Geometry-params `gp` UBO is contributed by the geometry composer as the

--- a/packages/babylon-lite/src/material/standard/standard-pipeline.ts
+++ b/packages/babylon-lite/src/material/standard/standard-pipeline.ts
@@ -12,6 +12,7 @@
 
 import { F32 } from "../../engine/typed-arrays.js";
 import type { EngineContext } from "../../engine/engine.js";
+import type { SceneContext } from "../../scene/scene-core.js";
 import type { RenderTargetSignature } from "../../engine/render-target.js";
 import type { StandardMaterialProps, StandardSceneShaderContext } from "./standard-material.js";
 import type { Mesh } from "../../mesh/mesh.js";
@@ -318,7 +319,7 @@ export function getOrCreateStandardPipeline(
  *
  *  Mirrors `createPbrMeshBindGroup` in pbr-pipeline.ts. */
 export function createStandardMeshBindGroup(
-    engine: EngineContext,
+    scene: SceneContext,
     bindings: StandardShaderBindings,
     meshUBO: GPUBuffer,
     materialUBO: GPUBuffer,
@@ -326,6 +327,7 @@ export function createStandardMeshBindGroup(
     morphTargets: { deltasBuffer: GPUBuffer; weightsBuffer: GPUBuffer } | null = null,
     mesh?: Mesh
 ): GPUBindGroup {
+    const engine = scene.surface.engine;
     const device = engine._device;
     const features = bindings._features;
     const hasDiffuseTex = features & HAS_DIFFUSE_TEXTURE;
@@ -367,7 +369,7 @@ export function createStandardMeshBindGroup(
     // to match composer's fragment sort order.
     for (const ext of _getStdExtsSorted()) {
         if (features & ext._feature && ext._bind) {
-            nextBinding = ext._bind(material, entries, nextBinding, mesh, engine);
+            nextBinding = ext._bind(material, entries, nextBinding, mesh, scene);
         }
     }
 

--- a/packages/babylon-lite/src/material/standard/standard-renderable.ts
+++ b/packages/babylon-lite/src/material/standard/standard-renderable.ts
@@ -211,7 +211,7 @@ export function buildStandardMeshRenderables(scene: SceneContext, meshes: Mesh[]
         const matData = new F32(24);
         writeStdMaterialData(matData, mat, textureLevel);
         const materialUBO = createUniformBuffer(engine, matData);
-        const meshBindGroup = createStandardMeshBindGroup(engine, bindings, meshUBO, materialUBO, mat, mesh.morphTargets ?? null, mesh);
+        const meshBindGroup = createStandardMeshBindGroup(s, bindings, meshUBO, materialUBO, mat, mesh.morphTargets ?? null, mesh);
 
         // Shadow bind group (group 2) — shared across receiving meshes via shadowBGCache.
         let shadowBindGroup: GPUBindGroup | null = null;

--- a/packages/babylon-lite/src/mesh/get-mesh-geometry.ts
+++ b/packages/babylon-lite/src/mesh/get-mesh-geometry.ts
@@ -1,5 +1,20 @@
 import type { Mesh } from "./mesh.js";
 
+/**
+ * Return caller-owned copies of a mesh's indexed triangle positions.
+ *
+ * Unlike {@link getMeshGeometry}, this does not require normals or other shading attributes.
+ * Returns `null` when positions or indices are not retained on the CPU.
+ */
+export function getMeshTriangles(mesh: Mesh): { positions: Float32Array; indices: Uint32Array } | null {
+    const positions = mesh._cpuPositions;
+    const indices = mesh._cpuIndices;
+    if (!positions || !indices) {
+        return null;
+    }
+    return { positions: positions.slice(), indices: indices.slice() };
+}
+
 /** Return caller-owned copies of the CPU geometry retained by a mesh.
  *  Returns `null` when positions, normals, or indices are unavailable. */
 export function getMeshGeometry(mesh: Mesh): {

--- a/packages/babylon-lite/src/scene/scene-core.ts
+++ b/packages/babylon-lite/src/scene/scene-core.ts
@@ -70,8 +70,10 @@ export interface RuntimeSceneBuildHooks {
     track(promise: Promise<void>): Promise<void>;
     base(builder: MeshGroupBuilder, rebuild: NonNullable<MeshGroupBuilder["_rebuildSingle"]>): NonNullable<MeshGroupBuilder["_rebuildSingle"]>;
     readonly w: boolean;
-    /** Disposer packet temporarily owned by an active async mesh build after it leaves `_meshDisposables`. */
+    /** Disposer packet temporarily owned by an active async mesh or group build after it leaves `_meshDisposables`. */
     pendingDisposers(mesh: Mesh): (() => void)[] | undefined;
+    holdPendingDisposers(mesh: Mesh, disposers: (() => void)[]): void;
+    releasePendingDisposers(mesh: Mesh, disposers: (() => void)[]): void;
     reset(mesh: Mesh): void;
     remove(mesh: Mesh): void;
     /** Forget every rebuild closure cached for this builder in this scene. Called when a group's output is

--- a/packages/babylon-lite/src/scene/scene-core.ts
+++ b/packages/babylon-lite/src/scene/scene-core.ts
@@ -70,6 +70,8 @@ export interface RuntimeSceneBuildHooks {
     track(promise: Promise<void>): Promise<void>;
     base(builder: MeshGroupBuilder, rebuild: NonNullable<MeshGroupBuilder["_rebuildSingle"]>): NonNullable<MeshGroupBuilder["_rebuildSingle"]>;
     readonly w: boolean;
+    /** Disposer packet temporarily owned by an active async mesh build after it leaves `_meshDisposables`. */
+    pendingDisposers(mesh: Mesh): (() => void)[] | undefined;
     reset(mesh: Mesh): void;
     remove(mesh: Mesh): void;
     /** Forget every rebuild closure cached for this builder in this scene. Called when a group's output is

--- a/packages/babylon-lite/src/scene/scene-rebuild.ts
+++ b/packages/babylon-lite/src/scene/scene-rebuild.ts
@@ -174,6 +174,7 @@ async function rebuildSceneGroups(scene: SceneContext, family: "standard" | "pbr
             await runtime?.wait(meshes);
             let unstable = false;
             const rebuild = async (): Promise<void> => {
+                const buildHooks = ctx._runtimeBuilds;
                 // Build only the meshes that currently belong to this group with this builder's material
                 // family: a mesh whose material was swapped away is still listed in `_groups` (the swap path
                 // does not move group membership) and its output would be discarded anyway. Pre-filtering
@@ -202,6 +203,7 @@ async function rebuildSceneGroups(scene: SceneContext, family: "standard" | "pbr
                     if (disposers) {
                         oldByMesh.set(mesh, disposers);
                         ctx._meshDisposables.delete(mesh);
+                        buildHooks?.holdPendingDisposers(mesh, disposers);
                     }
                 }
 
@@ -234,6 +236,9 @@ async function rebuildSceneGroups(scene: SceneContext, family: "standard" | "pbr
                                 retireOld(previous);
                             }
                         }
+                        if (previous) {
+                            buildHooks?.releasePendingDisposers(mesh, previous);
+                        }
                     }
                     throw error;
                 } finally {
@@ -256,6 +261,9 @@ async function rebuildSceneGroups(scene: SceneContext, family: "standard" | "pbr
                     }
                     const oldDisposers = [...oldByMesh.values()].flat();
                     retireOld(oldDisposers);
+                    for (const [mesh, disposers] of oldByMesh) {
+                        buildHooks?.releasePendingDisposers(mesh, disposers);
+                    }
                     return;
                 }
                 transmission?.[0]();
@@ -297,6 +305,9 @@ async function rebuildSceneGroups(scene: SceneContext, family: "standard" | "pbr
                                 retireOld(previous);
                             }
                         }
+                        if (previous) {
+                            buildHooks?.releasePendingDisposers(mesh, previous);
+                        }
                     }
                     unstable = true;
                     return;
@@ -314,6 +325,7 @@ async function rebuildSceneGroups(scene: SceneContext, family: "standard" | "pbr
                         if (previous && ctx.meshes.includes(mesh)) {
                             ctx._meshDisposables.set(mesh, previous);
                             oldByMesh.delete(mesh);
+                            buildHooks?.releasePendingDisposers(mesh, previous);
                         } else {
                             ctx._meshDisposables.delete(mesh);
                         }
@@ -354,6 +366,9 @@ async function rebuildSceneGroups(scene: SceneContext, family: "standard" | "pbr
                 // (refcount bumped), so they stay alive until the deferred release nets the refcount back down.
                 const oldDisposers = [...oldByMesh.values()].flat();
                 retireOld(oldDisposers);
+                for (const [mesh, disposers] of oldByMesh) {
+                    buildHooks?.releasePendingDisposers(mesh, disposers);
+                }
             };
 
             const { X } = await import("./scene-runtime-mesh-build.js");

--- a/packages/babylon-lite/src/scene/scene-runtime-mesh-build.ts
+++ b/packages/babylon-lite/src/scene/scene-runtime-mesh-build.ts
@@ -46,6 +46,16 @@ interface RuntimeBuildState {
     tail: Promise<void> | null;
 }
 
+function holdPendingDisposers(state: RuntimeBuildState, mesh: Mesh, disposers: (() => void)[]): void {
+    state.pendingDisposers.set(mesh, disposers);
+}
+
+function releasePendingDisposers(state: RuntimeBuildState, mesh: Mesh, disposers: (() => void)[] | undefined): void {
+    if (disposers && state.pendingDisposers.get(mesh) === disposers) {
+        state.pendingDisposers.delete(mesh);
+    }
+}
+
 interface PbrGeometrySceneState {
     _pbrGeomContext?: unknown;
     _pbrMeshGeomContexts?: WeakMap<Mesh, unknown>;
@@ -190,6 +200,8 @@ function installRuntimeBuilds(scene: SceneContext): RuntimeSceneBuildHooks {
             return !!state.tail;
         },
         pendingDisposers: (mesh) => state.pendingDisposers.get(mesh),
+        holdPendingDisposers: (mesh, disposers) => holdPendingDisposers(state, mesh, disposers),
+        releasePendingDisposers: (mesh, disposers) => releasePendingDisposers(state, mesh, disposers),
         reset: (mesh) => {
             resetRuntimeRebuild(scene, state, mesh);
             pbrState._pbrMeshGeomContexts?.delete(mesh);
@@ -305,7 +317,7 @@ async function materializeRuntimeMesh(scene: SceneContext, state: RuntimeBuildSt
     const previousDisposers = scene._meshDisposables.get(mesh);
     if (previousDisposers) {
         scene._meshDisposables.delete(mesh);
-        state.pendingDisposers.set(mesh, previousDisposers);
+        holdPendingDisposers(state, mesh, previousDisposers);
     }
     const previousRebuild = builder._rebuildSingle;
     const runtimeRebuilder = _runtimeRebuilders?.get(builder);
@@ -366,7 +378,7 @@ async function materializeRuntimeMesh(scene: SceneContext, state: RuntimeBuildSt
             }
         });
     }
-    state.pendingDisposers.delete(mesh);
+    releasePendingDisposers(state, mesh, previousDisposers);
     scene._renderables.push(...result.renderables);
     // Keep the group's tracked output in sync: a later topology rebuild drops the previous output by
     // identity, and a runtime-built renderable that is missing from it would survive and double-draw.
@@ -485,7 +497,7 @@ function discardMeshBuild(scene: SceneContext, state: RuntimeBuildState, mesh: M
             });
         }
     }
-    state.pendingDisposers.delete(mesh);
+    releasePendingDisposers(state, mesh, previousDisposers);
 }
 
 function discardDisposedSceneCallbacks(scene: SceneContext, state: RuntimeBuildState): void {

--- a/packages/babylon-lite/src/scene/scene-runtime-mesh-build.ts
+++ b/packages/babylon-lite/src/scene/scene-runtime-mesh-build.ts
@@ -42,6 +42,7 @@ interface RuntimeBuildState {
     generations: WeakMap<Mesh, number>;
     installed: WeakMap<Mesh, Set<MeshGroupBuilder>>;
     installedMeshes: Set<Mesh>;
+    pendingDisposers: WeakMap<Mesh, (() => void)[]>;
     tail: Promise<void> | null;
 }
 
@@ -129,6 +130,7 @@ function installRuntimeBuilds(scene: SceneContext): RuntimeSceneBuildHooks {
         generations: new WeakMap(),
         installed: new WeakMap(),
         installedMeshes: new Set(),
+        pendingDisposers: new WeakMap(),
         tail: null,
     };
     const pbrState = scene as SceneContext & PbrGeometrySceneState;
@@ -187,6 +189,7 @@ function installRuntimeBuilds(scene: SceneContext): RuntimeSceneBuildHooks {
         get w() {
             return !!state.tail;
         },
+        pendingDisposers: (mesh) => state.pendingDisposers.get(mesh),
         reset: (mesh) => {
             resetRuntimeRebuild(scene, state, mesh);
             pbrState._pbrMeshGeomContexts?.delete(mesh);
@@ -302,6 +305,7 @@ async function materializeRuntimeMesh(scene: SceneContext, state: RuntimeBuildSt
     const previousDisposers = scene._meshDisposables.get(mesh);
     if (previousDisposers) {
         scene._meshDisposables.delete(mesh);
+        state.pendingDisposers.set(mesh, previousDisposers);
     }
     const previousRebuild = builder._rebuildSingle;
     const runtimeRebuilder = _runtimeRebuilders?.get(builder);
@@ -362,6 +366,7 @@ async function materializeRuntimeMesh(scene: SceneContext, state: RuntimeBuildSt
             }
         });
     }
+    state.pendingDisposers.delete(mesh);
     scene._renderables.push(...result.renderables);
     // Keep the group's tracked output in sync: a later topology rebuild drops the previous output by
     // identity, and a runtime-built renderable that is missing from it would survive and double-draw.
@@ -480,6 +485,7 @@ function discardMeshBuild(scene: SceneContext, state: RuntimeBuildState, mesh: M
             });
         }
     }
+    state.pendingDisposers.delete(mesh);
 }
 
 function discardDisposedSceneCallbacks(scene: SceneContext, state: RuntimeBuildState): void {

--- a/tests/lite/unit/depth-pyramid.test.ts
+++ b/tests/lite/unit/depth-pyramid.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const pool = vi.hoisted(() => ({
+    acquireTexture: vi.fn(),
+    releaseTexture: vi.fn(),
+    getOrCreateSampler: vi.fn(() => ({}) as GPUSampler),
+}));
+
+vi.mock("../../../packages/babylon-lite/src/resource/gpu-pool.js", () => pool);
+
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import { createDepthPyramid } from "../../../packages/babylon-lite/src/frame-graph/depth-pyramid";
+
+function makeEngine(): { engine: EngineContext; createShaderModule: ReturnType<typeof vi.fn> } {
+    const createShaderModule = vi.fn((descriptor: GPUShaderModuleDescriptor) => descriptor as unknown as GPUShaderModule);
+    const texture = {
+        createView: vi.fn(() => ({}) as GPUTextureView),
+    } as unknown as GPUTexture;
+    const device = {
+        createBindGroupLayout: vi.fn(() => ({}) as GPUBindGroupLayout),
+        createPipelineLayout: vi.fn(() => ({}) as GPUPipelineLayout),
+        createShaderModule,
+        createRenderPipeline: vi.fn(() => ({}) as GPURenderPipeline),
+        createTexture: vi.fn(() => texture),
+        createBindGroup: vi.fn(() => ({}) as GPUBindGroup),
+    } as unknown as GPUDevice;
+    return { engine: { _device: device } as unknown as EngineContext, createShaderModule };
+}
+
+describe("depth pyramid reduction", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it.each(["min", "max"] as const)("includes odd source rows and columns for %s reduction", (reduce) => {
+        const { engine, createShaderModule } = makeEngine();
+
+        const pyramid = createDepthPyramid(engine, { width: 5, height: 3, reduce });
+        const shader = createShaderModule.mock.calls.map(([descriptor]) => (descriptor as GPUShaderModuleDescriptor).code).find((code) => code.includes("extraX"));
+
+        expect(shader).toContain("let extraX=(sd.x&1)==1");
+        expect(shader).toContain("let extraY=(sd.y&1)==1");
+        expect(shader).toContain(`r=${reduce}(r,`);
+
+        pyramid.dispose();
+    });
+});

--- a/tests/lite/unit/get-mesh-geometry.test.ts
+++ b/tests/lite/unit/get-mesh-geometry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { getMeshGeometry } from "../../../packages/babylon-lite/src/mesh/get-mesh-geometry";
+import { getMeshGeometry, getMeshTriangles } from "../../../packages/babylon-lite/src/mesh/get-mesh-geometry";
 import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
 
 function completeMesh(): Mesh {
@@ -29,6 +29,7 @@ describe("getMeshGeometry", () => {
             tangents: mesh._cpuTangents,
             colors: mesh._cpuColors,
         });
+
         expect(geometry).not.toBeNull();
         expect(geometry!.positions).not.toBe(mesh._cpuPositions);
         expect(geometry!.normals).not.toBe(mesh._cpuNormals);
@@ -89,5 +90,28 @@ describe("getMeshGeometry", () => {
         expect(geometry?.positions).not.toBe(positions);
         expect(geometry?.normals).not.toBe(normals);
         expect(geometry?.indices).not.toBe(indices);
+    });
+});
+
+describe("getMeshTriangles", () => {
+    it("returns caller-owned positions and indices without requiring normals", () => {
+        const mesh = completeMesh();
+        mesh._cpuNormals = undefined;
+
+        const triangles = getMeshTriangles(mesh);
+
+        expect(triangles).toEqual({
+            positions: mesh._cpuPositions,
+            indices: mesh._cpuIndices,
+        });
+        expect(triangles!.positions).not.toBe(mesh._cpuPositions);
+        expect(triangles!.indices).not.toBe(mesh._cpuIndices);
+    });
+
+    it.each(["_cpuPositions", "_cpuIndices"] as const)("returns null when %s is unavailable", (field) => {
+        const mesh = completeMesh();
+        mesh[field] = undefined;
+
+        expect(getMeshTriangles(mesh)).toBeNull();
     });
 });

--- a/tests/lite/unit/load-hdr.test.ts
+++ b/tests/lite/unit/load-hdr.test.ts
@@ -87,4 +87,14 @@ describe("loadHdrEnvironment", () => {
             scene.surface.engine
         );
     });
+
+    it("can load IBL without creating a background", async () => {
+        vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, status: 200, arrayBuffer: async () => new ArrayBuffer(4) })) as unknown as typeof fetch);
+        const scene = makeScene();
+
+        await loadHdrEnvironment(scene, "/studio.hdr", { skipSkybox: true, skipGround: true });
+        await scene._deferredBuilders[0]!();
+
+        expect(scene._renderables).toHaveLength(0);
+    });
 });

--- a/tests/lite/unit/pbr-uv-transform.test.ts
+++ b/tests/lite/unit/pbr-uv-transform.test.ts
@@ -32,6 +32,7 @@ import {
 import { composeStandardGeometryShader } from "../../../packages/babylon-lite/src/material/standard/standard-geometry-output-shader";
 import type { StandardMaterialProps } from "../../../packages/babylon-lite/src/material/standard/standard-material";
 import { composeStandardShader } from "../../../packages/babylon-lite/src/material/standard/standard-pipeline";
+import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
 
 describe("PBR UV transform detection", () => {
     beforeEach(() => {
@@ -141,7 +142,7 @@ describe("StandardMaterial UV transform detection", () => {
             _lightmapTexture: { uAng: Math.PI },
         } as StandardMaterialProps;
 
-        stdUvTransformExt._bind!(material, [], 0, undefined, engine);
+        stdUvTransformExt._bind!(material, [], 0, undefined, { surface: { engine } } as SceneContext);
         const c = Math.cos(0.42);
         const s = Math.sin(0.42);
         expect(written![2]).toBeCloseTo(s * 1.65);

--- a/tests/lite/unit/runtime-material-rebuild.test.ts
+++ b/tests/lite/unit/runtime-material-rebuild.test.ts
@@ -516,4 +516,42 @@ describe("runtime material rebuild ownership", () => {
         expect(oldDispose).not.toHaveBeenCalled();
         expect(engine._retirements).toHaveLength(1);
     });
+
+    it("keeps a removed disposer packet reachable while an async runtime build is active", async () => {
+        const engine = { _retirements: [] } as unknown as EngineContext;
+        const scene = createScene(engine);
+        scene._built = true;
+        let startBuild!: () => void;
+        let finishBuild!: () => void;
+        const started = new Promise<void>((resolve) => (startBuild = resolve));
+        const finish = new Promise<void>((resolve) => (finishBuild = resolve));
+        const builder = (async (ctx: SceneContext, meshes: Mesh[]) => {
+            startBuild();
+            await finish;
+            const rebuild = (_target: SceneContext, mesh: Mesh): Renderable => renderable(mesh);
+            for (const mesh of meshes) {
+                ctx._meshDisposables.set(mesh, [vi.fn()]);
+            }
+            return { renderables: meshes.map(renderable), rebuildSingle: rebuild };
+        }) as MeshGroupBuilder;
+        builder._materialFamily = "standard";
+        const material = { _buildGroup: builder } as Material;
+        const mesh = { _gpu: {}, material, children: [] } as unknown as Mesh;
+        const previousDisposers = [vi.fn()];
+        scene.meshes.push(mesh);
+        scene._groups.set(builder, Object.assign([mesh], { r: (_ctx: SceneContext, target: Mesh) => renderable(target) }));
+        scene._meshDisposables.set(mesh, previousDisposers);
+
+        const pending = startRuntimeMeshBuild(scene, builder, mesh);
+        await started;
+
+        expect(scene._meshDisposables.get(mesh)).toBeUndefined();
+        expect(scene._runtimeBuilds?.pendingDisposers(mesh)).toBe(previousDisposers);
+
+        finishBuild();
+        await pending;
+
+        expect(scene._runtimeBuilds?.pendingDisposers(mesh)).toBeUndefined();
+        expect(engine._retirements).toHaveLength(1);
+    });
 });

--- a/tests/lite/unit/scene-rebuild-renderables.test.ts
+++ b/tests/lite/unit/scene-rebuild-renderables.test.ts
@@ -145,6 +145,48 @@ describe("rebuildSceneRenderables", () => {
         expect(auxDisposed).toBe(false); // aux disposers belong to other tasks
     });
 
+    it("keeps group-rebuild disposer packets reachable while the async builder is blocked", async () => {
+        const scene = fakeScene();
+        let enterBuilder!: () => void;
+        const enteredBuilder = new Promise<void>((resolve) => {
+            enterBuilder = resolve;
+        });
+        let unblockBuilder!: () => void;
+        const blockedBuilder = new Promise<void>((resolve) => {
+            unblockBuilder = resolve;
+        });
+        const builder = (async () => {
+            enterBuilder();
+            await blockedBuilder;
+            return { renderables: [renderable(1)], rebuildSingle: () => renderable(1) };
+        }) as unknown as MeshGroupBuilder;
+        const mesh = { material: { _buildGroup: builder } } as never;
+        const oldDisposers: (() => void)[] = [];
+        scene.meshes.push(mesh);
+        scene._groups.set(builder, [mesh]);
+        scene._meshDisposables.set(mesh, oldDisposers);
+
+        const rebuilding = rebuildSceneRenderables(scene);
+        await enteredBuilder;
+
+        expect(scene._meshDisposables.has(mesh)).toBe(false);
+        const pending = scene._runtimeBuilds?.pendingDisposers(mesh);
+        expect(pending).toBe(oldDisposers);
+        let deferredTeardownRan = false;
+        pending?.push(() => {
+            deferredTeardownRan = true;
+        });
+        expect(deferredTeardownRan).toBe(false);
+
+        unblockBuilder();
+        await rebuilding;
+
+        expect(scene._runtimeBuilds?.pendingDisposers(mesh)).toBeUndefined();
+        expect(deferredTeardownRan).toBe(false);
+        drainRetirements(scene);
+        expect(deferredTeardownRan).toBe(true);
+    });
+
     it("keeps a deferred topology teardown queued when a later group's build rejects", async () => {
         const scene = fakeScene();
         const okBuilder = fakeBuilder(1);

--- a/tests/lite/unit/standard-material-plugin-dynamic.test.ts
+++ b/tests/lite/unit/standard-material-plugin-dynamic.test.ts
@@ -9,9 +9,10 @@ import { _computeStandardMaterialFeatures, type StandardMaterialProps } from "..
 import { MATERIAL_ALPHA_BLEND } from "../../../packages/babylon-lite/src/material/standard/standard-flags";
 import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
 import type { StdExt } from "../../../packages/babylon-lite/src/material/standard/standard-flags";
-import type { Renderable } from "../../../packages/babylon-lite/src/render/renderable";
+import type { MeshGroupBuilder, Renderable } from "../../../packages/babylon-lite/src/render/renderable";
 import { createSceneContext, disposeScene, onBeforeRender, type RuntimeSceneBuildHooks, type SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
 import { processMaterialSwaps } from "../../../packages/babylon-lite/src/scene/scene-material-swap";
+import { rebuildSceneRenderables } from "../../../packages/babylon-lite/src/scene/scene-rebuild";
 
 interface MockBuffer {
     readonly id: number;
@@ -368,5 +369,74 @@ describe("dynamic Standard material plugins", () => {
         engine._retirements = null;
         uboRetirements?.splice(0).forEach((retire) => retire());
         expect(oldBuffer.destroy).toHaveBeenCalledOnce();
+    });
+
+    it("keeps the old UBO alive during a blocked full-group rebuild with no scene disposer packet", async () => {
+        const { engine, buffers } = makeEngine();
+        const material = createStandardMaterial();
+        material.plugins = [valuePlugin({ current: 1 })];
+        const scene = pluginScene(engine, [material]);
+        const targetMesh = scene.meshes[0]!;
+
+        registerStdPlugins(scene, (ext) => {
+            registered = ext;
+        });
+        const oldBuffer = buffers[0]!;
+        const standardBuilder = material._buildGroup;
+        let enterBuilder!: () => void;
+        const enteredBuilder = new Promise<void>((resolve) => {
+            enterBuilder = resolve;
+        });
+        let unblockBuilder!: () => void;
+        const blockedBuilder = new Promise<void>((resolve) => {
+            unblockBuilder = resolve;
+        });
+        let reboundBuffer: GPUBuffer | undefined;
+        const builder = (async (targetScene: SceneContext) => {
+            enterBuilder();
+            await blockedBuilder;
+            const entries: GPUBindGroupEntry[] = [];
+            registered._bind!(material, entries, 0, targetMesh, targetScene);
+            reboundBuffer = (entries[0]!.resource as GPUBufferBinding).buffer;
+            targetScene._meshDisposables.set(targetMesh, []);
+            return {
+                renderables: [{ mesh: targetMesh, order: 0, isTransparent: false } as Renderable],
+                rebuildSingle: () => ({ mesh: targetMesh, order: 0, isTransparent: false }) as Renderable,
+            };
+        }) as unknown as MeshGroupBuilder;
+        Object.assign(material, { _buildGroup: builder });
+        scene._groups.set(builder, [targetMesh]);
+        scene._meshDisposables.set(targetMesh, []);
+        scene._built = true;
+
+        const rebuilding = rebuildSceneRenderables(scene);
+        await enteredBuilder;
+        expect(scene._meshDisposables.has(targetMesh)).toBe(false);
+        expect(scene._runtimeBuilds?.pendingDisposers(targetMesh)).toBeDefined();
+
+        Object.assign(material, { _buildGroup: standardBuilder });
+        bakeStdPluginMaterial(material, scene);
+        Object.assign(material, { _buildGroup: builder });
+        expect(buffers).toHaveLength(2);
+        expect(oldBuffer.destroy).not.toHaveBeenCalled();
+        expect(engine._retirements).toBeUndefined();
+
+        unblockBuilder();
+        await rebuilding;
+        expect(reboundBuffer).toBe(buffers[1]);
+        expect(oldBuffer.destroy).not.toHaveBeenCalled();
+        expect(engine._retirements).toHaveLength(1);
+
+        const bindingRetirements = engine._retirements!;
+        engine._retirements = null;
+        bindingRetirements.splice(0).forEach((retire) => retire());
+        expect(oldBuffer.destroy).not.toHaveBeenCalled();
+        expect(engine._retirements).toHaveLength(1);
+
+        const uboRetirements = engine._retirements!;
+        engine._retirements = null;
+        uboRetirements.splice(0).forEach((retire) => retire());
+        expect(oldBuffer.destroy).toHaveBeenCalledOnce();
+        expect(buffers[1]!.destroy).not.toHaveBeenCalled();
     });
 });

--- a/tests/lite/unit/standard-material-plugin-dynamic.test.ts
+++ b/tests/lite/unit/standard-material-plugin-dynamic.test.ts
@@ -1,16 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import { enableMaterialPlugins } from "../../../packages/babylon-lite/src/material/plugin/enable-material-plugins";
 import type { MaterialPlugin } from "../../../packages/babylon-lite/src/material/plugin/material-plugin";
 import { bakeStdPluginMaterial, refreshStdPluginUbos, registerStdPlugins } from "../../../packages/babylon-lite/src/material/plugin/std-plugin-bridge";
 import { createStandardMaterial } from "../../../packages/babylon-lite/src/material/standard/create-standard-material";
 import type { StandardMaterialProps } from "../../../packages/babylon-lite/src/material/standard/standard-material";
 import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
 import type { StdExt } from "../../../packages/babylon-lite/src/material/standard/standard-flags";
+import { onBeforeRender, type SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
 
-function makeEngine(): { engine: EngineContext; createBuffer: ReturnType<typeof vi.fn>; writeBuffer: ReturnType<typeof vi.fn>; uploadedValues: number[] } {
+function makeEngine(onWrite?: () => void): { engine: EngineContext; createBuffer: ReturnType<typeof vi.fn>; writeBuffer: ReturnType<typeof vi.fn>; uploadedValues: number[] } {
     const uploadedValues: number[] = [];
     const writeBuffer = vi.fn((_target: GPUBuffer, _targetOffset: number, source: ArrayBuffer, sourceOffset: number) => {
+        onWrite?.();
         uploadedValues.push(new Float32Array(source, sourceOffset, 1)[0]!);
     });
     let bufferId = 0;
@@ -99,5 +102,38 @@ describe("dynamic Standard material plugins", () => {
         });
 
         expect(createBuffer).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes after public before-render value updates regardless of enable order", () => {
+        const order: string[] = [];
+        const { engine, uploadedValues } = makeEngine(() => order.push("refresh"));
+        const value = { current: 1 };
+        const material = createStandardMaterial();
+        material.plugins = [valuePlugin(value)];
+        const scene = {
+            surface: { engine },
+            meshes: [mesh(material)],
+            _beforeRender: [
+                () => {
+                    order.push("existing");
+                    value.current = 2;
+                },
+            ],
+        } as unknown as SceneContext;
+
+        enableMaterialPlugins(scene);
+        uploadedValues.length = 0;
+        order.length = 0;
+        onBeforeRender(scene, () => {
+            order.push("future");
+            value.current = 3;
+        });
+
+        for (const callback of scene._beforeRender) {
+            callback(0);
+        }
+
+        expect(order).toEqual(["future", "existing", "refresh"]);
+        expect(uploadedValues).toEqual([2]);
     });
 });

--- a/tests/lite/unit/standard-material-plugin-dynamic.test.ts
+++ b/tests/lite/unit/standard-material-plugin-dynamic.test.ts
@@ -5,10 +5,13 @@ import { enableMaterialPlugins } from "../../../packages/babylon-lite/src/materi
 import type { MaterialPlugin } from "../../../packages/babylon-lite/src/material/plugin/material-plugin";
 import { bakeStdPluginMaterial, refreshStdPluginUbos, registerStdPlugins } from "../../../packages/babylon-lite/src/material/plugin/std-plugin-bridge";
 import { createStandardMaterial } from "../../../packages/babylon-lite/src/material/standard/create-standard-material";
-import type { StandardMaterialProps } from "../../../packages/babylon-lite/src/material/standard/standard-material";
+import { _computeStandardMaterialFeatures, type StandardMaterialProps } from "../../../packages/babylon-lite/src/material/standard/standard-material";
+import { MATERIAL_ALPHA_BLEND } from "../../../packages/babylon-lite/src/material/standard/standard-flags";
 import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
 import type { StdExt } from "../../../packages/babylon-lite/src/material/standard/standard-flags";
+import type { Renderable } from "../../../packages/babylon-lite/src/render/renderable";
 import { createSceneContext, disposeScene, onBeforeRender, type SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
+import { processMaterialSwaps } from "../../../packages/babylon-lite/src/scene/scene-material-swap";
 
 interface MockBuffer {
     readonly id: number;
@@ -87,8 +90,8 @@ describe("dynamic Standard material plugins", () => {
 
         const entriesA: GPUBindGroupEntry[] = [];
         const entriesB: GPUBindGroupEntry[] = [];
-        registered._bind!(materialA, entriesA, 0, undefined, engine);
-        registered._bind!(materialB, entriesB, 0, undefined, engine);
+        registered._bind!(materialA, entriesA, 0, undefined, scene);
+        registered._bind!(materialB, entriesB, 0, undefined, scene);
         expect((entriesA[0]!.resource as GPUBufferBinding).buffer).not.toBe((entriesB[0]!.resource as GPUBufferBinding).buffer);
         expect(uploadedValues).toEqual([1, 2]);
 
@@ -112,7 +115,7 @@ describe("dynamic Standard material plugins", () => {
 
         bakeStdPluginMaterial(material, scene);
         const entries: GPUBindGroupEntry[] = [];
-        registered._bind!(material, entries, 0, undefined, engine);
+        registered._bind!(material, entries, 0, undefined, scene);
 
         expect(entries).toHaveLength(1);
         expect(material._renderFeatures?.features).not.toBe(0);
@@ -184,6 +187,57 @@ describe("dynamic Standard material plugins", () => {
         expect(uploadedValues).toEqual([4]);
     });
 
+    it("binds a shared material to each scene's own UBO and isolates disposal", () => {
+        const { engine, buffers } = makeEngine();
+        const material = createStandardMaterial();
+        material.plugins = [valuePlugin({ current: 1 })];
+        const sceneA = pluginScene(engine, [material]);
+        const sceneB = pluginScene(engine, [material]);
+
+        registerStdPlugins(sceneA, (ext) => {
+            registered = ext;
+        });
+        registerStdPlugins(sceneB, (ext) => {
+            registered = ext;
+        });
+
+        const entriesA: GPUBindGroupEntry[] = [];
+        const entriesB: GPUBindGroupEntry[] = [];
+        registered._bind!(material, entriesA, 0, undefined, sceneA);
+        registered._bind!(material, entriesB, 0, undefined, sceneB);
+        expect((entriesA[0]!.resource as GPUBufferBinding).buffer).toBe(buffers[0]);
+        expect((entriesB[0]!.resource as GPUBufferBinding).buffer).toBe(buffers[1]);
+
+        sceneA.meshes.length = 0;
+        disposeScene(sceneA);
+        expect(buffers[0]!.destroy).toHaveBeenCalledOnce();
+        expect(buffers[1]!.destroy).not.toHaveBeenCalled();
+
+        const survivingEntries: GPUBindGroupEntry[] = [];
+        registered._bind!(material, survivingEntries, 0, undefined, sceneB);
+        expect((survivingEntries[0]!.resource as GPUBufferBinding).buffer).toBe(buffers[1]);
+    });
+
+    it("does not freeze plugin-free feature detection and only clears an existing plugin state", () => {
+        const { engine } = makeEngine();
+        const material = createStandardMaterial();
+        const scene = pluginScene(engine, [material]);
+
+        enableMaterialPlugins(scene);
+        expect(material._renderFeatures).toBeUndefined();
+
+        material.alpha = 0.5;
+        expect(_computeStandardMaterialFeatures(material) & MATERIAL_ALPHA_BLEND).toBe(MATERIAL_ALPHA_BLEND);
+
+        material.plugins = [valuePlugin({ current: 1 })];
+        bakeStdPluginMaterial(material, scene);
+        expect(material._renderFeatures).toBeDefined();
+
+        material.plugins = [];
+        bakeStdPluginMaterial(material, scene);
+        expect(material._renderFeatures).toBeUndefined();
+    });
+
     it("destroys plugin UBOs when their scene is disposed", () => {
         const { engine, buffers } = makeEngine();
         const material = createStandardMaterial();
@@ -198,20 +252,37 @@ describe("dynamic Standard material plugins", () => {
         expect(buffer.destroy).toHaveBeenCalledOnce();
     });
 
-    it("retires the previous plugin UBO when a material is baked again", () => {
+    it("rebuilds bindings with the replacement UBO and retires the previous one", () => {
         const { engine, buffers } = makeEngine();
         const material = createStandardMaterial();
         material.plugins = [valuePlugin({ current: 1 })];
         const scene = pluginScene(engine, [material]);
+        const targetMesh = scene.meshes[0]!;
 
-        enableMaterialPlugins(scene);
+        registerStdPlugins(scene, (ext) => {
+            registered = ext;
+        });
         const oldBuffer = buffers[0]!;
+        const oldRenderable = { mesh: targetMesh, order: 0, isTransparent: false } as Renderable;
+        let reboundBuffer: GPUBuffer | undefined;
+        const rebuild = vi.fn((targetScene: SceneContext) => {
+            const entries: GPUBindGroupEntry[] = [];
+            registered._bind!(material, entries, 0, targetMesh, targetScene);
+            reboundBuffer = (entries[0]!.resource as GPUBufferBinding).buffer;
+            return { mesh: targetMesh, order: 0, isTransparent: false } as Renderable;
+        });
+        scene._groups.set(material._buildGroup, Object.assign([targetMesh], { r: rebuild }));
+        scene._renderables.push(oldRenderable);
+        scene._meshDisposables.set(targetMesh, []);
         scene._built = true;
         bakeStdPluginMaterial(material, scene);
 
         expect(buffers).toHaveLength(2);
+        expect(scene._materialSwapQueue).toEqual([targetMesh]);
         expect(oldBuffer.destroy).not.toHaveBeenCalled();
-        expect(engine._retirements).toHaveLength(1);
+        processMaterialSwaps(scene);
+        expect(rebuild).toHaveBeenCalledOnce();
+        expect(reboundBuffer).toBe(buffers[1]);
         engine._retirements!.splice(0).forEach((retire) => retire());
         expect(oldBuffer.destroy).toHaveBeenCalledOnce();
         expect(buffers[1]!.destroy).not.toHaveBeenCalled();

--- a/tests/lite/unit/standard-material-plugin-dynamic.test.ts
+++ b/tests/lite/unit/standard-material-plugin-dynamic.test.ts
@@ -8,21 +8,39 @@ import { createStandardMaterial } from "../../../packages/babylon-lite/src/mater
 import type { StandardMaterialProps } from "../../../packages/babylon-lite/src/material/standard/standard-material";
 import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
 import type { StdExt } from "../../../packages/babylon-lite/src/material/standard/standard-flags";
-import { onBeforeRender, type SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
+import { createSceneContext, disposeScene, onBeforeRender, type SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
 
-function makeEngine(onWrite?: () => void): { engine: EngineContext; createBuffer: ReturnType<typeof vi.fn>; writeBuffer: ReturnType<typeof vi.fn>; uploadedValues: number[] } {
+interface MockBuffer {
+    readonly id: number;
+    readonly destroy: ReturnType<typeof vi.fn>;
+}
+
+function makeEngine(onWrite?: () => void): {
+    engine: EngineContext;
+    createBuffer: ReturnType<typeof vi.fn>;
+    writeBuffer: ReturnType<typeof vi.fn>;
+    uploadedValues: number[];
+    buffers: MockBuffer[];
+} {
     const uploadedValues: number[] = [];
+    const buffers: MockBuffer[] = [];
     const writeBuffer = vi.fn((_target: GPUBuffer, _targetOffset: number, source: ArrayBuffer, sourceOffset: number) => {
         onWrite?.();
         uploadedValues.push(new Float32Array(source, sourceOffset, 1)[0]!);
     });
     let bufferId = 0;
-    const createBuffer = vi.fn(() => ({ id: ++bufferId }) as unknown as GPUBuffer);
+    const createBuffer = vi.fn(() => {
+        const buffer = { id: ++bufferId, destroy: vi.fn() };
+        buffers.push(buffer);
+        return buffer as unknown as GPUBuffer;
+    });
     const device = {
         createBuffer,
         queue: { writeBuffer },
     } as unknown as GPUDevice;
-    return { engine: { _device: device } as unknown as EngineContext, createBuffer, writeBuffer, uploadedValues };
+    const engine = { _device: device, _renderingContexts: [] } as unknown as EngineContext;
+    Object.assign(engine, { engine, surfaces: [engine], _surfaces: [engine] });
+    return { engine, createBuffer, writeBuffer, uploadedValues, buffers };
 }
 
 function valuePlugin(value: { current: number }, dynamic = true): MaterialPlugin {
@@ -40,6 +58,12 @@ function mesh(material: StandardMaterialProps): Mesh {
     return { material } as unknown as Mesh;
 }
 
+function pluginScene(engine: EngineContext, materials: StandardMaterialProps[]): SceneContext {
+    const scene = createSceneContext(engine, { defaultRenderTask: false });
+    scene.meshes.push(...materials.map(mesh));
+    return scene;
+}
+
 describe("dynamic Standard material plugins", () => {
     let registered: StdExt;
 
@@ -55,15 +79,16 @@ describe("dynamic Standard material plugins", () => {
         const materialB = createStandardMaterial();
         materialA.plugins = [valuePlugin(valueA)];
         materialB.plugins = [valuePlugin(valueB)];
+        const scene = pluginScene(engine, [materialA, materialB]);
 
-        registerStdPlugins([mesh(materialA), mesh(materialB)], engine, (ext) => {
+        registerStdPlugins(scene, (ext) => {
             registered = ext;
         });
 
         const entriesA: GPUBindGroupEntry[] = [];
         const entriesB: GPUBindGroupEntry[] = [];
-        registered._bind!(materialA, entriesA, 0);
-        registered._bind!(materialB, entriesB, 0);
+        registered._bind!(materialA, entriesA, 0, undefined, engine);
+        registered._bind!(materialB, entriesB, 0, undefined, engine);
         expect((entriesA[0]!.resource as GPUBufferBinding).buffer).not.toBe((entriesB[0]!.resource as GPUBufferBinding).buffer);
         expect(uploadedValues).toEqual([1, 2]);
 
@@ -71,22 +96,23 @@ describe("dynamic Standard material plugins", () => {
         valueB.current = 4;
         writeBuffer.mockClear();
         uploadedValues.length = 0;
-        refreshStdPluginUbos(engine);
+        refreshStdPluginUbos(scene);
 
         expect(uploadedValues).toEqual([3, 4]);
     });
 
     it("bakes a Standard material created after initial registration", () => {
         const { engine } = makeEngine();
-        registerStdPlugins([], engine, (ext) => {
+        const scene = pluginScene(engine, []);
+        registerStdPlugins(scene, (ext) => {
             registered = ext;
         });
         const material = createStandardMaterial();
         material.plugins = [valuePlugin({ current: 5 }, false)];
 
-        bakeStdPluginMaterial(material, engine);
+        bakeStdPluginMaterial(material, scene);
         const entries: GPUBindGroupEntry[] = [];
-        registered._bind!(material, entries, 0);
+        registered._bind!(material, entries, 0, undefined, engine);
 
         expect(entries).toHaveLength(1);
         expect(material._renderFeatures?.features).not.toBe(0);
@@ -96,8 +122,9 @@ describe("dynamic Standard material plugins", () => {
         const { engine, createBuffer } = makeEngine();
         const material = createStandardMaterial();
         material.plugins = [valuePlugin({ current: 1 })];
+        const scene = pluginScene(engine, [material, material]);
 
-        registerStdPlugins([mesh(material), mesh(material)], engine, (ext) => {
+        registerStdPlugins(scene, (ext) => {
             registered = ext;
         });
 
@@ -110,16 +137,11 @@ describe("dynamic Standard material plugins", () => {
         const value = { current: 1 };
         const material = createStandardMaterial();
         material.plugins = [valuePlugin(value)];
-        const scene = {
-            surface: { engine },
-            meshes: [mesh(material)],
-            _beforeRender: [
-                () => {
-                    order.push("existing");
-                    value.current = 2;
-                },
-            ],
-        } as unknown as SceneContext;
+        const scene = pluginScene(engine, [material]);
+        scene._beforeRender.push(() => {
+            order.push("existing");
+            value.current = 2;
+        });
 
         enableMaterialPlugins(scene);
         uploadedValues.length = 0;
@@ -135,5 +157,63 @@ describe("dynamic Standard material plugins", () => {
 
         expect(order).toEqual(["future", "existing", "refresh"]);
         expect(uploadedValues).toEqual([2]);
+    });
+
+    it("keeps dynamic refresh state scoped to each scene", () => {
+        const { engine, uploadedValues } = makeEngine();
+        const valueA = { current: 1 };
+        const valueB = { current: 2 };
+        const materialA = createStandardMaterial();
+        const materialB = createStandardMaterial();
+        materialA.plugins = [valuePlugin(valueA)];
+        materialB.plugins = [valuePlugin(valueB)];
+        const sceneA = pluginScene(engine, [materialA]);
+        const sceneB = pluginScene(engine, [materialB]);
+
+        enableMaterialPlugins(sceneA);
+        enableMaterialPlugins(sceneB);
+        uploadedValues.length = 0;
+        valueA.current = 3;
+        valueB.current = 4;
+
+        sceneA._beforeRender.forEach((callback) => callback(0));
+        expect(uploadedValues).toEqual([3]);
+
+        uploadedValues.length = 0;
+        sceneB._beforeRender.forEach((callback) => callback(0));
+        expect(uploadedValues).toEqual([4]);
+    });
+
+    it("destroys plugin UBOs when their scene is disposed", () => {
+        const { engine, buffers } = makeEngine();
+        const material = createStandardMaterial();
+        material.plugins = [valuePlugin({ current: 1 })];
+        const scene = pluginScene(engine, [material]);
+
+        enableMaterialPlugins(scene);
+        const buffer = buffers[0]!;
+        scene.meshes.length = 0;
+        disposeScene(scene);
+
+        expect(buffer.destroy).toHaveBeenCalledOnce();
+    });
+
+    it("retires the previous plugin UBO when a material is baked again", () => {
+        const { engine, buffers } = makeEngine();
+        const material = createStandardMaterial();
+        material.plugins = [valuePlugin({ current: 1 })];
+        const scene = pluginScene(engine, [material]);
+
+        enableMaterialPlugins(scene);
+        const oldBuffer = buffers[0]!;
+        scene._built = true;
+        bakeStdPluginMaterial(material, scene);
+
+        expect(buffers).toHaveLength(2);
+        expect(oldBuffer.destroy).not.toHaveBeenCalled();
+        expect(engine._retirements).toHaveLength(1);
+        engine._retirements!.splice(0).forEach((retire) => retire());
+        expect(oldBuffer.destroy).toHaveBeenCalledOnce();
+        expect(buffers[1]!.destroy).not.toHaveBeenCalled();
     });
 });

--- a/tests/lite/unit/standard-material-plugin-dynamic.test.ts
+++ b/tests/lite/unit/standard-material-plugin-dynamic.test.ts
@@ -10,7 +10,7 @@ import { MATERIAL_ALPHA_BLEND } from "../../../packages/babylon-lite/src/materia
 import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
 import type { StdExt } from "../../../packages/babylon-lite/src/material/standard/standard-flags";
 import type { Renderable } from "../../../packages/babylon-lite/src/render/renderable";
-import { createSceneContext, disposeScene, onBeforeRender, type SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
+import { createSceneContext, disposeScene, onBeforeRender, type RuntimeSceneBuildHooks, type SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
 import { processMaterialSwaps } from "../../../packages/babylon-lite/src/scene/scene-material-swap";
 
 interface MockBuffer {
@@ -252,7 +252,7 @@ describe("dynamic Standard material plugins", () => {
         expect(buffer.destroy).toHaveBeenCalledOnce();
     });
 
-    it("rebuilds bindings with the replacement UBO and retires the previous one", () => {
+    it("keeps the old UBO alive while the swap queue is blocked, then retires it after rebinding", () => {
         const { engine, buffers } = makeEngine();
         const material = createStandardMaterial();
         material.plugins = [valuePlugin({ current: 1 })];
@@ -275,15 +275,39 @@ describe("dynamic Standard material plugins", () => {
         scene._renderables.push(oldRenderable);
         scene._meshDisposables.set(targetMesh, []);
         scene._built = true;
+        let blocked = true;
+        scene._runtimeBuilds = {
+            get w() {
+                return blocked;
+            },
+        } as RuntimeSceneBuildHooks;
         bakeStdPluginMaterial(material, scene);
 
         expect(buffers).toHaveLength(2);
         expect(scene._materialSwapQueue).toEqual([targetMesh]);
         expect(oldBuffer.destroy).not.toHaveBeenCalled();
+        expect(engine._retirements).toBeUndefined();
+
+        processMaterialSwaps(scene);
+        expect(rebuild).not.toHaveBeenCalled();
+        expect(oldBuffer.destroy).not.toHaveBeenCalled();
+        expect(engine._retirements).toBeUndefined();
+
+        blocked = false;
         processMaterialSwaps(scene);
         expect(rebuild).toHaveBeenCalledOnce();
         expect(reboundBuffer).toBe(buffers[1]);
-        engine._retirements!.splice(0).forEach((retire) => retire());
+        expect(engine._retirements).toHaveLength(1);
+
+        const bindingRetirements = engine._retirements!;
+        engine._retirements = null;
+        bindingRetirements.splice(0).forEach((retire) => retire());
+        expect(oldBuffer.destroy).not.toHaveBeenCalled();
+        expect(engine._retirements).toHaveLength(1);
+
+        const uboRetirements = engine._retirements!;
+        engine._retirements = null;
+        uboRetirements.splice(0).forEach((retire) => retire());
         expect(oldBuffer.destroy).toHaveBeenCalledOnce();
         expect(buffers[1]!.destroy).not.toHaveBeenCalled();
     });

--- a/tests/lite/unit/standard-material-plugin-dynamic.test.ts
+++ b/tests/lite/unit/standard-material-plugin-dynamic.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import type { MaterialPlugin } from "../../../packages/babylon-lite/src/material/plugin/material-plugin";
+import { bakeStdPluginMaterial, refreshStdPluginUbos, registerStdPlugins } from "../../../packages/babylon-lite/src/material/plugin/std-plugin-bridge";
+import { createStandardMaterial } from "../../../packages/babylon-lite/src/material/standard/create-standard-material";
+import type { StandardMaterialProps } from "../../../packages/babylon-lite/src/material/standard/standard-material";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
+import type { StdExt } from "../../../packages/babylon-lite/src/material/standard/standard-flags";
+
+function makeEngine(): { engine: EngineContext; createBuffer: ReturnType<typeof vi.fn>; writeBuffer: ReturnType<typeof vi.fn>; uploadedValues: number[] } {
+    const uploadedValues: number[] = [];
+    const writeBuffer = vi.fn((_target: GPUBuffer, _targetOffset: number, source: ArrayBuffer, sourceOffset: number) => {
+        uploadedValues.push(new Float32Array(source, sourceOffset, 1)[0]!);
+    });
+    let bufferId = 0;
+    const createBuffer = vi.fn(() => ({ id: ++bufferId }) as unknown as GPUBuffer);
+    const device = {
+        createBuffer,
+        queue: { writeBuffer },
+    } as unknown as GPUDevice;
+    return { engine: { _device: device } as unknown as EngineContext, createBuffer, writeBuffer, uploadedValues };
+}
+
+function valuePlugin(value: { current: number }, dynamic = true): MaterialPlugin {
+    return {
+        name: "value-plugin",
+        dynamic,
+        getUniforms: () => ({ ubo: [{ name: "pluginValue", type: "f32" }] }),
+        writeUbo(data, offsets) {
+            data[offsets.get("pluginValue")! / 4] = value.current;
+        },
+    };
+}
+
+function mesh(material: StandardMaterialProps): Mesh {
+    return { material } as unknown as Mesh;
+}
+
+describe("dynamic Standard material plugins", () => {
+    let registered: StdExt;
+
+    beforeEach(() => {
+        registered = undefined as unknown as StdExt;
+    });
+
+    it("keeps same-signature material values isolated and refreshes dynamic UBOs", () => {
+        const { engine, writeBuffer, uploadedValues } = makeEngine();
+        const valueA = { current: 1 };
+        const valueB = { current: 2 };
+        const materialA = createStandardMaterial();
+        const materialB = createStandardMaterial();
+        materialA.plugins = [valuePlugin(valueA)];
+        materialB.plugins = [valuePlugin(valueB)];
+
+        registerStdPlugins([mesh(materialA), mesh(materialB)], engine, (ext) => {
+            registered = ext;
+        });
+
+        const entriesA: GPUBindGroupEntry[] = [];
+        const entriesB: GPUBindGroupEntry[] = [];
+        registered._bind!(materialA, entriesA, 0);
+        registered._bind!(materialB, entriesB, 0);
+        expect((entriesA[0]!.resource as GPUBufferBinding).buffer).not.toBe((entriesB[0]!.resource as GPUBufferBinding).buffer);
+        expect(uploadedValues).toEqual([1, 2]);
+
+        valueA.current = 3;
+        valueB.current = 4;
+        writeBuffer.mockClear();
+        uploadedValues.length = 0;
+        refreshStdPluginUbos(engine);
+
+        expect(uploadedValues).toEqual([3, 4]);
+    });
+
+    it("bakes a Standard material created after initial registration", () => {
+        const { engine } = makeEngine();
+        registerStdPlugins([], engine, (ext) => {
+            registered = ext;
+        });
+        const material = createStandardMaterial();
+        material.plugins = [valuePlugin({ current: 5 }, false)];
+
+        bakeStdPluginMaterial(material, engine);
+        const entries: GPUBindGroupEntry[] = [];
+        registered._bind!(material, entries, 0);
+
+        expect(entries).toHaveLength(1);
+        expect(material._renderFeatures?.features).not.toBe(0);
+    });
+
+    it("bakes a material shared by multiple meshes only once", () => {
+        const { engine, createBuffer } = makeEngine();
+        const material = createStandardMaterial();
+        material.plugins = [valuePlugin({ current: 1 })];
+
+        registerStdPlugins([mesh(material), mesh(material)], engine, (ext) => {
+            registered = ext;
+        });
+
+        expect(createBuffer).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/lite/unit/standard-material-plugin-dynamic.test.ts
+++ b/tests/lite/unit/standard-material-plugin-dynamic.test.ts
@@ -280,7 +280,8 @@ describe("dynamic Standard material plugins", () => {
             get w() {
                 return blocked;
             },
-        } as RuntimeSceneBuildHooks;
+            pendingDisposers: () => undefined,
+        } as unknown as RuntimeSceneBuildHooks;
         bakeStdPluginMaterial(material, scene);
 
         expect(buffers).toHaveLength(2);
@@ -310,5 +311,62 @@ describe("dynamic Standard material plugins", () => {
         uboRetirements.splice(0).forEach((retire) => retire());
         expect(oldBuffer.destroy).toHaveBeenCalledOnce();
         expect(buffers[1]!.destroy).not.toHaveBeenCalled();
+    });
+
+    it("uses an active runtime rebuild's pending disposer packet when the scene map is empty", () => {
+        const { engine, buffers } = makeEngine();
+        const material = createStandardMaterial();
+        material.plugins = [valuePlugin({ current: 1 })];
+        const scene = pluginScene(engine, [material]);
+        const targetMesh = scene.meshes[0]!;
+
+        registerStdPlugins(scene, (ext) => {
+            registered = ext;
+        });
+        const oldBuffer = buffers[0]!;
+        const pendingDisposers: (() => void)[] = [];
+        let reboundBuffer: GPUBuffer | undefined;
+        const rebuild = vi.fn((targetScene: SceneContext) => {
+            const entries: GPUBindGroupEntry[] = [];
+            registered._bind!(material, entries, 0, targetMesh, targetScene);
+            reboundBuffer = (entries[0]!.resource as GPUBufferBinding).buffer;
+            return { mesh: targetMesh, order: 0, isTransparent: false } as Renderable;
+        });
+        scene._groups.set(material._buildGroup, Object.assign([targetMesh], { r: rebuild }));
+        scene._renderables.push({ mesh: targetMesh, order: 0, isTransparent: false } as Renderable);
+        scene._built = true;
+        let blocked = true;
+        scene._runtimeBuilds = {
+            get w() {
+                return blocked;
+            },
+            pendingDisposers: (mesh: Mesh) => (mesh === targetMesh ? pendingDisposers : undefined),
+        } as unknown as RuntimeSceneBuildHooks;
+
+        expect(scene._meshDisposables.get(targetMesh)).toBeUndefined();
+        bakeStdPluginMaterial(material, scene);
+
+        expect(pendingDisposers).toHaveLength(1);
+        expect(engine._retirements).toBeUndefined();
+        processMaterialSwaps(scene);
+        expect(rebuild).not.toHaveBeenCalled();
+        expect(oldBuffer.destroy).not.toHaveBeenCalled();
+
+        blocked = false;
+        scene._meshDisposables.set(targetMesh, []);
+        engine._retirements = [() => pendingDisposers.splice(0).forEach((dispose) => dispose())];
+        processMaterialSwaps(scene);
+
+        expect(rebuild).toHaveBeenCalledOnce();
+        expect(reboundBuffer).toBe(buffers[1]);
+        const bindingRetirements = engine._retirements;
+        engine._retirements = null;
+        bindingRetirements?.splice(0).forEach((retire) => retire());
+        expect(oldBuffer.destroy).not.toHaveBeenCalled();
+
+        const uboRetirements = engine._retirements as (() => void)[] | null;
+        engine._retirements = null;
+        uboRetirements?.splice(0).forEach((retire) => retire());
+        expect(oldBuffer.destroy).toHaveBeenCalledOnce();
     });
 });


### PR DESCRIPTION
## Summary

Improve reusable runtime utilities shared by the Lite demos and applications.

## Changes

- **Bug fix:** allow HDR environments to keep IBL and optional ground rendering without creating an HDR or solid skybox.
- **Bug fix:** preserve trailing source rows and columns when reducing odd-sized depth-pyramid mip levels.
- **Bug fix:** keep Standard material plugin uniform values isolated per material, including materials that share the same shader signature.
- Add opt-in per-frame UBO refresh for dynamic Standard material plugins.
- Add `bakeStdPluginMaterial()` for Standard materials created after the initial scene registration.
- Add `getMeshTriangles()` to retrieve caller-owned position/index copies without requiring normals.
- Document the Standard material plugin lifecycle and dynamic update behavior.

## Validation

- `pnpm lint`
- `pnpm test:unit` — 256 files passed, 1 skipped; 2,876 tests passed, 9 skipped
- `pnpm build`
- `pnpm test:build` — 33 tests passed
