### PR TITLE
fix(loader): reject malformed HDR scanlines

### DIFF
--- a/packages/babylon-lite/src/loader-hdr/hdr-parser.ts
+++ b/packages/babylon-lite/src/loader-hdr/hdr-parser.ts
@@ -72,15 +72,28 @@ export function parseRGBE(buffer: ArrayBuffer): HdrImage {
 }
 
 function decodeScanline(bytes: Uint8Array, pos: number, width: number, out: Float32Array, outOffset: number, scanline: Uint8Array): number {
-    if (width >= 8 && width <= 0x7fff && bytes[pos] === 2 && bytes[pos + 1] === 2 && bytes[pos + 2] === ((width >> 8) & 0xff) && bytes[pos + 3] === (width & 0xff)) {
+    const isRle = width >= 8 && width <= 0x7fff && bytes[pos] === 2 && bytes[pos + 1] === 2 && (bytes[pos + 2]! & 0x80) === 0;
+    if (isRle) {
+        if ((bytes[pos + 2]! << 8) + bytes[pos + 3]! !== width) {
+            throw new Error("Invalid HDR: RLE scanline width does not match image");
+        }
         pos += 4;
         for (let ch = 0; ch < 4; ch++) {
             let ptr = ch;
             let count = 0;
             while (count < width) {
+                if (pos >= bytes.length) {
+                    throw new Error("Invalid HDR: truncated RLE scanline");
+                }
                 const a = bytes[pos++]!;
+                if (a === 0) {
+                    throw new Error("Invalid HDR: zero-length RLE packet");
+                }
                 if (a > 128) {
                     const runLen = a - 128;
+                    if (runLen > width - count || pos >= bytes.length) {
+                        throw new Error("Invalid HDR: RLE run exceeds scanline");
+                    }
                     const val = bytes[pos++]!;
                     for (let i = 0; i < runLen; i++) {
                         scanline[ptr] = val;
@@ -88,6 +101,9 @@ function decodeScanline(bytes: Uint8Array, pos: number, width: number, out: Floa
                     }
                     count += runLen;
                 } else {
+                    if (a > width - count || pos + a > bytes.length) {
+                        throw new Error("Invalid HDR: RLE literal exceeds scanline");
+                    }
                     for (let i = 0; i < a; i++) {
                         scanline[ptr] = bytes[pos++]!;
                         ptr += 4;
@@ -100,6 +116,9 @@ function decodeScanline(bytes: Uint8Array, pos: number, width: number, out: Floa
             rgbeToFloat(scanline[x * 4]!, scanline[x * 4 + 1]!, scanline[x * 4 + 2]!, scanline[x * 4 + 3]!, out, outOffset + x * 3);
         }
     } else {
+        if (pos + width * 4 > bytes.length) {
+            throw new Error("Invalid HDR: truncated scanline");
+        }
         for (let x = 0; x < width; x++) {
             rgbeToFloat(bytes[pos]!, bytes[pos + 1]!, bytes[pos + 2]!, bytes[pos + 3]!, out, outOffset + x * 3);
             pos += 4;

--- a/tests/lite/unit/hdr-parser.test.ts
+++ b/tests/lite/unit/hdr-parser.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRGBE } from "../../../packages/babylon-lite/src/loader-hdr/hdr-parser.js";
+
+function makeHdr(width: number, body: number[]): ArrayBuffer {
+    const header = new TextEncoder().encode(`#?RADIANCE\nFORMAT=32-bit_rle_rgbe\n\n-Y 1 +X ${width}\n`);
+    const bytes = new Uint8Array(header.length + body.length);
+    bytes.set(header);
+    bytes.set(body, header.length);
+    return bytes.buffer;
+}
+
+describe("HDR parser", () => {
+    it("decodes a valid RLE scanline", () => {
+        const image = parseRGBE(makeHdr(8, [2, 2, 0, 8, 136, 1, 136, 2, 136, 3, 136, 129]));
+
+        expect(image.width).toBe(8);
+        expect(image.height).toBe(1);
+        expect(Array.from(image.data)).toEqual(Array.from({ length: 8 }, () => [1 / 128, 2 / 128, 3 / 128]).flat());
+    });
+
+    it("decodes valid RLE literal packets", () => {
+        const literal = (value: number): number[] => [8, ...Array<number>(8).fill(value)];
+        const image = parseRGBE(makeHdr(8, [2, 2, 0, 8, ...literal(1), ...literal(2), ...literal(3), ...literal(129)]));
+
+        expect(Array.from(image.data)).toEqual(Array.from({ length: 8 }, () => [1 / 128, 2 / 128, 3 / 128]).flat());
+    });
+
+    it("decodes a valid flat scanline", () => {
+        expect(Array.from(parseRGBE(makeHdr(1, [1, 2, 3, 129])).data)).toEqual([1 / 128, 2 / 128, 3 / 128]);
+    });
+
+    it("rejects zero-length RLE packets", () => {
+        expect(() => parseRGBE(makeHdr(8, [2, 2, 0, 8, 0]))).toThrow("zero-length RLE packet");
+    });
+
+    it("rejects RLE scanlines whose encoded width does not match the image", () => {
+        expect(() => parseRGBE(makeHdr(8, [2, 2, 0, 9]))).toThrow("RLE scanline width");
+    });
+
+    it("rejects RLE runs that exceed the scanline", () => {
+        expect(() => parseRGBE(makeHdr(8, [2, 2, 0, 8, 137, 1]))).toThrow("RLE run exceeds scanline");
+    });
+
+    it("rejects truncated RLE runs", () => {
+        expect(() => parseRGBE(makeHdr(8, [2, 2, 0, 8, 136]))).toThrow("RLE run exceeds scanline");
+    });
+
+    it("rejects truncated RLE literals", () => {
+        expect(() => parseRGBE(makeHdr(8, [2, 2, 0, 8, 8, 1, 2]))).toThrow("RLE literal exceeds scanline");
+    });
+
+    it("rejects truncated flat scanlines", () => {
+        expect(() => parseRGBE(makeHdr(1, []))).toThrow("truncated scanline");
+    });
+});


### PR DESCRIPTION
## Summary
- reject truncated flat and RLE HDR scanlines instead of decoding missing bytes as zero/NaN data
- validate RLE packet lengths and reject zero-length packets that cannot advance the decoder
- reject adaptive-RLE scanlines whose encoded width does not match the image width
- add focused coverage for valid run, literal, and flat encodings plus malformed inputs

## Validation
- on untouched `master`, the five truncated/invalid packet regressions silently decode instead of throwing
- Radiance adaptive RLE defines a four-byte scanline marker with the encoded width and packets that must exactly fill each component scanline
- `REUSE_BROWSER=1 corepack pnpm exec vitest run --project unit tests/lite/unit/hdr-parser.test.ts tests/lite/unit/load-hdr.test.ts` — 11 passed
- `corepack pnpm run lint`
- `REUSE_BROWSER=1 corepack pnpm build:lib`
- filtered Scene 8 HDR bundle build and live measurement — 72.4 KB raw under the unchanged 73.4 KB ceiling