### PR TITLE
fix(ci): fail type-check steps when tsc fails

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -546,23 +546,33 @@ stages:
                 - script: npx eslint . --format ./scripts/eslint-vso-formatter.cjs
                   displayName: "ESLint"
 
+                # Every type-check below pipes tsc into sed to turn TS diagnostics into
+                # `##vso[task.logissue]` annotations. A shell pipeline exits with the status
+                # of its LAST command, and sed always succeeds — so without `pipefail` a
+                # failing tsc reported green. `task.logissue type=error` annotates the build
+                # but does not fail the task on its own, so nothing else caught it either.
                 - script: |
+                      set -euo pipefail
                       npx tsc -p packages/babylon-lite/tsconfig.json --noEmit 2>&1 | sed -E 's/^(.+)\(([0-9]+),([0-9]+)\): error (TS[0-9]+): (.+)/##vso[task.logissue type=error;sourcepath=\1;linenumber=\2;columnnumber=\3]\4: \5/'
                   displayName: "TypeScript type-check (package)"
 
                 - script: |
+                      set -euo pipefail
                       npx tsc -p lab/tsconfig.typecheck.json --noEmit 2>&1 | sed -E 's/^(.+)\(([0-9]+),([0-9]+)\): error (TS[0-9]+): (.+)/##vso[task.logissue type=error;sourcepath=\1;linenumber=\2;columnnumber=\3]\4: \5/'
                   displayName: "TypeScript type-check (lab)"
 
                 - script: |
+                      set -euo pipefail
                       npx tsc -p tests/lite/tsconfig.json --noEmit 2>&1 | sed -E 's/^(.+)\(([0-9]+),([0-9]+)\): error (TS[0-9]+): (.+)/##vso[task.logissue type=error;sourcepath=\1;linenumber=\2;columnnumber=\3]\4: \5/'
                   displayName: "TypeScript type-check (tests)"
 
                 - script: |
+                      set -euo pipefail
                       npx tsc -p packages/babylon-lite-gl/tsconfig.json --noEmit 2>&1 | sed -E 's/^(.+)\(([0-9]+),([0-9]+)\): error (TS[0-9]+): (.+)/##vso[task.logissue type=error;sourcepath=\1;linenumber=\2;columnnumber=\3]\4: \5/'
                   displayName: "TypeScript type-check (gl package)"
 
                 - script: |
+                      set -euo pipefail
                       npx tsc -p tests/gl/tsconfig.json --noEmit 2>&1 | sed -E 's/^(.+)\(([0-9]+),([0-9]+)\): error (TS[0-9]+): (.+)/##vso[task.logissue type=error;sourcepath=\1;linenumber=\2;columnnumber=\3]\4: \5/'
                   displayName: "TypeScript type-check (gl tests)"
 
@@ -605,11 +615,16 @@ stages:
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 
+                # `set -euo pipefail` is required here for the same reason as in the Lint
+                # job above: sed is the last command in the pipeline, so without it a
+                # failing tsc is masked by sed's zero exit and the step reports green.
                 - script: |
+                      set -euo pipefail
                       npx tsc -p packages/babylon-lite-compat/tsconfig.json --noEmit 2>&1 | sed -E 's/^(.+)\(([0-9]+),([0-9]+)\): error (TS[0-9]+): (.+)/##vso[task.logissue type=error;sourcepath=\1;linenumber=\2;columnnumber=\3]\4: \5/'
                   displayName: "TypeScript type-check (compat src)"
 
                 - script: |
+                      set -euo pipefail
                       npx tsc -p packages/babylon-lite-compat/tests/tsconfig.json --noEmit 2>&1 | sed -E 's/^(.+)\(([0-9]+),([0-9]+)\): error (TS[0-9]+): (.+)/##vso[task.logissue type=error;sourcepath=\1;linenumber=\2;columnnumber=\3]\4: \5/'
                   displayName: "TypeScript type-check (compat tests)"
 


### PR DESCRIPTION
## The defect

The seven TypeScript type-check steps in `azure-pipelines.yml` pipe `tsc` into `sed`:

```yaml
- script: |
      npx tsc -p packages/babylon-lite/tsconfig.json --noEmit 2>&1 | sed -E '...'
```

A shell pipeline exits with the status of its **last** command. `sed` always exits `0`. So a failing `tsc` produced a **green step**.

The `##vso[task.logissue type=error]` annotations that `sed` emits decorate the build summary but do **not** fail a task on their own, so nothing else caught it.

**Net effect: "Lint & Type Check ✅" has been vacuous — a type error would ship green.**

## Demonstration

```
failing tsc | sed                      -> exit 0   (CI: green)
set -euo pipefail; failing tsc | sed   -> exit 2   (CI: red)
set -euo pipefail; clean   tsc | sed   -> exit 0   (CI: green)
```

## The fix

`set -euo pipefail` on each of the seven steps (5 in `Lint & Type Check`, 2 in `Compat Layer`). The sed-based annotations are unchanged, so inline PR error reporting still works.

## Blast radius

All seven tsconfig projects were verified to type-check cleanly on master (`c5f8f660`) before this change:

```
packages/babylon-lite/tsconfig.json                  rc=0 errors=0
lab/tsconfig.typecheck.json                          rc=0 errors=0
tests/lite/tsconfig.json                             rc=0 errors=0
packages/babylon-lite-gl/tsconfig.json               rc=0 errors=0
tests/gl/tsconfig.json                               rc=0 errors=0
packages/babylon-lite-compat/tsconfig.json           rc=0 errors=0
packages/babylon-lite-compat/tests/tsconfig.json     rc=0 errors=0
```

So this should not turn anything red today. It ensures a *future* type error cannot pass.

## Scope

Deliberately minimal and self-contained. All other `azure-pipelines*.yml`, `config/templates/`, and `.github/workflows/` piped steps were audited — the rest already set `pipefail`. The one other flagged step (`Resolve baseline ref`, line 354) is a false positive: those are `||` or-lists, not pipes, and it already has `set -u` plus an explicit empty-value guard.

15 lines: 7 guards + 8 lines of comment explaining why.