### PR TITLE
fix(ci): initialize bundle asset cache

### DIFF
--- a/azure-pipelines-bundle-manifest.yml
+++ b/azure-pipelines-bundle-manifest.yml
@@ -183,6 +183,9 @@ stages:
                 # never hits (so newly fetched assets are always saved at job end)
                 # while restoreKeys restores the most recent prefix match.
                 # Measurement re-fetches on a miss, so a cold cache is only slower.
+                - script: mkdir -p "$(System.DefaultWorkingDirectory)/.bundle-asset-cache"
+                  displayName: "Initialize remote scene asset cache"
+
                 - task: Cache@2
                   displayName: "Cache remote scene assets"
                   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,6 +237,9 @@ stages:
                 # accumulates new assets instead of freezing. Measurement still
                 # fetches-with-retry on a miss, so a cold/expired cache is only slower,
                 # never incorrect.
+                - script: mkdir -p "$(System.DefaultWorkingDirectory)/.bundle-asset-cache"
+                  displayName: "Initialize remote scene asset cache"
+
                 - task: Cache@2
                   displayName: "Cache remote scene assets"
                   condition: eq(variables['RUN_BUNDLE_TESTS'], 'true')

--- a/tests/lite/unit/pipeline-asset-cache-path.test.ts
+++ b/tests/lite/unit/pipeline-asset-cache-path.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(__dirname, "..", "..", "..");
+const pipelineFiles = ["azure-pipelines.yml", "azure-pipelines-bundle-manifest.yml"];
+const cachePath = "$(System.DefaultWorkingDirectory)/.bundle-asset-cache";
+
+function uniqueLine(lines: string[], value: string, label: string): number {
+    const matches = lines.flatMap((line, index) => (line.trim() === value ? [index] : []));
+    expect(matches, label).toHaveLength(1);
+    return matches[0] ?? -1;
+}
+
+function nextStep(lines: string[], after: number): number {
+    return lines.findIndex((line, index) => index > after && /^\s*-\s+\S/.test(line));
+}
+
+function previousLine(lines: string[], before: number, value: string): number {
+    for (let index = before - 1; index >= 0; index--) {
+        if (lines[index]?.trim() === value) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+describe("remote scene asset cache pipelines", () => {
+    it.each(pipelineFiles)("%s creates the cache directory before Cache@2 registers its post-job save", (pipelineFile) => {
+        const lines = readFileSync(join(repoRoot, pipelineFile), "utf8").split(/\r?\n/);
+        const initScript = uniqueLine(lines, `- script: mkdir -p "${cachePath}"`, `${pipelineFile} must initialize the cache path exactly once`);
+        const initDisplayName = uniqueLine(lines, 'displayName: "Initialize remote scene asset cache"', `${pipelineFile} must identify the cache initialization step exactly once`);
+        const cacheDisplayName = uniqueLine(lines, 'displayName: "Cache remote scene assets"', `${pipelineFile} must declare one remote scene cache`);
+        const cacheTask = previousLine(lines, cacheDisplayName, "- task: Cache@2");
+        const cachePathInput = uniqueLine(lines, `path: ${cachePath}`, `${pipelineFile} must cache the initialized path`);
+
+        expect(initDisplayName).toBeGreaterThan(initScript);
+        expect(lines.slice(initScript, cacheTask).some((line) => /^\s*condition\s*:/.test(line))).toBe(false);
+        expect(nextStep(lines, initScript)).toBe(cacheTask);
+        expect(cacheTask).toBeGreaterThan(initDisplayName);
+        expect(cachePathInput).toBeGreaterThan(cacheDisplayName);
+    });
+});


### PR DESCRIPTION
## Summary
- create `.bundle-asset-cache` before Azure `Cache@2` registers its post-job save
- apply the initialization in both pull-request and bundle-manifest pipelines
- add focused regression coverage that keeps the initialized and cached paths aligned

## Why
On a cold cache, the measurement step may not create `.bundle-asset-cache`. Azure's `Cache@2` post-job save then fails because the configured path does not exist. Initializing the directory makes cold and expired caches slower but successful, while preserving the existing fetch-on-miss behavior.

## Validation
- `pnpm exec prettier --check azure-pipelines.yml azure-pipelines-bundle-manifest.yml tests/lite/unit/pipeline-asset-cache-path.test.ts`
- `pnpm exec vitest run tests/lite/unit/pipeline-asset-cache-path.test.ts`
- `pnpm run lint`
- `git diff --check`

Unblocks #667