### PR TITLE
fix(loader): validate packed PLY chunk metadata

### DIFF
--- a/packages/babylon-lite/src/loader-splat/splat-ply-compressed.ts
+++ b/packages/babylon-lite/src/loader-splat/splat-ply-compressed.ts
@@ -311,6 +311,10 @@ export function convertCompressedPlyToParsedSplat(data: ArrayBuffer): ParsedSpla
     }
 
     const isCompressed = header.chunkCount > 0;
+    const needsChunk = header.vertexProps.some((prop) => prop.name === "packed_position" || prop.name === "packed_scale" || prop.name === "packed_color");
+    if (needsChunk && header.chunkCount < Math.ceil(header.vertexCount / 256)) {
+        throw new Error("Invalid compressed PLY: packed vertex properties require chunk metadata for every vertex");
+    }
     const dv = new DV(data, header.dataStart);
     const out = new ArrayBuffer(ROW_OUTPUT_LENGTH * header.vertexCount);
 

--- a/tests/lite/unit/splat-ply-parser.test.ts
+++ b/tests/lite/unit/splat-ply-parser.test.ts
@@ -31,6 +31,15 @@ function makePositionPly(newline: "\n" | "\r\n", compressed = false): ArrayBuffe
     return combine(header, body);
 }
 
+type PackedProperty = "packed_position" | "packed_rotation" | "packed_scale" | "packed_color";
+
+function makePackedPly(vertexCount: number, chunkCount: number, property: PackedProperty): ArrayBuffer {
+    const header = ["ply", "format binary_little_endian 1.0", `element chunk ${chunkCount}`, `element vertex ${vertexCount}`, `property uint ${property}`, "end_header", ""].join(
+        "\n"
+    );
+    return combine(header, new Uint8Array(vertexCount * 4));
+}
+
 describe("PLY parser", () => {
     it.each(["\n", "\r\n"] as const)("parses standard PLY headers using %j line endings", (newline) => {
         const data = makePositionPly(newline);
@@ -58,5 +67,21 @@ describe("PLY parser", () => {
         const data = combine("ply\nformat binary_little_endian 1.0\nend_header\n", body);
 
         expect(convertCompressedPlyToParsedSplat(data).data).toBe(data);
+    });
+
+    it.each(["packed_position", "packed_scale", "packed_color"] as const)("rejects %s without chunk metadata", (property) => {
+        expect(() => convertCompressedPlyToParsedSplat(makePackedPly(1, 0, property))).toThrow("packed vertex properties require chunk metadata");
+    });
+
+    it("rejects packed vertices when the final chunk metadata is missing", () => {
+        expect(() => convertCompressedPlyToParsedSplat(makePackedPly(257, 1, "packed_position"))).toThrow("packed vertex properties require chunk metadata");
+    });
+
+    it("allows packed rotation without chunk metadata", () => {
+        expect(convertCompressedPlyToParsedSplat(makePackedPly(1, 0, "packed_rotation")).data.byteLength).toBe(32);
+    });
+
+    it("allows packed vertices with chunk metadata for every 256 vertices", () => {
+        expect(convertCompressedPlyToParsedSplat(makePackedPly(257, 2, "packed_position")).data.byteLength).toBe(257 * 32);
     });
 });


### PR DESCRIPTION
## Summary
- reject packed PLY properties that depend on chunk ranges when metadata does not cover every vertex
- validate the format's one-chunk-per-256-vertices invariant before decoding
- keep chunk-independent packed rotation valid without chunk metadata
- cover missing, incomplete, sufficient, and property-specific metadata cases

## Validation
- on untouched `master`, zero chunk metadata crashes with a null `minX` dereference and a missing final chunk crashes with an undefined `minX` dereference
- the compressed PLY writer defines `CHUNK_SIZE = 256`, emits `Math.ceil(numSplats / CHUNK_SIZE)` chunk records, and Lite indexes them with `chunks[vertexIndex >> 8]`
- `REUSE_BROWSER=1 corepack pnpm exec vitest run --project unit tests/lite/unit/splat-ply-parser.test.ts` — 11 passed
- `corepack pnpm run lint`
- `REUSE_BROWSER=1 corepack pnpm build:lib`
- filtered Scene 124 compressed-PLY bundle build and live measurement passed its unchanged ceiling