### PR TITLE
feat(sprite): add Sprite2D view utilities

### DIFF
--- a/docs/lite/architecture/32-sprites.md
+++ b/docs/lite/architecture/32-sprites.md
@@ -775,6 +775,38 @@ export function setSprite2DShaderParams(layer: Sprite2DLayer, params: readonly [
 export function setSprite2DUvOffset(layer: Sprite2DLayer, index: number, uvOffset: readonly [number, number]): void;
 ```
 
+### Sprite2D view utilities
+
+`sprite-2d-view.ts` owns the CPU form of the same transform used by the
+Sprite2D vertex shader. A view maps its `positionPx` to screen `(0, 0)`, then
+applies `rotation` and `zoom`. Screen dimensions and coordinates are backing-
+store pixels with a top-left origin, matching the renderer; pointer callers
+must convert CSS pixels by the canvas backing-store scale first.
+
+```typescript
+export interface Sprite2DVisibleBounds {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+}
+
+export function sprite2DWorldToScreenToRef<T extends Vec2>(view: Sprite2DView, worldX: number, worldY: number, result: T): T;
+export function sprite2DScreenToWorldToRef<T extends Vec2>(view: Sprite2DView, screenX: number, screenY: number, result: T): T;
+export function getSprite2DVisibleBoundsToRef<T extends Sprite2DVisibleBounds>(view: Sprite2DView, viewportWidthPx: number, viewportHeightPx: number, result: T): T;
+export function centerSprite2DView<T extends Sprite2DView>(view: T, worldX: number, worldY: number, viewportWidthPx: number, viewportHeightPx: number): T;
+```
+
+The `ToRef` functions write into caller-owned objects, and centering mutates the
+supplied view, so steady-state camera and culling updates allocate nothing.
+Negative zoom remains valid and mirrors the renderer. Inverse projection,
+visible bounds, and centering throw for `zoom === 0`, where no inverse exists;
+world-to-screen projection still matches the renderer and collapses to `(0, 0)`.
+
+The module has only type imports and pure functions. Nothing in `sprite-2d.ts`,
+`sprite-pipeline.ts`, or the render loop imports it, so applications that do not
+reference these helpers retain no runtime bytes or branches from them.
+
 The Handle API (`addSprite2D` / `removeSprite2D`, returning a
 `Sprite2DHandle` with a stable id) lives in the separately importable
 `sprite-2d-handle.ts` module so Index-only scenes do not pull handle code,

--- a/docs/lite/architecture/32-sprites.md
+++ b/docs/lite/architecture/32-sprites.md
@@ -778,13 +778,13 @@ export function setSprite2DUvOffset(layer: Sprite2DLayer, index: number, uvOffse
 ### Sprite2D view utilities
 
 `sprite-2d-view.ts` owns the CPU form of the same transform used by the
-Sprite2D vertex shader. A view maps its `positionPx` to screen `(0, 0)`, then
-applies `rotation` and `zoom`. Screen dimensions and coordinates are backing-
-store pixels with a top-left origin, matching the renderer; pointer callers
-must convert CSS pixels by the canvas backing-store scale first.
+Sprite2D vertex shader. A view maps its `positionPx` to logical screen `(0, 0)`,
+then applies `rotation` and `zoom`. Screen dimensions and coordinates are
+backing-store pixels with a top-left origin. `Bounds2D` is a reusable math type;
+the visible-bounds helper writes world-space values into it.
 
 ```typescript
-export interface Sprite2DVisibleBounds {
+export interface Bounds2D {
     minX: number;
     minY: number;
     maxX: number;
@@ -793,9 +793,30 @@ export interface Sprite2DVisibleBounds {
 
 export function sprite2DWorldToScreenToRef<T extends Vec2>(view: Sprite2DView, worldX: number, worldY: number, result: T): T;
 export function sprite2DScreenToWorldToRef<T extends Vec2>(view: Sprite2DView, screenX: number, screenY: number, result: T): T;
-export function getSprite2DVisibleBoundsToRef<T extends Sprite2DVisibleBounds>(view: Sprite2DView, viewportWidthPx: number, viewportHeightPx: number, result: T): T;
-export function centerSprite2DView<T extends Sprite2DView>(view: T, worldX: number, worldY: number, viewportWidthPx: number, viewportHeightPx: number): T;
+export function getSprite2DVisibleBoundsToRef<T extends Bounds2D>(view: Sprite2DView, screenWidthPx: number, screenHeightPx: number, result: T): T;
+export function centerSprite2DView<T extends Sprite2DView>(view: T, worldX: number, worldY: number, screenWidthPx: number, screenHeightPx: number): T;
 ```
+
+For a `SpriteRenderer`, and for a depth-hosted layer rendered through a full
+camera viewport, logical screen coordinates are absolute framebuffer
+coordinates. Pointer callers first convert CSS pixels by the canvas backing-
+store scale. A depth-hosted layer under a non-full camera viewport keeps the
+full render target as its logical screen size because the render pass applies
+the camera viewport after the Sprite2D vertex transform. Use
+`resolveCameraViewport`, then remap an absolute framebuffer point before
+unprojecting it:
+
+```typescript
+const screenX = ((framebufferX - viewport.x) * targetWidth) / viewport.width;
+const screenY = ((framebufferY - viewport.y) * targetHeight) / viewport.height;
+sprite2DScreenToWorldToRef(layer.view, screenX, screenY, worldPosition);
+```
+
+The inverse mapping places a projected Sprite2D point in the absolute
+framebuffer: `framebufferX = viewport.x + screenX * viewport.width /
+targetWidth`, with the equivalent expression for Y. Pass the full render-target
+width and height to `getSprite2DVisibleBoundsToRef` and `centerSprite2DView`, not
+the camera viewport's reduced pixel size.
 
 The `ToRef` functions write into caller-owned objects, and centering mutates the
 supplied view, so steady-state camera and culling updates allocate nothing.

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -726,6 +726,7 @@ export { createGridSpriteAtlas, loadSpriteAtlas, disposeSpriteAtlas } from "./sp
 export type { SpriteAtlasFrameSource, SpriteAtlasPackOptions } from "./sprite/shared/sprite-atlas-packer.js";
 export { appendSpriteAtlasFrames, createSpriteAtlasFromFrames } from "./sprite/shared/sprite-atlas-packer.js";
 export type { Sprite2DLayer, Sprite2DLayerOptions, Sprite2DProps, Sprite2DView, Sprite2DDepthMode, SpriteBlendMode } from "./sprite/sprite-2d.js";
+export type { Sprite2DVisibleBounds } from "./sprite/sprite-2d-view.js";
 export type { SpriteBlendDescriptor } from "./sprite/sprite-blend.js";
 export { spriteBlendOpaque, spriteBlendAlpha, spriteBlendPremultiplied, spriteBlendAdditive, spriteBlendOneOne, spriteBlendMultiply } from "./sprite/sprite-blend.js";
 export {
@@ -737,6 +738,7 @@ export {
     setSprite2DFrameIndex,
     setSprite2DShaderParams,
 } from "./sprite/sprite-2d.js";
+export { sprite2DWorldToScreenToRef, sprite2DScreenToWorldToRef, getSprite2DVisibleBoundsToRef, centerSprite2DView } from "./sprite/sprite-2d-view.js";
 export type { CustomShaderTexture } from "./sprite/custom-shader-core.js";
 export { setSprite2DCoverageGamma } from "./sprite/sprite-2d-coverage-gamma.js";
 export { setSprite2DUvOffset } from "./sprite/sprite-2d-uvscroll.js";

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -558,7 +558,7 @@ export {
 } from "./math/spherical.js";
 export type { SphericalCoordinates } from "./math/spherical.js";
 export { scaleBoundsFromCenterToRef } from "./math/scale-bounds-from-center-to-ref.js";
-export type { Vec2, Vec3, Vec3Tuple, Vec4, Color3, Color4, Mat4, Quat } from "./math/types.js";
+export type { Vec2, Bounds2D, Vec3, Vec3Tuple, Vec4, Color3, Color4, Mat4, Quat } from "./math/types.js";
 export type { Aabb } from "./math/aabb.js";
 export { computeAabb } from "./math/aabb.js";
 export { eulerToQuat, quatToEulerXYZ } from "./math/quat-euler.js";
@@ -726,7 +726,6 @@ export { createGridSpriteAtlas, loadSpriteAtlas, disposeSpriteAtlas } from "./sp
 export type { SpriteAtlasFrameSource, SpriteAtlasPackOptions } from "./sprite/shared/sprite-atlas-packer.js";
 export { appendSpriteAtlasFrames, createSpriteAtlasFromFrames } from "./sprite/shared/sprite-atlas-packer.js";
 export type { Sprite2DLayer, Sprite2DLayerOptions, Sprite2DProps, Sprite2DView, Sprite2DDepthMode, SpriteBlendMode } from "./sprite/sprite-2d.js";
-export type { Sprite2DVisibleBounds } from "./sprite/sprite-2d-view.js";
 export type { SpriteBlendDescriptor } from "./sprite/sprite-blend.js";
 export { spriteBlendOpaque, spriteBlendAlpha, spriteBlendPremultiplied, spriteBlendAdditive, spriteBlendOneOne, spriteBlendMultiply } from "./sprite/sprite-blend.js";
 export {

--- a/packages/babylon-lite/src/math/index.ts
+++ b/packages/babylon-lite/src/math/index.ts
@@ -1,4 +1,4 @@
-export type { Vec3, Vec3Tuple, Vec4, Color3, Color4, Mat4, Quat, Mat4Storage } from "./types.js";
+export type { Bounds2D, Vec3, Vec3Tuple, Vec4, Color3, Color4, Mat4, Quat, Mat4Storage } from "./types.js";
 export { randomRange } from "./random-range.js";
 export { linearToSrgbByte, srgbByteToLinear, packedSrgbToLinearRgba } from "./color.js";
 export { copyColor4, scaleColor4ToRef } from "./color4-ref.js";

--- a/packages/babylon-lite/src/math/types.ts
+++ b/packages/babylon-lite/src/math/types.ts
@@ -7,6 +7,18 @@ export interface Vec2 {
     y: number;
 }
 
+/** Mutable axis-aligned bounds in an arbitrary 2D coordinate space. */
+export interface Bounds2D {
+    /** Minimum X coordinate. */
+    minX: number;
+    /** Minimum Y coordinate. */
+    minY: number;
+    /** Maximum X coordinate. */
+    maxX: number;
+    /** Maximum Y coordinate. */
+    maxY: number;
+}
+
 /** 3-component vector (position, direction, color) */
 export interface Vec3 {
     x: number;

--- a/packages/babylon-lite/src/sprite/sprite-2d-view.ts
+++ b/packages/babylon-lite/src/sprite/sprite-2d-view.ts
@@ -1,0 +1,70 @@
+import type { Vec2 } from "../math/types.js";
+import type { Sprite2DView } from "./sprite-2d.js";
+
+/** Axis-aligned world-space bounds visible through a {@link Sprite2DView}. */
+export interface Sprite2DVisibleBounds {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+}
+
+/** Project a world-space point through `view` into backing-store screen pixels. */
+export function sprite2DWorldToScreenToRef<T extends Vec2>(view: Sprite2DView, worldX: number, worldY: number, result: T): T {
+    const dx = worldX - view.positionPx[0];
+    const dy = worldY - view.positionPx[1];
+    const cos = Math.cos(view.rotation);
+    const sin = Math.sin(view.rotation);
+    result.x = (dx * cos - dy * sin) * view.zoom;
+    result.y = (dx * sin + dy * cos) * view.zoom;
+    return result;
+}
+
+/** Unproject a backing-store screen-pixel point through `view` into world space. */
+export function sprite2DScreenToWorldToRef<T extends Vec2>(view: Sprite2DView, screenX: number, screenY: number, result: T): T {
+    const inverseZoom = inverseViewZoom(view);
+    const x = screenX * inverseZoom;
+    const y = screenY * inverseZoom;
+    const cos = Math.cos(view.rotation);
+    const sin = Math.sin(view.rotation);
+    result.x = view.positionPx[0] + x * cos + y * sin;
+    result.y = view.positionPx[1] - x * sin + y * cos;
+    return result;
+}
+
+/** Write the rotation-safe world-space AABB visible through `view` for a backing-store viewport size. */
+export function getSprite2DVisibleBoundsToRef<T extends Sprite2DVisibleBounds>(view: Sprite2DView, viewportWidthPx: number, viewportHeightPx: number, result: T): T {
+    const inverseZoom = inverseViewZoom(view);
+    const cos = Math.cos(view.rotation);
+    const sin = Math.sin(view.rotation);
+    const rightX = viewportWidthPx * inverseZoom * cos;
+    const rightY = -viewportWidthPx * inverseZoom * sin;
+    const bottomX = viewportHeightPx * inverseZoom * sin;
+    const bottomY = viewportHeightPx * inverseZoom * cos;
+    const x = view.positionPx[0];
+    const y = view.positionPx[1];
+    result.minX = Math.min(x, x + rightX, x + bottomX, x + rightX + bottomX);
+    result.minY = Math.min(y, y + rightY, y + bottomY, y + rightY + bottomY);
+    result.maxX = Math.max(x, x + rightX, x + bottomX, x + rightX + bottomX);
+    result.maxY = Math.max(y, y + rightY, y + bottomY, y + rightY + bottomY);
+    return result;
+}
+
+/** Position `view` so the supplied world point appears at the backing-store viewport center. */
+export function centerSprite2DView<T extends Sprite2DView>(view: T, worldX: number, worldY: number, viewportWidthPx: number, viewportHeightPx: number): T {
+    const inverseZoom = inverseViewZoom(view);
+    const halfWidth = viewportWidthPx * 0.5 * inverseZoom;
+    const halfHeight = viewportHeightPx * 0.5 * inverseZoom;
+    const cos = Math.cos(view.rotation);
+    const sin = Math.sin(view.rotation);
+    view.positionPx[0] = worldX - halfWidth * cos - halfHeight * sin;
+    view.positionPx[1] = worldY + halfWidth * sin - halfHeight * cos;
+    return view;
+}
+
+function inverseViewZoom(view: Sprite2DView): number {
+    if (view.zoom === 0) {
+        throw new RangeError("Sprite2DView.zoom must be non-zero.");
+    }
+    return 1 / view.zoom;
+}

--- a/packages/babylon-lite/src/sprite/sprite-2d-view.ts
+++ b/packages/babylon-lite/src/sprite/sprite-2d-view.ts
@@ -1,15 +1,10 @@
-import type { Vec2 } from "../math/types.js";
+import type { Bounds2D, Vec2 } from "../math/types.js";
 import type { Sprite2DView } from "./sprite-2d.js";
 
-/** Axis-aligned world-space bounds visible through a {@link Sprite2DView}. */
-export interface Sprite2DVisibleBounds {
-    minX: number;
-    minY: number;
-    maxX: number;
-    maxY: number;
-}
-
-/** Project a world-space point through `view` into backing-store screen pixels. */
+/**
+ * Project a world-space point through `view` into the layer's logical backing-store screen space.
+ * A non-full render-pass viewport is applied after this transform; see {@link sprite2DScreenToWorldToRef}.
+ */
 export function sprite2DWorldToScreenToRef<T extends Vec2>(view: Sprite2DView, worldX: number, worldY: number, result: T): T {
     const dx = worldX - view.positionPx[0];
     const dy = worldY - view.positionPx[1];
@@ -20,7 +15,11 @@ export function sprite2DWorldToScreenToRef<T extends Vec2>(view: Sprite2DView, w
     return result;
 }
 
-/** Unproject a backing-store screen-pixel point through `view` into world space. */
+/**
+ * Unproject a point from the layer's logical backing-store screen space into world space.
+ * For a depth-hosted layer under a non-full camera viewport, remap absolute framebuffer
+ * coordinates from the resolved camera viewport into the full render-target dimensions first.
+ */
 export function sprite2DScreenToWorldToRef<T extends Vec2>(view: Sprite2DView, screenX: number, screenY: number, result: T): T {
     const inverseZoom = inverseViewZoom(view);
     const x = screenX * inverseZoom;
@@ -32,15 +31,15 @@ export function sprite2DScreenToWorldToRef<T extends Vec2>(view: Sprite2DView, s
     return result;
 }
 
-/** Write the rotation-safe world-space AABB visible through `view` for a backing-store viewport size. */
-export function getSprite2DVisibleBoundsToRef<T extends Sprite2DVisibleBounds>(view: Sprite2DView, viewportWidthPx: number, viewportHeightPx: number, result: T): T {
+/** Write the rotation-safe world-space AABB visible through `view` for its logical screen size. */
+export function getSprite2DVisibleBoundsToRef<T extends Bounds2D>(view: Sprite2DView, screenWidthPx: number, screenHeightPx: number, result: T): T {
     const inverseZoom = inverseViewZoom(view);
     const cos = Math.cos(view.rotation);
     const sin = Math.sin(view.rotation);
-    const rightX = viewportWidthPx * inverseZoom * cos;
-    const rightY = -viewportWidthPx * inverseZoom * sin;
-    const bottomX = viewportHeightPx * inverseZoom * sin;
-    const bottomY = viewportHeightPx * inverseZoom * cos;
+    const rightX = screenWidthPx * inverseZoom * cos;
+    const rightY = -screenWidthPx * inverseZoom * sin;
+    const bottomX = screenHeightPx * inverseZoom * sin;
+    const bottomY = screenHeightPx * inverseZoom * cos;
     const x = view.positionPx[0];
     const y = view.positionPx[1];
     result.minX = Math.min(x, x + rightX, x + bottomX, x + rightX + bottomX);
@@ -50,11 +49,11 @@ export function getSprite2DVisibleBoundsToRef<T extends Sprite2DVisibleBounds>(v
     return result;
 }
 
-/** Position `view` so the supplied world point appears at the backing-store viewport center. */
-export function centerSprite2DView<T extends Sprite2DView>(view: T, worldX: number, worldY: number, viewportWidthPx: number, viewportHeightPx: number): T {
+/** Position `view` so the supplied world point appears at the center of its logical screen space. */
+export function centerSprite2DView<T extends Sprite2DView>(view: T, worldX: number, worldY: number, screenWidthPx: number, screenHeightPx: number): T {
     const inverseZoom = inverseViewZoom(view);
-    const halfWidth = viewportWidthPx * 0.5 * inverseZoom;
-    const halfHeight = viewportHeightPx * 0.5 * inverseZoom;
+    const halfWidth = screenWidthPx * 0.5 * inverseZoom;
+    const halfHeight = screenHeightPx * 0.5 * inverseZoom;
     const cos = Math.cos(view.rotation);
     const sin = Math.sin(view.rotation);
     view.positionPx[0] = worldX - halfWidth * cos - halfHeight * sin;

--- a/tests/lite/unit/sprite-2d-view.test.ts
+++ b/tests/lite/unit/sprite-2d-view.test.ts
@@ -1,17 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import type { Vec2 } from "../../../packages/babylon-lite/src/math/types";
+import type { Bounds2D, Vec2 } from "../../../packages/babylon-lite/src/math/types";
 import type { Sprite2DView } from "../../../packages/babylon-lite/src/sprite/sprite-2d";
 import {
     centerSprite2DView,
     getSprite2DVisibleBoundsToRef,
     sprite2DScreenToWorldToRef,
     sprite2DWorldToScreenToRef,
-    type Sprite2DVisibleBounds,
 } from "../../../packages/babylon-lite/src/sprite/sprite-2d-view";
 
 const point = (): Vec2 => ({ x: 0, y: 0 });
-const bounds = (): Sprite2DVisibleBounds => ({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+const bounds = (): Bounds2D => ({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
 
 describe("Sprite2D view utilities", () => {
     it("preserves coordinates through an identity view", () => {
@@ -39,6 +38,22 @@ describe("Sprite2D view utilities", () => {
         expect(sprite2DScreenToWorldToRef(view, screen.x, screen.y, world)).toBe(world);
         expect(world.x).toBeCloseTo(151.25, 10);
         expect(world.y).toBeCloseTo(-92.5, 10);
+    });
+
+    it("unprojects framebuffer coordinates remapped from a camera sub-viewport", () => {
+        const view: Sprite2DView = { positionPx: [0, 0], zoom: 1, rotation: 0 };
+        const targetWidth = 800;
+        const targetHeight = 600;
+        const viewport = { x: 200, y: 150, width: 400, height: 300 };
+        const framebufferX = 300;
+        const framebufferY = 225;
+        const screenX = ((framebufferX - viewport.x) * targetWidth) / viewport.width;
+        const screenY = ((framebufferY - viewport.y) * targetHeight) / viewport.height;
+
+        expect(sprite2DScreenToWorldToRef(view, screenX, screenY, point())).toEqual({ x: 200, y: 150 });
+        const projected = sprite2DWorldToScreenToRef(view, 200, 150, point());
+        expect(viewport.x + (projected.x * viewport.width) / targetWidth).toBe(framebufferX);
+        expect(viewport.y + (projected.y * viewport.height) / targetHeight).toBe(framebufferY);
     });
 
     it("supports negative zoom", () => {

--- a/tests/lite/unit/sprite-2d-view.test.ts
+++ b/tests/lite/unit/sprite-2d-view.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import type { Vec2 } from "../../../packages/babylon-lite/src/math/types";
+import type { Sprite2DView } from "../../../packages/babylon-lite/src/sprite/sprite-2d";
+import {
+    centerSprite2DView,
+    getSprite2DVisibleBoundsToRef,
+    sprite2DScreenToWorldToRef,
+    sprite2DWorldToScreenToRef,
+    type Sprite2DVisibleBounds,
+} from "../../../packages/babylon-lite/src/sprite/sprite-2d-view";
+
+const point = (): Vec2 => ({ x: 0, y: 0 });
+const bounds = (): Sprite2DVisibleBounds => ({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+
+describe("Sprite2D view utilities", () => {
+    it("preserves coordinates through an identity view", () => {
+        const view: Sprite2DView = { positionPx: [0, 0], zoom: 1, rotation: 0 };
+
+        expect(sprite2DWorldToScreenToRef(view, -12, 34, point())).toEqual({ x: -12, y: 34 });
+        expect(sprite2DScreenToWorldToRef(view, -12, 34, point())).toEqual({ x: -12, y: 34 });
+    });
+
+    it("matches the renderer's world-to-screen transform", () => {
+        const view: Sprite2DView = { positionPx: [10, 20], zoom: 2, rotation: Math.PI / 2 };
+        const result = point();
+
+        expect(sprite2DWorldToScreenToRef(view, 20, 40, result)).toBe(result);
+        expect(result.x).toBeCloseTo(-40, 10);
+        expect(result.y).toBeCloseTo(20, 10);
+    });
+
+    it("round-trips points through translated, scaled, and rotated views", () => {
+        const view: Sprite2DView = { positionPx: [-73, 42], zoom: 1.75, rotation: -0.63 };
+        const screen = point();
+        const world = point();
+
+        sprite2DWorldToScreenToRef(view, 151.25, -92.5, screen);
+        expect(sprite2DScreenToWorldToRef(view, screen.x, screen.y, world)).toBe(world);
+        expect(world.x).toBeCloseTo(151.25, 10);
+        expect(world.y).toBeCloseTo(-92.5, 10);
+    });
+
+    it("supports negative zoom", () => {
+        const view: Sprite2DView = { positionPx: [5, 7], zoom: -2, rotation: 0 };
+        const screen = sprite2DWorldToScreenToRef(view, 8, 11, point());
+
+        expect(screen).toEqual({ x: -6, y: -8 });
+        expect(sprite2DScreenToWorldToRef(view, screen.x, screen.y, point())).toEqual({ x: 8, y: 11 });
+    });
+
+    it("computes a conservative AABB for a rotated viewport", () => {
+        const view: Sprite2DView = { positionPx: [10, 20], zoom: 2, rotation: Math.PI / 2 };
+        const result = bounds();
+
+        expect(getSprite2DVisibleBoundsToRef(view, 200, 100, result)).toBe(result);
+        expect(result.minX).toBeCloseTo(10, 10);
+        expect(result.minY).toBeCloseTo(-80, 10);
+        expect(result.maxX).toBeCloseTo(60, 10);
+        expect(result.maxY).toBeCloseTo(20, 10);
+    });
+
+    it("contains every inverse-projected corner at a non-axis-aligned rotation", () => {
+        const view: Sprite2DView = { positionPx: [-30, 45], zoom: 1.25, rotation: 0.37 };
+        const result = getSprite2DVisibleBoundsToRef(view, 320, 180, bounds());
+
+        for (const [screenX, screenY] of [
+            [0, 0],
+            [320, 0],
+            [0, 180],
+            [320, 180],
+        ] as const) {
+            const world = sprite2DScreenToWorldToRef(view, screenX, screenY, point());
+            expect(world.x).toBeGreaterThanOrEqual(result.minX);
+            expect(world.x).toBeLessThanOrEqual(result.maxX);
+            expect(world.y).toBeGreaterThanOrEqual(result.minY);
+            expect(world.y).toBeLessThanOrEqual(result.maxY);
+        }
+    });
+
+    it("collapses zero-size viewport bounds to the view origin", () => {
+        const view: Sprite2DView = { positionPx: [10, 20], zoom: 2, rotation: 0.75 };
+
+        expect(getSprite2DVisibleBoundsToRef(view, 0, 0, bounds())).toEqual({ minX: 10, minY: 20, maxX: 10, maxY: 20 });
+    });
+
+    it("centers a world point without changing zoom or rotation", () => {
+        const view: Sprite2DView = { positionPx: [0, 0], zoom: 2, rotation: Math.PI / 2 };
+
+        expect(centerSprite2DView(view, 300, 400, 200, 100)).toBe(view);
+        expect(view.zoom).toBe(2);
+        expect(view.rotation).toBe(Math.PI / 2);
+        const screen = sprite2DWorldToScreenToRef(view, 300, 400, point());
+        expect(screen.x).toBeCloseTo(100, 10);
+        expect(screen.y).toBeCloseTo(50, 10);
+    });
+
+    it("centers a world point in an unrotated view", () => {
+        const view: Sprite2DView = { positionPx: [0, 0], zoom: 2, rotation: 0 };
+
+        centerSprite2DView(view, 300, 400, 200, 100);
+        expect(view.positionPx).toEqual([250, 375]);
+        expect(sprite2DWorldToScreenToRef(view, 300, 400, point())).toEqual({ x: 100, y: 50 });
+    });
+
+    it("rejects inverse operations for a non-invertible zero zoom", () => {
+        const view: Sprite2DView = { positionPx: [0, 0], zoom: 0, rotation: 0 };
+
+        expect(() => sprite2DScreenToWorldToRef(view, 0, 0, point())).toThrow(RangeError);
+        expect(() => getSprite2DVisibleBoundsToRef(view, 100, 100, bounds())).toThrow(RangeError);
+        expect(() => centerSprite2DView(view, 0, 0, 100, 100)).toThrow(RangeError);
+        expect(sprite2DWorldToScreenToRef(view, 10, 20, point())).toEqual({ x: 0, y: 0 });
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- add allocation-free helpers for converting between Sprite2D world coordinates and logical backing-store screen space
- add rotation-safe visible world bounds and view-centering utilities
- add reusable `Bounds2D` math state for 2D axis-aligned bounds; Lite's existing `Aabb` remains the generic 3D representation
- export the new API from the package root and document its coordinate and tree-shaking contracts
- cover identity, translation, rotation, positive/negative/zero zoom, camera sub-viewports, visible bounds, and centering behavior

## Motivation

`Sprite2DView` already defines the pan, zoom, and rotation applied by the Sprite2D vertex shader, but CPU-side consumers previously had to reproduce that math themselves. That made transformed-view picking, culling, camera framing, overlays, and editor interactions prone to sign, rotation, zoom, and device-pixel-ratio mistakes.

These helpers use the exact same transform as the renderer:

- `sprite2DWorldToScreenToRef`
- `sprite2DScreenToWorldToRef`
- `getSprite2DVisibleBoundsToRef`
- `centerSprite2DView`

Inverse operations reject `zoom === 0`, while negative zoom remains supported for mirroring.

For `SpriteRenderer` and full camera viewports, logical screen coordinates are absolute framebuffer coordinates. For a depth-hosted layer under a non-full camera viewport, the render pass applies the viewport after the Sprite2D vertex transform; the docs show how to use `resolveCameraViewport` to remap absolute framebuffer coordinates through the full render-target dimensions before unprojection.

## Existing Lite precedent

This follows utility patterns already used elsewhere in Lite:

- [`resolveCameraViewport`](https://github.com/BabylonJS/Babylon-Lite/blob/master/packages/babylon-lite/src/camera/viewport.ts) converts normalized camera viewports into integer render-target pixels.
- [`createPickingRay`](https://github.com/BabylonJS/Babylon-Lite/blob/master/packages/babylon-lite/src/picking/ray.ts) maps screen coordinates back through an inverse view-projection transform for 3D picking.
- Math helpers such as [`normalizeVec2ToRef`](https://github.com/BabylonJS/Babylon-Lite/blob/master/packages/babylon-lite/src/math/normalize-vec2-to-ref.ts) write into caller-owned results to avoid steady-state allocations.
- [`Aabb`](https://github.com/BabylonJS/Babylon-Lite/blob/master/packages/babylon-lite/src/math/aabb.ts) already provides generic 3D axis-aligned bounds, so this PR adds only the missing reusable `Bounds2D` shape rather than a duplicate `Bounds3D` representation.

The new module applies those same standalone, allocation-conscious conventions to pure-2D `Sprite2DView` transforms; it does not add camera behavior or game policy.

## Bundle impact

The implementation lives in a separate side-effect-free module with type-only imports. Nothing in the Sprite2D layer, pipeline, or render loop imports it, so applications that do not reference these helpers retain no runtime bytes, allocations, branches, or GPU work from the feature.

## Validation

- `corepack pnpm exec vitest run tests/lite/unit/sprite-2d-view.test.ts --project unit` — 11 tests passed
- `corepack pnpm run lint` — passed
- public declaration generation and type validation — passed
- Rollup and webpack tree-shaking checks — 14 tests passed
- task-scoped Prettier check — passed

TypeDoc currently cannot start on this checkout because `markdown-it@14.3.0` imports a default export that the locked `linkify-it@6.1.0` package does not provide; the failure occurs during dependency module loading before project documentation is read.
