### PR TITLE
Fix runtime blur updates and bundle tooling correctness

### DIFF
--- a/lab/tsconfig.json
+++ b/lab/tsconfig.json
@@ -1,8 +1,14 @@
 {
-  "extends": "../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "."
-  },
-  "include": ["lite/src", "gl/src"]
+    // The project an editor picks up for lab/ and the one `pnpm lint` checks through
+    // tsconfig.typecheck.json, which extends this file.
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "paths": {
+            "babylon-lite": ["../packages/babylon-lite/src/index.ts"],
+            "babylon-lite/*": ["../packages/babylon-lite/src/*"],
+            "babylon-lite-gl": ["../packages/babylon-lite-gl/src/index.ts"]
+        }
+    },
+    "include": ["lite/src", "gl/src", "../packages/babylon-lite/src/vite-env.d.ts"]
 }

--- a/lab/tsconfig.json
+++ b/lab/tsconfig.json
@@ -1,14 +1,14 @@
 {
-    // The project an editor picks up for lab/ and the one `pnpm lint` checks through
-    // tsconfig.typecheck.json, which extends this file.
-    "extends": "../tsconfig.base.json",
-    "compilerOptions": {
-        "noEmit": true,
-        "paths": {
-            "babylon-lite": ["../packages/babylon-lite/src/index.ts"],
-            "babylon-lite/*": ["../packages/babylon-lite/src/*"],
-            "babylon-lite-gl": ["../packages/babylon-lite-gl/src/index.ts"]
-        }
-    },
-    "include": ["lite/src", "gl/src", "../packages/babylon-lite/src/vite-env.d.ts"]
+  // The project an editor picks up for lab/ and the one `pnpm lint` checks through
+  // tsconfig.typecheck.json, which extends this file.
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "paths": {
+      "babylon-lite": ["../packages/babylon-lite/src/index.ts"],
+      "babylon-lite/*": ["../packages/babylon-lite/src/*"],
+      "babylon-lite-gl": ["../packages/babylon-lite-gl/src/index.ts"]
+    }
+  },
+  "include": ["lite/src", "gl/src", "../packages/babylon-lite/src/vite-env.d.ts", "../packages/babylon-lite/src/xr/xr-webgpu-globals.d.ts"]
 }

--- a/lab/tsconfig.typecheck.json
+++ b/lab/tsconfig.typecheck.json
@@ -1,12 +1,3 @@
 {
-  "extends": "../tsconfig.base.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "paths": {
-      "babylon-lite": ["../packages/babylon-lite/src/index.ts"],
-      "babylon-lite/*": ["../packages/babylon-lite/src/*"],
-      "babylon-lite-gl": ["../packages/babylon-lite-gl/src/index.ts"]
-    }
-  },
-  "include": ["lite/src", "gl/src", "../packages/babylon-lite/src/vite-env.d.ts", "../packages/babylon-lite/src/xr/xr-webgpu-globals.d.ts"]
+  "extends": "./tsconfig.json"
 }

--- a/packages/babylon-lite/src/frame-graph/post-process-task.ts
+++ b/packages/babylon-lite/src/frame-graph/post-process-task.ts
@@ -54,6 +54,8 @@ export interface PostProcessTask extends Task, PostProcessTaskSettings {
     outputTexture: RenderTarget;
     /** Recompute and upload the pass's uniform buffer from current settings. Call after mutating effect parameters. */
     updateUniforms(): void;
+    /** @internal Rebuild the shader pipeline and bindings without recreating render targets. */
+    _rebuildGpuState(): void;
     /** @internal */
     readonly _shader: PostProcessShaderConfig;
 }
