### PR TITLE
perf(text): recycle individual style entries instead of palette blocks

### DIFF
--- a/packages/babylon-lite/src/text/text-data.ts
+++ b/packages/babylon-lite/src/text/text-data.ts
@@ -107,12 +107,12 @@ export interface TextData {
     /** @internal Total *capacity* used (live + dead slots across all groups). */
     _instanceCount: number;
     /** @internal Style palette: `TEXT_STYLE_FLOATS` per entry, indexed by the high 16 bits of
-     *  an instance's packed word. Entries are owned by runs — see `RunRecord._styleStart`. */
+     *  an instance's packed word. */
     _styles: Float32Array;
-    /** @internal Entries spanned by `_styles`, including reusable holes below the tail. */
+    /** @internal High-water mark for allocated style entries. */
     _styleCount: number;
-    /** @internal Sorted, coalesced pairs of `[start, count]` describing reusable style blocks. */
-    _freeStyleBlocks: number[];
+    /** @internal Reusable individual style indices. */
+    _freeStyleSlots: number[];
     /** @internal Monotonic version bumped whenever `_styles` content changes, so renderers can
      *  skip the palette upload entirely when nothing moved. */
     _styleVersion: number;
@@ -169,12 +169,8 @@ export type RunRecord = {
     /** @internal Absolute slot indices (within `TextData._instances`) currently occupied by this run.
      *  Length === number of glyphs actually written (skipped glyphs do not occupy slots). */
     _slots: number[];
-    /** @internal First style-palette entry owned by this run. That entry holds the run default
-     *  (`defaultColor` + `invScale`); one entry per glyph carrying its own `color` follows it,
-     *  in glyph order. */
-    _styleStart: number;
-    /** @internal Palette entries reserved at `_styleStart`. */
-    _styleCount: number;
+    /** @internal Style indices owned by this run: default first, then color overrides in glyph order. */
+    _styleSlots: number[];
 };
 
 /** Floats per instance: the anchor (x, y) plus one packed u32 holding the glyph index in its
@@ -270,144 +266,28 @@ function countRunStyles(run: GlyphRun): number {
     return n;
 }
 
-function countLiveStyles(data: TextData, omit?: RunRecord): number {
-    let count = 0;
-    for (const record of data._runRecords.values()) {
-        if (record !== omit) {
-            count += record._styleCount;
-        }
-    }
-    return count;
-}
-
-function assertStyleAllocationFits(data: TextData, previous: RunRecord | undefined, count: number): void {
-    if (count > MAX_STYLE_ENTRIES || (data._styleCount + count > MAX_STYLE_ENTRIES && countLiveStyles(data, previous) + count > MAX_STYLE_ENTRIES)) {
-        throw new Error(`TextData style palette cannot exceed ${MAX_STYLE_ENTRIES} entries.`);
+function releaseStyles(data: TextData, slots: number[]): void {
+    for (let i = 0; i < slots.length; i++) {
+        data._freeStyleSlots.push(slots[i]!);
     }
 }
 
-function takeFreeStyles(data: TextData, count: number): number {
-    const blocks = data._freeStyleBlocks;
-    for (let i = 0; i < blocks.length; i += 2) {
-        const blockCount = blocks[i + 1]!;
-        if (blockCount < count) {
-            continue;
-        }
-        const start = blocks[i]!;
-        if (blockCount === count) {
-            blocks.splice(i, 2);
-        } else {
-            blocks[i] = start + count;
-            blocks[i + 1] = blockCount - count;
-        }
-        return start;
+function allocateStyles(data: TextData, count: number, previous?: number[]): number[] {
+    if (previous?.length === count) {
+        return previous;
     }
-    return -1;
-}
-
-function releaseStyles(data: TextData, start: number, count: number): void {
-    const blocks = data._freeStyleBlocks;
-    let i = 0;
-    while (i < blocks.length && blocks[i]! < start) {
-        i += 2;
+    const free = data._freeStyleSlots;
+    const needed = Math.max(0, count - free.length - (previous?.length ?? 0));
+    ensureStyleCapacity(data, data._styleCount + needed);
+    if (previous) {
+        releaseStyles(data, previous);
     }
-    blocks.splice(i, 0, start, count);
-    if (i > 0 && blocks[i - 2]! + blocks[i - 1]! === start) {
-        blocks[i - 1]! += count;
-        blocks.splice(i, 2);
-        i -= 2;
+    const slots = new Array<number>(count);
+    for (let i = 0; i < count; i++) {
+        slots[i] = free.pop() ?? data._styleCount++;
     }
-    if (i + 2 < blocks.length && blocks[i]! + blocks[i + 1]! === blocks[i + 2]!) {
-        blocks[i + 1]! += blocks[i + 3]!;
-        blocks.splice(i + 2, 2);
-    }
-    while (blocks.length > 0) {
-        const tail = blocks.length - 2;
-        if (blocks[tail]! + blocks[tail + 1]! !== data._styleCount) {
-            break;
-        }
-        data._styleCount = blocks[tail]!;
-        blocks.length = tail;
-    }
-}
-
-/** Densely rebuild the live palette, optionally dropping the block being replaced. This is rare:
- *  the free-block allocator handles normal edits, and compaction runs only when fragmentation
- *  would otherwise push a packed style index beyond 16 bits. */
-function compactStyles(data: TextData, omit?: RunRecord): void {
-    const maxFloats = MAX_STYLE_ENTRIES * TEXT_STYLE_FLOATS;
-    const compacted = new Float32Array(Math.min(data._styles.length, maxFloats));
-    let writeEntry = 0;
-    let movedInstances = false;
-    for (const run of data._runs) {
-        const record = data._runRecords.get(run)!;
-        if (record === omit) {
-            continue;
-        }
-        const previousStart = record._styleStart;
-        const count = record._styleCount;
-        const sourceStart = previousStart * TEXT_STYLE_FLOATS;
-        compacted.set(data._styles.subarray(sourceStart, sourceStart + count * TEXT_STYLE_FLOATS), writeEntry * TEXT_STYLE_FLOATS);
-        if (writeEntry !== previousStart) {
-            for (const slot of record._slots) {
-                const packedOffset = slot * TEXT_INSTANCE_FLOATS + 2;
-                const packed = data._instancesU32[packedOffset]!;
-                const relativeStyle = (packed >>> 16) - previousStart;
-                data._instancesU32[packedOffset] = (packed & 0xffff) | ((writeEntry + relativeStyle) << 16);
-            }
-            movedInstances = true;
-        }
-        record._styleStart = writeEntry;
-        writeEntry += count;
-    }
-    data._styles = compacted;
-    data._styleCount = writeEntry;
-    data._freeStyleBlocks.length = 0;
     data._styleVersion++;
-    if (movedInstances) {
-        markDirty(data, 0, data._instanceCount);
-    }
-}
-
-/** Reserve `count` contiguous palette entries. Same-count edits retain their block, tail blocks
- *  resize in place, and other edits first reuse released blocks. */
-function reserveStyles(data: TextData, previous: RunRecord | undefined, count: number): number {
-    const prevStart = previous?._styleStart ?? 0;
-    const prevCount = previous?._styleCount ?? 0;
-    if (previous && prevCount === count) {
-        return prevStart;
-    }
-    if (previous && prevStart + prevCount === data._styleCount && prevStart + count <= MAX_STYLE_ENTRIES) {
-        ensureStyleCapacity(data, prevStart + count);
-        data._styleCount = prevStart + count;
-        data._styleVersion++;
-        return prevStart;
-    }
-    let start = takeFreeStyles(data, count);
-    if (start >= 0) {
-        if (previous) {
-            releaseStyles(data, prevStart, prevCount);
-        }
-        data._styleVersion++;
-        return start;
-    }
-    if (data._styleCount + count <= MAX_STYLE_ENTRIES) {
-        start = data._styleCount;
-        ensureStyleCapacity(data, start + count);
-        data._styleCount += count;
-        if (previous) {
-            releaseStyles(data, prevStart, prevCount);
-        }
-        data._styleVersion++;
-        return start;
-    }
-    compactStyles(data, previous);
-    start = data._styleCount;
-    ensureStyleCapacity(data, start + count);
-    data._styleCount += count;
-    // The block moved or resized, so it now covers entries the GPU may never have been sent.
-    data._styleVersion++;
-    return start;
+    return slots;
 }
 
 /** Write one palette entry, bumping `_styleVersion` only when the entry's contents actually
@@ -634,20 +514,17 @@ function ensureGroup(data: TextData, curveSetId: CurveSetId): TextDataDrawGroup 
     return group;
 }
 
-/** Write a run's glyphs into the given (already-allocated) slots, and its styles into the
- *  palette block reserved at `styleStart`. Returns the subset of slots that actually received
+/** Write a run's glyphs into the given (already-allocated) instance and style slots.
+ *  Returns the subset of instance slots that actually received
  *  live glyphs (skipped glyphs leave their slot dead). When every glyph lands — the
  *  overwhelmingly common case — that subset *is* `slots`, and the caller gets the same array
  *  back rather than a freshly built copy. */
-function writeRunToSlots(data: TextData, group: TextDataDrawGroup, run: GlyphRun, slots: number[], styleStart: number): number[] {
+function writeRunToSlots(data: TextData, group: TextDataDrawGroup, run: GlyphRun, slots: number[], styleSlots: number[]): number[] {
     const ratio = run.pixelsPerFontUnit;
     const invScale = ratio !== 0 ? 1 / ratio : 0;
-    // The block's first entry is the run default, which is what every glyph without its own
-    // `color` points at — so the common path costs one already-loaded local, no lookup.
-    writeStyle(data, styleStart, run.defaultColor ?? WHITE_COLOR, invScale);
-    // Overrides take the entries after the default, handed out in glyph order. `countRunStyles`
-    // sized the block by the same rule, so this can never run past it.
-    let overrideEntry = styleStart;
+    const defaultStyle = styleSlots[0]!;
+    writeStyle(data, defaultStyle, run.defaultColor ?? WHITE_COLOR, invScale);
+    let overrideEntry = 0;
     // Materialized only once a glyph actually misses the atlas, seeded with the prefix that
     // did land; while it stays null, `slots` is by definition the live set.
     let liveSlots: number[] | null = null;
@@ -656,10 +533,10 @@ function writeRunToSlots(data: TextData, group: TextDataDrawGroup, run: GlyphRun
     for (let i = 0; i < run.glyphs.length; i++) {
         const pg = run.glyphs[i]!;
         const slot = slots[i]!;
-        let styleIdx = styleStart;
+        let styleIdx = defaultStyle;
         const color = pg.color;
         if (color !== undefined) {
-            styleIdx = ++overrideEntry;
+            styleIdx = styleSlots[++overrideEntry]!;
             writeStyle(data, styleIdx, color, invScale);
         }
         const ok = packGlyphAtSlot(data._instances, data._instancesU32, slot, group._curveSet, pg.glyphId, pg.x, pg.y, styleIdx);
@@ -728,10 +605,10 @@ function applyReset(data: TextData, runs: readonly GlyphRun[], storage: GlyphSto
     const newGroups: TextDataDrawGroup[] = [];
     const newRunRecords = new Map<GlyphRun, RunRecord>();
     let writeSlot = 0;
-    // Reset is also the compaction path: dropping the palette reclaims every block orphaned by
-    // a run whose style count changed since the last reset.
+    // A reset rebuilds the palette densely and drops all free-slot state.
     data._styleCount = 0;
-    data._freeStyleBlocks.length = 0;
+    data._freeStyleSlots.length = 0;
+    data._styleVersion++;
 
     for (const [curveSetId, groupRuns] of runsByCurveSet) {
         const curveSet = lookupCurveSet(storage, curveSetId, "reset");
@@ -758,11 +635,13 @@ function applyReset(data: TextData, runs: readonly GlyphRun[], storage: GlyphSto
                 slots[i] = writeSlot++;
             }
             const styleCount = countRunStyles(run);
-            const styleStart = data._styleCount;
-            data._styleCount += styleCount;
-            const live = writeRunToSlots(data, group, run, slots, styleStart);
+            const styleSlots = new Array<number>(styleCount);
+            for (let i = 0; i < styleCount; i++) {
+                styleSlots[i] = data._styleCount++;
+            }
+            const live = writeRunToSlots(data, group, run, slots, styleSlots);
             liveInGroup += live.length;
-            newRunRecords.set(run, { _run: run, _groupIdx: groupIdx, _slots: live, _styleStart: styleStart, _styleCount: styleCount });
+            newRunRecords.set(run, { _run: run, _groupIdx: groupIdx, _slots: live, _styleSlots: styleSlots });
         }
         group._slotCount = writeSlot - group._slotStart;
         group._liveCount = liveInGroup;
@@ -807,16 +686,15 @@ function applyAddRun(data: TextData, run: GlyphRun, insertBefore?: number): void
     if (data._runRecords.has(run)) {
         throw new Error("updateTextData addRun: GlyphRun reference is already in this TextData.");
     }
-    const styleCount = countRunStyles(run);
-    assertStyleAllocationFits(data, undefined, styleCount);
+    const at = insertBefore ?? data._runs.length;
+    lookupCurveSet(data._storage, run.curveSet, "addRun");
+    const styleSlots = allocateStyles(data, countRunStyles(run));
     const group = ensureGroup(data, run.curveSet);
     const groupIdx = data._groups.indexOf(group);
     const slots = allocateSlots(data, group, run.glyphs.length);
-    const styleStart = reserveStyles(data, undefined, styleCount);
-    const live = writeRunToSlots(data, group, run, slots, styleStart);
+    const live = writeRunToSlots(data, group, run, slots, styleSlots);
     group._liveCount += live.length;
-    data._runRecords.set(run, { _run: run, _groupIdx: groupIdx, _slots: live, _styleStart: styleStart, _styleCount: styleCount });
-    const at = insertBefore ?? data._runs.length;
+    data._runRecords.set(run, { _run: run, _groupIdx: groupIdx, _slots: live, _styleSlots: styleSlots });
     data._runs.splice(at, 0, run);
 }
 
@@ -829,7 +707,7 @@ function applyRemoveRun(data: TextData, ref: GlyphRun | number): void {
     const group = data._groups[rec._groupIdx]!;
     freeSlots(data, group, rec._slots);
     group._liveCount -= rec._slots.length;
-    releaseStyles(data, rec._styleStart, rec._styleCount);
+    releaseStyles(data, rec._styleSlots);
     data._runRecords.delete(run);
     const runIdx = resolveRunIndex(data, ref);
     if (runIdx >= 0) {
@@ -880,14 +758,13 @@ function applyReplaceRun(data: TextData, prevRef: GlyphRun | number, newRun: Gly
     if (prev !== newRun && data._runRecords.has(newRun)) {
         throw new Error("updateTextData replaceRun: new GlyphRun reference is already in this TextData.");
     }
-    const styleCount = countRunStyles(newRun);
-    assertStyleAllocationFits(data, rec, styleCount);
     const group = data._groups[rec._groupIdx]!;
     // Staying in the same draw group means the run keeps its position in `_runs`, so the whole
     // edit reduces to slot bookkeeping — no list splices, and no index scan to drive them. An
     // empty new run is the one exception: it can leave the group with nothing live, and only
     // the remove path knows how to retire a group.
     if (newRun.curveSet === group._curveSetId && newRun.glyphs.length > 0) {
+        const styleSlots = allocateStyles(data, countRunStyles(newRun), rec._styleSlots);
         const prevSlotCount = rec._slots.length;
         let slots = rec._slots;
         if (newRun.glyphs.length !== prevSlotCount) {
@@ -897,19 +774,17 @@ function applyReplaceRun(data: TextData, prevRef: GlyphRun | number, newRun: Gly
             freeSlots(data, group, slots);
             slots = allocateSlots(data, group, newRun.glyphs.length);
         }
-        const styleStart = reserveStyles(data, rec, styleCount);
-        const live = writeRunToSlots(data, group, newRun, slots, styleStart);
+        const live = writeRunToSlots(data, group, newRun, slots, styleSlots);
         // Absorbs both a changed glyph count and any glyph that missed the atlas.
         group._liveCount += live.length - prevSlotCount;
         if (prev === newRun) {
             // In-place glyph edits: the record and `_runs` already point at this run, so its
-            // live slot list and style block are the only things that can have moved.
+            // live instance and style slot lists are the only things that can have moved.
             rec._slots = live;
-            rec._styleStart = styleStart;
-            rec._styleCount = styleCount;
+            rec._styleSlots = styleSlots;
         } else {
             data._runRecords.delete(prev);
-            data._runRecords.set(newRun, { _run: newRun, _groupIdx: rec._groupIdx, _slots: live, _styleStart: styleStart, _styleCount: styleCount });
+            data._runRecords.set(newRun, { _run: newRun, _groupIdx: rec._groupIdx, _slots: live, _styleSlots: styleSlots });
             const runIdx = resolveRunIndex(data, prevRef);
             if (runIdx >= 0) {
                 data._runs[runIdx] = newRun;
@@ -919,6 +794,10 @@ function applyReplaceRun(data: TextData, prevRef: GlyphRun | number, newRun: Gly
     }
     // Different curve set, or an empty replacement → remove + add at the same position.
     const insertPos = resolveRunIndex(data, prevRef);
+    lookupCurveSet(data._storage, newRun.curveSet, "replaceRun");
+    if (countRunStyles(newRun) > data._freeStyleSlots.length + rec._styleSlots.length + MAX_STYLE_ENTRIES - data._styleCount) {
+        throw new Error(`TextData style palette cannot exceed ${MAX_STYLE_ENTRIES} entries.`);
+    }
     applyRemoveRun(data, insertPos >= 0 ? insertPos : prev);
     applyAddRun(data, newRun, insertPos >= 0 ? insertPos : undefined);
 }
@@ -940,7 +819,7 @@ export function createTextData(storage: GlyphStorage, runs?: readonly GlyphRun[]
         _instanceCount: 0,
         _styles: new Float32Array(TEXT_STYLE_FLOATS),
         _styleCount: 0,
-        _freeStyleBlocks: [],
+        _freeStyleSlots: [],
         _styleVersion: 1,
         _storage: storage,
         _version: 1,
@@ -990,7 +869,7 @@ export function disposeTextData(data: TextData): void {
     data._groups = [];
     data._instanceCount = 0;
     data._styleCount = 0;
-    data._freeStyleBlocks.length = 0;
+    data._freeStyleSlots.length = 0;
     data._runs.length = 0;
     data._runRecords.clear();
 }

--- a/packages/babylon-lite/src/text/text-data.ts
+++ b/packages/babylon-lite/src/text/text-data.ts
@@ -282,11 +282,18 @@ function allocateStyles(data: TextData, count: number, previous?: number[]): num
     if (previous) {
         releaseStyles(data, previous);
     }
+    const highWater = data._styleCount;
     const slots = new Array<number>(count);
     for (let i = 0; i < count; i++) {
         slots[i] = free.pop() ?? data._styleCount++;
     }
-    data._styleVersion++;
+    // Growing past the high-water mark lengthens the upload, and `ensureStyleGpu` only uploads
+    // when the version moved — so the bump cannot be left to `writeStyle`, which stays silent for
+    // an entry whose contents already match (an all-zero style writes nothing). Slots taken from
+    // the free list keep the upload length unchanged, so there `writeStyle` alone is enough.
+    if (data._styleCount !== highWater) {
+        data._styleVersion++;
+    }
     return slots;
 }
 

--- a/tests/lite/unit/text-data-run-edits.test.ts
+++ b/tests/lite/unit/text-data-run-edits.test.ts
@@ -195,7 +195,8 @@ describe("updateTextData replaceRun", () => {
 
         for (let i = 0; i < 101; i++) {
             const replaceFirst = i % 2 === 0;
-            const replacement = styledRun(replaceFirst ? 0 : 10, Math.floor(i / 2) % 2 === 0);
+            const withOverride = Math.floor(i / 2) % 2 === 0;
+            const replacement = styledRun(replaceFirst ? 0 : 10, withOverride);
             updateTextData(data, { update: "replaceRun", previous: replaceFirst ? first : second, run: replacement });
             if (replaceFirst) {
                 first = replacement;
@@ -203,6 +204,14 @@ describe("updateTextData replaceRun", () => {
                 second = replacement;
             }
             expect(data._styleCount).toBeLessThanOrEqual(5);
+            // Bounding the high-water mark only proves slots are recycled; it says nothing about
+            // whether a recycled slot was rewritten. Follow the second glyph's packed index into
+            // the palette so a stale entry surfaces as a wrong colour rather than passing silently.
+            const record = data._runRecords.get(replacement)!;
+            const styleIndex = data._instancesU32[record._slots[1]! * TEXT_INSTANCE_FLOATS + 2]! >>> 16;
+            expect(Array.from(data._styles.subarray(styleIndex * TEXT_STYLE_FLOATS, styleIndex * TEXT_STYLE_FLOATS + 4))).toEqual(
+                withOverride ? [0.25, 0.5, 0.75, 1] : [1, 1, 1, 1]
+            );
         }
     });
 
@@ -328,6 +337,60 @@ describe("updateTextData removeRun", () => {
             updateTextData(data, { update: "removeRun", run: added });
             expect(data._styleCount).toBeLessThanOrEqual(3);
         }
+    });
+});
+
+/** A run whose palette entry is entirely zero — `[0, 0, 0, 0]` with `invScale` 0, since a
+ *  `pixelsPerFontUnit` of 0 maps to 0. Writing it into a never-used slot changes nothing, so
+ *  `writeStyle` stays silent and any `_styleVersion` movement must come from the allocator. */
+function zeroStyleRun(x: number): GlyphRun {
+    return { curveSet: "f", glyphs: [{ glyphId: 1, x, y: 0 }], pixelsPerFontUnit: 0, defaultColor: [0, 0, 0, 0] };
+}
+
+// `ensureStyleGpu` skips the palette upload entirely while `_styleVersion` is unchanged, and
+// uploads exactly `_styleCount` entries when it moves. Both halves of that contract need pinning:
+// a version that moves too eagerly costs a redundant upload every edit, and one that moves too
+// rarely leaves the GPU holding a short or stale palette. Neither shows up in a content
+// assertion, so only these tests stand between the two failure modes.
+describe("TextData _styleVersion", () => {
+    it("does not move when an edit is satisfied entirely from recycled slots", () => {
+        const data = createTextData(makeStorage(), [run("f", 0), run("f", 10)]);
+        updateTextData(data, { update: "removeRun", run: 1 });
+        const before = data._styleVersion;
+        const highWater = data._styleCount;
+
+        // Same curve set, same default colour and `pixelsPerFontUnit` as the run just removed, so
+        // the recycled entry is rewritten with the bytes it already holds.
+        updateTextData(data, { update: "addRun", run: run("f", 20) });
+
+        expect(data._styleCount).toBe(highWater);
+        expect(data._styleVersion).toBe(before);
+    });
+
+    it("moves when an allocation grows the palette past its high-water mark", () => {
+        const data = createTextData(makeStorage(), [run("f", 0)]);
+        const before = data._styleVersion;
+        const highWater = data._styleCount;
+
+        updateTextData(data, { update: "addRun", run: zeroStyleRun(10) });
+
+        // `writeStyle` is a no-op here, so a version that has not moved means the lengthened
+        // palette would never reach the GPU.
+        expect(data._styleCount).toBeGreaterThan(highWater);
+        expect(data._styleVersion).toBeGreaterThan(before);
+    });
+
+    it("moves when a reset shrinks the palette", () => {
+        const data = createTextData(makeStorage(), [run("f", 0), styledRun(10, true), styledRun(20, true)]);
+        const highWater = data._styleCount;
+        const before = data._styleVersion;
+
+        // The surviving run reproduces entry 0 exactly, so `writeStyle` stays silent and the
+        // shorter upload length is the only thing left to report.
+        updateTextData(data, { update: "reset", runs: [run("f", 5)] });
+
+        expect(data._styleCount).toBeLessThan(highWater);
+        expect(data._styleVersion).toBeGreaterThan(before);
     });
 });
 

--- a/tests/lite/unit/text-data-run-edits.test.ts
+++ b/tests/lite/unit/text-data-run-edits.test.ts
@@ -191,46 +191,41 @@ describe("updateTextData replaceRun", () => {
     it("reuses styles across alternating non-tail replacements", () => {
         let first = styledRun(0, false);
         let second = styledRun(10, false);
-        const last = run("f", 20, [3]);
-        const data = createTextData(makeStorage(), [first, second, last]);
+        const data = createTextData(makeStorage(), [first, second, run("f", 20, [3])]);
 
         for (let i = 0; i < 101; i++) {
             const replaceFirst = i % 2 === 0;
             const replacement = styledRun(replaceFirst ? 0 : 10, Math.floor(i / 2) % 2 === 0);
-            const previous = replaceFirst ? first : second;
-            updateTextData(data, { update: "replaceRun", previous, run: replacement });
+            updateTextData(data, { update: "replaceRun", previous: replaceFirst ? first : second, run: replacement });
             if (replaceFirst) {
                 first = replacement;
             } else {
                 second = replacement;
             }
-            expect(data._styleCount).toBeLessThanOrEqual(7);
+            expect(data._styleCount).toBeLessThanOrEqual(5);
         }
-
-        const record = data._runRecords.get(first)!;
-        const packed = data._instancesU32[record._slots[1]! * TEXT_INSTANCE_FLOATS + 2]!;
-        const styleIndex = packed >>> 16;
-        expect(Array.from(data._styles.subarray(styleIndex * TEXT_STYLE_FLOATS, styleIndex * TEXT_STYLE_FLOATS + 4))).toEqual([0.25, 0.5, 0.75, 1]);
     });
 
-    it("compacts styles before a new allocation exceeds packed indices", () => {
+    it("reuses individual style entries at the packed-index limit", () => {
         const first = styledRun(0, false);
         const last: GlyphRun = { ...run("f", 10, [3]), defaultColor: [0.125, 0.25, 0.5, 1] };
         const data = createTextData(makeStorage(), [first, last]);
         data._styleCount = 0xffff;
+        data._freeStyleSlots.push(10);
 
         const replacement = styledRun(0, true);
         updateTextData(data, { update: "replaceRun", previous: first, run: replacement });
 
-        expect(data._styleCount).toBe(3);
+        expect(data._styleCount).toBe(0xffff);
         const survivingRecord = data._runRecords.get(last)!;
-        const survivingStyleIndex = data._instancesU32[survivingRecord._slots[0]! * TEXT_INSTANCE_FLOATS + 2]! >>> 16;
-        expect(survivingStyleIndex).toBe(0);
-        expect(Array.from(data._styles.subarray(0, 4))).toEqual([0.125, 0.25, 0.5, 1]);
-        const record = data._runRecords.get(replacement)!;
-        for (const slot of record._slots) {
-            expect(data._instancesU32[slot * TEXT_INSTANCE_FLOATS + 2]! >>> 16).toBeLessThan(0xffff);
-        }
+        const survivingStyle = data._instancesU32[survivingRecord._slots[0]! * TEXT_INSTANCE_FLOATS + 2]! >>> 16;
+        expect(survivingStyle).toBe(1);
+        expect(Array.from(data._styles.subarray(survivingStyle * TEXT_STYLE_FLOATS, survivingStyle * TEXT_STYLE_FLOATS + 4))).toEqual([0.125, 0.25, 0.5, 1]);
+        const replacementRecord = data._runRecords.get(replacement)!;
+        expect(replacementRecord._styleSlots).toEqual([0, 10]);
+        const overrideStyle = data._instancesU32[replacementRecord._slots[1]! * TEXT_INSTANCE_FLOATS + 2]! >>> 16;
+        expect(overrideStyle).toBe(10);
+        expect(Array.from(data._styles.subarray(overrideStyle * TEXT_STYLE_FLOATS, overrideStyle * TEXT_STYLE_FLOATS + 4))).toEqual([0.25, 0.5, 0.75, 1]);
     });
 
     // The free list is shared by every path that allocates, so an added run reuses a removed
@@ -323,7 +318,7 @@ describe("updateTextData removeRun", () => {
         expect(data._runRecords.has(target)).toBe(false);
     });
 
-    it("reclaims style blocks across repeated add/remove cycles", () => {
+    it("reuses style entries across repeated add/remove cycles", () => {
         const base = run("f", 10, [3]);
         const data = createTextData(makeStorage(), [base]);
 
@@ -331,7 +326,7 @@ describe("updateTextData removeRun", () => {
             const added = styledRun(0, true);
             updateTextData(data, { update: "addRun", run: added, insertBefore: 0 });
             updateTextData(data, { update: "removeRun", run: added });
-            expect(data._styleCount).toBe(1);
+            expect(data._styleCount).toBeLessThanOrEqual(3);
         }
     });
 });


### PR DESCRIPTION
### Proposal

The follow-up to #607 (acb91b69) addressed @deltakosh's review feedback — incremental run edits must reclaim style-palette blocks rather than leak them, and must compact before the 16-bit style index overflows — with a bounded free-**block** allocator: splitting, coalescing, overflow compaction, packed-index rewriting, and a reset fallback. That's ~150 lines of allocator to audit.

This proposes the same guarantees with far less machinery.

### Why it's simpler

Every style-palette entry is a **fixed 32 bytes**. Variable-sized blocks existed only because each run reserved one default entry plus contiguous per-glyph overrides. Recycling *individual* style indices makes fragmentation impossible — so there is nothing to compact.

- Each run owns a list of style indices (replaces `_styleStart`/`_styleCount`).
- Freed indices go on a free-index stack and are reused indefinitely.
- No splitting, coalescing, compaction, index rewriting, or reset fallback.
- Cap is 65,535 live entries (`0x0000`–`0xfffe`; `0xffff` stays the dead-instance sentinel); genuine exhaustion throws an explicit error.
- Validation now runs before mutation on the add/replace paths, so a rejected edit leaves the palette untouched rather than half-applied.

### Impact

|  | merged allocator | this proposal |
| --- | --- | --- |
| scene180 raw bundle | 29,733 B | **28,894 B** (−839 B) |
| `text-data.ts` | 930 lines | **820 lines** (−110) |

### Test coverage

Review-requested coverage is kept and updated: repeated add/remove cycles, and alternating non-tail replacements — the latter now verifies on every iteration that a *recycled* slot still resolves to the right palette values, not just that the high-water mark stays bounded.

Separately, `_styleVersion` turned out to have no behavioural coverage at all: the only reference in the suite asserted the uploaded version matched after a device-lost rebuild. Since `ensureStyleGpu` gates the whole palette upload on that version and writes exactly `_styleCount` entries, both failure modes were invisible — a version that moves too eagerly costs a redundant upload on every edit, and one that moves too rarely leaves the GPU with a short or stale palette. Neither shows up in a content or pixel assertion. There's now a `TextData _styleVersion` block pinning all three directions, which in turn allowed narrowing the allocator's bump to fire only when the palette actually grows.

Each new assertion is mutation-verified — making the bump unconditional, removing it entirely, removing the reset bump, and skipping the override `writeStyle` each fail exactly the intended test.

### Accepted tradeoff

`_styleCount` remains a high-water mark, so the palette upload keeps its peak size until a reset — a peak of 65,535 entries later dropping to 10 still uploads ~2 MiB, not 320 B. Uploads only occur when `_styleVersion` changes (style values change, the palette grows, data reset); geometry/position-only edits don't trigger one.

Threshold-based compaction was considered and deliberately rejected: it would rewrite every live style and every packed instance index, spike latency, risk thrashing around the threshold, and reintroduce the complexity this removes. Styles are shared — each run has one default entry shared by all its glyphs, and only explicit color overrides get dedicated entries — and a single `TextData` typically backs hundreds of cells or one cached paragraph, so 65,535 is unrealistic in practice. If profiling ever shows real high-water churn, the fallback is an absolute floor plus a ratio (e.g. only above 256 KiB and 75% free).
