### PR TITLE
feat(camera): add configurable pointer mappings

### DIFF
--- a/docs/lite/03-porting-guide.md
+++ b/docs/lite/03-porting-guide.md
@@ -126,6 +126,23 @@ scene.camera = camera;
 attachControl(camera, canvas, scene);
 ```
 
+Pointer-button behavior can be migrated without adding application-owned orbit
+or pan math. The defaults stay primary-button rotate and secondary-button pan;
+set either mapping independently when the application uses a different
+interaction convention:
+
+```typescript
+attachControl(camera, canvas, scene, {
+    pointerMappings: {
+        primaryButton: "pan",
+        secondaryButton: "rotate",
+    },
+});
+```
+
+This mapping applies to mouse and pen buttons. Touch remains one-finger rotate
+and two-finger pinch zoom, and wheel input remains zoom.
+
 ### 5. Loaders and Scene Registration
 
 `loadEnvironment()` adds its environment data/renderables to the scene internally. `loadGltf()` returns an asset container; pass it to `addToScene()` so transform-node hierarchies, meshes, and animation groups are registered explicitly.

--- a/docs/lite/architecture/00-overview.md
+++ b/docs/lite/architecture/00-overview.md
@@ -312,7 +312,7 @@ setEnvironmentRotation(scene: SceneContext, rotation: number): void
 
 // Camera — pure data; controls can register per-frame updates on a scene
 createArcRotateCamera(alpha: number, beta: number, radius: number, target: Vec3): ArcRotateCamera
-attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement, scene?: SceneContext): () => void
+attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement, scene?: SceneContext, options?: AttachControlOptions): () => void
 createFreeCamera(position: Vec3, target: Vec3): FreeCamera
 attachFreeControl(camera: FreeCamera, canvas: HTMLCanvasElement, scene?: SceneContext): () => void
 

--- a/docs/lite/architecture/02-camera.md
+++ b/docs/lite/architecture/02-camera.md
@@ -82,13 +82,41 @@ export function createArcRotateCamera(alpha: number, beta: number, radius: numbe
 ### `arc-rotate-controls.ts`
 
 ```typescript
+/** Camera gesture assigned to a pointer button. */
+export type ArcRotatePointerAction = "rotate" | "pan";
+
+/** Optional non-touch pointer-button mappings.
+ *  Omitted fields preserve the default independently. */
+export interface ArcRotatePointerMappings {
+    /** Primary button (PointerEvent.button 0). Default: "rotate". */
+    primaryButton?: ArcRotatePointerAction;
+    /** Secondary button (PointerEvent.button 2). Default: "pan". */
+    secondaryButton?: ArcRotatePointerAction;
+}
+
+export interface AttachControlOptions {
+    /** Non-touch pointer-button mappings. Touch remains one-finger rotate + pinch zoom. */
+    pointerMappings?: ArcRotatePointerMappings;
+    shouldHandlePointerDown?: (event: PointerEvent) => boolean;
+    isExternalDragActive?: () => boolean;
+    isExternalPickPending?: () => boolean;
+}
+
 /** Attach orbit/zoom/pan controls to an ArcRotateCamera.
  *  Matches Babylon.js ArcRotateCameraPointersInput behavior with inertia.
  *  Input handlers accumulate into the camera's inertial offset properties.
  *  Inertia is applied each frame via scene._beforeRender (single RAF loop).
  *  Returns a cleanup function to remove all event listeners and the beforeRender hook. */
-export function attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement, scene?: SceneContext): () => void;
+export function attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement, scene?: SceneContext, options?: AttachControlOptions): () => void;
 ```
+
+`pointerMappings` is resolved on each non-touch `pointerdown`. Each button falls
+back independently, so `{ primaryButton: "pan" }` changes only the primary
+button while the secondary button continues to pan. The selected action remains
+fixed for that drag. Both actions use the existing inertial paths and pointer
+capture; wheel input is always zoom and is not remappable. Touch ignores
+`pointerMappings`: one finger rotates and two fingers pinch-zoom exactly as in
+the default controls.
 
 ### `free-camera.ts`
 
@@ -412,14 +440,14 @@ Both cameras: `mat4Multiply(projectionMatrix, viewMatrix)`.
 
 Input handlers do **not** directly modify camera properties. They accumulate into the camera's `inertial*` offset fields, which are applied and decayed each frame by `applyInertia()`.
 
-#### Left-drag (Rotate)
+#### Rotate action (primary-button default)
 
 ```
 camera.inertialAlphaOffset -= dx / angularSensibility
 camera.inertialBetaOffset  -= dy / angularSensibility
 ```
 
-#### Right-drag (Pan)
+#### Pan action (secondary-button default)
 
 ```
 camera.inertialPanningX += -dx / panningSensibility
