### PR TITLE
fix(shadow): park the caster set while the registration preload is in flight

### DIFF
--- a/packages/babylon-lite/src/frame-graph/shadow-inputs.ts
+++ b/packages/babylon-lite/src/frame-graph/shadow-inputs.ts
@@ -15,21 +15,11 @@ export function setShadowTaskCasterMeshes(shadowGenerator: ShadowGenerator, cast
     if (!shadowTaskInputPreloader) {
         return;
     }
-    // The preload dynamically imports the no-colour material views for the caster families present in
-    // THIS set. Rendering before it resolves would call a factory that is still undefined, so the set is
-    // parked on the generator and skipped until the import lands. Initial registration is already awaited
-    // through the task's `_preload`; this covers the runtime updates, which cannot await.
-    shadowGenerator._preloadPending = casterMeshes;
-    void shadowTaskInputPreloader(shadowGenerator, casterMeshes).then(
-        () => {
-            if (shadowGenerator._preloadPending === casterMeshes) {
-                shadowGenerator._preloadPending = undefined;
-            }
-        },
-        // Leave the set parked — hence the generator skipped: a failed import means the factory is still
-        // missing, and rendering anyway would throw inside the frame with a far less actionable stack.
-        (error: unknown) => console.error(error)
-    );
+    // The preloader (installed by the shadow task, shared with its registration preload) parks the set on
+    // the generator while the no-colour material views for its caster families import, and lifts the park
+    // only on success. A runtime update cannot await it: a failed import is reported here, where the
+    // stack still names the set, and the generator stays skipped instead of throwing inside the frame.
+    void shadowTaskInputPreloader(shadowGenerator, casterMeshes).catch((error: unknown) => console.error(error));
 }
 
 /** @internal */

--- a/packages/babylon-lite/src/frame-graph/shadow-task.ts
+++ b/packages/babylon-lite/src/frame-graph/shadow-task.ts
@@ -39,7 +39,19 @@ export function createShadowTask(engine: EngineContext, scene: SceneContext): Sh
                 const casterMeshes = sg ? _getShadowTaskCasterMeshes(sg) : null;
                 if (sg?._preloadShadowTask && casterMeshes) {
                     shadowGenerators.add(sg);
-                    loads.push(sg._preloadShadowTask(casterMeshes));
+                    // Park the set while its no-colour views import, exactly like a runtime re-supply
+                    // (`setShadowTaskCasterMeshes`). Registration awaits this preload, but the scene is
+                    // already `_built` by then: a rebuild the application triggers during the await
+                    // (material swap, mesh added) runs `frameGraph.build()` → `record()` and would call a
+                    // family factory that is still undefined. `record`/`execute` skip a parked generator.
+                    sg._preloadPending = casterMeshes;
+                    loads.push(
+                        sg._preloadShadowTask(casterMeshes).then(() => {
+                            if (sg._preloadPending === casterMeshes) {
+                                sg._preloadPending = undefined;
+                            }
+                        })
+                    );
                 }
             }
             await Promise.all(loads);

--- a/packages/babylon-lite/src/frame-graph/shadow-task.ts
+++ b/packages/babylon-lite/src/frame-graph/shadow-task.ts
@@ -39,19 +39,12 @@ export function createShadowTask(engine: EngineContext, scene: SceneContext): Sh
                 const casterMeshes = sg ? _getShadowTaskCasterMeshes(sg) : null;
                 if (sg?._preloadShadowTask && casterMeshes) {
                     shadowGenerators.add(sg);
-                    // Park the set while its no-colour views import, exactly like a runtime re-supply
-                    // (`setShadowTaskCasterMeshes`). Registration awaits this preload, but the scene is
-                    // already `_built` by then: a rebuild the application triggers during the await
-                    // (material swap, mesh added) runs `frameGraph.build()` → `record()` and would call a
-                    // family factory that is still undefined. `record`/`execute` skip a parked generator.
-                    sg._preloadPending = casterMeshes;
-                    loads.push(
-                        sg._preloadShadowTask(casterMeshes).then(() => {
-                            if (sg._preloadPending === casterMeshes) {
-                                sg._preloadPending = undefined;
-                            }
-                        })
-                    );
+                    // Registration awaits this preload, but the scene is already `_built` by then: a rebuild
+                    // the application triggers during the await (material swap, mesh added) runs
+                    // `frameGraph.build()` → `record()` and would call a family factory that is still
+                    // undefined. `preloadShadowTaskInput` parks the set exactly like a runtime re-supply, and a
+                    // failed import rejects registration with the set still parked.
+                    loads.push(preloadShadowTaskInput(sg, casterMeshes));
                 }
             }
             await Promise.all(loads);
