### PR TITLE
fix(ci): route pnpm installs through proxy feed

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,15 @@
 public-hoist-pattern[]=*playwright*
 
+; Registry is intentionally NOT set here. Leaving it unset defaults to
+; https://registry.npmjs.org/, which keeps `pnpm install` working for external
+; contributors who clone this public repo locally. The hosted CI agents cannot
+; reach npmjs.org directly and must use the internal `Apps_PublicPackages` proxy
+; feed, so the pipelines inject `registry=` into this file at build time and
+; authenticate to it — see `config/templates/ci-proxy-registry.yml`. pnpm >= 11
+; reads the registry ONLY from `.npmrc`, which is why the proxy feed is added
+; here (append-only, CI) rather than in `pnpm-workspace.yaml`. Do NOT commit an
+; internal `registry=` line: it would break local installs for contributors.
+
 ; Raise the V8 heap limit for every Node process npm/npx spawns. Node sizes its default old-space
 ; from physical RAM (~2 GB when the machine has <= 16 GB, ~4 GB above that), so the 7 GB hosted CI
 ; agents get ~2 GB. The playground's `vite build` (`pnpm build:playground`) peaks above that and

--- a/azure-pipelines-bundle-manifest.yml
+++ b/azure-pipelines-bundle-manifest.yml
@@ -173,6 +173,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 

--- a/azure-pipelines-demos.yml
+++ b/azure-pipelines-demos.yml
@@ -49,6 +49,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 

--- a/azure-pipelines-npm-publish-gl.yml
+++ b/azure-pipelines-npm-publish-gl.yml
@@ -69,6 +69,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 

--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -90,6 +90,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 

--- a/azure-pipelines-playground.yml
+++ b/azure-pipelines-playground.yml
@@ -69,6 +69,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 
@@ -89,6 +90,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 
@@ -128,6 +130,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 
@@ -217,6 +220,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 
@@ -333,6 +337,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 
@@ -464,6 +469,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 
@@ -540,6 +546,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 
@@ -612,6 +619,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 
@@ -696,6 +704,7 @@ stages:
                       corepack prepare pnpm@$(PNPM_VERSION) --activate
                   displayName: "Enable pnpm via corepack"
 
+                - template: config/templates/ci-proxy-registry.yml
                 - script: pnpm install --frozen-lockfile
                   displayName: "Install dependencies"
 

--- a/config/templates/ci-proxy-registry.yml
+++ b/config/templates/ci-proxy-registry.yml
@@ -1,0 +1,32 @@
+# Reusable step template: point pnpm/npm at the internal Azure Artifacts proxy feed
+# for the duration of a CI job, then authenticate to it.
+#
+# Why this exists:
+#   The committed `.npmrc` intentionally leaves `registry=` unset so it defaults to
+#   https://registry.npmjs.org/. That keeps `pnpm install` working for external
+#   contributors who clone https://github.com/BabylonJS/Babylon-Lite locally (see
+#   README/CONTRIBUTING). The hosted CI agents, however, cannot reach npmjs.org
+#   directly — they must go through the `Apps_PublicPackages` proxy feed. pnpm >= 11
+#   reads the registry ONLY from `.npmrc`, so we append it here (CI only) instead of
+#   committing it, then let `npmAuthenticate@0` inject a read token for the feed.
+#
+#   Reference the template immediately before every `pnpm install` step:
+#       - template: config/templates/ci-proxy-registry.yml
+#
+# Required: the job's checkout must have already run so the repo `.npmrc` exists.
+
+steps:
+    - script: |
+          set -euo pipefail
+          registry="https://pkgs.dev.azure.com/microsoft/Apps/_packaging/Apps_PublicPackages/npm/registry/"
+          # Idempotent: only add the proxy registry if one is not already configured,
+          # so a future committed `registry=` (or a re-run of this step) is respected.
+          if ! grep -qE '^registry=' .npmrc 2>/dev/null; then
+              printf '\nregistry=%s\n' "$registry" >> .npmrc
+          fi
+      displayName: "Point pnpm at Apps_PublicPackages proxy feed (CI only)"
+
+    - task: npmAuthenticate@0
+      displayName: "Authenticate to Apps_PublicPackages proxy feed"
+      inputs:
+          workingFile: .npmrc


### PR DESCRIPTION
## Summary

- route every CI `pnpm install` through the internal `Apps_PublicPackages` Azure Artifacts proxy
- authenticate the CI-only registry configuration with `npmAuthenticate@0`
- keep the committed `.npmrc` usable by external contributors who cannot access the internal feed

## Why

Build [156076233](https://microsoft.visualstudio.com/Apps/_build/results?buildId=156076233&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=26452410-bb74-52b8-246c-3b6de8b4706f) failed because pnpm attempted to connect directly to `registry.npmjs.org`. The v9 lockfile does not store tarball URLs, so pnpm derives them from the configured registry. With no `registry=` setting, pnpm uses npmjs.org by default.

The proxy registry is injected only in CI because this is a public repository and committing the internal Azure Artifacts URL would break local installs for external contributors.