@@ -133,6 +135,9 @@ export function createPostProcessTask(config: PostProcessTaskConfig, engine: Eng
         },
         updateUniforms(): void {
             writePostProcessUniforms(task, engine);
+        },
+        _rebuildGpuState(): void {
+            createPostProcessGpuState(task, engine);
         },
         dispose(): void {
             task._passes.length = 0;

--- a/packages/babylon-lite/src/post-process/blur.ts
+++ b/packages/babylon-lite/src/post-process/blur.ts
@@ -146,6 +146,7 @@ export function createBlurPostProcessTask(config: BlurPostProcessTaskConfig, eng
             shaderKernel = params.kernel;
             updateBlurShader(task._shader, params.kernel);
             task._rebuildGpuState();
+            return;
         }
         baseUpdateUniforms();
     };

--- a/packages/babylon-lite/src/post-process/blur.ts
+++ b/packages/babylon-lite/src/post-process/blur.ts
@@ -145,7 +145,7 @@ export function createBlurPostProcessTask(config: BlurPostProcessTaskConfig, eng
         if (shaderKernel !== params.kernel) {
             shaderKernel = params.kernel;
             updateBlurShader(task._shader, params.kernel);
-            task.record();
+            task._rebuildGpuState();
         }
         baseUpdateUniforms();
     };

--- a/packages/babylon-lite/src/post-process/depth-of-field-blur.ts
+++ b/packages/babylon-lite/src/post-process/depth-of-field-blur.ts
@@ -187,7 +187,8 @@ export function createDepthOfFieldBlurPostProcessTask(config: DepthOfFieldBlurPo
         if (shaderKernel !== params.kernel) {
             shaderKernel = params.kernel;
             updateDofBlurShader(task._shader, params.kernel);
-            task.record();
+            task._rebuildGpuState();
+            return;
         }
         baseUpdateUniforms();
     };

--- a/scripts/bundle-demos-core.ts
+++ b/scripts/bundle-demos-core.ts
@@ -381,7 +381,7 @@ export async function buildDemo(slug: string): Promise<void> {
         newNames.add(f);
         writeFileSync(resolve(demosDir, f), readFileSync(resolve(demoOutDir, f)));
     }
