### PR TITLE
feat(camera): add world-to-screen projection

### DIFF
--- a/docs/lite/03-porting-guide.md
+++ b/docs/lite/03-porting-guide.md
@@ -35,6 +35,7 @@ This guide shows how to translate a Babylon.js (BJS) scene to Babylon Lite, side
 | `scene.createDefaultCamera(true, true, true)`                       | `createDefaultCamera(scene)`                                                                                |
 | `camera.attachControl(canvas, true)`                                | `attachControl(camera, canvas, scene)` _(arc-rotate)_ / `attachFreeControl(camera, canvas, scene)` _(free)_ |
 | `camera.mode = Camera.ORTHOGRAPHIC_CAMERA`                          | `enableOrthographicCamera(camera, { halfHeight })`                                                          |
+| `Vector3.Project(point, world, scene.getTransformMatrix(), viewport)` | `projectWorldToScreen(point, view, viewProjection, options)`                                              |
 | `new HemisphericLight("h", new Vector3(0,1,0), scene)`              | `createHemisphericLight([0,1,0], 1.0)`                                                                      |
 | `new DirectionalLight("d", new Vector3(0,-1,0), scene)`             | `createDirectionalLight([0,-1,0])`                                                                          |
 | `new SpotLight("s", pos, dir, angle, exp, scene)`                   | `createSpotLight(pos, dir, angle, exp)`                                                                     |
