### PR TITLE
fix(text): wrap Slug band references across texture rows

### DIFF
--- a/packages/babylon-lite/src/text/shaders/slug.frag.wgsl
+++ b/packages/babylon-lite/src/text/shaders/slug.frag.wgsl
@@ -106,7 +106,7 @@ fn main(in: FIn) -> @location(0) vec4<f32> {
   let hbandOffset = i32(hbandRaw.y + 0.5);
   let hbandLoc = calcBandLoc(glyphLoc, hbandOffset);
   for (var ci: i32 = 0; ci < hbandCount; ci = ci + 1) {
-    let locRaw = textureLoad(bandTex, vec2<i32>(hbandLoc.x + ci, hbandLoc.y), 0);
+    let locRaw = textureLoad(bandTex, calcBandLoc(hbandLoc, ci), 0);
     let curveLoc = vec2<i32>(i32(locRaw.x + 0.5), i32(locRaw.y + 0.5));
     let p12 = textureLoad(curveTex, curveLoc, 0) - vec4<f32>(renderCoord, renderCoord);
     let p3 = textureLoad(curveTex, vec2<i32>(curveLoc.x + 1, curveLoc.y), 0).xy - renderCoord;
@@ -132,7 +132,7 @@ fn main(in: FIn) -> @location(0) vec4<f32> {
   let vbandOffset = i32(vbandRaw.y + 0.5);
   let vbandLoc = calcBandLoc(glyphLoc, vbandOffset);
   for (var ci: i32 = 0; ci < vbandCount; ci = ci + 1) {
-    let locRaw = textureLoad(bandTex, vec2<i32>(vbandLoc.x + ci, vbandLoc.y), 0);
+    let locRaw = textureLoad(bandTex, calcBandLoc(vbandLoc, ci), 0);
     let curveLoc = vec2<i32>(i32(locRaw.x + 0.5), i32(locRaw.y + 0.5));
     let p12 = textureLoad(curveTex, curveLoc, 0) - vec4<f32>(renderCoord, renderCoord);
     let p3 = textureLoad(curveTex, vec2<i32>(curveLoc.x + 1, curveLoc.y), 0).xy - renderCoord;

--- a/tests/lite/unit/text-band-row-wrap.test.ts
+++ b/tests/lite/unit/text-band-row-wrap.test.ts
@@ -29,7 +29,8 @@ describe("Slug band-reference row wrapping", () => {
         const bandRef = (texel: number) => Array.from(atlas._bandTexData.subarray(texel * 4, texel * 4 + 2));
         expect(bandRef(TEX_WIDTH - 1)).toEqual([0, 0]);
         expect(bandRef(TEX_WIDTH)).toEqual([2, 0]);
-        expect(slugFragment).toContain("textureLoad(bandTex, calcBandLoc(hbandLoc, ci), 0)");
-        expect(slugFragment).toContain("textureLoad(bandTex, calcBandLoc(vbandLoc, ci), 0)");
+        const normalizedSlugFragment = slugFragment.replace(/\s+/g, " ");
+        expect(normalizedSlugFragment).toContain("textureLoad(bandTex, calcBandLoc(hbandLoc, ci), 0)");
+        expect(normalizedSlugFragment).toContain("textureLoad(bandTex, calcBandLoc(vbandLoc, ci), 0)");
     });
 });

--- a/tests/lite/unit/text-band-row-wrap.test.ts
+++ b/tests/lite/unit/text-band-row-wrap.test.ts
@@ -29,8 +29,8 @@ describe("Slug band-reference row wrapping", () => {
         const bandRef = (texel: number) => Array.from(atlas._bandTexData.subarray(texel * 4, texel * 4 + 2));
         expect(bandRef(TEX_WIDTH - 1)).toEqual([0, 0]);
         expect(bandRef(TEX_WIDTH)).toEqual([2, 0]);
-        const normalizedSlugFragment = slugFragment.replace(/\s+/g, " ");
-        expect(normalizedSlugFragment).toContain("textureLoad(bandTex, calcBandLoc(hbandLoc, ci), 0)");
-        expect(normalizedSlugFragment).toContain("textureLoad(bandTex, calcBandLoc(vbandLoc, ci), 0)");
+        const normalizedSlugFragment = slugFragment.replace(/\s+/g, "");
+        expect(normalizedSlugFragment).toContain("textureLoad(bandTex,calcBandLoc(hbandLoc,ci),0)");
+        expect(normalizedSlugFragment).toContain("textureLoad(bandTex,calcBandLoc(vbandLoc,ci),0)");
     });
 });

