### PR TITLE
Add body-local rigid-body rotation axis locks

### DIFF
--- a/docs/lite/architecture/42-physics.md
+++ b/docs/lite/architecture/42-physics.md
@@ -188,6 +188,17 @@ steps matches the animation and sprite managers.
 
 ---
 
+## Rigid-body angular locks
+
+`lockPhysicsBodyRotationAxes(world, body, axes)` locks selected body-local
+axes after the collision shape and mass properties have been configured. Havok
+represents a locked angular degree of freedom with a zero inertia component, so
+the helper reads the body's current mass properties, zeros only the requested
+`"x"`, `"y"`, or `"z"` components, aligns the inertia frame with the body, and
+preserves its mass, centre of mass, and unlocked inertia magnitudes.
+
+---
+
 ## Feature modules (opt-in)
 
 - **Collision events** (`havok-collision.ts`): `setPhysicsBodyCollisionEventsEnabled`
@@ -221,5 +232,8 @@ steps matches the animation and sprite managers.
   (independent of `scene.fixedDeltaMs`), follows the scene's per-frame delta when
   unset (respecting runtime changes), is converted to seconds for `HP_World_Step`,
   and is settable via `setPhysicsTimestep` / `setPhysicsTimestepMs`.
+- `tests/lite/unit/physics-rotation-axis-locks.test.ts` — selected body-local inertia
+  components are zeroed while mass, centre of mass, and unlocked components are
+  preserved; empty input and native read failures do not write mass properties.
 - Parity scenes (physics drop/stack/constraint scenes) set
   `scene.fixedDeltaMs = 1000 / 60` so Lite and Babylon.js step identically.

--- a/docs/lite/architecture/42-physics.md
+++ b/docs/lite/architecture/42-physics.md
@@ -194,11 +194,16 @@ steps matches the animation and sprite managers.
 axes after the collision shape and mass properties have been configured. Havok
 represents a locked angular degree of freedom with a zero inertia component. Its
 shape-derived inertia is expressed in a rotated principal-axis frame, so the
-helper first evaluates the diagonal of `R · diag(inertia) · Rᵀ` in body space,
-then zeros the requested `"x"`, `"y"`, or `"z"` components and sets the inertia
-orientation to identity. Mass and centre of mass are preserved. The active lock
-mask is retained on the body and reapplied by `setPhysicsBodyMass` and
+helper evaluates `R · diag(inertia) · Rᵀ` in body space and zeros the requested
+`"x"`, `"y"`, or `"z"` components. A single-axis lock retains the exact coupled
+inertia in the remaining free plane through a rotation around the locked axis;
+multi-axis locks use an identity inertia orientation. Mass and centre of mass are
+preserved. The active lock mask and latest unlocked mass properties are retained
+on the body and reapplied by `setPhysicsBodyMass` and
 `setPhysicsBodyMassProperties` when they rebuild shape-derived mass properties.
+`unlockPhysicsBodyRotationAxes(world, body, axes)` selectively restores axes from
+those unlocked properties and removes the internal persistence seam after the
+last axis is unlocked.
 
 ---
 
@@ -237,7 +242,8 @@ mask is retained on the body and reapplied by `setPhysicsBodyMass` and
   and is settable via `setPhysicsTimestep` / `setPhysicsTimestepMs`.
 - `tests/lite/unit/physics-rotation-axis-locks.test.ts` — selected body-local inertia
   components are zeroed after transforming a non-identity principal inertia frame
-  into body space; mass updates preserve active locks, and empty input/native read
-  failures do not write mass properties.
+  into body space; single-axis locks preserve free-plane coupling, mass updates
+  preserve active locks, selective unlocking restores the latest unlocked
+  properties, and empty input/native read failures do not write mass properties.
 - Parity scenes (physics drop/stack/constraint scenes) set
   `scene.fixedDeltaMs = 1000 / 60` so Lite and Babylon.js step identically.

--- a/docs/lite/architecture/42-physics.md
+++ b/docs/lite/architecture/42-physics.md
@@ -192,10 +192,13 @@ steps matches the animation and sprite managers.
 
 `lockPhysicsBodyRotationAxes(world, body, axes)` locks selected body-local
 axes after the collision shape and mass properties have been configured. Havok
-represents a locked angular degree of freedom with a zero inertia component, so
-the helper reads the body's current mass properties, zeros only the requested
-`"x"`, `"y"`, or `"z"` components, aligns the inertia frame with the body, and
-preserves its mass, centre of mass, and unlocked inertia magnitudes.
+represents a locked angular degree of freedom with a zero inertia component. Its
+shape-derived inertia is expressed in a rotated principal-axis frame, so the
+helper first evaluates the diagonal of `R · diag(inertia) · Rᵀ` in body space,
+then zeros the requested `"x"`, `"y"`, or `"z"` components and sets the inertia
+orientation to identity. Mass and centre of mass are preserved. The active lock
+mask is retained on the body and reapplied by `setPhysicsBodyMass` and
+`setPhysicsBodyMassProperties` when they rebuild shape-derived mass properties.
 
 ---
 