@@ -503,6 +531,32 @@ When `scene` is omitted (fallback):
 | `touchend`    | `onTouchEnd`    | —                             |
 
 Pointer capture (`setPointerCapture`/`releasePointerCapture`) keeps drags active outside canvas.
+
+The primary and secondary buttons can independently select the rotate or pan
+action through `AttachControlOptions.pointerMappings`. Defaults are equivalent
+to the historic fixed mapping:
+
+```typescript
+attachControl(camera, canvas, scene, {
+    pointerMappings: {
+        primaryButton: "rotate",
+        secondaryButton: "pan",
+    },
+});
+```
+
+To make a primary-button drag pan without application-owned camera math:
+
+```typescript
+attachControl(camera, canvas, scene, {
+    pointerMappings: { primaryButton: "pan" },
+});
+```
+
+Non-touch pointers include mouse and pen input. Touch pointer events deliberately
+bypass this mapping so one-finger orbit and two-finger pinch zoom are stable.
+Wheel zoom, external-interaction guards, pointer capture, and cleanup do not
+depend on the mapping.
 
 ---
 
@@ -611,8 +665,8 @@ Cleanup removes all 6 event listeners and the `_beforeRender` callback.
 | `angularSensibility = 1000`                          | `camera.inputs.attached.pointers.angularSensibilityX/Y`                    |
 | `panningSensibility = 50`                            | `camera.inputs.attached.pointers.panningSensibility`                       |
 | `wheelPrecision = 3`                                 | `camera.inputs.attached.mousewheel.wheelPrecision`                         |
-| Left-drag → rotate                                   | `ArcRotateCameraPointersInput` button 0                                    |
-| Right-drag → pan                                     | `ArcRotateCameraPointersInput` button 2                                    |
+| Primary drag → rotate (default, configurable)        | `ArcRotateCameraPointersInput` button 0                                    |
+| Secondary drag → pan (default, configurable)         | `ArcRotateCameraPointersInput` button 2                                    |
 | Wheel → zoom radius                                  | `ArcRotateCameraMouseWheelInput`                                           |
 | Pinch → zoom radius (direct, no inertia)             | `ArcRotateCameraPointersInput` multitouch pinch                            |
 | Beta clamped to `[0.01, π-0.01]`                     | `camera.lowerBetaLimit / upperBetaLimit`                                   |
@@ -651,6 +705,8 @@ Cleanup removes all 6 event listeners and the `_beforeRender` callback.
 | `pinch zoom`                                   | Two-touch events correctly scale radius directly                                                  |
 | `inertia decay`                                | After input stops, offsets decay by `camera.inertia` per frame                                    |
 | `cleanup removes all listeners + beforeRender` | After cleanup, events and RAF hook removed                                                        |
+| `primary/secondary mappings are independent`   | Either button can select rotate or pan without changing the other button                          |
+| `custom mappings preserve touch`               | One-finger touch still rotates and two-finger pinch still zooms                                   |
 | **FreeCamera**                                 |                                                                                                   |
 | `initial yaw/pitch from position→target`       | Verify atan2 computation                                                                          |
 | `WASD movement in local space`                 | W moves along +Z local, A along −X local                                                          |

--- a/packages/babylon-lite/src/camera/arc-rotate-controls.ts
+++ b/packages/babylon-lite/src/camera/arc-rotate-controls.ts
@@ -1,6 +1,22 @@
 import type { ArcRotateCamera } from "./arc-rotate.js";
 import type { SceneContext } from "../scene/scene.js";
 