@@ -104,6 +97,19 @@ export function createShadowTask(engine: EngineContext, scene: SceneContext): Sh
     return task;
 }
 
+/**
+ * Park `casterMeshes` on the generator while the no-colour material views for its caster families
+ * import — rendering before that would call a factory that is still undefined, so `record`/`execute`
+ * skip a parked generator — then lift the park, only on success and only if no newer set superseded
+ * this one meanwhile. A rejected import leaves the set parked: the factory is still missing, and
+ * rendering anyway would throw inside the frame with a far less actionable stack. Shared by the
+ * registration preload above, which awaits it, and — installed through `_setShadowTaskInputPreloader` —
+ * by the runtime re-supply in `setShadowTaskCasterMeshes`, which cannot.
+ */
 async function preloadShadowTaskInput(shadowGenerator: ShadowGenerator, casterMeshes: readonly Mesh[]): Promise<void> {
+    shadowGenerator._preloadPending = casterMeshes;
     await shadowGenerator._preloadShadowTask?.(casterMeshes);
+    if (shadowGenerator._preloadPending === casterMeshes) {
+        shadowGenerator._preloadPending = undefined;
+    }
 }

--- a/tests/lite/unit/shadow-caster-preload-race.test.ts
+++ b/tests/lite/unit/shadow-caster-preload-race.test.ts
@@ -5,26 +5,48 @@ import type { Material } from "../../../packages/babylon-lite/src/material/mater
 import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
 import type { SceneContext } from "../../../packages/babylon-lite/src/scene/scene-core";
 import type { ShadowGenerator } from "../../../packages/babylon-lite/src/shadow/shadow-generator";
-import { _setShadowTaskInputPreloader, setShadowTaskCasterMeshes } from "../../../packages/babylon-lite/src/frame-graph/shadow-inputs";
+import { setShadowTaskCasterMeshes } from "../../../packages/babylon-lite/src/frame-graph/shadow-inputs";
 import { createShadowTask } from "../../../packages/babylon-lite/src/frame-graph/shadow-task";
 import { getNoColorView, preloadPcfShadowTaskState } from "../../../packages/babylon-lite/src/shadow/pcf-shadow-task-hooks";
 
