### PR TITLE
fix(build): playground build errors on windows

### DIFF
--- a/playground/scripts/build-engine-types.ts
+++ b/playground/scripts/build-engine-types.ts
@@ -51,7 +51,7 @@ if (isUpToDate()) {
 
 if (!existsSync(generatedDts) || statSync(generatedDts).mtimeMs < newestMtime(engineSrcDir)) {
     console.log("[engine-types] generating rolled-up d.ts via babylon-lite build:dist (~10s)…");
-    execFileSync("pnpm", ["--filter", "babylon-lite", "build:dist"], { cwd: repoRoot, stdio: "inherit" });
+    execFileSync("pnpm", ["--filter", "babylon-lite", "build:dist"], { cwd: repoRoot, stdio: "inherit", shell: process.platform === "win32" });
 }
 
 mkdirSync(outDir, { recursive: true });


### PR DESCRIPTION
Running `pnpm dev:playground` was unable to spawn pnpm on windows:

```
$ tsx scripts/build-engine-types.ts
[engine-types] generating rolled-up d.ts via babylon-lite build:dist (~10s)…
node:internal/child_process:1160
    result.error = new ErrnoException(result.error, 'spawnSync ' + options.file);
                   ^

<ref *1> Error: spawnSync pnpm ENOENT
    at Object.spawnSync (node:internal/child_process:1160:20)
    at spawnSync (node:child_process:928:24)
    at execFileSync (node:child_process:971:15)
    at <anonymous> (D:\XXXXX\Babylon-Lite\playground\scripts\build-engine-types.ts:54:5)
    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
    at async node:internal/modules/esm/loader:643:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawnSync pnpm',
  path: 'pnpm',
  spawnargs: [ '--filter', 'babylon-lite', 'build:dist' ],
  error: [Circular *1],
  status: null,
  signal: null,
  output: null,
  pid: 0,
  stdout: undefined,
  stderr: undefined
}

Node.js v24.19.0
```

This is even when pnpm is in my path.

Note if you first "manually" do `pnpm build`, the error doesn't seem to show up
