### PR TITLE
Allow null textures in setEffectTexture

### DIFF
--- a/packages/babylon-lite-gl/src/effect.ts
+++ b/packages/babylon-lite-gl/src/effect.ts
@@ -543,7 +543,7 @@ export function setEffectIntArray(engine: GLEngineContext, effect: GLEffect, nam
  *  is issued — that was done exactly once per program lifetime during
  *  finalization. This is the key win over Babylon's `Effect.setTexture` which
  *  re-issues the sampler binding on every call. */
-export function setEffectTexture(engine: GLEngineContext, effect: GLEffect, samplerName: string, tex: GLTexture): void {
+export function setEffectTexture(engine: GLEngineContext, effect: GLEffect, samplerName: string, tex: GLTexture | null): void {
     if (engine._isLost || !effect.isReady) {
         return;
     }

--- a/packages/babylon-lite-gl/src/effect.ts
+++ b/packages/babylon-lite-gl/src/effect.ts
@@ -539,8 +539,8 @@ export function setEffectIntArray(engine: GLEngineContext, effect: GLEffect, nam
     engine.gl.uniform1iv(loc, array);
 }
 
-/** Bind a texture to the sampler's pre-assigned unit (§4.4). NO `gl.uniform1i`
- *  is issued — that was done exactly once per program lifetime during
+/** Bind a texture to the sampler's pre-assigned unit, or pass `null` to unbind
+ *  that unit (§4.4). NO `gl.uniform1i` is issued — that was done exactly once per program lifetime during
  *  finalization. This is the key win over Babylon's `Effect.setTexture` which
  *  re-issues the sampler binding on every call. */
 export function setEffectTexture(engine: GLEngineContext, effect: GLEffect, samplerName: string, tex: GLTexture | null): void {

--- a/tests/gl/unit/effect-setters.test.ts
+++ b/tests/gl/unit/effect-setters.test.ts
@@ -10,8 +10,10 @@ import {
     setEffectFloatArray,
     setEffectFloatArray4,
     setEffectIntArray,
+    setEffectTexture,
     type GLEffect,
 } from "../../../packages/babylon-lite-gl/src/effect";
+import { createRawTexture } from "../../../packages/babylon-lite-gl/src/texture";
 import { createMockCanvas, createMockGL, fireLost, fireRestored, type MockCall, type MockGL } from "./_lite-gl-mock";
 
 function makeEngine() {
@@ -95,6 +97,25 @@ describe("lite-gl effect: extended uniform setters", () => {
         mock.clear();
         setEffectIntArray(engine, eff, "u_iarr", a);
         expect(callsNamed(mock, "uniform1iv")[0]?.args[1]).toBe(a);
+    });
+
+    it("setEffectTexture unbinds a sampler unit when passed null", () => {
+        const { mock, engine } = makeEngine();
+        const eff = createEffect(engine, {
+            name: "texture-setter",
+            vertexSource: "v",
+            fragmentSource: "f",
+            uniformNames: [],
+            samplerNames: ["u_tex"],
+        });
+        isEffectReady(engine, eff);
+        const tex = createRawTexture(engine, new Uint8Array(4), 1, 1, engine.gl.RGBA, engine.gl.UNSIGNED_BYTE);
+        setEffectTexture(engine, eff, "u_tex", tex);
+        mock.clear();
+
+        setEffectTexture(engine, eff, "u_tex", null);
+
+        expect(callsNamed(mock, "bindTexture")[0]?.args).toEqual([engine.gl.TEXTURE_2D, null]);
     });
 
     it("matrix/array setters no-op on a missing uniform", () => {


### PR DESCRIPTION
## Summary

- allow `setEffectTexture` callers to pass `null`
- forward `null` through the existing texture-binding cache to unbind the sampler unit
- add a regression test covering bind followed by null unbind

## Validation

- focused GL setter and cache tests: 47 passed
- GL package typecheck
- GL test typecheck
- targeted ESLint
- `git diff --check`