-/** A generator whose caster set is supplied at runtime, after the scene already booted. */
-function makeGenerator(): ShadowGenerator {
-    return {
-        _preloadShadowTask: undefined,
-        _ensureShadowTaskState: undefined,
-        _renderShadowMap: undefined,
+type Preload = (casterMeshes: readonly Mesh[]) => Promise<void>;
+
+/**
+ * A generator whose no-colour view import is driven by the test through `_preloadShadowTask`, plus a spy on
+ * its state builder. The preloader that parks the set is the real one: `createShadowTask` installs it for
+ * the runtime re-supply path and uses it for the registration preload.
+ */
+function makeGenerator(preloadShadowTask: Preload = () => Promise.resolve()) {
+    const ensureState = vi.fn(() => ({ _task: { record: vi.fn(), dispose: vi.fn() }, _casterMeshes: [] }));
+    const renderShadowMap = vi.fn(() => 1);
+    const sg = {
+        _preloadShadowTask: preloadShadowTask,
+        _ensureShadowTaskState: ensureState,
+        _renderShadowMap: renderShadowMap,
         _shadowTaskState: undefined,
     } as unknown as ShadowGenerator;
+    const scene = { lights: [{ shadowGenerator: sg }], _renderableVersion: 1 } as unknown as SceneContext;
+    const task = createShadowTask({} as EngineContext, scene);
+    return { sg, task, ensureState, renderShadowMap };
+}
+
+/** A per-set import the test releases by hand. */
+function gate() {
+    let release!: () => void;
+    const promise = new Promise<void>((resolve) => (release = resolve));
+    return { promise, release };
+}
+
+async function settle(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 }
 
 describe("shadow caster preload race", () => {
     it("keeps a generator out of the frame until its runtime caster preload resolves", async () => {
-        const sg = makeGenerator();
-        let releasePreload!: () => void;
-        const preloaded = new Promise<void>((resolve) => (releasePreload = resolve));
-        _setShadowTaskInputPreloader(() => preloaded);
+        const preload = gate();
+        const { sg } = makeGenerator(() => preload.promise);
 
         setShadowTaskCasterMeshes(sg, [{} as Mesh]);
 
@@ -32,31 +54,15 @@ describe("shadow caster preload race", () => {
         // no-colour material factory that is still undefined.
         expect(sg._preloadPending).toBeDefined();
 
-        releasePreload();
-        await preloaded;
-        await Promise.resolve();
+        preload.release();
+        await settle();
 
         expect(sg._preloadPending).toBeUndefined();
     });
 
     it("does not build or render shadow state for a generator whose preload is still in flight", async () => {
-        const sg = makeGenerator();
-        const recordTask = vi.fn();
-        const ensureState = vi.fn(() => ({ _task: { record: recordTask, dispose: vi.fn() }, _casterMeshes: [] }));
-        const renderShadowMap = vi.fn(() => 1);
-        const generator = sg as unknown as {
-            _ensureShadowTaskState: unknown;
-            _renderShadowMap: unknown;
-        };
-        generator._ensureShadowTaskState = ensureState;
-        generator._renderShadowMap = renderShadowMap;
-
-        const scene = { lights: [{ shadowGenerator: sg }], _renderableVersion: 1 } as unknown as SceneContext;
-        // `createShadowTask` installs the real preloader, so the stub must be registered after it.
-        const task = createShadowTask({} as EngineContext, scene);
-        let releasePreload!: () => void;
-        const preloaded = new Promise<void>((resolve) => (releasePreload = resolve));
-        _setShadowTaskInputPreloader(() => preloaded);
+        const preload = gate();
+        const { sg, task, ensureState, renderShadowMap } = makeGenerator(() => preload.promise);
 
         setShadowTaskCasterMeshes(sg, [{} as Mesh]);
 
@@ -64,10 +70,8 @@ describe("shadow caster preload race", () => {
         expect(ensureState).not.toHaveBeenCalled();
         expect(renderShadowMap).not.toHaveBeenCalled();
 
-        releasePreload();
-        await preloaded;
-        await Promise.resolve();
-        await Promise.resolve();
+        preload.release();
+        await settle();
 
         expect(task.execute?.()).toBe(1);
         expect(renderShadowMap).toHaveBeenCalledTimes(1);
@@ -75,14 +79,10 @@ describe("shadow caster preload race", () => {
 
     it("keeps the generator skipped and reports the failure when the preload rejects", async () => {
         const error = vi.spyOn(console, "error").mockImplementation(() => {});
-        const sg = makeGenerator();
-        const rejected = Promise.reject(new Error("no-colour view import failed"));
-        _setShadowTaskInputPreloader(() => rejected);
+        const { sg } = makeGenerator(() => Promise.reject(new Error("no-colour view import failed")));
 
         setShadowTaskCasterMeshes(sg, [{} as Mesh]);
-        await rejected.catch(() => undefined);
-        await Promise.resolve();
-        await Promise.resolve();
+        await settle();
 
         // Rendering with a missing factory would throw inside the frame; staying skipped is the safe state.
         expect(sg._preloadPending).toBeDefined();
@@ -91,13 +91,10 @@ describe("shadow caster preload race", () => {
     });
 
     it("does not let a superseded caster set clear the pending flag of the one that replaced it", async () => {
-        const sg = makeGenerator();
-        let releaseFirst!: () => void;
-        let releaseSecond!: () => void;
-        const first = new Promise<void>((resolve) => (releaseFirst = resolve));
-        const second = new Promise<void>((resolve) => (releaseSecond = resolve));
+        const first = gate();
+        const second = gate();
         let call = 0;
-        _setShadowTaskInputPreloader(() => (call++ === 0 ? first : second));
+        const { sg } = makeGenerator(() => (call++ === 0 ? first.promise : second.promise));
 
         setShadowTaskCasterMeshes(sg, [{} as Mesh]);
         const secondSet = [{} as Mesh];
@@ -105,14 +102,12 @@ describe("shadow caster preload race", () => {
 
         // The first set resolving must not unblock the generator: the views for the SECOND set are the
         // ones the next frame will need.
-        releaseFirst();
-        await first;
-        await Promise.resolve();
+        first.release();
+        await settle();
         expect(sg._preloadPending).toBe(secondSet);
 
-        releaseSecond();
-        await second;
-        await Promise.resolve();
+        second.release();
+        await settle();
         expect(sg._preloadPending).toBeUndefined();
     });
 
@@ -139,23 +134,32 @@ describe("shadow caster preload race", () => {
 });
 
 describe("shadow caster preload during scene registration", () => {
-    it("parks the caster set on the generator until the registration preload resolves", async () => {
-        const sg = makeGenerator();
-        let releasePreload!: () => void;
-        const preloaded = new Promise<void>((resolve) => (releasePreload = resolve));
-        const generator = sg as unknown as { _preloadShadowTask: unknown; _ensureShadowTaskState: unknown };
-        generator._preloadShadowTask = () => preloaded;
-        const ensureState = vi.fn(() => ({ _task: { record: vi.fn(), dispose: vi.fn() }, _casterMeshes: [] }));
-        generator._ensureShadowTaskState = ensureState;
+    /**
+     * The first `_preloadShadowTask` call belongs to the runtime registration of `casters` and resolves at
+     * once, so the park is lifted before the test starts; every later call is driven by `next`.
+     */
+    function makeRegisteringGenerator(next: Preload) {
+        let first = true;
+        return makeGenerator((casterMeshes) => {
+            if (first) {
+                first = false;
+                return Promise.resolve();
+            }
+            return next(casterMeshes);
+        });
+    }
 
-        const scene = { lights: [{ shadowGenerator: sg }], _renderableVersion: 1 } as unknown as SceneContext;
-        const task = createShadowTask({} as EngineContext, scene);
-        _setShadowTaskInputPreloader(() => Promise.resolve());
-        const casters = [{} as Mesh];
+    async function registerCasters(sg: ShadowGenerator, casters: readonly Mesh[]): Promise<void> {
         setShadowTaskCasterMeshes(sg, casters);
-        await Promise.resolve();
-        await Promise.resolve();
+        await settle();
         expect(sg._preloadPending).toBeUndefined();
+    }
+
+    it("parks the caster set on the generator until the registration preload resolves", async () => {
+        const preload = gate();
+        const { sg, task, ensureState } = makeRegisteringGenerator(() => preload.promise);
+        const casters = [{} as Mesh];
+        await registerCasters(sg, casters);
 
         // Registration: `_preload()` is awaited, but the scene is already `_built`, so an application
         // rebuild can call `record()` in the meantime. The generator must stay parked until the import lands.
@@ -164,10 +168,53 @@ describe("shadow caster preload during scene registration", () => {
         task.record();
         expect(ensureState).not.toHaveBeenCalled();
 
-        releasePreload();
+        preload.release();
         await preloading;
         expect(sg._preloadPending).toBeUndefined();
         task.record();
         expect(ensureState).toHaveBeenCalledTimes(1);
+    });
+
+    it("lets a runtime re-supply supersede an in-flight registration preload", async () => {
+        const gates = new Map<readonly Mesh[], ReturnType<typeof gate>>();
+        const { sg, task, ensureState } = makeRegisteringGenerator((casterMeshes) => {
+            const g = gate();
+            gates.set(casterMeshes, g);
+            return g.promise;
+        });
+        const first = [{} as Mesh];
+        const second = [{} as Mesh];
+        await registerCasters(sg, first);
+
+        const preloading = task._preload!();
+        expect(sg._preloadPending).toBe(first);
+        // The application re-supplies the casters while registration is still importing the first set.
+        setShadowTaskCasterMeshes(sg, second);
+        expect(sg._preloadPending).toBe(second);
+
+        // The older preload landing must not lift the park that now belongs to the newer set.
+        gates.get(first)!.release();
+        await preloading;
+        expect(sg._preloadPending).toBe(second);
+        task.record();
+        expect(ensureState).not.toHaveBeenCalled();
+
+        gates.get(second)!.release();
+        await settle();
+        expect(sg._preloadPending).toBeUndefined();
+        task.record();
+        expect(ensureState).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the set parked and rejects registration when the preload fails", async () => {
+        const { sg, task, ensureState } = makeRegisteringGenerator(() => Promise.reject(new Error("no-colour view import failed")));
+        const casters = [{} as Mesh];
+        await registerCasters(sg, casters);
+
+        await expect(task._preload!()).rejects.toThrow("no-colour view import failed");
+        // The factory is still missing: the generator stays out of the frame rather than throwing inside it.
+        expect(sg._preloadPending).toBe(casters);
+        task.record();
+        expect(ensureState).not.toHaveBeenCalled();
     });
 });

--- a/tests/lite/unit/shadow-caster-preload-race.test.ts
+++ b/tests/lite/unit/shadow-caster-preload-race.test.ts
@@ -137,3 +137,37 @@ describe("shadow caster preload race", () => {
         expect(String(thrown ?? "")).not.toContain("is not a function");
     });
 });
+
+describe("shadow caster preload during scene registration", () => {
+    it("parks the caster set on the generator until the registration preload resolves", async () => {
+        const sg = makeGenerator();
+        let releasePreload!: () => void;
+        const preloaded = new Promise<void>((resolve) => (releasePreload = resolve));
+        const generator = sg as unknown as { _preloadShadowTask: unknown; _ensureShadowTaskState: unknown };
+        generator._preloadShadowTask = () => preloaded;
+        const ensureState = vi.fn(() => ({ _task: { record: vi.fn(), dispose: vi.fn() }, _casterMeshes: [] }));
+        generator._ensureShadowTaskState = ensureState;
+
+        const scene = { lights: [{ shadowGenerator: sg }], _renderableVersion: 1 } as unknown as SceneContext;
+        const task = createShadowTask({} as EngineContext, scene);
+        _setShadowTaskInputPreloader(() => Promise.resolve());
+        const casters = [{} as Mesh];
+        setShadowTaskCasterMeshes(sg, casters);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(sg._preloadPending).toBeUndefined();
+
+        // Registration: `_preload()` is awaited, but the scene is already `_built`, so an application
+        // rebuild can call `record()` in the meantime. The generator must stay parked until the import lands.
+        const preloading = task._preload!();
+        expect(sg._preloadPending).toBe(casters);
+        task.record();
+        expect(ensureState).not.toHaveBeenCalled();
+
+        releasePreload();
+        await preloading;
+        expect(sg._preloadPending).toBeUndefined();
+        task.record();
+        expect(ensureState).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary

`setShadowTaskCasterMeshes` parks a runtime-supplied caster set on `sg._preloadPending` while the no-colour material views import, and the shadow task's `record`/`execute` skip a parked generator. The registration path had no such guard: `registerScene[WithShadowSupport]` awaits the task's `_preload()`, but `buildScene` has already set `_built`, so an application rebuild during that await (a material swap, a mesh added) runs `frameGraph.build()` → `shadow-task.record()` → `ensurePcfShadowTaskState` → `getNoColorView`, which calls a family factory that is still `undefined`:

```
TypeError: createPbrNoColorMaterialView is not a function
  shadow/pcf-shadow-task-hooks.js  getNoColorView
  shadow/pcf-directional-shadow-generator.js  ensurePcfShadowTaskState
  frame-graph/shadow-task.js  record
  frame-graph/frame-graph.js  build
  scene/scene-rebuild.js
```

Roughly one project open in three in a kitchen configurator that keeps loading content while the scene registers.

## Change

`_preload()` parks each generator's caster set exactly like the runtime path and clears it once the import lands (only if the set was not superseded meanwhile).

## Test

New case in `tests/lite/unit/shadow-caster-preload-race.test.ts`: `_preload()` keeps `record()` from building shadow state until the preload resolves; fails without the fix.
