### PR TITLE
fix(gizmo): keep rotation sector direction across faces

### DIFF
--- a/packages/babylon-lite/src/gizmo/rotation-sector-material.ts
+++ b/packages/babylon-lite/src/gizmo/rotation-sector-material.ts
@@ -19,19 +19,18 @@ const VERTEX_SOURCE = `struct VertexOutput{@builtin(position) position:vec4<f32>
 // Port of BJS rotation sector GLSL:
 //   uv = vUV - 0.5
 //   angle = atan2(uv.y, uv.x) + π
-//   delta = frontFacing ? angles.y : -angles.y
+//   delta = -angles.y
 //   begin = angles.x - delta * angles.z
 //   start = min(begin, begin + delta)
 //   end   = max(begin, begin + delta)
 //   ... wrap and accumulate intensity over 5 periods
 //   colour = vec4(rotationColor, min(intensity * 0.25, 0.8)) * (1 - step(0.5, len))
 const FRAGMENT_SOURCE = `struct VertexOutput{@builtin(position) position:vec4<f32>,@location(0) uv:vec2<f32>,};
-@fragment fn mainFragment(input:VertexOutput,@builtin(front_facing) frontFacing:bool)->@location(0) vec4<f32>{
+@fragment fn mainFragment(input:VertexOutput)->@location(0) vec4<f32>{
 let TWO_PI:f32=6.283185307;
 let uv:vec2<f32>=input.uv-vec2<f32>(0.5,0.5);
 var angle:f32=atan2(uv.y,uv.x)+3.141592;
-let yAngle:f32=shaderUniforms.angles.y;
-let delta:f32=select(-yAngle,yAngle,frontFacing);
+let delta:f32=-shaderUniforms.angles.y;
 let begin:f32=shaderUniforms.angles.x-delta*shaderUniforms.angles.z;
 var startA:f32=select(begin+delta,begin,begin<begin+delta);
 var endA:f32=select(begin+delta,begin,begin>begin+delta);

--- a/tests/lite/unit/rotation-sector-material.test.ts
+++ b/tests/lite/unit/rotation-sector-material.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { createRotationSectorMaterial } from "../../../packages/babylon-lite/src/gizmo/rotation-sector-material";
+
+describe("rotation sector material", () => {
+    it("keeps the drag-angle sign independent of which side of the ring is visible", () => {
+        const material = createRotationSectorMaterial([1, 1, 0]);
+
+        expect(material.fragmentSource).not.toContain("@builtin(front_facing)");
+        expect(material.fragmentSource).toContain("let delta:f32=-shaderUniforms.angles.y;");
+    });
+});


### PR DESCRIPTION
## Summary
- remove the redundant `front_facing` sign inversion from the rotation-sector shader
- preserve the sector sweep direction when viewing the same ring from either side
- add a focused regression test that pins the view-independent shader contract

## Reproduction
On the Z rotation ring, the same 48-degree counter-clockwise screen gesture produced a clockwise/mirrored sector from the negative-normal camera side, while object rotation remained correct. The opposite camera side rendered the sector correctly.

## Validation
- `corepack pnpm exec vitest run --project unit tests/lite/unit/rotation-sector-material.test.ts`
- targeted ESLint for the changed source and test
- TypeScript checks for the package and Lite tests

Fixes #636
