### PR TITLE
fix(compat): forward only geometry-backed meshes to the native shadow task

### DIFF
--- a/packages/babylon-lite-compat/src/shadows/shadow-generator.ts
+++ b/packages/babylon-lite-compat/src/shadows/shadow-generator.ts
@@ -131,10 +131,26 @@ export class ShadowGenerator {
             return;
         }
         this._casterSyncDirty = false;
-        setShadowTaskCasterMeshes(
-            this._liteGen,
-            this._casters.map((caster) => caster._lite as LiteMesh)
-        );
+        setShadowTaskCasterMeshes(this._liteGen, this._liteCasterMeshes());
+    }
+
+    /**
+     * The Lite meshes handed to the native shadow task: every requested caster that carries GPU geometry.
+     * The compat loader wraps a model's complete hierarchy as `Mesh`es, so `addShadowCaster(root, true)`
+     * legitimately collects transform-only roots and intermediate nodes into `renderList`, exactly as
+     * Babylon.js does. Those nodes must not reach the native state: the render task cannot build a
+     * renderable for a mesh without `_gpu` (it would throw inside the frame, every frame), and directional
+     * fitting would substitute default bounds for it, distorting the shadow volume.
+     */
+    private _liteCasterMeshes(): LiteMesh[] {
+        const meshes: LiteMesh[] = [];
+        for (const caster of this._casters) {
+            const lite = caster._lite as LiteMesh;
+            if ((lite as { _gpu?: unknown })._gpu) {
+                meshes.push(lite);
+            }
+        }
+        return meshes;
     }
 
     /** Babylon.js `getShadowMap()` — returns a minimal render-list holder for parity. */
@@ -219,8 +235,7 @@ export class ShadowGenerator {
         (liteLight as { shadowGenerator?: unknown }).shadowGenerator = liteGen;
         this._liteGen = liteGen;
         this._casterSyncDirty = false;
-        const casterMeshes = this._casters.map((m) => m._lite as LiteMesh);
-        setShadowTaskCasterMeshes(liteGen, casterMeshes);
+        setShadowTaskCasterMeshes(liteGen, this._liteCasterMeshes());
     }
 }
 

--- a/packages/babylon-lite-compat/tests/shadows.test.ts
+++ b/packages/babylon-lite-compat/tests/shadows.test.ts
@@ -13,17 +13,19 @@ vi.mock("babylon-lite", async (importOriginal) => ({
     setShadowTaskCasterMeshes,
 }));
 
-import type { EngineContext, Mesh as LiteMesh } from "babylon-lite";
+import type { AssetContainer as LiteAssetContainer, EngineContext, Mesh as LiteMesh } from "babylon-lite";
 
 import { NullEngine } from "../src/engine/engine";
 import { DirectionalLight, SpotLight } from "../src/lights/lights";
 import { Vector3 } from "../src/math/vector";
+import { collectLoadedMeshes, type LoadedMeshRegistry } from "../src/loading/loaded-mesh";
 import { AbstractMesh, TransformNode } from "../src/meshes/meshes";
 import { Scene } from "../src/scene/scene";
 import { CascadedShadowGenerator, ShadowGenerator } from "../src/shadows/shadow-generator";
 
+/** A geometry-backed caster: only Lite meshes carrying `_gpu` reach the native shadow task. */
 function createTestMesh(name: string): AbstractMesh {
-    return new AbstractMesh(name, { name, visible: true, children: [], receiveShadows: false } as unknown as LiteMesh);
+    return new AbstractMesh(name, { name, visible: true, children: [], receiveShadows: false, _gpu: {} } as unknown as LiteMesh);
 }
 
 async function flushCasterSync(): Promise<void> {
@@ -139,6 +141,38 @@ describe("ShadowGenerator caster synchronization", () => {
 
         expect(generator.getShadowMap().renderList).toEqual([]);
         expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith(generator._liteGen, []);
+    });
+
+    it("forwards only geometry-backed Lite meshes of a loaded hierarchy, keeping the full renderList", async () => {
+        // The compat loader wraps the whole hierarchy as `Mesh` wrappers: a transform-only `__root__`, a
+        // transform-only intermediate node, and the geometry-backed leaves (`_gpu`) under them.
+        type FakeLite = { name: string; children: FakeLite[]; visible: boolean; _gpu?: object };
+        const leaf = (name: string): FakeLite => ({ name, children: [], visible: true, _gpu: {} });
+        const body = leaf("body");
+        const wheel = leaf("wheel");
+        const intermediate: FakeLite = { name: "chassis", children: [body, wheel], visible: true };
+        const root: FakeLite = { name: "__root__", children: [intermediate], visible: true };
+        const registry: LoadedMeshRegistry = new Map();
+        const [rootWrapper] = collectLoadedMeshes({ entities: [root] } as unknown as LiteAssetContainer, registry);
+        const generator = new ShadowGenerator(1024, new DirectionalLight("directional", new Vector3(0, -1, -1)));
+
+        generator.addShadowCaster(rootWrapper!, true);
+        // Babylon.js parity: the render list holds every node the caller asked for, geometry or not.
+        expect(generator.getShadowMap().renderList.map((mesh) => mesh.name)).toEqual(["__root__", "chassis", "body", "wheel"]);
+
+        generator._build({} as EngineContext);
+        // Only the geometry-backed leaves enter the native state (and hence directional fitting).
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledOnce();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith({ kind: "esm" }, [body, wheel]);
+
+        // The runtime re-supply path applies the same rule.
+        const spare = leaf("spare");
+        const [spareRoot] = collectLoadedMeshes({ entities: [{ name: "__root__", children: [spare], visible: true }] } as unknown as LiteAssetContainer, new Map());
+        vi.clearAllMocks();
+        generator.addShadowCaster(spareRoot!, true);
+        await flushCasterSync();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledOnce();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith(generator._liteGen, [body, wheel, spare]);
     });
 
     it("flushes mutations made during before-render callbacks before Lite renders", async () => {


### PR DESCRIPTION
## Summary

The compat loader wraps a model's complete hierarchy as `Mesh` wrappers, so `addShadowCaster(root, true)` legitimately collects transform-only roots and intermediate nodes into `getShadowMap().renderList`, exactly as Babylon.js does. Until now `_build()` and `_flushCasterSync()` forwarded every wrapper's `_lite` to `setShadowTaskCasterMeshes()` through an unchecked cast, so a Lite node without `_gpu` reached the native shadow task: `resolvePendingMeshes` then dereferenced `mesh._gpu` inside the frame and every subsequent frame rejected with

```
TypeError: Cannot read properties of undefined (reading 'tangentBuffer')
```

(600+ occurrences per project open in a kitchen configurator that registers every loaded mesh as a caster), and directional fitting substituted default bounds for the node, distorting the shadow volume.

## Change

One compat helper, `ShadowGenerator._liteCasterMeshes()`, maps the requested caster list to the geometry-backed Lite meshes and is used by both `_build()` and `_flushCasterSync()`. `renderList` keeps every requested node (Babylon.js parity); the native task and directional fitting only ever see meshes that carry `_gpu`. No native code changes.

## Test

`packages/babylon-lite-compat/tests/shadows.test.ts`: a loaded hierarchy (`__root__` → transform-only intermediate → geometry-backed leaves) built through `collectLoadedMeshes`, `addShadowCaster(root, true)`, and only the leaves forwarded at build time and on a runtime re-supply, while `renderList` still lists all four nodes. Fails without the helper. The existing fixtures gained a `_gpu` stub, since a geometry-less caster is now exactly what the helper drops.

Supersedes the earlier render-task guard from this PR, withdrawn per review.