@@ -233,7 +236,8 @@ preserves its mass, centre of mass, and unlocked inertia magnitudes.
   unset (respecting runtime changes), is converted to seconds for `HP_World_Step`,
   and is settable via `setPhysicsTimestep` / `setPhysicsTimestepMs`.
 - `tests/lite/unit/physics-rotation-axis-locks.test.ts` — selected body-local inertia
-  components are zeroed while mass, centre of mass, and unlocked components are
-  preserved; empty input and native read failures do not write mass properties.
+  components are zeroed after transforming a non-identity principal inertia frame
+  into body space; mass updates preserve active locks, and empty input/native read
+  failures do not write mass properties.
 - Parity scenes (physics drop/stack/constraint scenes) set
   `scene.fixedDeltaMs = 1000 / 60` so Lite and Babylon.js step identically.

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -911,6 +911,7 @@ export {
     getPhysicsBodyAngularVelocity,
     setPhysicsBodyAngularVelocity,
     lockPhysicsBodyRotationAxes,
+    unlockPhysicsBodyRotationAxes,
     setPhysicsBodyMotionType,
     setPhysicsBodyTransform,
     removePhysicsBody,

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -910,6 +910,7 @@ export {
     getPhysicsBodyLinearVelocity,
     getPhysicsBodyAngularVelocity,
     setPhysicsBodyAngularVelocity,
+    lockPhysicsBodyRotationAxes,
     setPhysicsBodyMotionType,
     setPhysicsBodyTransform,
     removePhysicsBody,
@@ -931,6 +932,7 @@ export type {
     PhysicsShapeParameters,
     PhysicsAggregateOptions,
     PhysicsMassProperties,
+    PhysicsRotationAxis,
     PhysicsConstraintOptions,
     PhysicsConstraintLimit,
 } from "./physics/havok.js";

--- a/packages/babylon-lite/src/physics/havok.ts
+++ b/packages/babylon-lite/src/physics/havok.ts
@@ -128,6 +128,9 @@ export interface PhysicsMassProperties {
     inertiaOrientation?: Quat;
 }
 
+/** Principal body axis whose angular motion may be locked. */
+export type PhysicsRotationAxis = "x" | "y" | "z";
+
 /** Pivot/axis options used to create a physics constraint. */
 export interface PhysicsConstraintOptions {
     pivotA?: Vec3;
@@ -1163,6 +1166,38 @@ export function getPhysicsBodyAngularVelocity(world: PhysicsWorld, body: Physics
  */
 export function setPhysicsBodyAngularVelocity(world: PhysicsWorld, body: PhysicsBody, velocity: Vec3): void {
     world._hknp.HP_Body_SetAngularVelocity(body._hkBody, [velocity.x, velocity.y, velocity.z]);
+}
+
+/**
+ * Lock angular motion around selected body-local axes.
+ * Havok represents a locked angular degree of freedom with zero inertia.
+ */
+export function lockPhysicsBodyRotationAxes(world: PhysicsWorld, body: PhysicsBody, axes: readonly PhysicsRotationAxis[]): void {
+    if (axes.length === 0) {
+        return;
+    }
+    const hknp = world._hknp;
+    const result = hknp.HP_Body_GetMassProperties(body._hkBody);
+    const ok = hknp.Result?.RESULT_OK ?? 0;
+    if (result[0] !== ok) {
+        throw new Error("Failed to read physics body mass properties.");
+    }
+    const massProperties = result[1];
+    const inertia = [...massProperties[2]];
+    for (const axis of axes) {
+        if (axis === "x") {
+            inertia[0] = 0;
+        } else if (axis === "y") {
+            inertia[1] = 0;
+        } else if (axis === "z") {
+            inertia[2] = 0;
+        } else {
+            throw new Error(`Unknown physics rotation axis "${String(axis)}".`);
+        }
+    }
+    massProperties[2] = inertia;
+    massProperties[3] = [0, 0, 0, 1];
+    hknp.HP_Body_SetMassProperties(body._hkBody, massProperties);
 }
 
 /**

--- a/packages/babylon-lite/src/physics/havok.ts
+++ b/packages/babylon-lite/src/physics/havok.ts
@@ -1186,6 +1186,9 @@ export function lockPhysicsBodyRotationAxes(world: PhysicsWorld, body: PhysicsBo
     }
     const previousMask = body._rotationLockMask ?? 0;
     const mask = previousMask | requestedMask;
+    if (mask === previousMask) {
+        return;
+    }
     let source = body._rotationLockSource;
     if (previousMask === 0) {
         const hknp = world._hknp;

--- a/packages/babylon-lite/src/physics/havok.ts
+++ b/packages/babylon-lite/src/physics/havok.ts
@@ -160,6 +160,7 @@ export interface PhysicsBody {
     /** @internal */ readonly _world: PhysicsWorld;
     /** @internal */ _shape?: PhysicsShape | null;
     /** @internal */ _rotationLockMask?: number;
+    /** @internal */ _rotationLockSource?: any[];
     /** @internal */ _massPropertiesTransform?: (massProperties: any[]) => void;
     /** @internal */ _preStep: boolean;
     /** @internal How a moved node is propagated to the body pre-step (TELEPORT by default). */
@@ -1179,10 +1180,56 @@ export function setPhysicsBodyAngularVelocity(world: PhysicsWorld, body: Physics
  * Locks are cumulative and remain active when the body's mass properties are rebuilt.
  */
 export function lockPhysicsBodyRotationAxes(world: PhysicsWorld, body: PhysicsBody, axes: readonly PhysicsRotationAxis[]): void {
-    if (axes.length === 0) {
+    const requestedMask = physicsRotationAxesMask(axes);
+    if (requestedMask === 0) {
         return;
     }
-    let mask = body._rotationLockMask ?? 0;
+    const previousMask = body._rotationLockMask ?? 0;
+    const mask = previousMask | requestedMask;
+    let source = body._rotationLockSource;
+    if (previousMask === 0) {
+        const hknp = world._hknp;
+        const result = hknp.HP_Body_GetMassProperties(body._hkBody);
+        const ok = hknp.Result?.RESULT_OK ?? 0;
+        if (result[0] !== ok) {
+            throw new Error("Failed to read physics body mass properties.");
+        }
+        source = cloneMassProperties(result[1]);
+    }
+    const massProperties = cloneMassProperties(source!);
+    applyBodyRotationLocks(massProperties, mask);
+    world._hknp.HP_Body_SetMassProperties(body._hkBody, massProperties);
+    body._rotationLockMask = mask;
+    body._rotationLockSource = source;
+    body._massPropertiesTransform ??= (properties) => {
+        body._rotationLockSource = cloneMassProperties(properties);
+        applyBodyRotationLocks(properties, body._rotationLockMask ?? 0);
+    };
+}
+
+/**
+ * Unlock angular motion around selected body-local axes.
+ * Axes that remain locked continue to be reapplied when mass properties are rebuilt.
+ */
+export function unlockPhysicsBodyRotationAxes(world: PhysicsWorld, body: PhysicsBody, axes: readonly PhysicsRotationAxis[]): void {
+    const requestedMask = physicsRotationAxesMask(axes);
+    const previousMask = body._rotationLockMask ?? 0;
+    const mask = previousMask & ~requestedMask;
+    if (mask === previousMask) {
+        return;
+    }
+    const massProperties = cloneMassProperties(body._rotationLockSource!);
+    applyBodyRotationLocks(massProperties, mask);
+    world._hknp.HP_Body_SetMassProperties(body._hkBody, massProperties);
+    body._rotationLockMask = mask || undefined;
+    if (mask === 0) {
+        body._rotationLockSource = undefined;
+        body._massPropertiesTransform = undefined;
+    }
+}
+
+function physicsRotationAxesMask(axes: readonly PhysicsRotationAxis[]): number {
+    let mask = 0;
     for (const axis of axes) {
         if (axis === "x") {
             mask |= 1;
@@ -1194,17 +1241,11 @@ export function lockPhysicsBodyRotationAxes(world: PhysicsWorld, body: PhysicsBo
             throw new Error(`Unknown physics rotation axis "${String(axis)}".`);
         }
     }
-    const hknp = world._hknp;
-    const result = hknp.HP_Body_GetMassProperties(body._hkBody);
-    const ok = hknp.Result?.RESULT_OK ?? 0;
-    if (result[0] !== ok) {
-        throw new Error("Failed to read physics body mass properties.");
-    }
-    const massProperties = result[1];
-    applyBodyRotationLocks(massProperties, mask);
-    hknp.HP_Body_SetMassProperties(body._hkBody, massProperties);
-    body._rotationLockMask = mask;
-    body._massPropertiesTransform = (properties) => applyBodyRotationLocks(properties, mask);
+    return mask;
+}
+
+function cloneMassProperties(massProperties: any[]): any[] {
+    return [[...massProperties[0]], massProperties[1], [...massProperties[2]], [...massProperties[3]]];
 }
 
 function applyBodyRotationLocks(massProperties: any[], mask: number): void {
@@ -1235,12 +1276,39 @@ function applyBodyRotationLocks(massProperties: any[], mask: number): void {
         r20 = 2 * (xz - yw),
         r21 = 2 * (yz + xw),
         r22 = 1 - 2 * (xx + yy);
-    massProperties[2] = [
-        mask & 1 ? 0 : r00 * r00 * inertia[0] + r01 * r01 * inertia[1] + r02 * r02 * inertia[2],
-        mask & 2 ? 0 : r10 * r10 * inertia[0] + r11 * r11 * inertia[1] + r12 * r12 * inertia[2],
-        mask & 4 ? 0 : r20 * r20 * inertia[0] + r21 * r21 * inertia[1] + r22 * r22 * inertia[2],
-    ];
+    const ixx = r00 * r00 * inertia[0] + r01 * r01 * inertia[1] + r02 * r02 * inertia[2];
+    const iyy = r10 * r10 * inertia[0] + r11 * r11 * inertia[1] + r12 * r12 * inertia[2];
+    const izz = r20 * r20 * inertia[0] + r21 * r21 * inertia[1] + r22 * r22 * inertia[2];
+    if (mask === 1) {
+        setSingleAxisLockedInertia(massProperties, 0, iyy, izz, r10 * r20 * inertia[0] + r11 * r21 * inertia[1] + r12 * r22 * inertia[2]);
+        return;
+    }
+    if (mask === 2) {
+        setSingleAxisLockedInertia(massProperties, 1, ixx, izz, -(r00 * r20 * inertia[0] + r01 * r21 * inertia[1] + r02 * r22 * inertia[2]));
+        return;
+    }
+    if (mask === 4) {
+        setSingleAxisLockedInertia(massProperties, 2, ixx, iyy, r00 * r10 * inertia[0] + r01 * r11 * inertia[1] + r02 * r12 * inertia[2]);
+        return;
+    }
+    massProperties[2] = [mask & 1 ? 0 : ixx, mask & 2 ? 0 : iyy, mask & 4 ? 0 : izz];
     massProperties[3] = [0, 0, 0, 1];
+}
+
+function setSingleAxisLockedInertia(massProperties: any[], axis: number, a: number, b: number, coupling: number): void {
+    if (coupling === 0) {
+        massProperties[2] = axis === 0 ? [0, a, b] : axis === 1 ? [a, 0, b] : [a, b, 0];
+        massProperties[3] = [0, 0, 0, 1];
+        return;
+    }
+    const mean = (a + b) * 0.5;
+    const radius = Math.hypot((a - b) * 0.5, coupling);
+    const halfAngle = Math.atan2(2 * coupling, a - b) * 0.25;
+    const s = Math.sin(halfAngle);
+    const q = [0, 0, 0, Math.cos(halfAngle)];
+    q[axis] = s;
+    massProperties[2] = axis === 0 ? [0, mean + radius, mean - radius] : axis === 1 ? [mean + radius, 0, mean - radius] : [mean + radius, mean - radius, 0];
+    massProperties[3] = q;
 }
 
 /**

--- a/packages/babylon-lite/src/physics/havok.ts
+++ b/packages/babylon-lite/src/physics/havok.ts
@@ -128,7 +128,7 @@ export interface PhysicsMassProperties {
     inertiaOrientation?: Quat;
 }
 
-/** Principal body axis whose angular motion may be locked. */
+/** Body-local axis whose angular motion may be locked. */
 export type PhysicsRotationAxis = "x" | "y" | "z";
 
 /** Pivot/axis options used to create a physics constraint. */
@@ -159,6 +159,8 @@ export interface PhysicsBody {
     /** @internal */ readonly _hkBody: any;
     /** @internal */ readonly _world: PhysicsWorld;
     /** @internal */ _shape?: PhysicsShape | null;
+    /** @internal */ _rotationLockMask?: number;
+    /** @internal */ _massPropertiesTransform?: (massProperties: any[]) => void;
     /** @internal */ _preStep: boolean;
     /** @internal How a moved node is propagated to the body pre-step (TELEPORT by default). */
     _prestepType: PhysicsPrestepType;
@@ -1054,10 +1056,10 @@ export function setPhysicsShapeMaterial(world: PhysicsWorld, shape: PhysicsShape
 // ─── Mass ────────────────────────────────────────────────────────────
 
 /**
- * Sets a body's mass, preserving the shape-derived inertia tensor, centre of mass, and inertia
- * orientation (matching Babylon.js `HavokPlugin` — only the mass scalar is overridden). A body with
- * no shape attached yet has no inertia tensor to derive, so it falls back to an isotropic inertia
- * proportional to the mass until a shape is set.
+ * Sets a body's mass, preserving the shape-derived inertia tensor, centre of mass, inertia
+ * orientation, and active rotation-axis locks (matching Babylon.js `HavokPlugin` — only the mass
+ * scalar is overridden). A body with no shape attached yet has no inertia tensor to derive, so it
+ * falls back to an isotropic inertia proportional to the mass until a shape is set.
  * @param world - The physics world.
  * @param body - The body to update.
  * @param mass - Mass in kilograms.
@@ -1077,11 +1079,13 @@ export function setPhysicsBodyMass(world: PhysicsWorld, body: PhysicsBody, mass:
     if (centerOfMass) {
         massProps[0] = [centerOfMass.x, centerOfMass.y, centerOfMass.z];
     }
+    body._massPropertiesTransform?.(massProps);
     world._hknp.HP_Body_SetMassProperties(body._hkBody, massProps);
 }
 
 /**
- * Sets a body's mass properties, preserving Havok's shape-derived values for omitted fields.
+ * Sets a body's mass properties, preserving Havok's shape-derived values for omitted fields and
+ * reapplying active rotation-axis locks.
  * @param world - The physics world.
  * @param body - The body to update.
  * @param properties - Mass-property overrides.
@@ -1100,6 +1104,7 @@ export function setPhysicsBodyMassProperties(world: PhysicsWorld, body: PhysicsB
     if (properties.inertiaOrientation) {
         massProps[3] = [properties.inertiaOrientation.x, properties.inertiaOrientation.y, properties.inertiaOrientation.z, properties.inertiaOrientation.w];
     }
+    body._massPropertiesTransform?.(massProps);
     world._hknp.HP_Body_SetMassProperties(body._hkBody, massProps);
 }
 
@@ -1171,10 +1176,23 @@ export function setPhysicsBodyAngularVelocity(world: PhysicsWorld, body: Physics
 /**
  * Lock angular motion around selected body-local axes.
  * Havok represents a locked angular degree of freedom with zero inertia.
+ * Locks are cumulative and remain active when the body's mass properties are rebuilt.
  */
 export function lockPhysicsBodyRotationAxes(world: PhysicsWorld, body: PhysicsBody, axes: readonly PhysicsRotationAxis[]): void {
     if (axes.length === 0) {
         return;
+    }
+    let mask = body._rotationLockMask ?? 0;
+    for (const axis of axes) {
+        if (axis === "x") {
+            mask |= 1;
+        } else if (axis === "y") {
+            mask |= 2;
+        } else if (axis === "z") {
+            mask |= 4;
+        } else {
+            throw new Error(`Unknown physics rotation axis "${String(axis)}".`);
+        }
     }
     const hknp = world._hknp;
     const result = hknp.HP_Body_GetMassProperties(body._hkBody);
@@ -1183,21 +1201,46 @@ export function lockPhysicsBodyRotationAxes(world: PhysicsWorld, body: PhysicsBo
         throw new Error("Failed to read physics body mass properties.");
     }
     const massProperties = result[1];
-    const inertia = [...massProperties[2]];
-    for (const axis of axes) {
-        if (axis === "x") {
-            inertia[0] = 0;
-        } else if (axis === "y") {
-            inertia[1] = 0;
-        } else if (axis === "z") {
-            inertia[2] = 0;
-        } else {
-            throw new Error(`Unknown physics rotation axis "${String(axis)}".`);
-        }
-    }
-    massProperties[2] = inertia;
-    massProperties[3] = [0, 0, 0, 1];
+    applyBodyRotationLocks(massProperties, mask);
     hknp.HP_Body_SetMassProperties(body._hkBody, massProperties);
+    body._rotationLockMask = mask;
+    body._massPropertiesTransform = (properties) => applyBodyRotationLocks(properties, mask);
+}
+
+function applyBodyRotationLocks(massProperties: any[], mask: number): void {
+    if (mask === 0) {
+        return;
+    }
+    const inertia = massProperties[2];
+    const q = massProperties[3];
+    const x = q[0],
+        y = q[1],
+        z = q[2],
+        w = q[3];
+    const xx = x * x,
+        yy = y * y,
+        zz = z * z,
+        xy = x * y,
+        xz = x * z,
+        yz = y * z,
+        xw = x * w,
+        yw = y * w,
+        zw = z * w;
+    const r00 = 1 - 2 * (yy + zz),
+        r01 = 2 * (xy - zw),
+        r02 = 2 * (xz + yw),
+        r10 = 2 * (xy + zw),
+        r11 = 1 - 2 * (xx + zz),
+        r12 = 2 * (yz - xw),
+        r20 = 2 * (xz - yw),
+        r21 = 2 * (yz + xw),
+        r22 = 1 - 2 * (xx + yy);
+    massProperties[2] = [
+        mask & 1 ? 0 : r00 * r00 * inertia[0] + r01 * r01 * inertia[1] + r02 * r02 * inertia[2],
+        mask & 2 ? 0 : r10 * r10 * inertia[0] + r11 * r11 * inertia[1] + r12 * r12 * inertia[2],
+        mask & 4 ? 0 : r20 * r20 * inertia[0] + r21 * r21 * inertia[1] + r22 * r22 * inertia[2],
+    ];
+    massProperties[3] = [0, 0, 0, 1];
 }
 
 /**

--- a/tests/lite/build/public-api-types.test.ts
+++ b/tests/lite/build/public-api-types.test.ts
@@ -151,6 +151,7 @@ describe("build/index.d.ts", () => {
 
         expect(dts).toContain('type PhysicsRotationAxis = "x" | "y" | "z"');
         expect(dts).toMatch(/lockPhysicsBodyRotationAxes\(world: PhysicsWorld, body: PhysicsBody, axes: readonly PhysicsRotationAxis\[\]\): void/);
+        expect(dts).toMatch(/unlockPhysicsBodyRotationAxes\(world: PhysicsWorld, body: PhysicsBody, axes: readonly PhysicsRotationAxis\[\]\): void/);
     });
 
     it("rejects invalid emitter fields while preserving extended provider options", () => {

--- a/tests/lite/build/public-api-types.test.ts
+++ b/tests/lite/build/public-api-types.test.ts
@@ -146,6 +146,13 @@ describe("build/index.d.ts", () => {
         expect(dts).not.toContain("_localVariableLoopEpoch");
     });
 
+    it("exposes rigid-body rotation axis locks", () => {
+        const dts = readFileSync(DTS_PATH, "utf-8");
+
+        expect(dts).toContain('type PhysicsRotationAxis = "x" | "y" | "z"');
+        expect(dts).toMatch(/lockPhysicsBodyRotationAxes\(world: PhysicsWorld, body: PhysicsBody, axes: readonly PhysicsRotationAxis\[\]\): void/);
+    });
+
     it("rejects invalid emitter fields while preserving extended provider options", () => {
         const probePath = resolve(BUILD_DIR, "public-api-types.probe.ts");
         try {

--- a/tests/lite/unit/physics-rotation-axis-locks.test.ts
+++ b/tests/lite/unit/physics-rotation-axis-locks.test.ts
@@ -1,32 +1,56 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { lockPhysicsBodyRotationAxes, type PhysicsBody, type PhysicsWorld } from "../../../packages/babylon-lite/src/physics/havok";
+import {
+    lockPhysicsBodyRotationAxes,
+    setPhysicsBodyMass,
+    setPhysicsBodyMassProperties,
+    type PhysicsBody,
+    type PhysicsWorld,
+} from "../../../packages/babylon-lite/src/physics/havok";
 
-function makeWorld(getMassProperties: ReturnType<typeof vi.fn>) {
+function makeWorld(getMassProperties: ReturnType<typeof vi.fn>, shapeMassProperties?: unknown[]) {
     const setMassProperties = vi.fn();
     const world = {
         _hknp: {
             Result: { RESULT_OK: 7 },
             HP_Body_GetMassProperties: getMassProperties,
             HP_Body_SetMassProperties: setMassProperties,
+            HP_Body_GetShape: vi.fn(() => [7, "shape"]),
+            HP_Shape_BuildMassProperties: vi.fn(() => [7, shapeMassProperties?.map((value) => (Array.isArray(value) ? [...value] : value))]),
         },
     } as unknown as PhysicsWorld;
-    const body = { _hkBody: "body" } as unknown as PhysicsBody;
+    const body = { _hkBody: "body", _shape: shapeMassProperties ? ({} as never) : undefined } as unknown as PhysicsBody;
     return { world, body, setMassProperties };
 }
 
 describe("physics body rotation axis locks", () => {
-    it("zeros selected body-local inertia axes while preserving the other mass properties", () => {
+    it("converts a rotated principal inertia frame before locking body-local axes", () => {
         const sourceInertia = [4, 5, 6];
-        const massProperties = [[1, 2, 3], 12, sourceInertia, [0.1, 0.2, 0.3, 0.9]];
+        const massProperties = [[1, 2, 3], 12, sourceInertia, [0, 0, Math.sin(Math.PI / 8), Math.cos(Math.PI / 8)]];
         const getMassProperties = vi.fn(() => [7, massProperties]);
         const { world, body, setMassProperties } = makeWorld(getMassProperties);
 
-        lockPhysicsBodyRotationAxes(world, body, ["x", "z"]);
+        lockPhysicsBodyRotationAxes(world, body, ["x"]);
 
         expect(getMassProperties).toHaveBeenCalledWith("body");
-        expect(setMassProperties).toHaveBeenCalledWith("body", [[1, 2, 3], 12, [0, 5, 0], [0, 0, 0, 1]]);
+        expect(setMassProperties).toHaveBeenCalledWith("body", [[1, 2, 3], 12, [0, expect.closeTo(4.5), 6], [0, 0, 0, 1]]);
         expect(sourceInertia).toEqual([4, 5, 6]);
+    });
+
+    it("accumulates and reapplies active locks when mass properties are rebuilt", () => {
+        const orientation = [0, 0, Math.sin(Math.PI / 8), Math.cos(Math.PI / 8)];
+        const getMassProperties = vi.fn(() => [7, [[1, 2, 3], 12, [4, 8, 16], orientation]]);
+        const { world, body, setMassProperties } = makeWorld(getMassProperties, [[4, 5, 6], 9, [4, 8, 16], orientation]);
+
+        lockPhysicsBodyRotationAxes(world, body, ["x"]);
+        lockPhysicsBodyRotationAxes(world, body, ["z"]);
+        setMassProperties.mockClear();
+
+        setPhysicsBodyMass(world, body, 12);
+        expect(setMassProperties).toHaveBeenLastCalledWith("body", [[4, 5, 6], 12, [0, expect.closeTo(6), 0], [0, 0, 0, 1]]);
+
+        setPhysicsBodyMassProperties(world, body, { centerOfMass: { x: 7, y: 8, z: 9 } });
+        expect(setMassProperties).toHaveBeenLastCalledWith("body", [[7, 8, 9], 9, [0, expect.closeTo(6), 0], [0, 0, 0, 1]]);
     });
 
     it("does not query or update Havok when no axes are requested", () => {
@@ -52,6 +76,7 @@ describe("physics body rotation axis locks", () => {
         const { world, body, setMassProperties } = makeWorld(getMassProperties);
 
         expect(() => lockPhysicsBodyRotationAxes(world, body, ["w" as never])).toThrow('Unknown physics rotation axis "w".');
+        expect(getMassProperties).not.toHaveBeenCalled();
         expect(setMassProperties).not.toHaveBeenCalled();
     });
 });

--- a/tests/lite/unit/physics-rotation-axis-locks.test.ts
+++ b/tests/lite/unit/physics-rotation-axis-locks.test.ts
@@ -4,6 +4,7 @@ import {
     lockPhysicsBodyRotationAxes,
     setPhysicsBodyMass,
     setPhysicsBodyMassProperties,
+    unlockPhysicsBodyRotationAxes,
     type PhysicsBody,
     type PhysicsWorld,
 } from "../../../packages/babylon-lite/src/physics/havok";
@@ -23,6 +24,16 @@ function makeWorld(getMassProperties: ReturnType<typeof vi.fn>, shapeMassPropert
     return { world, body, setMassProperties };
 }
 
+function inertiaTensor(inertia: number[], q: number[]): number[][] {
+    const [x, y, z, w] = q;
+    const rotation = [
+        [1 - 2 * (y! * y! + z! * z!), 2 * (x! * y! - z! * w!), 2 * (x! * z! + y! * w!)],
+        [2 * (x! * y! + z! * w!), 1 - 2 * (x! * x! + z! * z!), 2 * (y! * z! - x! * w!)],
+        [2 * (x! * z! - y! * w!), 2 * (y! * z! + x! * w!), 1 - 2 * (x! * x! + y! * y!)],
+    ];
+    return rotation.map((row) => rotation.map((other) => row.reduce((sum, value, j) => sum + value * inertia[j]! * other[j]!, 0)));
+}
+
 describe("physics body rotation axis locks", () => {
     it("converts a rotated principal inertia frame before locking body-local axes", () => {
         const sourceInertia = [4, 5, 6];
@@ -35,6 +46,28 @@ describe("physics body rotation axis locks", () => {
         expect(getMassProperties).toHaveBeenCalledWith("body");
         expect(setMassProperties).toHaveBeenCalledWith("body", [[1, 2, 3], 12, [0, expect.closeTo(4.5), 6], [0, 0, 0, 1]]);
         expect(sourceInertia).toEqual([4, 5, 6]);
+    });
+
+    it.each([
+        ["x", 0, 1, 2],
+        ["y", 1, 0, 2],
+        ["z", 2, 0, 1],
+    ] as const)("preserves free-plane inertia coupling for a single %s-axis lock", (axis, lockedAxis, freeAxisA, freeAxisB) => {
+        const orientation = [0.2, 0.3, 0.1, Math.sqrt(0.86)];
+        const inertia = [4, 8, 16];
+        const getMassProperties = vi.fn(() => [7, [[0, 0, 0], 1, inertia, orientation]]);
+        const { world, body, setMassProperties } = makeWorld(getMassProperties);
+
+        lockPhysicsBodyRotationAxes(world, body, [axis]);
+
+        const locked = setMassProperties.mock.calls[0]![1];
+        const sourceTensor = inertiaTensor(inertia, orientation);
+        const lockedTensor = inertiaTensor(locked[2], locked[3]);
+        expect(lockedTensor[lockedAxis]).toEqual([expect.closeTo(0), expect.closeTo(0), expect.closeTo(0)]);
+        expect(lockedTensor[freeAxisA]![freeAxisA]).toBeCloseTo(sourceTensor[freeAxisA]![freeAxisA]!);
+        expect(lockedTensor[freeAxisA]![freeAxisB]).toBeCloseTo(sourceTensor[freeAxisA]![freeAxisB]!);
+        expect(lockedTensor[freeAxisB]![freeAxisA]).toBeCloseTo(sourceTensor[freeAxisB]![freeAxisA]!);
+        expect(lockedTensor[freeAxisB]![freeAxisB]).toBeCloseTo(sourceTensor[freeAxisB]![freeAxisB]!);
     });
 
     it("accumulates and reapplies active locks when mass properties are rebuilt", () => {
@@ -51,6 +84,14 @@ describe("physics body rotation axis locks", () => {
 
         setPhysicsBodyMassProperties(world, body, { centerOfMass: { x: 7, y: 8, z: 9 } });
         expect(setMassProperties).toHaveBeenLastCalledWith("body", [[7, 8, 9], 9, [0, expect.closeTo(6), 0], [0, 0, 0, 1]]);
+
+        unlockPhysicsBodyRotationAxes(world, body, ["x"]);
+        expect(body._rotationLockMask).toBe(4);
+
+        unlockPhysicsBodyRotationAxes(world, body, ["z"]);
+        expect(setMassProperties).toHaveBeenLastCalledWith("body", [[7, 8, 9], 9, [4, 8, 16], orientation]);
+        expect(body._rotationLockMask).toBeUndefined();
+        expect(body._massPropertiesTransform).toBeUndefined();
     });
 
     it("does not query or update Havok when no axes are requested", () => {
@@ -58,6 +99,16 @@ describe("physics body rotation axis locks", () => {
         const { world, body, setMassProperties } = makeWorld(getMassProperties);
 
         lockPhysicsBodyRotationAxes(world, body, []);
+
+        expect(getMassProperties).not.toHaveBeenCalled();
+        expect(setMassProperties).not.toHaveBeenCalled();
+    });
+
+    it("does not update Havok when unlocking an axis that is not locked", () => {
+        const getMassProperties = vi.fn();
+        const { world, body, setMassProperties } = makeWorld(getMassProperties);
+
+        unlockPhysicsBodyRotationAxes(world, body, ["x"]);
 
         expect(getMassProperties).not.toHaveBeenCalled();
         expect(setMassProperties).not.toHaveBeenCalled();

--- a/tests/lite/unit/physics-rotation-axis-locks.test.ts
+++ b/tests/lite/unit/physics-rotation-axis-locks.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { lockPhysicsBodyRotationAxes, type PhysicsBody, type PhysicsWorld } from "../../../packages/babylon-lite/src/physics/havok";
+
+function makeWorld(getMassProperties: ReturnType<typeof vi.fn>) {
+    const setMassProperties = vi.fn();
+    const world = {
+        _hknp: {
+            Result: { RESULT_OK: 7 },
+            HP_Body_GetMassProperties: getMassProperties,
+            HP_Body_SetMassProperties: setMassProperties,
+        },
+    } as unknown as PhysicsWorld;
+    const body = { _hkBody: "body" } as unknown as PhysicsBody;
+    return { world, body, setMassProperties };
+}
+
+describe("physics body rotation axis locks", () => {
+    it("zeros selected body-local inertia axes while preserving the other mass properties", () => {
+        const sourceInertia = [4, 5, 6];
+        const massProperties = [[1, 2, 3], 12, sourceInertia, [0.1, 0.2, 0.3, 0.9]];
+        const getMassProperties = vi.fn(() => [7, massProperties]);
+        const { world, body, setMassProperties } = makeWorld(getMassProperties);
+
+        lockPhysicsBodyRotationAxes(world, body, ["x", "z"]);
+
+        expect(getMassProperties).toHaveBeenCalledWith("body");
+        expect(setMassProperties).toHaveBeenCalledWith("body", [[1, 2, 3], 12, [0, 5, 0], [0, 0, 0, 1]]);
+        expect(sourceInertia).toEqual([4, 5, 6]);
+    });
+
+    it("does not query or update Havok when no axes are requested", () => {
+        const getMassProperties = vi.fn();
+        const { world, body, setMassProperties } = makeWorld(getMassProperties);
+
+        lockPhysicsBodyRotationAxes(world, body, []);
+
+        expect(getMassProperties).not.toHaveBeenCalled();
+        expect(setMassProperties).not.toHaveBeenCalled();
+    });
+
+    it("reports a failed Havok mass-properties read", () => {
+        const getMassProperties = vi.fn(() => [3, null]);
+        const { world, body, setMassProperties } = makeWorld(getMassProperties);
+
+        expect(() => lockPhysicsBodyRotationAxes(world, body, ["y"])).toThrow("Failed to read physics body mass properties.");
+        expect(setMassProperties).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown axis supplied by untyped JavaScript", () => {
+        const getMassProperties = vi.fn(() => [7, [[0, 0, 0], 1, [1, 2, 3], [0, 0, 0, 1]]]);
+        const { world, body, setMassProperties } = makeWorld(getMassProperties);
+
+        expect(() => lockPhysicsBodyRotationAxes(world, body, ["w" as never])).toThrow('Unknown physics rotation axis "w".');
+        expect(setMassProperties).not.toHaveBeenCalled();
+    });
+});

--- a/tests/lite/unit/physics-rotation-axis-locks.test.ts
+++ b/tests/lite/unit/physics-rotation-axis-locks.test.ts
@@ -104,6 +104,20 @@ describe("physics body rotation axis locks", () => {
         expect(setMassProperties).not.toHaveBeenCalled();
     });
 
+    it("does not query or update Havok when requested axes are already locked", () => {
+        const getMassProperties = vi.fn(() => [7, [[0, 0, 0], 1, [1, 2, 3], [0, 0, 0, 1]]]);
+        const { world, body, setMassProperties } = makeWorld(getMassProperties);
+
+        lockPhysicsBodyRotationAxes(world, body, ["x", "z"]);
+        getMassProperties.mockClear();
+        setMassProperties.mockClear();
+
+        lockPhysicsBodyRotationAxes(world, body, ["x"]);
+
+        expect(getMassProperties).not.toHaveBeenCalled();
+        expect(setMassProperties).not.toHaveBeenCalled();
+    });
+
     it("does not update Havok when unlocking an axis that is not locked", () => {
         const getMassProperties = vi.fn();
         const { world, body, setMassProperties } = makeWorld(getMassProperties);


### PR DESCRIPTION
## Summary

- add public helpers to lock and selectively unlock rigid-body rotation around body-local X, Y, and Z axes
- convert Havok principal-axis inertia into body space before applying locks, preserving exact free-plane coupling for single-axis locks
- retain the latest unlocked mass properties so active locks survive `setPhysicsBodyMass` and `setPhysicsBodyMassProperties`, while the final unlock fully removes the persistence seam
- document the mass-property lifecycle and expose the APIs through the root package entry

## Validation

- `tests/lite/unit/physics-rotation-axis-locks.test.ts`: 9 passed
- `tests/lite/build/public-api-types.test.ts`: 9 passed
- `pnpm lint`
- `pnpm build:lib`
- filtered Scene 40 bundle: 48.3 KB raw / 19.7 KB gzip, 177 B below ceiling