### PR TITLE
fix(ci): import npm publish token group

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -315,6 +315,10 @@ Five parallel jobs:
 
 ### Required Pipeline Variable Groups
 
+The npm publish pipelines use `NPM_Publish` for the npm authentication secret:
+
+- `NPM_TOKEN`
+
 Azure Pipelines uses `BabylonJS-BrowserStack` for shared BrowserStack
 credentials:
 

--- a/azure-pipelines-npm-publish-gl.yml
+++ b/azure-pipelines-npm-publish-gl.yml
@@ -124,7 +124,7 @@ stages:
                       set -euo pipefail
 
                       if [ -z "${NPM_TOKEN:-}" ]; then
-                        echo "NPM_TOKEN must be configured as a secret pipeline variable."
+                        echo "NPM_TOKEN must be configured as a secret in the NPM_Publish variable group."
                         exit 1
                       fi
 

--- a/azure-pipelines-npm-publish-gl.yml
+++ b/azure-pipelines-npm-publish-gl.yml
@@ -1,7 +1,7 @@
 # Azure Pipelines — Babylon Lite GL npm Publish
 #
-# Publishes the built @babylonjs/lite-gl package to npm. Configure NPM_TOKEN as
-# a secret pipeline variable or variable-group value before enabling this run.
+# Publishes the built @babylonjs/lite-gl package to npm. NPM_TOKEN is provided
+# by the NPM_Publish variable group.
 #
 # Manual runs can choose patch, minor, major, or auto. Scheduled runs use auto.
 # Pushes to master that change config/release-gl.json read the release type from
@@ -37,6 +37,7 @@ parameters:
           - major
 
 variables:
+    - group: NPM_Publish
     - name: NODE_VERSION
       value: "22.x"
     - name: PNPM_VERSION

--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -1,7 +1,7 @@
 # Azure Pipelines — Babylon Lite npm Publish
 #
-# Publishes the built @babylonjs/lite package to npm. Configure NPM_TOKEN as
-# a secret pipeline variable or variable-group value before enabling this run.
+# Publishes the built @babylonjs/lite package to npm. NPM_TOKEN is provided by
+# the NPM_Publish variable group.
 #
 # Manual runs can choose patch, minor, major, or auto. Scheduled runs use auto.
 # Pushes to master that change config/release.json read the release type from
@@ -51,6 +51,7 @@ parameters:
       default: false
 
 variables:
+    - group: NPM_Publish
     - group: BabylonJS-Deployment
     # Provides TOOLS_STORAGE_ACCOUNT — the tools storage account backing
     # liteplayground.babylonjs.com, so versioned playground snapshots serve

--- a/azure-pipelines-npm-publish.yml
+++ b/azure-pipelines-npm-publish.yml
@@ -149,7 +149,7 @@ stages:
                       set -euo pipefail
 
                       if [ -z "${NPM_TOKEN:-}" ]; then
-                        echo "NPM_TOKEN must be configured as a secret pipeline variable."
+                        echo "NPM_TOKEN must be configured as a secret in the NPM_Publish variable group."
                         exit 1
                       fi
 
@@ -231,7 +231,7 @@ stages:
                       set -euo pipefail
 
                       if [ -z "${NPM_TOKEN:-}" ]; then
-                        echo "NPM_TOKEN must be configured as a secret pipeline variable."
+                        echo "NPM_TOKEN must be configured as a secret in the NPM_Publish variable group."
                         exit 1
                       fi
 

--- a/tests/lite/unit/pipeline-variable-groups-documented.test.ts
+++ b/tests/lite/unit/pipeline-variable-groups-documented.test.ts
@@ -117,7 +117,7 @@ describe("pipeline variable groups are documented", () => {
     // a new pipeline, which is how the original defect would recur inverted.
     it("does not list groups no azure-pipelines file imports", () => {
         const declared = declaredGroups();
-        const stale = [...documentedSection().matchAll(/`(BabylonJS-[A-Za-z0-9-]+)`/g)]
+        const stale = [...documentedSection().matchAll(/`(BabylonJS-[A-Za-z0-9-]+|NPM_Publish)`/g)]
             .map((m) => m[1])
             .filter((group): group is string => group !== undefined)
             .filter((group, index, all) => all.indexOf(group) === index)


### PR DESCRIPTION
## Summary
- import the `NPM_Publish` variable group in the Lite and Lite-GL npm publish pipelines
- document that the group supplies `NPM_TOKEN`
- include `NPM_Publish` in the stale variable-group documentation guard

## Validation
- `REUSE_BROWSER=1 pnpm exec vitest run tests/lite/unit/pipeline-variable-groups-documented.test.ts`
- `pnpm run lint`