### PR TITLE
fix: refresh auxiliary surface swapchain views

### DIFF
--- a/docs/lite/architecture/22-engine.md
+++ b/docs/lite/architecture/22-engine.md
@@ -171,11 +171,15 @@ Scenes read `engine._currentDelta` during their `_update()` step. If `scene.fixe
 Each frame consists of:
 
 1. **Create command encoder**: `device.createCommandEncoder({ label: "frame" })` and assign `engine._currentEncoder`.
-2. **Obtain swapchain view**: `engine.context.getCurrentTexture().createView()` and assign `engine._swapchainView`.
-3. **Update/record contexts**: For each registered `RenderingContext`, call `_update()` then `_record()`.
+2. **Prepare each surface**: run its optional screenshot pre-frame hook, then acquire the surface's current swapchain texture into `surface.scRT`.
+3. **Update/record contexts**: For each surface, call `_update()` then `_record()` on every registered `RenderingContext`.
     - A scene `_update()` runs before-render callbacks, material swaps, shadow maps, legacy pre-passes, and shared uniform updaters.
     - A scene `_record()` delegates to `scene._frameGraph.execute()`.
-4. **Submit**: finish the command encoder and submit via the reusable `engine._cbs` array to avoid per-frame array allocation.
+    - A render task that targets `scene.surface.scRT` re-reads that surface's attachment view immediately before opening the pass. It must not compare against `engine.scRT`, which identifies only the primary canvas and would leave auxiliary scenes submitting an expired build-time swapchain view.
+4. **Record screenshot copies**: each promoted surface with queued requests copies its just-rendered swapchain texture into one staging buffer.
+5. **Submit**: finish the command encoder and submit via the reusable `engine._cbs` array to avoid per-frame array allocation.
+
+The per-surface attachment refresh is required because `GPUCanvasContext.getCurrentTexture()` returns a new swapchain texture over time. Reusing the auxiliary surface's view captured during frame-graph build produces a WebGPU validation error; because one command buffer contains every surface's work, that invalid auxiliary pass also discards the primary canvas's rendering.
 
 ### Deferred Builder Execution
 

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -435,10 +435,8 @@ function buildRenderPassDescriptor(task: RenderTask, rt: RenderTarget): void {
     const att = task._colorAttachment;
     att.view = rt._colorView!;
     // End-of-pass MSAA resolve into a caller-supplied single-sample target.
-    // record() only builds the target's color view for an MSAA rt, so its
-    // presence is the gate. The swapchain case is wired per-frame in
-    // executePass (its view changes each frame); this custom view is stable.
-    att.resolveTarget = config.rst?._colorView ?? undefined;
+    // executePass wires the resolve target immediately before every pass so
+    // swapchain targets pick up their current per-frame view.
     task._renderPassDescriptor.colorAttachments = rt._colorView ? [att] : [];
 
     const depthSrc = config.depth ?? rt;

--- a/packages/babylon-lite/src/frame-graph/render-task.ts
+++ b/packages/babylon-lite/src/frame-graph/render-task.ts
@@ -515,12 +515,13 @@ function executePass(task: RenderTask, eng: EngineContext, targetSignature: Rend
     const att = task._colorAttachment;
     const cfg = task._config;
     if (cfg.rt._colorView) {
-        // The engine scRT's color view is re-acquired every frame, so re-read
-        // it here. Offscreen color views are stable between rebuilds — leaving att.view
-        // untouched preserves an external override (swapchain-overlay shares the base
-        // scene's MSAA color view). The resolve target (rst) is re-read each frame so an
-        // `rst === scRT` picks up its fresh per-frame view.
-        if (cfg.rt === eng.scRT) {
+        // This scene's surface scRT color view is re-acquired every frame, so re-read it
+        // here. Checking the bound surface (not the engine's primary scRT) is required for
+        // auxiliary createSurface scenes. Offscreen color views are stable between rebuilds
+        // — leaving att.view untouched preserves an external override (swapchain-overlay
+        // shares the base scene's MSAA color view). The resolve target (rst) is re-read each
+        // frame so an `rst === scRT` picks up its fresh per-frame view.
+        if (cfg.rt === sc.surface.scRT) {
             att.view = cfg.rt._colorView;
         }
         att.resolveTarget = cfg.rst?._colorView ?? undefined;

--- a/tests/lite/unit/render-pass-task.test.ts
+++ b/tests/lite/unit/render-pass-task.test.ts
@@ -985,7 +985,7 @@ describe("RenderPassTask transparent sorting", () => {
 });
 
 describe("RenderTask MSAA resolveTarget", () => {
-    it("wires a single-sample resolveTarget as the color attachment's end-of-pass resolve when the RT is MSAA", () => {
+    it("wires a single-sample resolveTarget at execution when the RT is MSAA", () => {
         const engine = makeMockEngine({ msaaSamples: 4 });
         const scene = createSceneContext(engine, { defaultRenderTask: false }) as SceneContext;
         scene.camera = makeCamera();
@@ -1006,6 +1006,7 @@ describe("RenderTask MSAA resolveTarget", () => {
 
         const task = createRenderTask({ name: "msaa-scene", rt: msaaRt, rst: resolveTarget }, engine, scene);
         task.record();
+        task.execute!();
 
         // The resolve target's color view must be allocated and used as the
         // attachment's resolveTarget so WebGPU resolves the 4x MSAA in-pass.

--- a/tests/lite/unit/render-pass-task.test.ts
+++ b/tests/lite/unit/render-pass-task.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 
 import type { Camera } from "../../../packages/babylon-lite/src/camera/camera";
 import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import type { SurfaceContext } from "../../../packages/babylon-lite/src/engine/surface";
 import type { Material } from "../../../packages/babylon-lite/src/material/material";
 import type { Mat4 } from "../../../packages/babylon-lite/src/math/types";
 import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
@@ -740,6 +741,45 @@ describe("RenderPassTask transparent sorting", () => {
         expect(colorAttachments[0]).toBeTruthy();
         expect(colorAttachments[0]!.view).toBe(engine.scRT._colorView);
         expect(colorAttachments[0]!.resolveTarget).toBeUndefined();
+    });
+
+    it("refreshes the default task from an auxiliary surface scRT every frame", async () => {
+        const seenDescriptors: GPURenderPassDescriptor[] = [];
+        const engine = makeMockEngine({
+            msaaSamples: 1,
+            onBeginPass: (descriptor) => {
+                seenDescriptors.push(descriptor);
+            },
+        });
+        const initialView = {} as GPUTextureView;
+        const currentView = {} as GPUTextureView;
+        const surface = {
+            engine,
+            canvas: { width: 320, height: 240 },
+            msaaSamples: 1,
+            format: engine.format,
+            scRT: {
+                _colorTexture: {},
+                _colorView: initialView,
+                _depthTexture: null,
+                _depthView: null,
+                _descriptor: { format: engine.format, samples: 1, size: { width: 320, height: 240 } },
+                _width: 320,
+                _height: 240,
+                _eager: true,
+            } as unknown as RenderTarget,
+            _renderingContexts: [],
+        } as unknown as SurfaceContext;
+        const scene = createSceneContext(surface);
+        await registerScene(scene);
+        surface.scRT._colorView = currentView;
+
+        scene._record();
+
+        const swapDescriptor = seenDescriptors[seenDescriptors.length - 1]!;
+        const colorAttachments = swapDescriptor.colorAttachments as readonly GPURenderPassColorAttachment[];
+        expect(colorAttachments[0]!.view).toBe(currentView);
+        expect(colorAttachments[0]!.view).not.toBe(engine.scRT._colorView);
     });
 
     it("binds an external depthTexture in place of the color RT's own depth view", async () => {


### PR DESCRIPTION
## Summary

- refresh each render task's swapchain attachment from its scene-bound surface
- prevent an expired auxiliary-surface view from invalidating the shared WebGPU command buffer
- add regression coverage and document the per-surface swapchain lifecycle

## Context

Addresses the auxiliary fixed-resolution screenshot failure reported at https://forum.babylonjs.com/t/lite-screenshot-grab-framebuffer/63997.

## Validation

- reproduced the forum workflow with primary and auxiliary surfaces
- captured the expected pixels from both surfaces without WebGPU validation warnings
- automated test suites were not run locally