@@ -125,6 +126,41 @@ const camera = createArcRotateCamera(-Math.PI / 2, Math.PI / 2, 5, { x: 0, y: 0,
 scene.camera = camera;
 attachControl(camera, canvas, scene);
 ```
+
+#### Projecting a world point to canvas or CSS pixels
+
+Babylon.js `Vector3.Project` returns render pixels and leaves visibility checks and CSS scaling to the caller. Lite's generic helper returns backing pixels, CSS pixels, reverse-Z NDC depth, and explicit behind/clipped/offscreen flags:
+
+```typescript
+import {
+    getEffectiveAspectRatio,
+    getViewMatrix,
+    getViewProjectionMatrix,
+    projectWorldToScreen,
+    resolveCameraViewport,
+} from "@babylonjs/lite";
+
+const backingWidth = canvas.width;
+const backingHeight = canvas.height;
+const projection = projectWorldToScreen(
+    worldPoint,
+    getViewMatrix(camera),
+    getViewProjectionMatrix(camera, getEffectiveAspectRatio(camera, backingWidth, backingHeight)),
+    {
+        viewport: resolveCameraViewport(camera, backingWidth, backingHeight),
+        backingWidth,
+        backingHeight,
+        cssWidth: canvas.clientWidth,
+        cssHeight: canvas.clientHeight,
+    }
+);
+
+if (!projection.clipped) {
+    overlay.style.transform = `translate(${projection.cssX}px, ${projection.cssY}px)`;
+}
+```
+
+The projection helper itself has no DOM dependency. For `OffscreenCanvas`, pass the visible host canvas's CSS dimensions. Use `projectWorldToScreenToRef` with a reused result object when projecting many points per frame.
 
 ### 5. Loaders and Scene Registration
 

--- a/docs/lite/03-porting-guide.md
+++ b/docs/lite/03-porting-guide.md
@@ -133,6 +133,7 @@ Babylon.js `Vector3.Project` returns render pixels and leaves visibility checks 
 
 ```typescript
 import {
+    getFloatingOriginOffset,
     getEffectiveAspectRatio,
     getViewMatrix,
     getViewProjectionMatrix,
@@ -150,6 +151,7 @@ const projection = projectWorldToScreen(
         viewport: resolveCameraViewport(camera, backingWidth, backingHeight),
         backingWidth,
         backingHeight,
+        worldOrigin: engine.useFloatingOrigin ? getFloatingOriginOffset(scene) : undefined,
         cssWidth: canvas.clientWidth,
         cssHeight: canvas.clientHeight,
     }
@@ -160,7 +162,7 @@ if (!projection.clipped) {
 }
 ```
 
-The projection helper itself has no DOM dependency. For `OffscreenCanvas`, pass the visible host canvas's CSS dimensions. Use `projectWorldToScreenToRef` with a reused result object when projecting many points per frame.
+The projection helper itself has no DOM dependency. For `OffscreenCanvas`, pass the visible host canvas's CSS dimensions. With Large World Rendering, `worldOrigin` rebases absolute CPU positions into the eye-relative frame used by the camera matrices. Use `projectWorldToScreenToRef` with a reused result object when projecting many points per frame.
 
 Pointer-button behavior can be migrated without adding application-owned orbit
 or pan math. The defaults stay primary-button rotate and secondary-button pan;

--- a/docs/lite/architecture/54-world-screen-projection.md
+++ b/docs/lite/architecture/54-world-screen-projection.md
@@ -14,6 +14,7 @@ const backingHeight = surface.canvas.height;
 const view = getViewMatrix(camera);
 const viewProjection = getViewProjectionMatrix(camera, getEffectiveAspectRatio(camera, backingWidth, backingHeight));
 const viewport = resolveCameraViewport(camera, backingWidth, backingHeight);
+const worldOrigin = engine.useFloatingOrigin ? getFloatingOriginOffset(scene) : undefined;
 ```
 
 For a DOM canvas, pass its current canvas-relative CSS dimensions as `cssWidth` and `cssHeight` (normally `clientWidth` / `clientHeight`, or `getBoundingClientRect()` dimensions when CSS transforms must be included). For an `OffscreenCanvas`, the host supplies the visible canvas's CSS dimensions alongside the backing size. Omitting the CSS dimensions makes CSS coordinates equal backing-pixel coordinates.
@@ -27,6 +28,8 @@ export interface ScreenProjectionOptions {
     /** Full canvas backing-store dimensions in device pixels. */
     backingWidth: number;
     backingHeight: number;
+    /** World-space position represented by zero in the supplied matrices. */
+    worldOrigin?: Vec3;
     /** Canvas-relative CSS dimensions. Both must be supplied together. */
     cssWidth?: number;
     cssHeight?: number;
@@ -70,9 +73,17 @@ export function projectWorldToScreen(
 
 `projectWorldToScreenToRef` performs no allocations and returns the exact `result` object supplied by the caller. `projectWorldToScreen` is the convenience form and allocates one result object.
 
+`worldOrigin` identifies the absolute world-space position represented by `(0, 0, 0)` in the supplied matrices. Omit it when `view` and `viewProjection` operate on absolute world coordinates. When Large World Rendering is active, pass `getFloatingOriginOffset(scene)`: Lite's floating-origin matrices are eye-relative while CPU node positions remain absolute. The helper subtracts `worldOrigin` from the input point before applying either matrix, matching the GPU upload rebase without importing camera, scene, or floating-origin runtime code.
+
 ## Projection Contract
 
-Babylon Lite matrices are column-major and cameras are left-handed. For world point `(x, y, z)`, the helper computes:
+Babylon Lite matrices are column-major and cameras are left-handed. For absolute world point `point` and optional `worldOrigin`, the helper first computes:
+
+```text
+(x, y, z) = point - (worldOrigin ?? (0, 0, 0))
+```
+
+It then computes:
 
 ```text
 viewZ = view[2]*x + view[6]*y + view[10]*z + view[14]
@@ -112,11 +123,11 @@ This ratio handles device-pixel ratio, `maxDevicePixelRatio`, explicit backing-s
 - `offscreen` concerns only whether the point can appear in the viewport's 2D rectangle. It is true for behind-camera/non-finite points, negative `clipW`, or `ndcX` / `ndcY` outside `[-1, 1]`. Negative `clipW` is non-displayable even if a separately supplied view matrix reports positive `viewZ`. A point inside the 2D rectangle but clipped only by near/far depth has `offscreen=false` and `clipped=true`.
 - Coordinates are not clamped. Finite points outside the viewport retain their extrapolated backing/CSS coordinates so callers can place edge indicators themselves.
 - When `clipW` is zero or any input calculation is non-finite, `x`, `y`, `z`, `cssX`, and `cssY` are `NaN`; all state flags except `behindCamera` report non-displayable behavior (`clipped=true`, `offscreen=true`).
-- Backing dimensions and viewport width/height must be positive finite numbers, and viewport x/y must be finite. CSS dimensions, when supplied, must both be positive finite numbers. Invalid options throw `RangeError` instead of returning success-shaped coordinates.
+- Backing dimensions and viewport width/height must be positive finite numbers, viewport x/y must be finite, and `worldOrigin`, when supplied, must contain finite components. CSS dimensions, when supplied, must both be positive finite numbers. Invalid options throw `RangeError` instead of returning success-shaped coordinates.
 
 ## Internal Architecture
 
-The module has no mutable module state, caches, DOM imports, or module-level allocations. The `ToRef` function reads scalar matrix elements directly and writes all result fields on every call, so reusing a result cannot leak stale CSS coordinates or flags.
+The module has no mutable module state, caches, DOM imports, or module-level allocations. The `ToRef` function subtracts optional origin components as scalars, reads scalar matrix elements directly, and writes all result fields on every call, so reusing a result cannot leak stale CSS coordinates or flags.
 
 The allocating wrapper constructs one plain result object and delegates to `projectWorldToScreenToRef`; it owns no separate math path.
 
@@ -146,6 +157,8 @@ Both imports are type-only. The module remains a leaf and adds no runtime depend
 | Partial viewport | NDC corners and center include viewport offset/extent |
 | Behind perspective | `behindCamera`, `clipped`, and `offscreen` are true |
 | Behind orthographic | Separate view-space test identifies it despite `clipW=1` |
+| Floating-origin perspective | Rebasing preserves projection and behind-camera classification after a large world translation |
+| Floating-origin orthographic | Rebasing preserves projection and behind-camera classification after a large world translation |
 | XY offscreen | Extrapolated coordinates are retained; both clipped/offscreen true |
 | Negative clip W | Non-displayable even when the separately supplied view matrix reports a point in front |
 | Depth-only clip | Clipped true while offscreen remains false |

--- a/docs/lite/architecture/54-world-screen-projection.md
+++ b/docs/lite/architecture/54-world-screen-projection.md
@@ -1,0 +1,162 @@
+# Module: World-to-Screen Projection
+
+> Package path: `packages/babylon-lite/src/camera/world-to-screen.ts`
+
+## Purpose
+
+The world-to-screen projection module converts a world-space `Vec3` into canvas backing-store pixels and canvas-relative CSS pixels. It is a pure CPU math helper: it does not create or position DOM overlays, read global browser state, or retain camera/surface state.
+
+The caller supplies the camera's view matrix and view-projection matrix. This keeps the hot projection function general-purpose and lets a caller cache the matrices once per frame. The existing camera and viewport helpers derive the active render state:
+
+```typescript
+const backingWidth = surface.canvas.width;
+const backingHeight = surface.canvas.height;
+const view = getViewMatrix(camera);
+const viewProjection = getViewProjectionMatrix(camera, getEffectiveAspectRatio(camera, backingWidth, backingHeight));
+const viewport = resolveCameraViewport(camera, backingWidth, backingHeight);
+```
+
+For a DOM canvas, pass its current canvas-relative CSS dimensions as `cssWidth` and `cssHeight` (normally `clientWidth` / `clientHeight`, or `getBoundingClientRect()` dimensions when CSS transforms must be included). For an `OffscreenCanvas`, the host supplies the visible canvas's CSS dimensions alongside the backing size. Omitting the CSS dimensions makes CSS coordinates equal backing-pixel coordinates.
+
+## Public API Surface
+
+```typescript
+export interface ScreenProjectionOptions {
+    /** Active viewport in canvas backing pixels, with top-left origin. */
+    viewport: PixelViewport;
+    /** Full canvas backing-store dimensions in device pixels. */
+    backingWidth: number;
+    backingHeight: number;
+    /** Canvas-relative CSS dimensions. Both must be supplied together. */
+    cssWidth?: number;
+    cssHeight?: number;
+}
+
+export interface ScreenProjectionResult extends Vec3 {
+    /** Canvas backing-pixel X coordinate. */
+    x: number;
+    /** Canvas backing-pixel Y coordinate. */
+    y: number;
+    /** WebGPU NDC depth. In Lite's reverse-Z cameras, near=1 and far=0. */
+    z: number;
+    /** Canvas-relative CSS pixel coordinate. */
+    cssX: number;
+    cssY: number;
+    /** Homogeneous clip-space W before perspective divide. */
+    clipW: number;
+    /** True when the point's left-handed view-space Z is <= 0. */
+    behindCamera: boolean;
+    /** True when the point is outside any WebGPU clip plane or is non-finite. */
+    clipped: boolean;
+    /** True when the point cannot appear inside the viewport's 2D rectangle. */
+    offscreen: boolean;
+}
+
+export function projectWorldToScreenToRef<T extends ScreenProjectionResult>(
+    point: Vec3,
+    view: Mat4,
+    viewProjection: Mat4,
+    options: ScreenProjectionOptions,
+    result: T
+): T;
+
+export function projectWorldToScreen(
+    point: Vec3,
+    view: Mat4,
+    viewProjection: Mat4,
+    options: ScreenProjectionOptions
+): ScreenProjectionResult;
+```
+
+`projectWorldToScreenToRef` performs no allocations and returns the exact `result` object supplied by the caller. `projectWorldToScreen` is the convenience form and allocates one result object.
+
+## Projection Contract
+
+Babylon Lite matrices are column-major and cameras are left-handed. For world point `(x, y, z)`, the helper computes:
+
+```text
+viewZ = view[2]*x + view[6]*y + view[10]*z + view[14]
+
+clipX = vp[0]*x + vp[4]*y + vp[8]*z  + vp[12]
+clipY = vp[1]*x + vp[5]*y + vp[9]*z  + vp[13]
+clipZ = vp[2]*x + vp[6]*y + vp[10]*z + vp[14]
+clipW = vp[3]*x + vp[7]*y + vp[11]*z + vp[15]
+
+ndcX = clipX / clipW
+ndcY = clipY / clipW
+ndcZ = clipZ / clipW
+```
+
+The view matrix is required separately because homogeneous W identifies the camera-facing half-space for perspective projections but remains `1` for orthographic projections. Left-handed `viewZ <= 0` identifies behind-camera points correctly for both.
+
+NDC maps into the active top-origin backing-pixel viewport:
+
+```text
+canvasX = viewport.x + (ndcX + 1) * viewport.width  / 2
+canvasY = viewport.y + (1 - ndcY) * viewport.height / 2
+```
+
+The full backing dimensions are used only to map the absolute canvas coordinate to CSS space, so viewport offsets and partial-canvas viewports scale correctly:
+
+```text
+cssX = canvasX * cssWidth  / backingWidth
+cssY = canvasY * cssHeight / backingHeight
+```
+
+This ratio handles device-pixel ratio, `maxDevicePixelRatio`, explicit backing-store sizing, and non-integer CSS-to-backing scales without reading `globalThis.devicePixelRatio`.
+
+## Clipped and Offscreen Behavior
+
+- `behindCamera` is true when `viewZ <= 0`.
+- `clipped` is true when the point is behind the camera, any calculated coordinate is non-finite, `ndcX` or `ndcY` is outside `[-1, 1]`, or `ndcZ` is outside WebGPU's `[0, 1]` depth range.
+- `offscreen` concerns only whether the point can appear in the viewport's 2D rectangle. It is true for behind-camera/non-finite points or when `ndcX` / `ndcY` is outside `[-1, 1]`. A point inside the 2D rectangle but clipped only by near/far depth has `offscreen=false` and `clipped=true`.
+- Coordinates are not clamped. Finite points outside the viewport retain their extrapolated backing/CSS coordinates so callers can place edge indicators themselves.
+- When `clipW` is zero or any input calculation is non-finite, `x`, `y`, `z`, `cssX`, and `cssY` are `NaN`; all state flags except `behindCamera` report non-displayable behavior (`clipped=true`, `offscreen=true`).
+- Backing dimensions and viewport width/height must be positive finite numbers, and viewport x/y must be finite. CSS dimensions, when supplied, must both be positive finite numbers. Invalid options throw `RangeError` instead of returning success-shaped coordinates.
+
+## Internal Architecture
+
+The module has no mutable module state, caches, DOM imports, or module-level allocations. The `ToRef` function reads scalar matrix elements directly and writes all result fields on every call, so reusing a result cannot leak stale CSS coordinates or flags.
+
+The allocating wrapper constructs one plain result object and delegates to `projectWorldToScreenToRef`; it owns no separate math path.
+
+## Babylon.js Equivalence Map
+
+| Babylon Lite | Babylon.js |
+| --- | --- |
+| `projectWorldToScreen(point, view, viewProjection, options)` | `Vector3.Project(point, Matrix.Identity(), scene.getTransformMatrix(), viewport)` plus backing-to-CSS scaling |
+| `projectWorldToScreenToRef(..., result)` | `Vector3.ProjectToRef(...)` plus backing-to-CSS scaling and explicit visibility flags |
+| `result.z` | projected `Vector3.z` |
+| `result.behindCamera` | explicit view-space test not returned by `Vector3.Project` |
+| `result.clipped` / `result.offscreen` | explicit status not returned by `Vector3.Project` |
+
+## Dependencies
+
+- `../math/types.js` — `Vec3`, `Mat4`
+- `./viewport.js` — `PixelViewport` type only
+
+Both imports are type-only. The module remains a leaf and adds no runtime dependency edge.
+
+## Test Specification
+
+| Test | Expected behavior |
+| --- | --- |
+| Perspective center | Camera-forward point maps to viewport center |
+| Backing/CSS scaling | DPR-like backing-to-CSS ratio scales both axes |
+| Partial viewport | NDC corners and center include viewport offset/extent |
+| Behind perspective | `behindCamera`, `clipped`, and `offscreen` are true |
+| Behind orthographic | Separate view-space test identifies it despite `clipW=1` |
+| XY offscreen | Extrapolated coordinates are retained; both clipped/offscreen true |
+| Depth-only clip | Clipped true while offscreen remains false |
+| Zero clip W | Coordinates are NaN; clipped/offscreen true |
+| ToRef reuse | Exact result identity returned; every field overwritten |
+| Invalid dimensions | Non-positive/non-finite backing, viewport, or partial CSS size throws |
+| Unused tree shaking | Importing another root export retains zero code from this module |
+
+## File Manifest
+
+| File | Purpose |
+| --- | --- |
+| `src/camera/world-to-screen.ts` | Pure projection functions and result/options contracts |
+| `tests/lite/unit/world-to-screen.test.ts` | Focused math, viewport, CSS, status, and validation coverage |
+| `tests/lite/build/world-to-screen-treeshake.test.ts` | Root-export unused-retention regression |

--- a/docs/lite/architecture/54-world-screen-projection.md
+++ b/docs/lite/architecture/54-world-screen-projection.md
@@ -48,7 +48,7 @@ export interface ScreenProjectionResult extends Vec3 {
     behindCamera: boolean;
     /** True when the point is outside any WebGPU clip plane or is non-finite. */
     clipped: boolean;
-    /** True when the point cannot appear inside the viewport's 2D rectangle. */
+    /** True when the point cannot appear inside the viewport's 2D rectangle, including negative clip W. */
     offscreen: boolean;
 }
 
@@ -108,8 +108,8 @@ This ratio handles device-pixel ratio, `maxDevicePixelRatio`, explicit backing-s
 ## Clipped and Offscreen Behavior
 
 - `behindCamera` is true when `viewZ <= 0`.
-- `clipped` is true when the point is behind the camera, any calculated coordinate is non-finite, `ndcX` or `ndcY` is outside `[-1, 1]`, or `ndcZ` is outside WebGPU's `[0, 1]` depth range.
-- `offscreen` concerns only whether the point can appear in the viewport's 2D rectangle. It is true for behind-camera/non-finite points or when `ndcX` / `ndcY` is outside `[-1, 1]`. A point inside the 2D rectangle but clipped only by near/far depth has `offscreen=false` and `clipped=true`.
+- `clipped` is true when the point is behind the camera, has negative `clipW`, has any non-finite calculated coordinate, has `ndcX` or `ndcY` outside `[-1, 1]`, or has `ndcZ` outside WebGPU's `[0, 1]` depth range.
+- `offscreen` concerns only whether the point can appear in the viewport's 2D rectangle. It is true for behind-camera/non-finite points, negative `clipW`, or `ndcX` / `ndcY` outside `[-1, 1]`. Negative `clipW` is non-displayable even if a separately supplied view matrix reports positive `viewZ`. A point inside the 2D rectangle but clipped only by near/far depth has `offscreen=false` and `clipped=true`.
 - Coordinates are not clamped. Finite points outside the viewport retain their extrapolated backing/CSS coordinates so callers can place edge indicators themselves.
 - When `clipW` is zero or any input calculation is non-finite, `x`, `y`, `z`, `cssX`, and `cssY` are `NaN`; all state flags except `behindCamera` report non-displayable behavior (`clipped=true`, `offscreen=true`).
 - Backing dimensions and viewport width/height must be positive finite numbers, and viewport x/y must be finite. CSS dimensions, when supplied, must both be positive finite numbers. Invalid options throw `RangeError` instead of returning success-shaped coordinates.
@@ -147,6 +147,7 @@ Both imports are type-only. The module remains a leaf and adds no runtime depend
 | Behind perspective | `behindCamera`, `clipped`, and `offscreen` are true |
 | Behind orthographic | Separate view-space test identifies it despite `clipW=1` |
 | XY offscreen | Extrapolated coordinates are retained; both clipped/offscreen true |
+| Negative clip W | Non-displayable even when the separately supplied view matrix reports a point in front |
 | Depth-only clip | Clipped true while offscreen remains false |
 | Zero clip W | Coordinates are NaN; clipped/offscreen true |
 | ToRef reuse | Exact result identity returned; every field overwritten |

--- a/packages/babylon-lite/src/camera/world-to-screen.ts
+++ b/packages/babylon-lite/src/camera/world-to-screen.ts
@@ -1,0 +1,138 @@
+import type { Mat4, Vec3 } from "../math/types.js";
+import type { PixelViewport } from "./viewport.js";
+
+/** Dimensions and active backing-pixel viewport used by world-to-screen projection. */
+export interface ScreenProjectionOptions {
+    /** Active viewport in canvas backing pixels, with its origin at the top left. */
+    viewport: PixelViewport;
+    /** Full canvas backing-store width in device pixels. */
+    backingWidth: number;
+    /** Full canvas backing-store height in device pixels. */
+    backingHeight: number;
+    /** Canvas-relative CSS width. Must be supplied together with {@link cssHeight}. */
+    cssWidth?: number;
+    /** Canvas-relative CSS height. Must be supplied together with {@link cssWidth}. */
+    cssHeight?: number;
+}
+
+/**
+ * Projected world point. `x`/`y` are canvas backing pixels; `cssX`/`cssY` are
+ * canvas-relative CSS pixels; `z` is WebGPU NDC depth.
+ */
+export interface ScreenProjectionResult extends Vec3 {
+    cssX: number;
+    cssY: number;
+    /** Homogeneous clip-space W before perspective divide. */
+    clipW: number;
+    /** True when the point's left-handed view-space Z is at or behind the camera plane. */
+    behindCamera: boolean;
+    /** True when the point is outside any WebGPU clip plane or is non-finite. */
+    clipped: boolean;
+    /** True when the point cannot appear inside the viewport's 2D rectangle. */
+    offscreen: boolean;
+}
+
+function validateOptions(options: ScreenProjectionOptions): void {
+    const { viewport, backingWidth, backingHeight, cssWidth, cssHeight } = options;
+    if (
+        !Number.isFinite(viewport.x) ||
+        !Number.isFinite(viewport.y) ||
+        !(viewport.width > 0) ||
+        !Number.isFinite(viewport.width) ||
+        !(viewport.height > 0) ||
+        !Number.isFinite(viewport.height) ||
+        !(backingWidth > 0) ||
+        !Number.isFinite(backingWidth) ||
+        !(backingHeight > 0) ||
+        !Number.isFinite(backingHeight)
+    ) {
+        throw new RangeError("ScreenProjectionOptions backing dimensions and viewport must be positive and finite.");
+    }
+    if (
+        (cssWidth === undefined) !== (cssHeight === undefined) ||
+        (cssWidth !== undefined && (!(cssWidth > 0) || !Number.isFinite(cssWidth))) ||
+        (cssHeight !== undefined && (!(cssHeight > 0) || !Number.isFinite(cssHeight)))
+    ) {
+        throw new RangeError("ScreenProjectionOptions CSS dimensions must both be positive and finite.");
+    }
+}
+
+/**
+ * Project a world-space point into canvas backing pixels and canvas-relative CSS pixels,
+ * writing every output field into `result`.
+ *
+ * `view` is required separately from `viewProjection` so `behindCamera` works for
+ * orthographic projections, whose homogeneous W remains 1. Coordinates are not clamped:
+ * finite offscreen points keep their extrapolated positions for edge-indicator placement.
+ *
+ * This function performs no allocations. Derive the matrices and viewport once per frame
+ * with `getViewMatrix`, `getViewProjectionMatrix`, `getEffectiveAspectRatio`, and
+ * `resolveCameraViewport`, then reuse both `options` and `result` for each projected point.
+ */
+export function projectWorldToScreenToRef<T extends ScreenProjectionResult>(point: Vec3, view: Mat4, viewProjection: Mat4, options: ScreenProjectionOptions, result: T): T {
+    validateOptions(options);
+
+    const v = view;
+    const vp = viewProjection;
+    const x = point.x;
+    const y = point.y;
+    const z = point.z;
+    const viewZ = x * v[2]! + y * v[6]! + z * v[10]! + v[14]!;
+    const clipX = x * vp[0]! + y * vp[4]! + z * vp[8]! + vp[12]!;
+    const clipY = x * vp[1]! + y * vp[5]! + z * vp[9]! + vp[13]!;
+    const clipZ = x * vp[2]! + y * vp[6]! + z * vp[10]! + vp[14]!;
+    const clipW = x * vp[3]! + y * vp[7]! + z * vp[11]! + vp[15]!;
+    const behindCamera = viewZ <= 0;
+
+    result.clipW = clipW;
+    result.behindCamera = behindCamera;
+
+    if (!Number.isFinite(viewZ) || !Number.isFinite(clipX) || !Number.isFinite(clipY) || !Number.isFinite(clipZ) || !Number.isFinite(clipW) || clipW === 0) {
+        result.x = result.y = result.z = result.cssX = result.cssY = Number.NaN;
+        result.clipped = true;
+        result.offscreen = true;
+        return result;
+    }
+
+    const invW = 1 / clipW;
+    const ndcX = clipX * invW;
+    const ndcY = clipY * invW;
+    const ndcZ = clipZ * invW;
+    if (!Number.isFinite(ndcX) || !Number.isFinite(ndcY) || !Number.isFinite(ndcZ)) {
+        result.x = result.y = result.z = result.cssX = result.cssY = Number.NaN;
+        result.clipped = true;
+        result.offscreen = true;
+        return result;
+    }
+
+    const viewport = options.viewport;
+    result.x = viewport.x + (ndcX + 1) * viewport.width * 0.5;
+    result.y = viewport.y + (1 - ndcY) * viewport.height * 0.5;
+    result.z = ndcZ;
+    result.cssX = result.x * ((options.cssWidth ?? options.backingWidth) / options.backingWidth);
+    result.cssY = result.y * ((options.cssHeight ?? options.backingHeight) / options.backingHeight);
+
+    const outsideXY = ndcX < -1 || ndcX > 1 || ndcY < -1 || ndcY > 1;
+    const nonDisplayable = behindCamera || clipW < 0;
+    result.offscreen = nonDisplayable || outsideXY;
+    result.clipped = result.offscreen || ndcZ < 0 || ndcZ > 1;
+    return result;
+}
+
+/**
+ * Allocating convenience wrapper for {@link projectWorldToScreenToRef}.
+ * Use the `ToRef` form when projecting repeatedly.
+ */
+export function projectWorldToScreen(point: Vec3, view: Mat4, viewProjection: Mat4, options: ScreenProjectionOptions): ScreenProjectionResult {
+    return projectWorldToScreenToRef(point, view, viewProjection, options, {
+        x: 0,
+        y: 0,
+        z: 0,
+        cssX: 0,
+        cssY: 0,
+        clipW: 0,
+        behindCamera: false,
+        clipped: false,
+        offscreen: false,
+    });
+}

--- a/packages/babylon-lite/src/camera/world-to-screen.ts
+++ b/packages/babylon-lite/src/camera/world-to-screen.ts
@@ -9,6 +9,8 @@ export interface ScreenProjectionOptions {
     backingWidth: number;
     /** Full canvas backing-store height in device pixels. */
     backingHeight: number;
+    /** World-space position represented by zero in the supplied matrices. Omit for absolute-world matrices. */
+    worldOrigin?: Vec3;
     /** Canvas-relative CSS width. Must be supplied together with {@link cssHeight}. */
     cssWidth?: number;
     /** Canvas-relative CSS height. Must be supplied together with {@link cssWidth}. */
@@ -33,7 +35,7 @@ export interface ScreenProjectionResult extends Vec3 {
 }
 
 function validateOptions(options: ScreenProjectionOptions): void {
-    const { viewport, backingWidth, backingHeight, cssWidth, cssHeight } = options;
+    const { viewport, backingWidth, backingHeight, worldOrigin, cssWidth, cssHeight } = options;
     if (
         !Number.isFinite(viewport.x) ||
         !Number.isFinite(viewport.y) ||
@@ -47,6 +49,9 @@ function validateOptions(options: ScreenProjectionOptions): void {
         !Number.isFinite(backingHeight)
     ) {
         throw new RangeError("ScreenProjectionOptions backing dimensions and viewport extents must be positive and finite; viewport offsets must be finite.");
+    }
+    if (worldOrigin && (!Number.isFinite(worldOrigin.x) || !Number.isFinite(worldOrigin.y) || !Number.isFinite(worldOrigin.z))) {
+        throw new RangeError("ScreenProjectionOptions world origin must be finite.");
     }
     if (
         (cssWidth === undefined) !== (cssHeight === undefined) ||
@@ -65,7 +70,9 @@ function validateOptions(options: ScreenProjectionOptions): void {
  * orthographic projections, whose homogeneous W remains 1. Coordinates are not clamped:
  * finite offscreen points keep their extrapolated positions for edge-indicator placement.
  *
- * This function performs no allocations. Derive the matrices and viewport once per frame
+ * This function performs no allocations. When the matrices use a rebased coordinate frame,
+ * set `options.worldOrigin` to the absolute world position represented by their origin.
+ * Derive the matrices and viewport once per frame
  * with `getViewMatrix`, `getViewProjectionMatrix`, `getEffectiveAspectRatio`, and
  * `resolveCameraViewport`, then reuse both `options` and `result` for each projected point.
  */
@@ -74,9 +81,10 @@ export function projectWorldToScreenToRef<T extends ScreenProjectionResult>(poin
 
     const v = view;
     const vp = viewProjection;
-    const x = point.x;
-    const y = point.y;
-    const z = point.z;
+    const origin = options.worldOrigin;
+    const x = point.x - (origin?.x ?? 0);
+    const y = point.y - (origin?.y ?? 0);
+    const z = point.z - (origin?.z ?? 0);
     const viewZ = x * v[2]! + y * v[6]! + z * v[10]! + v[14]!;
     const clipX = x * vp[0]! + y * vp[4]! + z * vp[8]! + vp[12]!;
     const clipY = x * vp[1]! + y * vp[5]! + z * vp[9]! + vp[13]!;

--- a/packages/babylon-lite/src/camera/world-to-screen.ts
+++ b/packages/babylon-lite/src/camera/world-to-screen.ts
@@ -28,7 +28,7 @@ export interface ScreenProjectionResult extends Vec3 {
     behindCamera: boolean;
     /** True when the point is outside any WebGPU clip plane or is non-finite. */
     clipped: boolean;
-    /** True when the point cannot appear inside the viewport's 2D rectangle. */
+    /** True when the point cannot appear inside the viewport's 2D rectangle, including negative clip W. */
     offscreen: boolean;
 }
 
@@ -46,7 +46,7 @@ function validateOptions(options: ScreenProjectionOptions): void {
         !(backingHeight > 0) ||
         !Number.isFinite(backingHeight)
     ) {
-        throw new RangeError("ScreenProjectionOptions backing dimensions and viewport must be positive and finite.");
+        throw new RangeError("ScreenProjectionOptions backing dimensions and viewport extents must be positive and finite; viewport offsets must be finite.");
     }
     if (
         (cssWidth === undefined) !== (cssHeight === undefined) ||

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -608,6 +608,8 @@ export { getViewMatrix, getProjectionMatrix, getViewProjectionMatrix, getCameraP
 export { getEffectiveAspectRatio } from "./camera/camera.js";
 export { resolveCameraViewport } from "./camera/viewport.js";
 export type { PixelViewport } from "./camera/viewport.js";
+export { projectWorldToScreen, projectWorldToScreenToRef } from "./camera/world-to-screen.js";
+export type { ScreenProjectionOptions, ScreenProjectionResult } from "./camera/world-to-screen.js";
 export type { FreeCamera } from "./camera/free-camera.js";
 export type { BankedFreeCamera } from "./camera/banked-free-camera.js";
 export type { Mesh, MeshGPU } from "./mesh/mesh.js";

--- a/tests/lite/build/world-to-screen-treeshake.test.ts
+++ b/tests/lite/build/world-to-screen-treeshake.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { cleanupTempDirs, ensureLibBuilt, LIB_ENTRY, runRollup } from "./bundler-harness";
+
+afterAll(cleanupTempDirs);
+beforeAll(ensureLibBuilt);
+
+describe("world-to-screen tree shaking", () => {
+    it("retains zero projection bytes when unused", async () => {
+        const baseline = await runRollup({
+            entrySource: `import { createSceneContext } from ${JSON.stringify(LIB_ENTRY)};\nconsole.log(createSceneContext);\n`,
+            format: "es",
+            minify: false,
+        });
+        const result = await runRollup({
+            entrySource: `import { createSceneContext, projectWorldToScreen, projectWorldToScreenToRef } from ${JSON.stringify(LIB_ENTRY)};\nconsole.log(createSceneContext);\n`,
+            format: "es",
+            minify: false,
+        });
+
+        expect(baseline.errors).toEqual([]);
+        expect(baseline.significantWarnings).toEqual([]);
+        expect(result.errors).toEqual([]);
+        expect(result.significantWarnings).toEqual([]);
+        expect(result.code).toBe(baseline.code);
+        expect(result.code).not.toContain("ScreenProjectionOptions");
+        expect(result.code).not.toContain("behindCamera");
+    });
+
+    it("retains the projection module when its public helper is consumed", async () => {
+        const result = await runRollup({
+            entrySource: `import { projectWorldToScreenToRef } from ${JSON.stringify(LIB_ENTRY)};\nconsole.log(projectWorldToScreenToRef);\n`,
+            format: "es",
+            minify: false,
+        });
+
+        expect(result.errors).toEqual([]);
+        expect(result.significantWarnings).toEqual([]);
+        expect(result.code).toContain("ScreenProjectionOptions");
+        expect(result.code).toContain("behindCamera");
+    });
+});

--- a/tests/lite/unit/world-to-screen.test.ts
+++ b/tests/lite/unit/world-to-screen.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import { createArcRotateCamera } from "../../../packages/babylon-lite/src/camera/arc-rotate";
+import { getEffectiveAspectRatio, getViewMatrix, getViewProjectionMatrix } from "../../../packages/babylon-lite/src/camera/camera";
+import { enableOrthographicCamera } from "../../../packages/babylon-lite/src/camera/orthographic";
+import { resolveCameraViewport, type PixelViewport } from "../../../packages/babylon-lite/src/camera/viewport";
+import {
+    projectWorldToScreen,
+    projectWorldToScreenToRef,
+    type ScreenProjectionOptions,
+    type ScreenProjectionResult,
+} from "../../../packages/babylon-lite/src/camera/world-to-screen";
+
+const BACKING_WIDTH = 800;
+const BACKING_HEIGHT = 600;
+
+function result(): ScreenProjectionResult {
+    return {
+        x: -1,
+        y: -1,
+        z: -1,
+        cssX: -1,
+        cssY: -1,
+        clipW: -1,
+        behindCamera: true,
+        clipped: true,
+        offscreen: true,
+    };
+}
+
+function setup(viewport?: PixelViewport) {
+    const camera = createArcRotateCamera(-Math.PI / 2, Math.PI / 2, 10, { x: 0, y: 0, z: 0 });
+    const options: ScreenProjectionOptions = {
+        viewport: viewport ?? { x: 0, y: 0, width: BACKING_WIDTH, height: BACKING_HEIGHT },
+        backingWidth: BACKING_WIDTH,
+        backingHeight: BACKING_HEIGHT,
+        cssWidth: 400,
+        cssHeight: 300,
+    };
+    const aspect = options.viewport.width / options.viewport.height;
+    return {
+        camera,
+        options,
+        project(point: { x: number; y: number; z: number }): ScreenProjectionResult {
+            return projectWorldToScreen(point, getViewMatrix(camera), getViewProjectionMatrix(camera, aspect), options);
+        },
+    };
+}
+
+describe("world-to-screen projection", () => {
+    it("maps a camera-forward point to canvas and CSS center", () => {
+        const { project } = setup();
+
+        expect(project({ x: 0, y: 0, z: 0 })).toMatchObject({
+            x: 400,
+            y: 300,
+            cssX: 200,
+            cssY: 150,
+            behindCamera: false,
+            clipped: false,
+            offscreen: false,
+        });
+    });
+
+    it("applies non-full backing-pixel viewport offsets before CSS scaling", () => {
+        const { project } = setup({ x: 200, y: 150, width: 400, height: 300 });
+
+        expect(project({ x: 0, y: 0, z: 0 })).toMatchObject({
+            x: 400,
+            y: 300,
+            cssX: 200,
+            cssY: 150,
+        });
+    });
+
+    it("derives the active normalized camera viewport with existing public helpers", () => {
+        const camera = createArcRotateCamera(-Math.PI / 2, Math.PI / 2, 10, { x: 0, y: 0, z: 0 });
+        camera.viewport = { x: 0.25, y: 0.25, width: 0.5, height: 0.5 };
+        const viewport = resolveCameraViewport(camera, BACKING_WIDTH, BACKING_HEIGHT);
+        const aspect = getEffectiveAspectRatio(camera, BACKING_WIDTH, BACKING_HEIGHT);
+
+        const projected = projectWorldToScreen({ x: 0, y: 0, z: 0 }, getViewMatrix(camera), getViewProjectionMatrix(camera, aspect), {
+            viewport,
+            backingWidth: BACKING_WIDTH,
+            backingHeight: BACKING_HEIGHT,
+        });
+
+        expect(viewport).toEqual({ x: 200, y: 150, width: 400, height: 300 });
+        expect(projected).toMatchObject({ x: 400, y: 300, cssX: 400, cssY: 300 });
+    });
+
+    it("identifies a perspective point behind the camera", () => {
+        const { project } = setup();
+
+        expect(project({ x: 0, y: 0, z: -20 })).toMatchObject({
+            behindCamera: true,
+            clipped: true,
+            offscreen: true,
+        });
+    });
+
+    it("identifies an orthographic point behind the camera despite clip W remaining one", () => {
+        const { camera, options } = setup();
+        enableOrthographicCamera(camera, { halfHeight: 5 });
+
+        const projected = projectWorldToScreen({ x: 0, y: 0, z: -20 }, getViewMatrix(camera), getViewProjectionMatrix(camera, 4 / 3), options);
+
+        expect(projected.clipW).toBe(1);
+        expect(projected).toMatchObject({
+            behindCamera: true,
+            clipped: true,
+            offscreen: true,
+        });
+    });
+
+    it("retains extrapolated coordinates for finite XY-offscreen points", () => {
+        const { project } = setup();
+        const projected = project({ x: 100, y: 0, z: 0 });
+
+        expect(projected.x).toBeGreaterThan(BACKING_WIDTH);
+        expect(projected.cssX).toBeGreaterThan(400);
+        expect(projected).toMatchObject({
+            behindCamera: false,
+            clipped: true,
+            offscreen: true,
+        });
+    });
+
+    it("distinguishes depth-only clipping from XY offscreen behavior", () => {
+        const { project } = setup();
+        const projected = project({ x: 0, y: 0, z: -9.95 });
+
+        expect(projected.z).toBeGreaterThan(1);
+        expect(projected).toMatchObject({
+            behindCamera: false,
+            clipped: true,
+            offscreen: false,
+        });
+    });
+
+    it("writes NaN coordinates and non-displayable flags when clip W is zero", () => {
+        const { camera, options } = setup();
+        const projected = projectWorldToScreen({ x: 0, y: 0, z: -10 }, getViewMatrix(camera), getViewProjectionMatrix(camera, 4 / 3), options);
+
+        expect(projected.clipW).toBeCloseTo(0, 10);
+        expect(projected.x).toBeNaN();
+        expect(projected.y).toBeNaN();
+        expect(projected.z).toBeNaN();
+        expect(projected.cssX).toBeNaN();
+        expect(projected.cssY).toBeNaN();
+        expect(projected.clipped).toBe(true);
+        expect(projected.offscreen).toBe(true);
+    });
+
+    it("reuses and fully overwrites the supplied result", () => {
+        const { camera, options } = setup();
+        const target = result();
+
+        const returned = projectWorldToScreenToRef({ x: 0, y: 0, z: 0 }, getViewMatrix(camera), getViewProjectionMatrix(camera, 4 / 3), options, target);
+
+        expect(returned).toBe(target);
+        expect(target).toMatchObject({
+            x: 400,
+            y: 300,
+            cssX: 200,
+            cssY: 150,
+            behindCamera: false,
+            clipped: false,
+            offscreen: false,
+        });
+    });
+
+    it("rejects invalid backing, viewport, and partial CSS dimensions", () => {
+        const { camera, options } = setup();
+        const view = getViewMatrix(camera);
+        const viewProjection = getViewProjectionMatrix(camera, 4 / 3);
+        const point = { x: 0, y: 0, z: 0 };
+
+        expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, backingWidth: 0 })).toThrow(RangeError);
+        expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, viewport: { ...options.viewport, height: Number.NaN } })).toThrow(RangeError);
+        expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, cssHeight: undefined })).toThrow(RangeError);
+    });
+});

--- a/tests/lite/unit/world-to-screen.test.ts
+++ b/tests/lite/unit/world-to-screen.test.ts
@@ -4,6 +4,8 @@ import { createArcRotateCamera } from "../../../packages/babylon-lite/src/camera
 import { getEffectiveAspectRatio, getViewMatrix, getViewProjectionMatrix } from "../../../packages/babylon-lite/src/camera/camera";
 import { enableOrthographicCamera } from "../../../packages/babylon-lite/src/camera/orthographic";
 import { resolveCameraViewport, type PixelViewport } from "../../../packages/babylon-lite/src/camera/viewport";
+import { mat4Identity } from "../../../packages/babylon-lite/src/math/mat4-identity";
+import type { Mat4Storage } from "../../../packages/babylon-lite/src/math/types";
 import {
     projectWorldToScreen,
     projectWorldToScreenToRef,
@@ -126,6 +128,26 @@ describe("world-to-screen projection", () => {
         });
     });
 
+    it("marks negative clip W as non-displayable independently of view-space facing", () => {
+        const { options } = setup();
+        const viewProjection = mat4Identity();
+        const storage = viewProjection as unknown as Mat4Storage;
+        storage[10] = -0.5;
+        storage[15] = -1;
+
+        const projected = projectWorldToScreen({ x: 0, y: 0, z: 1 }, mat4Identity(), viewProjection, options);
+
+        expect(projected).toMatchObject({
+            x: 400,
+            y: 300,
+            z: 0.5,
+            clipW: -1,
+            behindCamera: false,
+            clipped: true,
+            offscreen: true,
+        });
+    });
+
     it("distinguishes depth-only clipping from XY offscreen behavior", () => {
         const { project } = setup();
         const projected = project({ x: 0, y: 0, z: -9.95 });
@@ -176,8 +198,13 @@ describe("world-to-screen projection", () => {
         const viewProjection = getViewProjectionMatrix(camera, 4 / 3);
         const point = { x: 0, y: 0, z: 0 };
 
-        expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, backingWidth: 0 })).toThrow(RangeError);
+        expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, backingWidth: 0 })).toThrow(
+            "ScreenProjectionOptions backing dimensions and viewport extents must be positive and finite; viewport offsets must be finite."
+        );
         expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, viewport: { ...options.viewport, height: Number.NaN } })).toThrow(RangeError);
+        expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, viewport: { ...options.viewport, x: Number.NaN } })).toThrow(
+            "viewport offsets must be finite"
+        );
         expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, cssHeight: undefined })).toThrow(RangeError);
     });
 });

--- a/tests/lite/unit/world-to-screen.test.ts
+++ b/tests/lite/unit/world-to-screen.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { createArcRotateCamera } from "../../../packages/babylon-lite/src/camera/arc-rotate";
 import { getEffectiveAspectRatio, getViewMatrix, getViewProjectionMatrix } from "../../../packages/babylon-lite/src/camera/camera";
+import { createFreeCamera } from "../../../packages/babylon-lite/src/camera/free-camera";
 import { enableOrthographicCamera } from "../../../packages/babylon-lite/src/camera/orthographic";
 import { resolveCameraViewport, type PixelViewport } from "../../../packages/babylon-lite/src/camera/viewport";
+import { allocateF64Mat4 } from "../../../packages/babylon-lite/src/math/_mat4-storage-f64";
+import { _resetMatrixAllocatorForTests, _setHpmAllocator } from "../../../packages/babylon-lite/src/math/_matrix-allocator";
 import { mat4Identity } from "../../../packages/babylon-lite/src/math/mat4-identity";
 import type { Mat4Storage } from "../../../packages/babylon-lite/src/math/types";
 import {
@@ -15,6 +18,7 @@ import {
 
 const BACKING_WIDTH = 800;
 const BACKING_HEIGHT = 600;
+const FAR = 4_637_862.01;
 
 function result(): ScreenProjectionResult {
     return {
@@ -50,6 +54,9 @@ function setup(viewport?: PixelViewport) {
 }
 
 describe("world-to-screen projection", () => {
+    beforeAll(() => _setHpmAllocator(allocateF64Mat4));
+    afterAll(() => _resetMatrixAllocatorForTests());
+
     it("maps a camera-forward point to canvas and CSS center", () => {
         const { project } = setup();
 
@@ -115,6 +122,64 @@ describe("world-to-screen projection", () => {
         });
     });
 
+    it("preserves perspective projection and facing under floating-origin rebasing", () => {
+        const { options } = setup();
+        const worldOrigin = { x: FAR, y: -FAR, z: FAR };
+        const absoluteCamera = createFreeCamera({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 10 });
+        const floatingCamera = createFreeCamera(worldOrigin, { x: FAR, y: -FAR, z: FAR + 10 });
+        floatingCamera._useFloatingOrigin = true;
+        const aspect = BACKING_WIDTH / BACKING_HEIGHT;
+        const floatingView = getViewMatrix(floatingCamera);
+        const floatingViewProjection = getViewProjectionMatrix(floatingCamera, aspect);
+
+        const absoluteFront = projectWorldToScreen({ x: 0, y: 0, z: 10 }, getViewMatrix(absoluteCamera), getViewProjectionMatrix(absoluteCamera, aspect), options);
+        const floatingFront = projectWorldToScreen({ x: FAR, y: -FAR, z: FAR + 10 }, floatingView, floatingViewProjection, {
+            ...options,
+            worldOrigin,
+        });
+        const unrebasedBehind = projectWorldToScreen({ x: FAR, y: -FAR, z: FAR - 10 }, floatingView, floatingViewProjection, options);
+        const floatingBehind = projectWorldToScreen({ x: FAR, y: -FAR, z: FAR - 10 }, floatingView, floatingViewProjection, {
+            ...options,
+            worldOrigin,
+        });
+
+        expect(floatingFront.x).toBeCloseTo(absoluteFront.x);
+        expect(floatingFront.y).toBeCloseTo(absoluteFront.y);
+        expect(floatingFront.z).toBeCloseTo(absoluteFront.z);
+        expect(floatingFront).toMatchObject({ behindCamera: false, clipped: false, offscreen: false });
+        expect(unrebasedBehind.behindCamera).toBe(false);
+        expect(floatingBehind).toMatchObject({ behindCamera: true, clipped: true, offscreen: true });
+    });
+
+    it("preserves orthographic projection and facing under floating-origin rebasing", () => {
+        const { options } = setup();
+        const worldOrigin = { x: FAR, y: -FAR, z: FAR };
+        const absoluteCamera = createFreeCamera({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 10 });
+        const floatingCamera = createFreeCamera(worldOrigin, { x: FAR, y: -FAR, z: FAR + 10 });
+        enableOrthographicCamera(absoluteCamera, { halfHeight: 5 });
+        enableOrthographicCamera(floatingCamera, { halfHeight: 5 });
+        floatingCamera._useFloatingOrigin = true;
+        const aspect = BACKING_WIDTH / BACKING_HEIGHT;
+        const floatingView = getViewMatrix(floatingCamera);
+        const floatingViewProjection = getViewProjectionMatrix(floatingCamera, aspect);
+
+        const absoluteFront = projectWorldToScreen({ x: 2, y: 1, z: 10 }, getViewMatrix(absoluteCamera), getViewProjectionMatrix(absoluteCamera, aspect), options);
+        const floatingFront = projectWorldToScreen({ x: FAR + 2, y: -FAR + 1, z: FAR + 10 }, floatingView, floatingViewProjection, {
+            ...options,
+            worldOrigin,
+        });
+        const floatingBehind = projectWorldToScreen({ x: FAR, y: -FAR, z: FAR - 10 }, floatingView, floatingViewProjection, {
+            ...options,
+            worldOrigin,
+        });
+
+        expect(floatingFront.x).toBeCloseTo(absoluteFront.x);
+        expect(floatingFront.y).toBeCloseTo(absoluteFront.y);
+        expect(floatingFront.z).toBeCloseTo(absoluteFront.z);
+        expect(floatingFront).toMatchObject({ behindCamera: false, clipped: false, offscreen: false });
+        expect(floatingBehind).toMatchObject({ behindCamera: true, clipped: true, offscreen: true });
+    });
+
     it("retains extrapolated coordinates for finite XY-offscreen points", () => {
         const { project } = setup();
         const projected = project({ x: 100, y: 0, z: 0 });
@@ -178,7 +243,13 @@ describe("world-to-screen projection", () => {
         const { camera, options } = setup();
         const target = result();
 
-        const returned = projectWorldToScreenToRef({ x: 0, y: 0, z: 0 }, getViewMatrix(camera), getViewProjectionMatrix(camera, 4 / 3), options, target);
+        const returned = projectWorldToScreenToRef(
+            { x: FAR, y: 0, z: 0 },
+            getViewMatrix(camera),
+            getViewProjectionMatrix(camera, 4 / 3),
+            { ...options, worldOrigin: { x: FAR, y: 0, z: 0 } },
+            target
+        );
 
         expect(returned).toBe(target);
         expect(target).toMatchObject({
@@ -205,6 +276,7 @@ describe("world-to-screen projection", () => {
         expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, viewport: { ...options.viewport, x: Number.NaN } })).toThrow(
             "viewport offsets must be finite"
         );
+        expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, worldOrigin: { x: Number.NaN, y: 0, z: 0 } })).toThrow("world origin must be finite");
         expect(() => projectWorldToScreen(point, view, viewProjection, { ...options, cssHeight: undefined })).toThrow(RangeError);
     });
 });


### PR DESCRIPTION
## Summary

- add public `projectWorldToScreen` and allocation-free `projectWorldToScreenToRef` helpers
- return canvas backing-pixel and canvas-relative CSS coordinates with explicit `behindCamera`, `clipped`, and `offscreen` state
- support caller-derived view/projection matrices, partial backing-pixel viewports, CSS/backing scaling, and both perspective and orthographic cameras without DOM dependencies
- add an explicit optional `worldOrigin` rebase for eye-relative/floating-origin matrices while keeping the leaf helper independent from camera and scene runtime code
- document the API contract and a generic Babylon.js migration example
- add focused behavior, floating-origin, public API, DOM-free import, and exact unused-retention coverage

## API contract

The helper uses Babylon Lite's column-major `Mat4`, `Vec3`, `PixelViewport`, and left-handed/reverse-Z conventions. Finite offscreen coordinates are not clamped. Near/far-only clipping is distinguished from XY offscreen state, and non-finite or zero-W projections return `NaN` coordinates with non-displayable flags.

The caller can derive active state with `getViewMatrix`, `getViewProjectionMatrix`, `getEffectiveAspectRatio`, and `resolveCameraViewport`. CSS dimensions are explicit, so the math supports DPR clamping, explicit backing sizes, and offscreen rendering without reading browser globals. When supplied matrices use a rebased frame, `worldOrigin` identifies the absolute world-space point represented by matrix-space zero. For Large World Rendering, pass `getFloatingOriginOffset(scene)`.

## Bundle impact

Measured with the shipped module-granular build, minified Vite/Rollup output, and gzip level 9 against an identical sentinel entry:

| Retained API | Raw delta | Gzip delta |
| --- | ---: | ---: |
| Unused helpers | 0 B | 0 B |
| `projectWorldToScreenToRef` | +3,157 B | +868 B |
| `projectWorldToScreen` | +3,441 B | +923 B |

The unused bundle is byte-for-byte identical to baseline.

## Validation

- `REUSE_BROWSER=1 pnpm exec vitest run tests/lite/unit/world-to-screen.test.ts`
- `REUSE_BROWSER=1 pnpm exec vitest run tests/lite/build/world-to-screen-treeshake.test.ts`
- `REUSE_BROWSER=1 pnpm exec vitest run tests/lite/no-webgpu/import-without-webgpu.test.ts`
- `REUSE_BROWSER=1 pnpm exec vitest run tests/lite/build/public-api-types.test.ts`
- `pnpm run lint`

`pnpm run docs:check` currently cannot start because the repository lock resolves `markdown-it@14.3.0` to incompatible `linkify-it@6.1.0`; no dependency or lockfile changes are included in this PR.