### PR TITLE
fix(texture): take a creation ref in createSolidTexture2D

### DIFF
--- a/packages/babylon-lite/src/texture/solid-texture.ts
+++ b/packages/babylon-lite/src/texture/solid-texture.ts
@@ -6,6 +6,7 @@ import { TU } from "../engine/gpu-flags.js";
 import type { Texture2D } from "./texture-2d.js";
 import type { EngineContext } from "../engine/engine.js";
 import { getBilinearSampler } from "../resource/samplers.js";
+import { acquireTexture } from "../resource/gpu-pool.js";
 
 /** Create a 1×1 solid-color `Texture2D` from straight RGBA components in [0, 1].
  *  @param engine - Engine context.
@@ -29,5 +30,10 @@ export function createSolidTexture2D(engine: EngineContext, r: number, g: number
 
     const tex: Texture2D = { texture, view: texture.createView(), sampler, width: 1, height: 1 };
     engine._dlr?.s(tex, r, g, b, a);
+    // Creation-time ownership ref, as every other texture factory takes. Without it the
+    // ref count starts at 0 instead of 1, so the FIRST `releaseTexture` — a single mesh
+    // leaving the scene — destroys a texture the material still points at, and every
+    // later frame submits the dead texture.
+    acquireTexture(tex);
     return tex;
 }

--- a/tests/lite/unit/solid-texture.test.ts
+++ b/tests/lite/unit/solid-texture.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { createSolidTexture2D } from "../../../packages/babylon-lite/src/texture/solid-texture";
+import { acquireTexture, releaseTexture } from "../../../packages/babylon-lite/src/resource/gpu-pool";
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+
+interface Captured {
+    createDesc?: GPUTextureDescriptor;
+    writeData?: ArrayBufferView;
+    destroyed: number;
+}
+
+function makeEngine(cap: Captured): EngineContext {
+    const device = {
+        createTexture: (desc: GPUTextureDescriptor) => {
+            cap.createDesc = desc;
+            return {
+                createView: () => ({ _kind: "view" }) as unknown as GPUTextureView,
+                destroy: () => {
+                    cap.destroyed++;
+                },
+            } as unknown as GPUTexture;
+        },
+        createSampler: () => ({ _kind: "sampler" }) as unknown as GPUSampler,
+        queue: {
+            writeTexture: (_dst: unknown, data: ArrayBufferView) => {
+                cap.writeData = data;
+            },
+        },
+    } as unknown as GPUDevice;
+    return { _device: device } as unknown as EngineContext;
+}
+
+describe("createSolidTexture2D", () => {
+    it("writes the colour as straight RGBA8 into a 1x1 texture", () => {
+        const cap: Captured = { destroyed: 0 };
+        const engine = makeEngine(cap);
+
+        createSolidTexture2D(engine, 1, 0.5, 0, 1);
+
+        expect(cap.createDesc?.size).toEqual({ width: 1, height: 1 });
+        expect(cap.createDesc?.format).toBe("rgba8unorm");
+        expect(Array.from(cap.writeData as Uint8Array)).toEqual([255, 128, 0, 255]);
+    });
+
+    it("takes a creation-time ownership ref so the texture outlives its materials", () => {
+        const cap: Captured = { destroyed: 0 };
+        const engine = makeEngine(cap);
+
+        // Creation acquire → ref 1. Without it the ref count starts at 0 and the first
+        // release below would destroy a texture the material still points at, leaving
+        // every later frame submitting a dead texture.
+        const tex = createSolidTexture2D(engine, 1, 1, 1, 1);
+
+        acquireTexture(tex); // a mesh's renderable binds it → ref 2
+        expect(releaseTexture(tex)).toBe(false); // that mesh leaves the scene → ref 1, survives
+        expect(cap.destroyed).toBe(0);
+    });
+
+    it("survives every mesh releasing it and is destroyed only when the creator releases too", () => {
+        const cap: Captured = { destroyed: 0 };
+        const engine = makeEngine(cap);
+        const tex = createSolidTexture2D(engine, 0.2, 0.2, 0.2, 1);
+
+        // Two meshes share the material's solid texture, then both go away.
+        acquireTexture(tex);
+        acquireTexture(tex);
+        expect(releaseTexture(tex)).toBe(false);
+        expect(releaseTexture(tex)).toBe(false);
+        expect(cap.destroyed).toBe(0);
+
+        // Only the creator's own release frees it.
+        expect(releaseTexture(tex)).toBe(true);
+        expect(cap.destroyed).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary

`createSolidTexture2D` handed out a `Texture2D` whose refcount did not include the creator, so the first `releaseTexture2D` from a material that stopped using the 1×1 fallback destroyed the GPU texture while other materials (and the material's own bind group) still referenced it.

Seen in a kitchen configurator on Lite 1.26.0 as `[Texture] used in submit while destroyed` right after a material swapped its albedo from the solid fallback to a loaded texture; the flood stopped only on a scene rebuild.

## Change

`createSolidTexture2D` now takes a creation ref like the other `createTexture2D*` paths, so the last user releasing the texture is what destroys it.

## Test

`tests/lite/unit/solid-texture.test.ts` — the solid texture survives a release by one of two users and is destroyed only after the creator's ref is dropped; fails without the fix.