--- a/tests/lite/unit/text-band-row-wrap.test.ts
+++ b/tests/lite/unit/text-band-row-wrap.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import type { GlyphCurves } from "../../../packages/babylon-lite/src/text/glyph-storage";
+import { createSharedAtlas, packAppendGlyph, TEX_WIDTH } from "../../../packages/babylon-lite/src/text/glyph-storage";
+import slugFragment from "../../../packages/babylon-lite/src/text/shaders/slug.frag.wgsl?raw";
+
+describe("Slug band-reference row wrapping", () => {
+    it("wraps every horizontal and vertical band-reference read to the next texture row", () => {
+        const glyph: GlyphCurves = {
+            glyphId: 1,
+            curves: [
+                { p0x: 0, p0y: 0, p1x: 1, p1y: 1, p2x: 2, p2y: 0 },
+                { p0x: 2, p0y: 0, p1x: 3, p1y: 1, p2x: 4, p2y: 0 },
+                { p0x: 4, p0y: 0, p1x: 5, p1y: 1, p2x: 6, p2y: 0 },
+            ],
+            bounds: { xMin: 0, yMin: 0, xMax: 6, yMax: 1 },
+            _bands: {
+                _hBands: [{ _curveIndices: [0, 1] }],
+                _vBands: [{ _curveIndices: [2] }],
+                _hBandCount: 1,
+                _vBandCount: 1,
+            },
+        };
+        const atlas = createSharedAtlas();
+        atlas._bandTexelsUsed = TEX_WIDTH - 3;
+
+        packAppendGlyph(atlas, glyph);
+
+        const bandRef = (texel: number) => Array.from(atlas._bandTexData.subarray(texel * 4, texel * 4 + 2));
+        expect(bandRef(TEX_WIDTH - 1)).toEqual([0, 0]);
+        expect(bandRef(TEX_WIDTH)).toEqual([2, 0]);
+        expect(slugFragment).toContain("textureLoad(bandTex, calcBandLoc(hbandLoc, ci), 0)");
+        expect(slugFragment).toContain("textureLoad(bandTex, calcBandLoc(vbandLoc, ci), 0)");
+    });
+});


### PR DESCRIPTION
## Summary

- Fix row-boundary addressing for horizontal and vertical curve-reference reads in the base Slug fragment shader.
- Add a focused regression that forces a packed band-reference list to cross texels 4095 -> 4096.

## Root cause

`glyph-storage.ts` packs each band's curve-reference list linearly in a 4096-texel-wide texture. Although `calcBandLoc` wrapped the list's starting address, the horizontal and vertical loops advanced only the x coordinate for each subsequent entry. A list crossing x=4095 therefore failed to continue at x=0 on the next row, which could omit a curve reference from one winding axis and create a visible seam.

## Fix

In `packages/babylon-lite/src/text/shaders/slug.frag.wgsl`, both per-entry reads now use `calcBandLoc(..., ci)` so x overflow advances to the next texture row.

## Before fix

![Lowercase Calibri t showing a seam caused by the Slug band-reference row-boundary bug](https://github.com/user-attachments/assets/2b8557e4-aba8-4dcc-8776-b4f21fb8df2e)

*Lowercase Calibri `t` showing the visible seam caused by the row-boundary addressing bug.*

## Test plan

- Focused row-wrap regression: constructs packed band data spanning texels 4095 -> 4096 and verifies both base shader reads use wrapped coordinates.
- Focused text unit suites: 7 files passed.
- Full lint and TypeScript checks passed.
- Filtered bundle validation passed for scenes 180, 181, and 275 (28.2 KB, 44.6 KB, and 39.2 KB raw; all below ceilings).

## Commits

- `c1b3db3d0` — regression coverage for Slug band row wrapping.
- `35c21992a` — base fragment shader fix.