### PR TITLE
chore: Add GHCP model allowlist

### DIFF
--- a/.github/allowed_models.txt
+++ b/.github/allowed_models.txt
@@ -1,0 +1,6 @@
+gpt-*
+gemini-*
+mai-code-*
+grok-*
+
+fallback: gpt-5.6-sol


### PR DESCRIPTION
GitHub Copilot supports a repo-level `.github/allowed_models.txt` file that controls which built-in models can be used. Both the CLI and desktop app respect the file.

See: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference#repository-level-models-allowlist-githuballowed_modelstxt