+/** Camera gesture assigned to an arc-rotate pointer button. */
+export type ArcRotatePointerAction = "rotate" | "pan";
+
+/**
+ * Optional mappings for non-touch pointer buttons.
+ *
+ * Each field falls back independently: the primary button rotates and the
+ * secondary button pans by default. Touch input is intentionally unaffected.
+ */
+export interface ArcRotatePointerMappings {
+    /** Gesture for `PointerEvent.button === 0`. Default: `"rotate"`. */
+    primaryButton?: ArcRotatePointerAction;
+    /** Gesture for `PointerEvent.button === 2`. Default: `"pan"`. */
+    secondaryButton?: ArcRotatePointerAction;
+}
+
 /**
  * Optional hooks that let an {@link attachControl} caller defer pointer
  * gestures to an external interactor (typically a gizmo pointer-drag
@@ -9,6 +25,11 @@ import type { SceneContext } from "../scene/scene.js";
  * the default behavior (the camera always handles its own pointer input).
  */
 export interface AttachControlOptions {
+    /**
+     * Independent primary/secondary mappings for mouse and pen drags.
+     * Touch remains one-finger rotate plus two-finger pinch zoom.
+     */
+    pointerMappings?: ArcRotatePointerMappings;
     /** Optional predicate consulted on every pointer-down.  When it returns
      *  false the camera ignores that gesture (no rotate / pan).  Used to defer
      *  to gizmo interaction so pressing or dragging a gizmo doesn't also orbit
@@ -140,10 +161,14 @@ export function setCameraLimits(camera: ArcRotateCamera, limits: ArcRotateCamera
 /**
  * Attach orbit/zoom/pan controls to an ArcRotateCamera.
  * Matches Babylon.js ArcRotateCameraPointersInput behavior with inertia:
- * - Left-drag: rotate (alpha/beta) with momentum
- * - Right-drag: pan (shift target) with momentum
+ * - Primary-button drag: rotate (alpha/beta) with momentum by default
+ * - Secondary-button drag: pan (shift target) with momentum by default
  * - Wheel: zoom (radius) with momentum
  * - Pinch: zoom (touch, direct — no inertia)
+ *
+ * Mouse and pen button actions can be configured independently through
+ * {@link AttachControlOptions.pointerMappings}. Touch and wheel behavior are
+ * fixed so remapping desktop pointer buttons cannot alter mobile gestures.
  *
  * Input handlers accumulate into the camera's inertial offset properties.
  * Inertia is applied each frame via scene._beforeRender (the engine's render
@@ -220,10 +245,19 @@ export function attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement
         lastX = e.clientX;
         lastY = e.clientY;
 
-        if (e.button === 0) {
+        const pointerAction =
+            e.button === 0
+                ? e.pointerType === "touch"
+                    ? "rotate"
+                    : (options?.pointerMappings?.primaryButton ?? "rotate")
+                : e.button === 2
+                  ? (options?.pointerMappings?.secondaryButton ?? "pan")
+                  : undefined;
+
+        if (pointerAction === "rotate") {
             isDragging = true;
             isPanning = false;
-        } else if (e.button === 2) {
+        } else if (pointerAction === "pan") {
             isDragging = false;
             isPanning = true;
         }

--- a/packages/babylon-lite/src/camera/arc-rotate-controls.ts
+++ b/packages/babylon-lite/src/camera/arc-rotate-controls.ts
@@ -254,12 +254,9 @@ export function attachControl(camera: ArcRotateCamera, canvas: HTMLCanvasElement
                   ? (options?.pointerMappings?.secondaryButton ?? "pan")
                   : undefined;
 
-        if (pointerAction === "rotate") {
-            isDragging = true;
-            isPanning = false;
-        } else if (pointerAction === "pan") {
-            isDragging = false;
-            isPanning = true;
+        if (pointerAction) {
+            isDragging = pointerAction === "rotate";
+            isPanning = !isDragging;
         }
     }
 

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -139,7 +139,7 @@ export type { ScreenSpaceGlobalIlluminationPostProcessTask, ScreenSpaceGlobalIll
 // ─── Camera ──────────────────────────────────────────────────────────
 export { createArcRotateCamera } from "./camera/arc-rotate.js";
 export { attachControl, setCameraLimits } from "./camera/arc-rotate-controls.js";
-export type { AttachControlOptions, ArcRotateCameraLimits } from "./camera/arc-rotate-controls.js";
+export type { ArcRotatePointerAction, ArcRotatePointerMappings, AttachControlOptions, ArcRotateCameraLimits } from "./camera/arc-rotate-controls.js";
 export { interpolateArcRotateCamera } from "./camera/arc-rotate-interpolate.js";
 export type { ArcRotateInterpolationGoal, ArcRotateInterpolationOptions } from "./camera/arc-rotate-interpolate.js";
 export { createFreeCamera } from "./camera/free-camera.js";

--- a/tests/lite/build/treeshake-rollup.test.ts
+++ b/tests/lite/build/treeshake-rollup.test.ts
@@ -190,6 +190,13 @@ describe("@babylonjs/lite has no module-level side effects", () => {
         ).toBe(normalize(SENTINEL));
     }, 180_000);
 
+    it("drops arc-rotate pointer mapping controls when only camera data is used", async () => {
+        const code = await bundleEntry(workDir, `import { createArcRotateCamera } from ${JSON.stringify(SRC_ENTRY)};\nconsole.log(createArcRotateCamera);\n`);
+        expect(code).toContain("createArcRotateCamera");
+        expect(code).not.toContain("pointerMappings");
+        expect(code).not.toContain("gesturestart");
+    }, 120_000);
+
     it("positive control: the harness DOES surface a real module-level side effect", async () => {
         // Guards against the assertions above silently passing because the bundler
         // stopped detecting side effects (config drift). A module that mutates a

--- a/tests/lite/unit/arc-rotate-controls.test.ts
+++ b/tests/lite/unit/arc-rotate-controls.test.ts
@@ -7,16 +7,22 @@ import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scen
 
 interface FakeCanvas {
     listeners: Map<string, EventListener[]>;
+    capturedPointers: number[];
+    releasedPointers: number[];
     addEventListener(type: string, h: EventListener): void;
     removeEventListener(type: string, h: EventListener): void;
-    setPointerCapture(): void;
-    releasePointerCapture(): void;
+    setPointerCapture(pointerId: number): void;
+    releasePointerCapture(pointerId: number): void;
 }
 
 function makeCanvas(): FakeCanvas {
     const listeners = new Map<string, EventListener[]>();
+    const capturedPointers: number[] = [];
+    const releasedPointers: number[] = [];
     return {
         listeners,
+        capturedPointers,
+        releasedPointers,
         addEventListener(type, h): void {
             const arr = listeners.get(type) ?? [];
             arr.push(h);
@@ -31,11 +37,11 @@ function makeCanvas(): FakeCanvas {
                 }
             }
         },
-        setPointerCapture(): void {
-            return;
+        setPointerCapture(pointerId): void {
+            capturedPointers.push(pointerId);
         },
-        releasePointerCapture(): void {
-            return;
+        releasePointerCapture(pointerId): void {
+            releasedPointers.push(pointerId);
         },
     };
 }
@@ -67,8 +73,8 @@ function touchEvent(changedTouches: Array<{ identifier: number; clientX: number;
     return { changedTouches, preventDefault: vi.fn() };
 }
 
-function pointerEvent(props: Partial<{ button: number; clientX: number; clientY: number; pointerId: number }>): unknown {
-    return { button: 0, clientX: 0, clientY: 0, pointerId: 1, ...props, preventDefault: vi.fn() };
+function pointerEvent(props: Partial<{ button: number; clientX: number; clientY: number; pointerId: number; pointerType: string }>): unknown {
+    return { button: 0, clientX: 0, clientY: 0, pointerId: 1, pointerType: "mouse", ...props, preventDefault: vi.fn() };
 }
 
 describe("attachControl — pinch / touch handling", () => {
@@ -204,6 +210,85 @@ describe("attachControl — pinch / touch handling", () => {
         dispose();
         expect(c.listeners.get("touchmove")?.length).toBe(0);
         expect(c.listeners.get("pointermove")?.length).toBe(0);
+    });
+});
+
+describe("attachControl — pointer mappings", () => {
+    it("preserves primary rotate and secondary pan as the defaults", () => {
+        const canvas = makeCanvas();
+        const camera = makeCamera();
+        attachControl(camera, canvas as unknown as HTMLCanvasElement, makeScene());
+
+        fire(canvas, "pointerdown", pointerEvent({ button: 0, pointerId: 1 }));
+        fire(canvas, "pointermove", pointerEvent({ clientX: 10, pointerId: 1 }));
+        fire(canvas, "pointerup", pointerEvent({ button: 0, clientX: 10, pointerId: 1 }));
+        expect(camera.inertialAlphaOffset).toBeCloseTo(-0.01, 5);
+        expect(camera.inertialPanningX).toBe(0);
+
+        fire(canvas, "pointerdown", pointerEvent({ button: 2, pointerId: 2 }));
+        fire(canvas, "pointermove", pointerEvent({ button: 2, clientX: 10, pointerId: 2 }));
+        fire(canvas, "pointerup", pointerEvent({ button: 2, clientX: 10, pointerId: 2 }));
+        expect(camera.inertialPanningX).toBeCloseTo(-0.2, 5);
+        expect(canvas.capturedPointers).toEqual([1, 2]);
+        expect(canvas.releasedPointers).toEqual([1, 2]);
+    });
+
+    it("configures primary and secondary actions independently", () => {
+        const primaryCanvas = makeCanvas();
+        const primaryCamera = makeCamera();
+        attachControl(primaryCamera, primaryCanvas as unknown as HTMLCanvasElement, makeScene(), {
+            pointerMappings: { primaryButton: "pan" },
+        });
+
+        fire(primaryCanvas, "pointerdown", pointerEvent({ button: 0 }));
+        fire(primaryCanvas, "pointermove", pointerEvent({ clientX: 10 }));
+        expect(primaryCamera.inertialAlphaOffset).toBe(0);
+        expect(primaryCamera.inertialPanningX).toBeCloseTo(-0.2, 5);
+
+        const secondaryCanvas = makeCanvas();
+        const secondaryCamera = makeCamera();
+        attachControl(secondaryCamera, secondaryCanvas as unknown as HTMLCanvasElement, makeScene(), {
+            pointerMappings: { secondaryButton: "rotate" },
+        });
+
+        fire(secondaryCanvas, "pointerdown", pointerEvent({ button: 0 }));
+        fire(secondaryCanvas, "pointermove", pointerEvent({ clientX: 10 }));
+        expect(secondaryCamera.inertialAlphaOffset).toBeCloseTo(-0.01, 5);
+
+        fire(secondaryCanvas, "pointerup", pointerEvent({ button: 0 }));
+        secondaryCamera.inertialAlphaOffset = 0;
+        fire(secondaryCanvas, "pointerdown", pointerEvent({ button: 2 }));
+        fire(secondaryCanvas, "pointermove", pointerEvent({ button: 2, clientX: 10 }));
+        expect(secondaryCamera.inertialAlphaOffset).toBeCloseTo(-0.01, 5);
+        expect(secondaryCamera.inertialPanningX).toBe(0);
+    });
+
+    it("keeps touch, wheel, cleanup, and reattachment behavior unchanged", () => {
+        const canvas = makeCanvas();
+        const camera = makeCamera();
+        const scene = makeScene();
+        const detach = attachControl(camera, canvas as unknown as HTMLCanvasElement, scene, {
+            pointerMappings: { primaryButton: "pan", secondaryButton: "rotate" },
+        });
+
+        fire(canvas, "pointerdown", pointerEvent({ pointerType: "touch" }));
+        fire(canvas, "pointermove", pointerEvent({ clientX: 10, pointerType: "touch" }));
+        expect(camera.inertialAlphaOffset).toBeCloseTo(-0.01, 5);
+        expect(camera.inertialPanningX).toBe(0);
+
+        fire(canvas, "wheel", { deltaY: 120, preventDefault: vi.fn() });
+        expect(camera.inertialRadiusOffset).toBeCloseTo(-0.4, 5);
+
+        detach();
+        expect(canvas.listeners.get("pointerdown")?.length).toBe(0);
+        expect((scene as unknown as { _beforeRender: unknown[] })._beforeRender).toHaveLength(0);
+
+        attachControl(camera, canvas as unknown as HTMLCanvasElement, scene);
+        camera.inertialAlphaOffset = 0;
+        fire(canvas, "pointerdown", pointerEvent({ button: 0, pointerId: 2 }));
+        fire(canvas, "pointermove", pointerEvent({ clientX: 10, pointerId: 2 }));
+        expect(camera.inertialAlphaOffset).toBeCloseTo(-0.01, 5);
+        expect(canvas.listeners.get("pointerdown")?.length).toBe(1);
     });
 });
 


### PR DESCRIPTION
## Summary
- add independent primary/secondary `"rotate" | "pan"` mappings to `attachControl` options
- preserve primary-rotate/secondary-pan defaults, pointer capture, detach/reattach, wheel zoom, and touch gestures
- export the mapping types from the root entrypoint and document the architecture plus a generic migration example
- add focused behavior, public API, and Rollup tree-shaking coverage

## Bundle impact
Measured with `pnpm run analyze-bundle scene147`:
- `arc-rotate-controls`: 5,919 B → 5,989 B raw (**+70 B**)
- gzip: 1,422 B → 1,466 B (**+44 B**)
- camera-data-only consumers still tree-shake the controls and mapping code completely

The focused `scene215` bundle-size check measures 81,191 raw bytes, 12 bytes below its fixed 79.30 KB ceiling.

## Validation
- `REUSE_BROWSER=1 pnpm exec vitest run --project unit tests/lite/unit/arc-rotate-controls.test.ts`
- `REUSE_BROWSER=1 pnpm exec vitest run --project build tests/lite/build/treeshake-rollup.test.ts`
- `REUSE_BROWSER=1 pnpm exec vitest run --project build tests/lite/build/public-api-types.test.ts`
- `pnpm run lint`
- `pnpm run build:lib`
- `REUSE_BROWSER=1 pnpm exec tsx scripts/build-bundle-scenes.ts --scenes scene215`

`pnpm run docs:check` currently exits before loading project docs because the locked `markdown-it@14.3.0` imports a default export that the overridden `linkify-it@6.1.0` no longer provides; this reproduces under Node 22.22.0 and 24.19.0.