### PR TITLE
fix(test): update world-to-screen identity import

### DIFF
--- a/tests/lite/unit/world-to-screen.test.ts
+++ b/tests/lite/unit/world-to-screen.test.ts
@@ -7,7 +7,7 @@ import { enableOrthographicCamera } from "../../../packages/babylon-lite/src/cam
 import { resolveCameraViewport, type PixelViewport } from "../../../packages/babylon-lite/src/camera/viewport";
 import { allocateF64Mat4 } from "../../../packages/babylon-lite/src/math/_mat4-storage-f64";
 import { _resetMatrixAllocatorForTests, _setHpmAllocator } from "../../../packages/babylon-lite/src/math/_matrix-allocator";
-import { mat4Identity } from "../../../packages/babylon-lite/src/math/mat4-identity";
+import { createIdentityMat4 } from "../../../packages/babylon-lite/src/math/create-identity-mat4";
 import type { Mat4Storage } from "../../../packages/babylon-lite/src/math/types";
 import {
     projectWorldToScreen,
@@ -195,12 +195,12 @@ describe("world-to-screen projection", () => {
 
     it("marks negative clip W as non-displayable independently of view-space facing", () => {
         const { options } = setup();
-        const viewProjection = mat4Identity();
+        const viewProjection = createIdentityMat4();
         const storage = viewProjection as unknown as Mat4Storage;
         storage[10] = -0.5;
         storage[15] = -1;
 
-        const projected = projectWorldToScreen({ x: 0, y: 0, z: 1 }, mat4Identity(), viewProjection, options);
+        const projected = projectWorldToScreen({ x: 0, y: 0, z: 1 }, createIdentityMat4(), viewProjection, options);
 
         expect(projected).toMatchObject({
             x: 400,


### PR DESCRIPTION
## Summary

- update the world-to-screen unit test to use the identity-matrix API renamed by #688
- restore test collection and the tests TypeScript check on current master

## Validation

- `pnpm exec vitest run tests/lite/unit/world-to-screen.test.ts`
- `pnpm exec tsc -p tests/lite/tsconfig.json --noEmit`
- `pnpm exec eslint tests/lite/unit/world-to-screen.test.ts`
- `pnpm exec prettier --check tests/lite/unit/world-to-screen.test.ts`