-    const demoSlugs = loadDemosConfig().map((demo) => demo.slug);
+    const demoSlugs = [...loadDemosConfig().map((demo) => demo.slug), ...DEMO_SUPPORT_BUNDLES];
     for (const existing of readdirSync(demosDir)) {
         if (demoOwnsBundleFile(existing, slug, demoSlugs) && !newNames.has(existing)) {
             rmSync(resolve(demosDir, existing));

--- a/scripts/bundle-demos-core.ts
+++ b/scripts/bundle-demos-core.ts
@@ -38,6 +38,7 @@ import {
 } from "./bundle-scenes-core";
 import { wgslMinifyPlugin } from "./wgsl-minify-plugin";
 import { fetchDemoAssets } from "./demo-fetchers";
+import { demoSlugForBundleFile } from "./demo-bundle-name";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const PAGES_SRC = resolve(ROOT, "pages");
@@ -380,8 +381,9 @@ export async function buildDemo(slug: string): Promise<void> {
         newNames.add(f);
         writeFileSync(resolve(demosDir, f), readFileSync(resolve(demoOutDir, f)));
     }
+    const demoSlugs = loadDemosConfig().map((demo) => demo.slug);
     for (const existing of readdirSync(demosDir)) {
-        if ((existing === `${slug}.js` || existing.startsWith(`${slug}-`)) && !newNames.has(existing)) {
+        if (demoSlugForBundleFile(existing, demoSlugs) === slug && !newNames.has(existing)) {
             rmSync(resolve(demosDir, existing));
         }
     }

--- a/scripts/bundle-demos-core.ts
+++ b/scripts/bundle-demos-core.ts
@@ -38,7 +38,7 @@ import {
 } from "./bundle-scenes-core";
 import { wgslMinifyPlugin } from "./wgsl-minify-plugin";
 import { fetchDemoAssets } from "./demo-fetchers";
-import { demoSlugForBundleFile } from "./demo-bundle-name";
+import { demoOwnsBundleFile } from "./demo-bundle-name";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const PAGES_SRC = resolve(ROOT, "pages");
@@ -383,7 +383,7 @@ export async function buildDemo(slug: string): Promise<void> {
     }
     const demoSlugs = loadDemosConfig().map((demo) => demo.slug);
     for (const existing of readdirSync(demosDir)) {
-        if (demoSlugForBundleFile(existing, demoSlugs) === slug && !newNames.has(existing)) {
+        if (demoOwnsBundleFile(existing, slug, demoSlugs) && !newNames.has(existing)) {
             rmSync(resolve(demosDir, existing));
         }
     }

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -1071,7 +1071,10 @@ function elapsed(startMs: number): string {
  *  preload form too late for a renderChunk/generateBundle hook to see it. */
 export function stripNoopPreloadWrappers(code: string): string {
     return code
-        .replace(/[\w$]+\(async\(\)=>\{const\{([\w$]+):([\w$]+)\}=await (import\([^()]*\));return\{\1:\2\}\},\[\]\)/g, "$3")
+        .replace(
+            /[\w$]+\(async\(\)=>\{const\{([\w$]+):([\w$]+)\}=await (import\([^()]*\));return\{\1:\2\}\},\[\]\)/g,
+            "$3"
+        )
         .replace(/[\w$]+\(\s*\(\s*\)\s*=>\s*(import\([^()]*\)(?:\.then\(\s*[\w$]+\s*=>\s*[\w$]+\.[\w$]+\s*\))?)\s*,\s*\[\s*\]\s*\)/g, "$1");
 }
 

--- a/scripts/bundle-scenes-core.ts
+++ b/scripts/bundle-scenes-core.ts
@@ -28,6 +28,8 @@ export function terserPropertyManglePlugin(): Plugin {
         name: "terser-property-mangle",
         async generateBundle(_options, bundle) {
             const nameCache: Record<string, unknown> = {};
+            // ESM export names are fixed, so namespace reads in another chunk must not be mangled.
+            const exportedProperties = [...new Set(Object.values(bundle).flatMap((entry) => (entry.type === "chunk" ? entry.exports.filter((name) => /^_[a-z]/.test(name)) : [])))];
 
             for (const [, chunk] of Object.entries(bundle)) {
                 if (chunk.type !== "chunk") continue;
@@ -93,6 +95,7 @@ export function terserPropertyManglePlugin(): Plugin {
                                 "_free",
                                 "_vertexSlots",
                                 "_fragmentSlots",
+                                ...exportedProperties,
                                 ...wasmReserved,
                             ],
                         },
@@ -1068,10 +1071,7 @@ function elapsed(startMs: number): string {
  *  preload form too late for a renderChunk/generateBundle hook to see it. */
 export function stripNoopPreloadWrappers(code: string): string {
     return code
-        .replace(
-            /[\w$]+\(async\(\)=>\{const\{([\w$]+):([\w$]+)\}=await (import\([^()]*\));return\{\1:\2\}\},\[\]\)/g,
-            "$3"
-        )
+        .replace(/[\w$]+\(async\(\)=>\{const\{([\w$]+):([\w$]+)\}=await (import\([^()]*\));return\{\1:\2\}\},\[\]\)/g, "$3")
         .replace(/[\w$]+\(\s*\(\s*\)\s*=>\s*(import\([^()]*\)(?:\.then\(\s*[\w$]+\s*=>\s*[\w$]+\.[\w$]+\s*\))?)\s*,\s*\[\s*\]\s*\)/g, "$1");
 }
 

--- a/scripts/demo-bundle-name.ts
+++ b/scripts/demo-bundle-name.ts
@@ -1,4 +1,8 @@
-/** Return the configured demo that owns an emitted bundle file, preferring the longest matching slug. */
-export function demoSlugForBundleFile(fileName: string, slugs: readonly string[]): string | undefined {
-    return slugs.filter((slug) => fileName === `${slug}.js` || fileName.startsWith(`${slug}-`)).sort((first, second) => second.length - first.length)[0];
+/** Return whether a demo owns an emitted bundle file, preferring the longest matching slug. */
+export function demoOwnsBundleFile(fileName: string, slug: string, configuredSlugs: readonly string[]): boolean {
+    const candidateSlugs = configuredSlugs.includes(slug) ? configuredSlugs : [slug, ...configuredSlugs];
+    const owner = candidateSlugs
+        .filter((candidate) => fileName === `${candidate}.js` || fileName.startsWith(`${candidate}-`))
+        .sort((first, second) => second.length - first.length)[0];
+    return owner === slug;
 }

--- a/scripts/demo-bundle-name.ts
+++ b/scripts/demo-bundle-name.ts
@@ -1,8 +1,10 @@
-/** Return whether a demo owns an emitted bundle file, preferring the longest matching slug. */
-export function demoOwnsBundleFile(fileName: string, slug: string, configuredSlugs: readonly string[]): boolean {
-    const candidateSlugs = configuredSlugs.includes(slug) ? configuredSlugs : [slug, ...configuredSlugs];
-    const owner = candidateSlugs
-        .filter((candidate) => fileName === `${candidate}.js` || fileName.startsWith(`${candidate}-`))
-        .sort((first, second) => second.length - first.length)[0];
+/** Return whether `slug` owns an emitted bundle file, preferring the longest matching slug.
+ *
+ *  `knownSlugs` must list every demo that emits into the shared output directory — configured demos
+ *  *and* support bundles. Ownership then depends only on the file name, so exactly one demo claims a
+ *  given file no matter which demo is being rebuilt. Omitting a slug lets a prefix-related demo claim,
+ *  and therefore delete, chunks it does not own (e.g. `landing` claiming `landing-bg-<hash>.js`). */
+export function demoOwnsBundleFile(fileName: string, slug: string, knownSlugs: readonly string[]): boolean {
+    const owner = knownSlugs.filter((candidate) => fileName === `${candidate}.js` || fileName.startsWith(`${candidate}-`)).sort((first, second) => second.length - first.length)[0];
     return owner === slug;
 }

--- a/scripts/demo-bundle-name.ts
+++ b/scripts/demo-bundle-name.ts
@@ -1,0 +1,4 @@
+/** Return the configured demo that owns an emitted bundle file, preferring the longest matching slug. */
+export function demoSlugForBundleFile(fileName: string, slugs: readonly string[]): string | undefined {
+    return slugs.filter((slug) => fileName === `${slug}.js` || fileName.startsWith(`${slug}-`)).sort((first, second) => second.length - first.length)[0];
+}

--- a/tests/lite/build/bundle-tooling.test.ts
+++ b/tests/lite/build/bundle-tooling.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { build } from "vite";
 
-import { demoSlugForBundleFile } from "../../../scripts/demo-bundle-name";
+import { demoOwnsBundleFile } from "../../../scripts/demo-bundle-name";
 import { terserPropertyManglePlugin } from "../../../scripts/bundle-scenes-core";
 
 const tempDirs: string[] = [];
@@ -53,9 +53,16 @@ describe("bundle tooling correctness", () => {
     it("assigns prefix-related bundle files to the longest matching demo slug", () => {
         const slugs = ["fluid", "fluid-worker", "racer"];
 
-        expect(demoSlugForBundleFile("fluid-worker-shared-abc123.js", slugs)).toBe("fluid-worker");
-        expect(demoSlugForBundleFile("fluid-old-abc123.js", slugs)).toBe("fluid");
-        expect(demoSlugForBundleFile("racer.js", slugs)).toBe("racer");
-        expect(demoSlugForBundleFile("unrelated.js", slugs)).toBeUndefined();
+        expect(demoOwnsBundleFile("fluid-worker-shared-abc123.js", "fluid-worker", slugs)).toBe(true);
+        expect(demoOwnsBundleFile("fluid-worker-shared-abc123.js", "fluid", slugs)).toBe(false);
+        expect(demoOwnsBundleFile("fluid-old-abc123.js", "fluid", slugs)).toBe(true);
+        expect(demoOwnsBundleFile("racer.js", "racer", slugs)).toBe(true);
+        expect(demoOwnsBundleFile("unrelated.js", "racer", slugs)).toBe(false);
+    });
+
+    it("recognizes support bundle files whose slug is not in the demo config", () => {
+        const configuredSlugs = ["fluid", "racer"];
+
+        expect(demoOwnsBundleFile("landing-bg-oldhash.js", "landing-bg", configuredSlugs)).toBe(true);
     });
 });

--- a/tests/lite/build/bundle-tooling.test.ts
+++ b/tests/lite/build/bundle-tooling.test.ts
@@ -61,8 +61,17 @@ describe("bundle tooling correctness", () => {
     });
 
     it("recognizes support bundle files whose slug is not in the demo config", () => {
-        const configuredSlugs = ["fluid", "racer"];
+        const knownSlugs = ["fluid", "racer", "landing-bg"];
 
-        expect(demoOwnsBundleFile("landing-bg-oldhash.js", "landing-bg", configuredSlugs)).toBe(true);
+        expect(demoOwnsBundleFile("landing-bg-oldhash.js", "landing-bg", knownSlugs)).toBe(true);
+    });
+
+    it("keeps ownership exclusive regardless of which prefix-related demo is being built", () => {
+        const knownSlugs = ["landing", "racer", "landing-bg"];
+
+        expect(demoOwnsBundleFile("landing-bg-oldhash.js", "landing-bg", knownSlugs)).toBe(true);
+        expect(demoOwnsBundleFile("landing-bg-oldhash.js", "landing", knownSlugs)).toBe(false);
+        expect(demoOwnsBundleFile("landing-oldhash.js", "landing", knownSlugs)).toBe(true);
+        expect(demoOwnsBundleFile("landing-oldhash.js", "landing-bg", knownSlugs)).toBe(false);
     });
 });

--- a/tests/lite/build/bundle-tooling.test.ts
+++ b/tests/lite/build/bundle-tooling.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { build } from "vite";
+
+import { demoSlugForBundleFile } from "../../../scripts/demo-bundle-name";
+import { terserPropertyManglePlugin } from "../../../scripts/bundle-scenes-core";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+describe("bundle tooling correctness", () => {
+    it("preserves underscore-prefixed ESM exports referenced through a dynamic-import namespace", async () => {
+        const root = mkdtempSync(join(tmpdir(), "lite-mangle-exports-"));
+        tempDirs.push(root);
+        const outDir = join(root, "out");
+        writeFileSync(join(root, "entry.js"), 'export async function run(){const feature=await import("./feature.js");return feature._apply();}');
+        writeFileSync(join(root, "feature.js"), "export const _apply=()=>42;");
+
+        await build({
+            root,
+            configFile: false,
+            publicDir: false,
+            logLevel: "silent",
+            plugins: [terserPropertyManglePlugin()],
+            build: {
+                outDir,
+                emptyOutDir: true,
+                minify: "esbuild",
+                rollupOptions: {
+                    input: join(root, "entry.js"),
+                    preserveEntrySignatures: "strict",
+                    output: {
+                        format: "es",
+                        entryFileNames: "entry.mjs",
+                        chunkFileNames: "[name]-[hash].mjs",
+                    },
+                },
+            },
+        });
+
+        const entry = (await import(`${pathToFileURL(join(outDir, "entry.mjs")).href}?test=${Date.now()}`)) as { run(): Promise<number> };
+        await expect(entry.run()).resolves.toBe(42);
+    });
+
+    it("assigns prefix-related bundle files to the longest matching demo slug", () => {
+        const slugs = ["fluid", "fluid-worker", "racer"];
+
+        expect(demoSlugForBundleFile("fluid-worker-shared-abc123.js", slugs)).toBe("fluid-worker");
+        expect(demoSlugForBundleFile("fluid-old-abc123.js", slugs)).toBe("fluid");
+        expect(demoSlugForBundleFile("racer.js", slugs)).toBe("racer");
+        expect(demoSlugForBundleFile("unrelated.js", slugs)).toBeUndefined();
+    });
+});

--- a/tests/lite/unit/blur-runtime-update.test.ts
+++ b/tests/lite/unit/blur-runtime-update.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import { createRenderTarget, type RenderTarget } from "../../../packages/babylon-lite/src/engine/render-target";
+import { createBlurPostProcessTask } from "../../../packages/babylon-lite/src/post-process/blur";
+
+function makeEagerTarget(label: string): RenderTarget {
+    const target = createRenderTarget({ lbl: label, format: "rgba8unorm", samples: 1, size: { width: 64, height: 32 } });
+    Object.assign(target, {
+        _eager: true,
+        _colorTexture: { destroy: vi.fn() } as unknown as GPUTexture,
+        _colorView: {} as GPUTextureView,
+        _width: 64,
+        _height: 32,
+    });
+    return target;
+}
+
+describe("blur runtime kernel updates", () => {
+    it("rebuilds shader GPU state without recording again or replacing the output target", () => {
+        const outputTextures: Array<{ createView(): GPUTextureView; destroy: ReturnType<typeof vi.fn> }> = [];
+        const createTexture = vi.fn(() => {
+            const texture = {
+                createView: () => ({}) as GPUTextureView,
+                destroy: vi.fn(),
+            };
+            outputTextures.push(texture);
+            return texture as unknown as GPUTexture;
+        });
+        const createRenderPipeline = vi.fn(() => ({}) as GPURenderPipeline);
+        const createBindGroup = vi.fn(() => ({}) as GPUBindGroup);
+        const engine = {
+            _device: {
+                createBuffer: vi.fn(() => ({ destroy: vi.fn() }) as unknown as GPUBuffer),
+                createBindGroupLayout: vi.fn(() => ({}) as GPUBindGroupLayout),
+                createPipelineLayout: vi.fn(() => ({}) as GPUPipelineLayout),
+                createShaderModule: vi.fn(() => ({}) as GPUShaderModule),
+                createRenderPipeline,
+                createBindGroup,
+                createSampler: vi.fn(() => ({}) as GPUSampler),
+                createTexture,
+                queue: { writeBuffer: vi.fn() },
+            },
+        } as unknown as EngineContext;
+        const source = makeEagerTarget("source");
+        const task = createBlurPostProcessTask({ sourceTexture: source, kernel: 9 }, engine);
+
+        task.record();
+        const outputTexture = task.outputTexture;
+        const outputGpuTexture = task.outputTexture._colorTexture;
+        const record = vi.spyOn(task, "record");
+
+        task.kernel = 13;
+        task.updateUniforms();
+
+        expect(record).not.toHaveBeenCalled();
+        expect(task.outputTexture).toBe(outputTexture);
+        expect(task.outputTexture._colorTexture).toBe(outputGpuTexture);
+        expect(createTexture).toHaveBeenCalledTimes(1);
+        expect(outputTextures[0]!.destroy).not.toHaveBeenCalled();
+        expect(createRenderPipeline).toHaveBeenCalledTimes(2);
+        expect(createBindGroup).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/lite/unit/blur-runtime-update.test.ts
+++ b/tests/lite/unit/blur-runtime-update.test.ts
@@ -2,7 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
 import { createRenderTarget, type RenderTarget } from "../../../packages/babylon-lite/src/engine/render-target";
+import { createBloomPostProcessTask } from "../../../packages/babylon-lite/src/post-process/bloom";
 import { createBlurPostProcessTask } from "../../../packages/babylon-lite/src/post-process/blur";
+import { createDepthOfFieldBlurPostProcessTask } from "../../../packages/babylon-lite/src/post-process/depth-of-field-blur";
+
+interface MockTexture {
+    createView(): GPUTextureView;
+    destroy: ReturnType<typeof vi.fn>;
+}
 
 function makeEagerTarget(label: string): RenderTarget {
     const target = createRenderTarget({ lbl: label, format: "rgba8unorm", samples: 1, size: { width: 64, height: 32 } });
@@ -16,34 +23,47 @@ function makeEagerTarget(label: string): RenderTarget {
     return target;
 }
 
+function makeMockEngine(): {
+    engine: EngineContext;
+    textures: MockTexture[];
+    createTexture: ReturnType<typeof vi.fn>;
+    createRenderPipeline: ReturnType<typeof vi.fn>;
+    createBindGroup: ReturnType<typeof vi.fn<(descriptor: GPUBindGroupDescriptor) => GPUBindGroup>>;
+    writeBuffer: ReturnType<typeof vi.fn>;
+} {
+    const textures: MockTexture[] = [];
+    const createTexture = vi.fn(() => {
+        const view = {} as GPUTextureView;
+        const texture: MockTexture = {
+            createView: () => view,
+            destroy: vi.fn(),
+        };
+        textures.push(texture);
+        return texture as unknown as GPUTexture;
+    });
+    const createRenderPipeline = vi.fn(() => ({}) as GPURenderPipeline);
+    const createBindGroup = vi.fn((descriptor: GPUBindGroupDescriptor) => ({ descriptor }) as unknown as GPUBindGroup);
+    const writeBuffer = vi.fn();
+    const engine = {
+        _device: {
+            createBuffer: vi.fn(() => ({ destroy: vi.fn() }) as unknown as GPUBuffer),
+            createBindGroupLayout: vi.fn(() => ({}) as GPUBindGroupLayout),
+            createPipelineLayout: vi.fn(() => ({}) as GPUPipelineLayout),
+            createShaderModule: vi.fn(() => ({}) as GPUShaderModule),
+            createRenderPipeline,
+            createBindGroup,
+            createSampler: vi.fn(() => ({}) as GPUSampler),
+            createTexture,
+            queue: { writeBuffer },
+        },
+    } as unknown as EngineContext;
+    return { engine, textures, createTexture, createRenderPipeline, createBindGroup, writeBuffer };
+}
+
 describe("blur runtime kernel updates", () => {
-    it("rebuilds shader GPU state without recording again or replacing the output target", () => {
-        const outputTextures: Array<{ createView(): GPUTextureView; destroy: ReturnType<typeof vi.fn> }> = [];
-        const createTexture = vi.fn(() => {
-            const texture = {
-                createView: () => ({}) as GPUTextureView,
-                destroy: vi.fn(),
-            };
-            outputTextures.push(texture);
-            return texture as unknown as GPUTexture;
-        });
-        const createRenderPipeline = vi.fn(() => ({}) as GPURenderPipeline);
-        const createBindGroup = vi.fn(() => ({}) as GPUBindGroup);
-        const engine = {
-            _device: {
-                createBuffer: vi.fn(() => ({ destroy: vi.fn() }) as unknown as GPUBuffer),
-                createBindGroupLayout: vi.fn(() => ({}) as GPUBindGroupLayout),
-                createPipelineLayout: vi.fn(() => ({}) as GPUPipelineLayout),
-                createShaderModule: vi.fn(() => ({}) as GPUShaderModule),
-                createRenderPipeline,
-                createBindGroup,
-                createSampler: vi.fn(() => ({}) as GPUSampler),
-                createTexture,
-                queue: { writeBuffer: vi.fn() },
-            },
-        } as unknown as EngineContext;
-        const source = makeEagerTarget("source");
-        const task = createBlurPostProcessTask({ sourceTexture: source, kernel: 9 }, engine);
+    it("rebuilds plain blur GPU state without replacing its output texture", () => {
+        const { engine, textures, createTexture, createRenderPipeline, createBindGroup, writeBuffer } = makeMockEngine();
+        const task = createBlurPostProcessTask({ sourceTexture: makeEagerTarget("source"), kernel: 9 }, engine);
 
         task.record();
         const outputTexture = task.outputTexture;
@@ -57,8 +77,59 @@ describe("blur runtime kernel updates", () => {
         expect(task.outputTexture).toBe(outputTexture);
         expect(task.outputTexture._colorTexture).toBe(outputGpuTexture);
         expect(createTexture).toHaveBeenCalledTimes(1);
-        expect(outputTextures[0]!.destroy).not.toHaveBeenCalled();
+        expect(textures[0]!.destroy).not.toHaveBeenCalled();
         expect(createRenderPipeline).toHaveBeenCalledTimes(2);
         expect(createBindGroup).toHaveBeenCalledTimes(2);
+        expect(writeBuffer).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps bloom merge bound to the live blur texture after a kernel change", () => {
+        const { engine, textures, createBindGroup } = makeMockEngine();
+        const task = createBloomPostProcessTask({ sourceTexture: makeEagerTarget("source"), kernel: 9 }, engine) as ReturnType<typeof createBloomPostProcessTask> & {
+            _blurYTarget: RenderTarget;
+        };
+
+        task.record();
+        const blurTexture = task._blurYTarget._colorTexture;
+        const blurView = task._blurYTarget._colorView;
+        const mergeBindGroup = createBindGroup.mock.calls.map(([descriptor]) => descriptor).find((descriptor) => descriptor.label === "bloom-merge-bind-group");
+        const boundBlurView = mergeBindGroup?.entries.find((entry) => entry.binding === 2)?.resource;
+
+        task.kernel = 13;
+        task.updateUniforms();
+
+        expect(boundBlurView).toBe(blurView);
+        expect(task._blurYTarget._colorTexture).toBe(blurTexture);
+        expect(task._blurYTarget._colorView).toBe(boundBlurView);
+        expect(textures.find((texture) => texture === (blurTexture as unknown as MockTexture))?.destroy).not.toHaveBeenCalled();
+    });
+
+    it("rebuilds depth-of-field blur GPU state without replacing its output texture", () => {
+        const { engine, textures, createTexture, createRenderPipeline, createBindGroup, writeBuffer } = makeMockEngine();
+        const task = createDepthOfFieldBlurPostProcessTask(
+            {
+                sourceTexture: makeEagerTarget("source"),
+                circleOfConfusionTexture: makeEagerTarget("circle-of-confusion"),
+                kernel: 9,
+            },
+            engine
+        );
+
+        task.record();
+        const outputTexture = task.outputTexture;
+        const outputGpuTexture = task.outputTexture._colorTexture;
+        const record = vi.spyOn(task, "record");
+
+        task.kernel = 13;
+        task.updateUniforms();
+
+        expect(record).not.toHaveBeenCalled();
+        expect(task.outputTexture).toBe(outputTexture);
+        expect(task.outputTexture._colorTexture).toBe(outputGpuTexture);
+        expect(createTexture).toHaveBeenCalledTimes(1);
+        expect(textures[0]!.destroy).not.toHaveBeenCalled();
+        expect(createRenderPipeline).toHaveBeenCalledTimes(2);
+        expect(createBindGroup).toHaveBeenCalledTimes(2);
+        expect(writeBuffer).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
## Summary

- rebuild plain and depth-of-field blur shader GPU state when the kernel changes at runtime, without re-recording the frame graph or recreating render targets
- preserve underscore-prefixed ESM exports during cross-chunk Terser property mangling
- make stale demo-bundle cleanup use exclusive longest-slug ownership across configured demos and support bundles
- align the lab editor and lint TypeScript projects with source path mappings and `noEmit`

## Details

Runtime blur kernel changes previously called `record()`, which disposes and recreates task-owned render targets. In bloom, the merge pass retained a bind group referencing the destroyed blur texture view. Kernel updates now rebuild only the shader module, pipeline, and bindings; the same correction is applied to the depth-of-field blur path.

The bundler now reserves underscore-prefixed names exported by any emitted chunk so namespace reads stay compatible with producer export tables. Demo cleanup now resolves ownership against the complete known slug set, preventing prefix-related demos and support bundles from deleting or orphaning each other's chunks.

The lab type-check config now extends the editor config, keeping source aliases, ambient WebGPU/XR declarations, and `noEmit` in one source of truth.

## Validation

- 7 focused runtime/build-tooling regression tests
- `pnpm lint`
- `pnpm build:lib`
- filtered Scene 1 bundle: 87.4 KB raw / 36.9 KB gzip, unchanged from baseline