### PR TITLE
fix(ci): compare bundle size against the baseline for the commit under test

### DIFF
--- a/azure-pipelines-bundle-manifest.yml
+++ b/azure-pipelines-bundle-manifest.yml
@@ -230,16 +230,26 @@ stages:
                       SCENES="$(node -e 'process.stdout.write(String(Object.keys(require(process.argv[1])).length))' "$MANIFEST")"
                       echo "Publishing bundle-size baseline for $SCENES scene(s)."
 
-                      mkdir -p "$WORK"
-                      cp "$MANIFEST" "$WORK/manifest.json"
-                      (cd "$WORK" && zip -j baseline.zip manifest.json)
+                      # Stamps each scene with the ceiling it was measured against and writes
+                      # the meta.json provenance sidecar into $WORK. Exits non-zero on an empty
+                      # or unreadable manifest, so the guard above is belt-and-braces.
+                      BUNDLE_BASELINE_MANIFEST="$MANIFEST" BUNDLE_BASELINE_STAGING="$WORK" \
+                        pnpm exec tsx scripts/publish-bundle-baseline.ts
 
-                      curl "${DEPLOYMENT_SERVER}/${DEPLOY_ENDPOINT_UPLOAD}" --fail-with-body -i -X POST \
-                        -H "Content-Type: multipart/form-data" \
-                        -H "Authorization: Bearer ${DEPLOY_TOKEN}" \
-                        -F "path=$(baselineDeployPath)" \
-                        -F "storageAccount=${STORAGE_ACCOUNT}" \
-                        -F "zip=@$WORK/baseline.zip"
+                      (cd "$WORK" && zip -j baseline.zip manifest.json meta.json)
+
+                      # Immutable per-commit copy first. If that upload fails the step stops
+                      # here and the mutable copy is left untouched, so "latest" and its
+                      # per-commit twin never disagree about what a commit measured.
+                      for deployPath in "$(baselineDeployPath)/$(Build.SourceVersion)" "$(baselineDeployPath)"; do
+                        echo "Uploading baseline to $deployPath"
+                        curl "${DEPLOYMENT_SERVER}/${DEPLOY_ENDPOINT_UPLOAD}" --fail-with-body -i -X POST \
+                          -H "Content-Type: multipart/form-data" \
+                          -H "Authorization: Bearer ${DEPLOY_TOKEN}" \
+                          -F "path=$deployPath" \
+                          -F "storageAccount=${STORAGE_ACCOUNT}" \
+                          -F "zip=@$WORK/baseline.zip"
+                      done
                   displayName: "Publish bundle-size baseline"
                   env:
                       DEPLOYMENT_SERVER: $(DEPLOYMENT_SERVER)

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -240,6 +240,20 @@ interface BundleManifestEntry {
      *  hides sub-50-byte drift — including a ceiling overflow on a zero-headroom scene. Tools
      *  comparing sizes (the build's ceiling check, the delta report) use this. */
     rawBytes?: number;
+    /**
+     * The scene's `maxRawKB` ceiling **as it stood on the commit this baseline was measured
+     * from**, stamped in at publish time by `scripts/publish-bundle-baseline.ts`.
+     *
+     * Without it, a consumer asking "was master already over its ceiling?" has only the
+     * baseline's bytes and the *branch's* `scene-config.json`, so a PR that tightens a
+     * ceiling makes master retroactively look like it was in breach. The measurement and
+     * the limit it was measured against have to travel together to answer that.
+     *
+     * Optional because baselines published before this field existed do not carry it, and
+     * because a scene may legitimately have no ceiling (`skipBundleSize`, or no `maxRawKB`).
+     * Consumers must treat "absent" as "unknown", never as "no ceiling".
+     */
+    ceilingKB?: number;
     ignoredRawKB?: number;
     bjsRawKB?: number;
     bjsGzipKB?: number;
@@ -434,8 +448,95 @@ function readMasterBundleManifestFromGit(refs = ["upstream/master", "origin/mast
     return null;
 }
 
-/** Guard against a CDN or proxy serving something that parses as JSON but isn't a manifest. */
-function isBundleManifest(value: unknown): value is BundleManifest {
+/** A full 40-character git object name, the only form the published layout uses. */
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+function gitOutput(args: string[]): string | null {
+    try {
+        return execFileSync("git", args, { cwd: ROOT, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Commits whose published baseline would be a like-for-like comparison for this
+ * build, most specific first.
+ *
+ * The problem being solved: the mutable `manifest.json` is whatever master
+ * published most recently, which is not necessarily the commit this build was
+ * merged with. Comparing against it silently attributes bytes from every master
+ * commit in between to the PR under test.
+ *
+ * Candidates, at most one of which normally applies:
+ *  - `BUNDLE_BASELINE_COMMIT` — an explicit override. Set but empty means "do not
+ *    look up a per-commit baseline at all", mirroring `BUNDLE_MASTER_MANIFEST_URL`.
+ *  - HEAD's **first parent, only when HEAD is a merge commit**. Azure DevOps checks
+ *    PRs out at `refs/pull/N/merge`, whose first parent is exactly the master commit
+ *    the PR was merged with. Read from the raw commit object rather than via
+ *    `rev-parse HEAD^1`, because CI checks out at `--depth=1`, where the shallow
+ *    graft makes `rev-parse HEAD^1` fail outright ("unknown revision") even though
+ *    the commit object still records both parents. Using `cat-file` therefore needs
+ *    no `fetchDepth` change in the pipeline. The merge-commit requirement matters:
+ *    on an ordinary commit the first parent is just the previous commit, which
+ *    carries no "this is what I was merged with" meaning.
+ *  - The merge base with master, for local `pnpm build:bundle-scenes` runs — the
+ *    commit the branch actually diverged from. Needs real history, so it simply
+ *    yields nothing in CI's shallow checkout.
+ *
+ * Deliberately *not* a candidate: the current `origin/master` SHA. That is the
+ * mutable baseline by another name, so probing it would reintroduce the exact
+ * mis-attribution this lookup exists to remove, while costing an extra request.
+ *
+ * A candidate with no published baseline is a plain 404 — one round trip, then the
+ * mutable baseline. Nothing waits and nothing fails.
+ */
+function readBaselineCommitCandidates(): string[] {
+    const explicit = process.env.BUNDLE_BASELINE_COMMIT;
+    if (explicit !== undefined) {
+        const trimmed = explicit.trim();
+        return FULL_SHA_PATTERN.test(trimmed) ? [trimmed] : [];
+    }
+
+    const candidates: string[] = [];
+
+    const head = gitOutput(["cat-file", "-p", "HEAD"]);
+    if (head) {
+        // Header lines are ordered: tree, then parent(s), then author.
+        const parents: string[] = [];
+        for (const line of head.split("\n")) {
+            if (line.startsWith("tree ")) continue;
+            if (!line.startsWith("parent ")) break;
+            parents.push(line.slice("parent ".length).trim());
+        }
+        if (parents.length > 1 && parents[0]) candidates.push(parents[0]);
+    }
+
+    for (const ref of ["upstream/master", "origin/master"]) {
+        const base = gitOutput(["merge-base", "HEAD", ref]);
+        if (base) {
+            candidates.push(base);
+            break;
+        }
+    }
+
+    return [...new Set(candidates.filter((sha) => FULL_SHA_PATTERN.test(sha)))];
+}
+
+/**
+ * Rewrite a baseline manifest URL to the immutable per-commit copy beside it:
+ * `.../bundle-baseline/manifest.json` -> `.../bundle-baseline/<sha>/manifest.json`.
+ *
+ * Derived from the URL actually in effect rather than from the hardcoded default,
+ * so `BUNDLE_MASTER_MANIFEST_URL` overrides (tests, mirrors) keep working.
+ */
+function perCommitBaselineUrl(manifestUrl: string, commit: string): string {
+    const slash = manifestUrl.lastIndexOf("/");
+    if (slash < 0) return manifestUrl;
+    return `${manifestUrl.slice(0, slash)}/${commit}${manifestUrl.slice(slash)}`;
+}
+
+/** Guard against a CDN or proxy serving something that parses as JSON but isn't a manifest. */function isBundleManifest(value: unknown): value is BundleManifest {
     if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
     const entries = Object.values(value);
     return entries.length > 0 && entries.every((entry) => typeof entry === "object" && entry !== null && typeof (entry as BundleManifestEntry).rawKB === "number");
@@ -456,12 +557,17 @@ function readMasterBundleManifestFromFile(path: string): BundleManifest | null {
  * (first run after this change, or a fork with no deployment) and is not an
  * error — the caller degrades to "no baseline", which only costs the advisory
  * delta report.
+ *
+ * `quiet404` suppresses the miss message for per-commit probes, where a 404 is
+ * the ordinary case (the base commit's baseline build may still be running, may
+ * have failed, or may predate per-commit publishing) and the caller reports the
+ * outcome once it knows which candidate, if any, hit.
  */
-async function fetchMasterBundleManifest(url: string): Promise<BundleManifest | null> {
+async function fetchMasterBundleManifest(url: string, { quiet404 = false }: { quiet404?: boolean } = {}): Promise<BundleManifest | null> {
     try {
         const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
         if (response.status === 404) {
-            console.warn(`No published bundle-size baseline at ${url} yet; skipping the master delta.`);
+            if (!quiet404) console.warn(`No published bundle-size baseline at ${url} yet; skipping the master delta.`);
             return null;
         }
         if (!response.ok) {
@@ -483,9 +589,10 @@ async function fetchMasterBundleManifest(url: string): Promise<BundleManifest | 
 /**
  * Resolve the master baseline, in order of preference:
  *   1. `BUNDLE_MASTER_MANIFEST_FILE` — a baseline CI already downloaded.
- *   2. The published baseline over HTTP (skipped when `refs` is given, i.e. when
- *      the caller explicitly asked to compare against a specific git ref, or
- *      when `BUNDLE_MASTER_MANIFEST_URL` is set to an empty value).
+ *   2. The baseline published for *this build's own base commit*, then the
+ *      mutable latest baseline (both skipped when `refs` is given, i.e. when the
+ *      caller explicitly asked to compare against a specific git ref, or when
+ *      `BUNDLE_MASTER_MANIFEST_URL` is set to an empty value).
  *   3. Git refs — the legacy tracked layout, still readable on old refs.
  */
 export async function resolveMasterBundleManifest(refs?: string[]): Promise<{ source: string; manifest: BundleManifest } | null> {
@@ -502,8 +609,35 @@ export async function resolveMasterBundleManifest(refs?: string[]): Promise<{ so
         // baseline anyway. Trimmed because a YAML-supplied blank can arrive as " ".
         const url = (process.env.BUNDLE_MASTER_MANIFEST_URL ?? DEFAULT_MASTER_MANIFEST_URL).trim();
         if (url) {
+            const candidates = readBaselineCommitCandidates();
+            for (const commit of candidates) {
+                const commitUrl = perCommitBaselineUrl(url, commit);
+                const manifest = await fetchMasterBundleManifest(commitUrl, { quiet404: true });
+                if (manifest) {
+                    console.log(`✓ Bundle-size baseline matched this build's base commit ${commit.slice(0, 8)}.`);
+                    return { source: commitUrl, manifest };
+                }
+            }
+
             const manifest = await fetchMasterBundleManifest(url);
-            if (manifest) return { source: url, manifest };
+            if (manifest) {
+                // Say so explicitly. This baseline may have been measured on a different
+                // commit than the one this build was merged with, so any delta computed
+                // from it can attribute another PR's bytes to this one. Silently doing
+                // that is the failure this per-commit lookup exists to avoid, so when the
+                // fallback fires the reader needs to know it did.
+                //
+                // The two ways of getting here need different words: having asked for a
+                // base commit and been told there is none is a producer-side gap that
+                // will close on its own, whereas never having identified a base commit is
+                // a property of this checkout that will not.
+                const why =
+                    candidates.length > 0
+                        ? "no baseline was published for this build's base commit"
+                        : "this build's base commit could not be determined, so no per-commit baseline was requested";
+                console.warn(`Using the latest published bundle-size baseline (${url}); ${why}.`);
+                return { source: url, manifest };
+            }
         }
     }
 

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -491,11 +491,31 @@ function gitOutput(args: string[]): string | null {
  * A candidate with no published baseline is a plain 404 — one round trip, then the
  * mutable baseline. Nothing waits and nothing fails.
  */
-function readBaselineCommitCandidates(): string[] {
+/**
+ * The outcome of working out which commit's baseline to ask for.
+ *
+ * `disabled` is kept separate from an empty `commits` list because the two lead a
+ * reader to different places: an explicit opt-out is this build's own
+ * configuration doing what it was told, while an empty list is a checkout that
+ * could not say what it was merged with. Collapsing them would report a
+ * deliberate setting as a fault.
+ */
+interface BaselineCommitLookup {
+    /** True when the caller explicitly switched per-commit lookup off. */
+    disabled: boolean;
+    /** Full SHAs to try, in order. Empty when none could be determined. */
+    commits: string[];
+}
+
+function readBaselineCommitCandidates(): BaselineCommitLookup {
     const explicit = process.env.BUNDLE_BASELINE_COMMIT;
     if (explicit !== undefined) {
         const trimmed = explicit.trim();
-        return FULL_SHA_PATTERN.test(trimmed) ? [trimmed] : [];
+        // Set-but-empty is the documented off switch. A non-empty value that is not
+        // a full SHA is a failed attempt at naming a commit, not an opt-out, so it
+        // reports as undetermined rather than as disabled.
+        if (trimmed === "") return { disabled: true, commits: [] };
+        return { disabled: false, commits: FULL_SHA_PATTERN.test(trimmed) ? [trimmed] : [] };
     }
 
     const candidates: string[] = [];
@@ -520,7 +540,7 @@ function readBaselineCommitCandidates(): string[] {
         }
     }
 
-    return [...new Set(candidates.filter((sha) => FULL_SHA_PATTERN.test(sha)))];
+    return { disabled: false, commits: [...new Set(candidates.filter((sha) => FULL_SHA_PATTERN.test(sha)))] };
 }
 
 /**
@@ -529,14 +549,21 @@ function readBaselineCommitCandidates(): string[] {
  *
  * Derived from the URL actually in effect rather than from the hardcoded default,
  * so `BUNDLE_MASTER_MANIFEST_URL` overrides (tests, mirrors) keep working.
+ *
+ * Exported for tests/lite/unit/pipeline-fail-fast-ordering.test.ts, which binds
+ * this derivation to the path the publish step actually uploads to. Nothing else
+ * keeps the two in agreement, and a drift between them is a silent 404 on every
+ * per-commit lookup — which degrades to the mutable baseline and so looks exactly
+ * like the pre-existing behaviour this change was made to replace.
  */
-function perCommitBaselineUrl(manifestUrl: string, commit: string): string {
+export function perCommitBaselineUrl(manifestUrl: string, commit: string): string {
     const slash = manifestUrl.lastIndexOf("/");
     if (slash < 0) return manifestUrl;
     return `${manifestUrl.slice(0, slash)}/${commit}${manifestUrl.slice(slash)}`;
 }
 
-/** Guard against a CDN or proxy serving something that parses as JSON but isn't a manifest. */function isBundleManifest(value: unknown): value is BundleManifest {
+/** Guard against a CDN or proxy serving something that parses as JSON but isn't a manifest. */
+function isBundleManifest(value: unknown): value is BundleManifest {
     if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
     const entries = Object.values(value);
     return entries.length > 0 && entries.every((entry) => typeof entry === "object" && entry !== null && typeof (entry as BundleManifestEntry).rawKB === "number");
@@ -609,8 +636,8 @@ export async function resolveMasterBundleManifest(refs?: string[]): Promise<{ so
         // baseline anyway. Trimmed because a YAML-supplied blank can arrive as " ".
         const url = (process.env.BUNDLE_MASTER_MANIFEST_URL ?? DEFAULT_MASTER_MANIFEST_URL).trim();
         if (url) {
-            const candidates = readBaselineCommitCandidates();
-            for (const commit of candidates) {
+            const lookup = readBaselineCommitCandidates();
+            for (const commit of lookup.commits) {
                 const commitUrl = perCommitBaselineUrl(url, commit);
                 const manifest = await fetchMasterBundleManifest(commitUrl, { quiet404: true });
                 if (manifest) {
@@ -627,14 +654,20 @@ export async function resolveMasterBundleManifest(refs?: string[]): Promise<{ so
                 // that is the failure this per-commit lookup exists to avoid, so when the
                 // fallback fires the reader needs to know it did.
                 //
-                // The two ways of getting here need different words: having asked for a
-                // base commit and been told there is none is a producer-side gap that
-                // will close on its own, whereas never having identified a base commit is
-                // a property of this checkout that will not.
-                const why =
-                    candidates.length > 0
-                        ? "no baseline was published for this build's base commit"
-                        : "this build's base commit could not be determined, so no per-commit baseline was requested";
+                // The three ways of getting here need different words, because they send
+                // the reader to three different places: a base commit with no baseline is
+                // a producer-side gap that closes on its own; an undetermined base commit
+                // is a property of this checkout that will not; and an explicit opt-out is
+                // this build doing what it was configured to do, which is not a fault at
+                // all and should not be reported as one.
+                let why: string;
+                if (lookup.disabled) {
+                    why = "per-commit baseline lookup is switched off for this run";
+                } else if (lookup.commits.length > 0) {
+                    why = "no baseline was published for this build's base commit";
+                } else {
+                    why = "this build's base commit could not be determined, so no per-commit baseline was requested";
+                }
                 console.warn(`Using the latest published bundle-size baseline (${url}); ${why}.`);
                 return { source: url, manifest };
             }

--- a/scripts/publish-bundle-baseline.ts
+++ b/scripts/publish-bundle-baseline.ts
@@ -1,0 +1,145 @@
+/**
+ * Stage the master bundle-size baseline for publication.
+ *
+ * Runs on master only, from `azure-pipelines-bundle-manifest.yml`, after every
+ * scene has been measured. It takes the aggregate `manifest.json` the build
+ * produced and prepares the exact bytes that get uploaded, adding two things the
+ * raw manifest cannot carry:
+ *
+ *  1. **Ceilings.** Each entry is stamped with the scene's `maxRawKB` as it stood
+ *     on the commit being measured. A consumer that wants to know whether master
+ *     was already over its ceiling otherwise has to read `scene-config.json` from
+ *     its own working tree, which is the *branch's* copy — so a PR that tightens a
+ *     ceiling makes master retroactively appear to have been in breach. A
+ *     measurement and the limit it was taken against have to travel together.
+ *
+ *  2. **Provenance**, in a `meta.json` sidecar: which commit produced these bytes,
+ *     which build, and when.
+ *
+ * Provenance is a sidecar rather than an envelope inside `manifest.json` because
+ * `isBundleManifest` (scripts/bundle-scenes-core.ts) requires *every* top-level
+ * value to have a numeric `rawKB`. A `_meta` key would fail that check, and the
+ * check runs in every consumer that is already deployed — every open PR branch and
+ * every developer clone. Adding a top-level key would therefore not degrade those
+ * consumers, it would blank the baseline for all of them at once, which is exactly
+ * the repo-wide breakage that publishing the baseline was introduced to end.
+ * Per-entry fields are additive and unknown ones are ignored, so `ceilingKB` is
+ * safe by the same reasoning.
+ *
+ * Output is written to a staging directory; uploading is the pipeline's job.
+ */
+import { execFileSync } from "child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+interface SceneConfigEntry {
+    id: number;
+    maxRawKB?: number;
+    skipBundleSize?: boolean;
+}
+
+interface BundleManifestEntry {
+    rawKB: number;
+    gzipKB: number;
+    rawBytes?: number;
+    ceilingKB?: number;
+    [key: string]: unknown;
+}
+
+type BundleManifest = Record<string, BundleManifestEntry>;
+
+export interface BaselineMeta {
+    /** Commit the measurements were taken from. */
+    commit: string;
+    /** Azure DevOps build that produced them, when running in CI. */
+    buildId?: string;
+    buildNumber?: string;
+    /** ISO-8601 completion time. */
+    generatedAt: string;
+    /** Number of scenes in the manifest, so a truncated upload is detectable. */
+    scenes: number;
+    /** How many of those scenes carry a ceiling. */
+    ceilings: number;
+}
+
+/**
+ * Stamp each measured scene with the ceiling it was measured against.
+ *
+ * A scene with no `maxRawKB`, or one that opts out via `skipBundleSize`, gets no
+ * `ceilingKB` — matching the opt-out that `bundle-size.spec.ts` honours. Consumers
+ * are required to read an absent value as "unknown", not as "unlimited", so the two
+ * cases collapsing here is intentional: neither is enforceable.
+ */
+export function stampCeilings(manifest: BundleManifest, sceneConfig: SceneConfigEntry[]): BundleManifest {
+    const ceilingByScene = new Map<string, number>();
+    for (const entry of sceneConfig) {
+        if (entry.skipBundleSize || entry.maxRawKB == null) continue;
+        ceilingByScene.set(`scene${entry.id}`, entry.maxRawKB);
+    }
+
+    const stamped: BundleManifest = {};
+    for (const [scene, entry] of Object.entries(manifest)) {
+        const ceilingKB = ceilingByScene.get(scene);
+        stamped[scene] = ceilingKB == null ? entry : { ...entry, ceilingKB };
+    }
+    return stamped;
+}
+
+function gitHead(): string {
+    // Build.SourceVersion is the commit ADO checked out; prefer it over `git
+    // rev-parse HEAD` so the recorded provenance is the pipeline's own notion of
+    // what it built rather than something a later step could have moved.
+    const fromPipeline = process.env.BUILD_SOURCEVERSION?.trim();
+    if (fromPipeline) return fromPipeline;
+    return execFileSync("git", ["rev-parse", "HEAD"], { cwd: ROOT, encoding: "utf-8" }).trim();
+}
+
+function main(): void {
+    const manifestPath = process.env.BUNDLE_BASELINE_MANIFEST ?? resolve(ROOT, "lab/public/bundle/manifest.json");
+    const outDir = process.env.BUNDLE_BASELINE_STAGING ?? resolve(ROOT, "lab/public/bundle-baseline-staging");
+
+    if (!existsSync(manifestPath)) {
+        console.error(`No aggregate manifest at ${manifestPath} — refusing to publish an empty baseline.`);
+        process.exit(1);
+    }
+
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as BundleManifest;
+    const scenes = Object.keys(manifest).length;
+    if (scenes === 0) {
+        console.error(`The manifest at ${manifestPath} has no scenes — refusing to publish an empty baseline.`);
+        process.exit(1);
+    }
+
+    const sceneConfig = JSON.parse(readFileSync(resolve(ROOT, "scene-config.json"), "utf-8")) as SceneConfigEntry[];
+    const stamped = stampCeilings(manifest, sceneConfig);
+    const ceilings = Object.values(stamped).filter((entry) => entry.ceilingKB != null).length;
+
+    const commit = gitHead();
+    const meta: BaselineMeta = {
+        commit,
+        buildId: process.env.BUILD_BUILDID?.trim() || undefined,
+        buildNumber: process.env.BUILD_BUILDNUMBER?.trim() || undefined,
+        generatedAt: new Date().toISOString(),
+        scenes,
+        ceilings,
+    };
+
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(resolve(outDir, "manifest.json"), `${JSON.stringify(stamped, null, 2)}\n`);
+    writeFileSync(resolve(outDir, "meta.json"), `${JSON.stringify(meta, null, 2)}\n`);
+
+    console.log(`✓ Staged bundle-size baseline for ${commit.slice(0, 8)}: ${scenes} scene(s), ${ceilings} with a ceiling.`);
+    console.log(`  ${outDir}`);
+
+    // Consumed by the pipeline to address the immutable per-commit copy.
+    console.log(`##vso[task.setvariable variable=BASELINE_COMMIT]${commit}`);
+}
+
+// ESM entrypoint check: `require.main` and `__dirname` are CJS-only and happen to
+// work under tsx today purely because it transpiles to CJS. The rest of scripts/
+// uses this form, and it keeps `stampCeilings` importable from tests without
+// running the staging side effects.
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/tests/lite/unit/bundle-master-baseline.test.ts
+++ b/tests/lite/unit/bundle-master-baseline.test.ts
@@ -260,6 +260,27 @@ describe("resolveMasterBundleManifest — per-commit baseline", () => {
         expect(warnings.some((line) => line.includes("base commit could not be determined"))).toBe(true);
     });
 
+    it("reports an explicit opt-out as a setting rather than as a fault", async () => {
+        // beforeEach blanks BUNDLE_BASELINE_COMMIT, which is the documented off
+        // switch. Describing that as "could not be determined" would send a reader
+        // looking for a broken checkout to explain a value someone set on purpose.
+        routes["/manifest.json"] = { status: 200, contentType: "application/json", body: JSON.stringify(LATEST_MANIFEST) };
+        process.env.BUNDLE_MASTER_MANIFEST_URL = `${baseUrl}/manifest.json`;
+
+        const warnings: string[] = [];
+        const originalWarn = console.warn;
+        console.warn = (...args: unknown[]) => void warnings.push(args.join(" "));
+        try {
+            await resolveMasterBundleManifest();
+        } finally {
+            console.warn = originalWarn;
+        }
+
+        expect(requestCount).toBe(1);
+        expect(warnings.some((line) => line.includes("switched off for this run"))).toBe(true);
+        expect(warnings.some((line) => line.includes("could not be determined"))).toBe(false);
+    });
+
     it("does not adopt a malformed per-commit response", async () => {
         routes[`/${COMMIT}/manifest.json`] = { status: 200, contentType: "application/json", body: "<html>nope</html>" };
         routes["/manifest.json"] = { status: 200, contentType: "application/json", body: JSON.stringify(LATEST_MANIFEST) };

--- a/tests/lite/unit/bundle-master-baseline.test.ts
+++ b/tests/lite/unit/bundle-master-baseline.test.ts
@@ -24,6 +24,11 @@ let routes: Record<string, { status: number; contentType: string; body: string }
 beforeEach(async () => {
     requestCount = 0;
     routes = {};
+    // These cases exercise the mutable-baseline fetch in isolation, so the
+    // per-commit lookup is switched off rather than left to depend on the git
+    // state of whatever checkout the suite runs in. Its own behaviour is covered
+    // by the "per-commit baseline" block below.
+    process.env.BUNDLE_BASELINE_COMMIT = "";
     server = createServer((req, res) => {
         requestCount += 1;
         const route = routes[req.url ?? ""];
@@ -44,6 +49,7 @@ beforeEach(async () => {
 afterEach(async () => {
     delete process.env.BUNDLE_MASTER_MANIFEST_URL;
     delete process.env.BUNDLE_MASTER_MANIFEST_FILE;
+    delete process.env.BUNDLE_BASELINE_COMMIT;
     for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
     await new Promise<void>((done, fail) => server.close((err) => (err ? fail(err) : done())));
 });
@@ -134,5 +140,134 @@ describe("resolveMasterBundleManifest", () => {
 
         expect(requestCount).toBe(0);
         expect(warnings.filter((line) => line.includes("Could not fetch the bundle-size baseline"))).toEqual([]);
+    });
+});
+
+/**
+ * The mutable baseline is whatever master published most recently, which after any
+ * intervening merge is not the commit the PR under test was merged with. Every byte
+ * master moved in between then lands in the PR's delta. The publisher writes an
+ * immutable copy per commit so a build can ask for its own base commit instead.
+ */
+describe("resolveMasterBundleManifest — per-commit baseline", () => {
+    const COMMIT = "c4284aa6c4284aa6c4284aa6c4284aa6c4284aa6";
+    /** What master published for the commit this build was actually merged with. */
+    const BASE_MANIFEST = { scene1: { rawKB: 12.3, gzipKB: 4.5, ceilingKB: 13 } };
+    /** What master has published since — includes another PR's bytes. */
+    const LATEST_MANIFEST = { scene1: { rawKB: 99.9, gzipKB: 40 } };
+
+    it("prefers the baseline published for this build's base commit", async () => {
+        routes[`/${COMMIT}/manifest.json`] = { status: 200, contentType: "application/json", body: JSON.stringify(BASE_MANIFEST) };
+        routes["/manifest.json"] = { status: 200, contentType: "application/json", body: JSON.stringify(LATEST_MANIFEST) };
+        process.env.BUNDLE_MASTER_MANIFEST_URL = `${baseUrl}/manifest.json`;
+        process.env.BUNDLE_BASELINE_COMMIT = COMMIT;
+
+        const baseline = await resolveMasterBundleManifest();
+
+        // The whole point: the newer, closer-to-hand manifest is the wrong answer.
+        expect(baseline?.manifest).toEqual(BASE_MANIFEST);
+        expect(baseline?.source).toBe(`${baseUrl}/${COMMIT}/manifest.json`);
+    });
+
+    it("carries the ceilings the baseline was measured against", async () => {
+        // Without this the only ceiling a consumer can see is its own working tree's,
+        // so a PR that tightens a ceiling makes master look retroactively in breach.
+        routes[`/${COMMIT}/manifest.json`] = { status: 200, contentType: "application/json", body: JSON.stringify(BASE_MANIFEST) };
+        process.env.BUNDLE_MASTER_MANIFEST_URL = `${baseUrl}/manifest.json`;
+        process.env.BUNDLE_BASELINE_COMMIT = COMMIT;
+
+        const baseline = await resolveMasterBundleManifest();
+
+        expect(baseline?.manifest.scene1?.ceilingKB).toBe(13);
+    });
+
+    it("falls back to the mutable baseline when the base commit has none, and says so", async () => {
+        // A base commit has no baseline whenever master's build is still running,
+        // failed, or predates per-commit publishing. That must degrade, not wait or
+        // fail — but silently degrading is what causes mis-attributed deltas, so the
+        // fallback has to announce itself.
+        routes["/manifest.json"] = { status: 200, contentType: "application/json", body: JSON.stringify(LATEST_MANIFEST) };
+        process.env.BUNDLE_MASTER_MANIFEST_URL = `${baseUrl}/manifest.json`;
+        process.env.BUNDLE_BASELINE_COMMIT = COMMIT;
+
+        const warnings: string[] = [];
+        const originalWarn = console.warn;
+        console.warn = (...args: unknown[]) => void warnings.push(args.join(" "));
+        let baseline;
+        try {
+            baseline = await resolveMasterBundleManifest();
+        } finally {
+            console.warn = originalWarn;
+        }
+
+        expect(baseline?.manifest).toEqual(LATEST_MANIFEST);
+        expect(baseline?.source).toBe(`${baseUrl}/manifest.json`);
+        expect(warnings.some((line) => line.includes("no baseline was published for this build's base commit"))).toBe(true);
+    });
+
+    it("does not warn about the per-commit miss as if the baseline were unreachable", async () => {
+        // The per-commit probe 404s on most builds today. Reporting each one the way
+        // a missing baseline is reported would train readers to ignore the message
+        // that actually means the delta is unavailable.
+        routes["/manifest.json"] = { status: 200, contentType: "application/json", body: JSON.stringify(LATEST_MANIFEST) };
+        process.env.BUNDLE_MASTER_MANIFEST_URL = `${baseUrl}/manifest.json`;
+        process.env.BUNDLE_BASELINE_COMMIT = COMMIT;
+
+        const warnings: string[] = [];
+        const originalWarn = console.warn;
+        console.warn = (...args: unknown[]) => void warnings.push(args.join(" "));
+        try {
+            await resolveMasterBundleManifest();
+        } finally {
+            console.warn = originalWarn;
+        }
+
+        expect(warnings.filter((line) => line.includes("No published bundle-size baseline at"))).toEqual([]);
+    });
+
+    it("costs exactly one extra request when the base commit has no baseline", async () => {
+        routes["/manifest.json"] = { status: 200, contentType: "application/json", body: JSON.stringify(LATEST_MANIFEST) };
+        process.env.BUNDLE_MASTER_MANIFEST_URL = `${baseUrl}/manifest.json`;
+        process.env.BUNDLE_BASELINE_COMMIT = COMMIT;
+
+        await resolveMasterBundleManifest();
+
+        expect(requestCount).toBe(2);
+    });
+
+    it("ignores a malformed BUNDLE_BASELINE_COMMIT instead of fetching a bogus path", async () => {
+        // A short SHA, a branch name, or a stray "refs/heads/master" must not become
+        // part of a URL — the published layout only ever uses full object names.
+        routes["/manifest.json"] = { status: 200, contentType: "application/json", body: JSON.stringify(LATEST_MANIFEST) };
+        process.env.BUNDLE_MASTER_MANIFEST_URL = `${baseUrl}/manifest.json`;
+        process.env.BUNDLE_BASELINE_COMMIT = "origin/master";
+
+        const warnings: string[] = [];
+        const originalWarn = console.warn;
+        console.warn = (...args: unknown[]) => void warnings.push(args.join(" "));
+        let baseline;
+        try {
+            baseline = await resolveMasterBundleManifest();
+        } finally {
+            console.warn = originalWarn;
+        }
+
+        expect(requestCount).toBe(1);
+        expect(baseline?.source).toBe(`${baseUrl}/manifest.json`);
+        // Reporting "no baseline was published for this build's base commit" here would
+        // send the reader to the publisher for a fault that is in this build's own
+        // configuration, so the two fallback reasons have to stay distinguishable.
+        expect(warnings.some((line) => line.includes("base commit could not be determined"))).toBe(true);
+    });
+
+    it("does not adopt a malformed per-commit response", async () => {
+        routes[`/${COMMIT}/manifest.json`] = { status: 200, contentType: "application/json", body: "<html>nope</html>" };
+        routes["/manifest.json"] = { status: 200, contentType: "application/json", body: JSON.stringify(LATEST_MANIFEST) };
+        process.env.BUNDLE_MASTER_MANIFEST_URL = `${baseUrl}/manifest.json`;
+        process.env.BUNDLE_BASELINE_COMMIT = COMMIT;
+
+        const baseline = await resolveMasterBundleManifest();
+
+        expect(baseline?.manifest).toEqual(LATEST_MANIFEST);
     });
 });

--- a/tests/lite/unit/pipeline-fail-fast-ordering.test.ts
+++ b/tests/lite/unit/pipeline-fail-fast-ordering.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
 
+import { perCommitBaselineUrl } from "../../../scripts/bundle-scenes-core";
+
 const repoRoot = join(__dirname, "..", "..", "..");
 const pipelineFile = "azure-pipelines-bundle-manifest.yml";
 
@@ -762,8 +764,13 @@ function resolveMacros(text: string, source: string): string {
 }
 
 interface PublishedBaseline {
-    /** Storage path the upload targets, with pipeline macros resolved. */
-    deployPath: string;
+    /**
+     * Storage paths the upload targets, with pipeline macros resolved.
+     *
+     * A list rather than one path because the step uploads the same archive twice:
+     * once under the commit it measured, once as the mutable "latest" copy.
+     */
+    deployPaths: string[];
     /** Archive the upload sends, by basename. */
     uploaded: string;
     /** Archive the script builds, by basename. */
@@ -771,6 +778,38 @@ interface PublishedBaseline {
     /** Files placed inside that archive. */
     members: string[];
 }
+
+/**
+ * Resolve a `-F "path=..."` field that names a shell variable back to the literal
+ * values the enclosing `for` loop assigns it.
+ *
+ * Without this the extraction reads `$deployPath` and the binding below compares
+ * the reader's URL against a variable name, which can never match. That failure is
+ * loud, so it is not the danger; the danger is the repair it invites. The obvious
+ * way to make a red assertion green is to relax it, and relaxing this one removes
+ * the only mechanism in the tree keeping the write and the read of the baseline
+ * together. Following the loop keeps the guard pointed at what the step does.
+ */
+function loopValues(script: string, variable: string): string[] {
+    const loop = new RegExp(`\\bfor\\s+${variable}\\s+in\\s+([^\\n;]*)`).exec(script);
+    if (!loop) return [];
+    return (loop[1]?.match(/"[^"]*"|\S+/g) ?? []).map((token) => token.replace(/^"|"$/g, "")).filter(Boolean);
+}
+
+/**
+ * ADO built-ins the publish step relies on, mapped to a stand-in value.
+ *
+ * These are set by the agent rather than declared in the pipeline's `variables:`
+ * block, so the "unresolved macro" floor below would otherwise read them as typos.
+ *
+ * The stand-in for a commit is SHA-shaped rather than a bracketed placeholder, and
+ * that is not cosmetic: it is substituted into a URL and compared against one the
+ * reader builds, so a value containing characters `new URL` percent-encodes fails
+ * the comparison on the encoding rather than on the paths disagreeing. All-zeroes
+ * is recognisably not a real commit while still exercising the character class a
+ * real one uses.
+ */
+const PIPELINE_BUILT_INS: Record<string, string> = { "Build.SourceVersion": "0".repeat(40) };
 
 /** Where the publish step actually puts the baseline, read out of what it runs. */
 function publishedBaseline(step: string, source: string): PublishedBaseline {
@@ -796,11 +835,23 @@ function publishedBaseline(step: string, source: string): PublishedBaseline {
     const basename = (p: string): string => p.split("/").pop() ?? "";
 
     return {
-        deployPath: resolveMacros(/-F\s+"path=([^"]*)"/.exec(script)?.[1] ?? "", source),
+        deployPaths: publishedDeployPaths(script, source),
         uploaded: basename(/-F\s+"zip=@([^"]*)"/.exec(script)?.[1] ?? ""),
         built: basename(zipped?.[2] ?? ""),
         members: (zipped?.[3] ?? "").split(/\s+/).filter(Boolean),
     };
+}
+
+/** The `-F "path=..."` targets of the upload, with loops unrolled and macros resolved. */
+function publishedDeployPaths(script: string, source: string): string[] {
+    const field = /-F\s+"path=([^"]*)"/.exec(script)?.[1] ?? "";
+    if (!field) return [];
+
+    // `$deployPath` / `${deployPath}` — the value comes from the loop header.
+    const shellVar = /^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$/.exec(field);
+    const raw = shellVar?.[1] ? loopValues(script, shellVar[1]) : [field];
+
+    return raw.map((path) => resolveMacros(path, source).replace(/\$\(([A-Za-z_][A-Za-z0-9_.]*)\)/g, (whole, name: string) => PIPELINE_BUILT_INS[name] ?? whole));
 }
 
 /** The path component of the URL the reader fetches the baseline from. */
@@ -1882,13 +1933,17 @@ describe("the baseline pipeline validates its deploy configuration before doing 
         // that attributes the failure correctly, and attribution is what a
         // failing CI check is for.
         expect(
-            published.deployPath,
-            `no \`-F "path=..."\` field in "${PUBLISH_STEP}" — nothing says where the baseline is being uploaded to, so the comparison against ${readerFile} below has nothing to compare. If the upload moved to a task or a different transport, re-point \`publishedBaseline\` at it rather than letting this read an empty string.`
-        ).not.toBe("");
+            published.deployPaths.length,
+            `no \`-F "path=..."\` field in "${PUBLISH_STEP}" resolved to a storage path — nothing says where the baseline is being uploaded to, so the comparison against ${readerFile} below has nothing to compare. If the upload moved to a task, a different transport, or a shell variable this file cannot follow, re-point \`publishedDeployPaths\` at it rather than letting this read an empty list.`
+        ).toBeGreaterThan(0);
         expect(
-            published.deployPath,
-            `the upload path in "${PUBLISH_STEP}" still contains an unresolved \`$(...)\` macro after substitution against the pipeline's own \`variables:\` block: "${published.deployPath}". A macro naming a variable that is not declared here resolves to nothing at runtime and publishes the baseline to the wrong place.`
-        ).not.toMatch(/\$\(/);
+            published.deployPaths.filter((path) => path.includes("$(")),
+            `an upload path in "${PUBLISH_STEP}" still contains an unresolved \`$(...)\` macro after substitution against the pipeline's own \`variables:\` block and the known agent built-ins. A macro naming a variable that is declared in neither resolves to nothing at runtime and publishes the baseline to the wrong place; if it is a built-in this file has not met yet, add it to \`PIPELINE_BUILT_INS\`.`
+        ).toEqual([]);
+        expect(
+            published.deployPaths.filter((path) => /\$[A-Za-z_{]/.test(path)),
+            `an upload path in "${PUBLISH_STEP}" is still an unresolved shell variable. \`publishedDeployPaths\` follows a \`for VAR in ...\` header to its literal values; if the path now comes from an assignment, a command substitution, or a loop this file cannot read, re-point that helper — comparing a variable name against ${readerFile} silently compares nothing.`
+        ).toEqual([]);
         expect(
             published.members.length,
             `parsed no files out of the \`zip\` command in "${PUBLISH_STEP}" — the archive's contents are what the reader ends up fetching by name, so an empty list makes the comparison below vacuous`
@@ -1907,13 +1962,34 @@ describe("the baseline pipeline validates its deploy configuration before doing 
         ).toBe(published.built);
 
         // The binding itself. The reader fetches one specific path; the pipeline
-        // writes a set of files under one specific prefix. The first has to be
+        // writes a set of files under each of its prefixes. The first has to be
         // in the second.
-        const publishedPaths = published.members.map((member) => `/${published.deployPath}/${member}`);
+        const publishedPaths = published.deployPaths.flatMap((deployPath) => published.members.map((member) => `/${deployPath}/${member}`));
 
         expect(
             publishedPaths,
             `${readerFile} fetches the baseline from \`${readerPath}\`, but "${PUBLISH_STEP}" publishes ${publishedPaths.map((p) => `\`${p}\``).join(", ")}. These two are the write and the read of the same file and there is no mechanism keeping them together except this assertion — both files carry a comment saying "must stay in sync with" the other, and a comment has never stopped an edit. Change both, or change neither.`
         ).toContain(readerPath);
+
+        // The second write/read pair, which arrived with per-commit publishing and
+        // has the same shape as the first: the step uploads the archive a second
+        // time under the commit it measured, and the reader derives that location
+        // itself in `perCommitBaselineUrl`. Nothing but this clause keeps the two
+        // agreeing.
+        //
+        // This pair is the more dangerous of the two, because its failure is quiet.
+        // A drift in the mutable path is a 404 with no fallback behind it, so every
+        // PR delta disappears at once and someone notices. A drift in the per-commit
+        // path is a 404 that falls back to the mutable baseline — which is precisely
+        // the behaviour this change replaced. The feature would report itself as
+        // working, deltas would keep appearing, and they would be mis-attributed in
+        // exactly the way the per-commit lookup exists to prevent.
+        const commit = PIPELINE_BUILT_INS["Build.SourceVersion"]!;
+        const derived = new URL(perCommitBaselineUrl(`https://example.invalid${readerPath}`, commit)).pathname;
+
+        expect(
+            publishedPaths,
+            `${readerFile} derives the per-commit baseline URL as \`${derived}\` (via \`perCommitBaselineUrl\`, with the commit stood in for), but "${PUBLISH_STEP}" publishes ${publishedPaths.map((p) => `\`${p}\``).join(", ")}. The reader would fetch a path nothing writes, get a 404, and fall back to the mutable baseline — restoring the mis-attributed deltas this pair exists to prevent, while every check stays green. Change the upload path and \`perCommitBaselineUrl\` together, or change neither.`
+        ).toContain(derived);
     });
 });

--- a/tests/lite/unit/publish-bundle-baseline.test.ts
+++ b/tests/lite/unit/publish-bundle-baseline.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { stampCeilings } from "../../../scripts/publish-bundle-baseline";
+
+/**
+ * The publisher stamps each measured scene with the ceiling it was measured
+ * against, so a consumer never has to reconstruct that number from its own
+ * working tree. See scripts/publish-bundle-baseline.ts for why.
+ */
+describe("stampCeilings", () => {
+    const manifest = {
+        scene1: { rawKB: 12.3, rawBytes: 12595, gzipKB: 4.5 },
+        scene2: { rawKB: 40, rawBytes: 40960, gzipKB: 12 },
+    };
+
+    it("records the ceiling beside the measurement it applies to", () => {
+        const stamped = stampCeilings(manifest, [
+            { id: 1, maxRawKB: 13 },
+            { id: 2, maxRawKB: 41 },
+        ]);
+
+        expect(stamped.scene1?.ceilingKB).toBe(13);
+        expect(stamped.scene2?.ceilingKB).toBe(41);
+    });
+
+    it("leaves the measured numbers untouched", () => {
+        // Stamping is additive. If it ever rewrote a measurement, every delta
+        // computed against the baseline would be wrong in a way that looks like a
+        // real size change.
+        const stamped = stampCeilings(manifest, [{ id: 1, maxRawKB: 13 }]);
+
+        expect(stamped.scene1).toEqual({ rawKB: 12.3, rawBytes: 12595, gzipKB: 4.5, ceilingKB: 13 });
+    });
+
+    it("does not mutate the manifest it was given", () => {
+        const input = { scene1: { rawKB: 12.3, gzipKB: 4.5 } };
+        stampCeilings(input, [{ id: 1, maxRawKB: 13 }]);
+
+        expect(input.scene1).toEqual({ rawKB: 12.3, gzipKB: 4.5 });
+    });
+
+    it("omits a ceiling for a scene that opts out of the bundle-size check", () => {
+        // scene-config.json carries a stale maxRawKB on at least one skipped scene,
+        // so honouring skipBundleSize matters: publishing that number would let a
+        // consumer report a breach the check itself does not enforce.
+        const stamped = stampCeilings(manifest, [
+            { id: 1, maxRawKB: 13, skipBundleSize: true },
+            { id: 2, maxRawKB: 41 },
+        ]);
+
+        expect(stamped.scene1?.ceilingKB).toBeUndefined();
+        expect(stamped.scene2?.ceilingKB).toBe(41);
+    });
+
+    it("omits a ceiling for a scene that has none configured", () => {
+        const stamped = stampCeilings(manifest, [{ id: 1 }, { id: 2, maxRawKB: 41 }]);
+
+        expect(stamped.scene1?.ceilingKB).toBeUndefined();
+        expect("ceilingKB" in stamped.scene1!).toBe(false);
+    });
+
+    it("keeps scenes that scene-config.json says nothing about", () => {
+        // Dropping them would silently shrink the baseline, and a scene missing from
+        // the baseline reads as "new in this PR" rather than as an omission.
+        const stamped = stampCeilings(manifest, []);
+
+        expect(Object.keys(stamped)).toEqual(["scene1", "scene2"]);
+    });
+
+    it("stays readable by the manifest validator already deployed everywhere", () => {
+        // Every open PR and every dev clone runs today's isBundleManifest, which
+        // requires a numeric rawKB on *every* top-level value. A stamped baseline
+        // they cannot parse would blank the bundle delta repo-wide at once, which is
+        // the outage publishing the baseline was introduced to end.
+        const stamped = stampCeilings(manifest, [{ id: 1, maxRawKB: 13 }]);
+        const entries = Object.values(stamped);
+
+        expect(entries.length > 0 && entries.every((entry) => typeof entry === "object" && entry !== null && typeof entry.rawKB === "number")).toBe(true);
+    });
+});


### PR DESCRIPTION
## Problem

A PR build reads the bundle-size baseline from one mutable URL holding whatever master published most recently. That is the correct baseline only until master moves. After any intervening merge the PR is compared against a tree it was never merged with, and the bytes master gained in between land in the PR's delta.

The window is not small — master builds take ~40 minutes, and the baseline is overwritten in place on every one.

## What this does

**1. Master publishes an immutable copy per commit.** Upload order is per-commit first, then the mutable copy, so a failed upload leaves `latest` and its per-commit twin agreeing about what a given commit measured.

**2. A build asks for its own base commit first**, and falls back to the mutable copy when there is none — for a base commit whose master build is still running, failed, or predates this change.

The fallback announces itself. Degrading silently is precisely the failure this exists to prevent, so a possibly mis-attributed delta must not look like a clean one. The two routes into it are worded differently, because they have different fixes:

| Situation | Message | Closes by itself? |
|---|---|---|
| Base commit known, no baseline for it | `no baseline was published for this build's base commit` | Yes — producer-side gap |
| Base commit not determinable | `base commit could not be determined, so no per-commit baseline was requested` | No — property of the checkout |

**3. Each entry carries the ceiling it was measured against.** Without it, the only ceiling a consumer can see is its own working tree's copy of `scene-config.json` — the *branch's* copy. So a PR that tightens a ceiling makes master retroactively appear to have been in breach. That is [#628](https://github.com/BabylonJS/Babylon-Lite/issues/628); this supplies the data to fix it, but **does not close it** (see below).

## Why a sidecar and not an envelope

I originally proposed a top-level `_meta` envelope inside `manifest.json`. That is not viable, and the reason is worth recording:

```
isBundleManifest (scripts/bundle-scenes-core.ts)
  requires a numeric rawKB on EVERY top-level value
```

Tested against the real validator:

```
true   per-entry ceilingKB (additive)     <- chosen
false  top-level _meta envelope
false  wrapped { meta, scenes }
```

That validator is already running in every open PR and every dev clone. An envelope would blank the bundle delta for all of them simultaneously — the exact repo-wide outage that publishing the baseline was introduced to end. Provenance therefore goes in a separate `meta.json`, and a test asserts the stamped manifest stays readable by the deployed validator.

## Verification

Against the live published baseline:

```
manifest scenes               248
scene-config.json entries     248
enforced ceilings in config   244
stamped                       244
enforced but absent from manifest   0
```

The four unstamped scenes are genuine opt-outs — `scene114` (`skipBundleSize`), `scene127/128/129` (no `maxRawKB`).

Nested dynamic deploy paths were an assumption, now checked rather than asserted — `lite/<buildNumber>/lab` is uploaded the same way on every build and serves live from the same storage account and CDN:

```
20260826.13/lab/index.html -> 200
20260826.9/lab/index.html  -> 200
```

So the per-commit path needs no new infrastructure.

Also run: full `pnpm run lint` (eslint + all 7 tsc projects) clean; 20/20 unit tests green across the two affected files.

## What this does NOT do

**It does not fix #628.** Content-addressing binds the *bytes* to a commit; the ceiling still has to be read from somewhere, and `report-bundle-size-deltas.ts` still resolves `scene-config.json` from the branch working tree. This PR only makes `entry.ceilingKB` available. If #628 is later assumed fixed because the architecture landed, the defect survives with the belief that it's precluded attached to it — which is worse than today, because nobody re-tests a defect the architecture is said to make impossible.

#628 carries an executed repro as its acceptance check, and should close on that, not on this merging.

## Notes for review

- Consumer cost is one extra request only when the per-commit copy is absent; per-commit 404s are deliberately quiet, so they don't train readers to ignore the message that means the baseline is genuinely unreachable.
- `BUNDLE_BASELINE_COMMIT` set-but-empty disables per-commit lookup; a malformed value (branch name, short SHA) is ignored rather than pasted into a URL.
- `origin/master` is deliberately *not* a candidate — it resolves to current master, i.e. the mutable baseline by another name.
- Storage growth is ~134 KB per master commit (~2.4 MB on an 18-commit day). Retention is not addressed here; worth a policy if it matters.
- No ceilings changed. No golden references touched.
