### PR TITLE
feat(shadow): spread drift-only CSM static refits across frames

### DIFF
--- a/docs/lite/architecture/17-cascaded-shadow.md
+++ b/docs/lite/architecture/17-cascaded-shadow.md
@@ -171,12 +171,17 @@ cache texture, and do not load the cache implementation.
 
 With `options.staticCascadesPerFrame` above zero, a refit whose only cause is light drift
 (`gate.lastRefitDriftOnly()`) re-renders at most that many static cascades per frame, round-robin,
-so the periodic refresh costs a slice of every frame instead of one long frame; the cascade
-cameras and the receiver UBO are still written for every cascade in the refit frame, so a
-cascade re-rendered later draws with the transform the receivers sample, and its layer lags
-by at most `ceil(cascades / budget) - 1` frames of light drift. A refit caused by the camera,
-the scene content, the caster set, a promotion or a demotion re-renders every cascade in its
-own frame, as without the option.
+so the periodic refresh costs a slice of every frame instead of one long frame. The cascade
+cameras and the receiver UBO are written for every cascade in the refit frame; a cascade
+re-rendered later draws with the transform the receivers sample, and until its turn the
+receivers sample its previous layer under the new transform. That inconsistency is bounded by
+the light drift accumulated over at most `ceil(cascades / budget) - 1` frames (about 0.0006 rad
+for three cascades, one per frame, at 35 ms frames and a 360 s day). A refit caused by the
+camera, the scene content, the caster set, a promotion or a demotion re-renders every cascade
+in its own frame, as without the option, and so does a drift refit that lands while a spread is
+still draining — a light turning faster than the drain (a fast game clock crossing the angle
+epsilon every frame) therefore falls back to the single-frame re-render instead of leaving the
+trailing cascades permanently behind.
 
 `createCsmRefitGate` exposes the CPU-only partition/refit state machine for consumers
 that need the same policy without engine or WebGPU dependencies. `createCsmStaticRefitScheduler`

--- a/docs/lite/architecture/17-cascaded-shadow.md
+++ b/docs/lite/architecture/17-cascaded-shadow.md
@@ -70,15 +70,6 @@ interface CsmRefitDecision {
     renderDynamic: boolean;
 }
 
-interface CsmStaticRefitScheduler {
-    arm(spread: boolean): void;
-    pending(): boolean;
-    take(): number[];
-    maxLagFrames(): number;
-}
-
-function createCsmStaticRefitScheduler(cascadeCount: number, cascadesPerFrame: number): CsmStaticRefitScheduler;
-
 interface CsmRefitGate<M extends CsmRefitCaster> {
     syncCasters(casters: readonly M[]): void;
     markDynamic(caster: M): void;
@@ -170,23 +161,24 @@ that are not explicitly enabled preserve the original single-task path, allocate
 cache texture, and do not load the cache implementation.
 
 With `options.staticCascadesPerFrame` above zero, a refit whose only cause is light drift
-(`gate.lastRefitDriftOnly()`) re-renders at most that many static cascades per frame, round-robin,
-so the periodic refresh costs a slice of every frame instead of one long frame. The cascade
-cameras and the receiver UBO are written for every cascade in the refit frame; a cascade
-re-rendered later draws with the transform the receivers sample, and until its turn the
-receivers sample its previous layer under the new transform. That inconsistency is bounded by
-the light drift accumulated over at most `ceil(cascades / budget) - 1` frames (about 0.0006 rad
-for three cascades, one per frame, at 35 ms frames and a 360 s day). A refit caused by the
-camera, the scene content, the caster set, a promotion or a demotion re-renders every cascade
-in its own frame, as without the option, and so does a drift refit that lands while a spread is
-still draining — a light turning faster than the drain (a fast game clock crossing the angle
-epsilon every frame) therefore falls back to the single-frame re-render instead of leaving the
-trailing cascades permanently behind.
+re-renders at most that many static cascades per frame, round-robin, so the periodic refresh
+costs a slice of every frame instead of one long frame. Each selected cascade advances
+atomically: its shadow camera and receiver transform are updated together, its static layer is
+rendered, only that array layer is copied to the live shadow map, and only that layer's dynamic
+overlay is rendered. Cascades still waiting retain both their previous depth and previous
+receiver transform, so the sampled data remains coherent throughout the spread.
+
+A refit caused by the camera, scene content, caster set, promotion or demotion updates every
+cascade in its own frame, as without the option. A drift refit that lands while a spread is
+still draining also updates every cascade immediately, preventing a fast-moving light from
+continually replacing the pending generation. If a dynamic caster changes during a spread,
+the cache is copied and the dynamic overlay is redrawn for every cascade, while each static
+layer remains paired with its currently published transform.
 
 `createCsmRefitGate` exposes the CPU-only partition/refit state machine for consumers
-that need the same policy without engine or WebGPU dependencies. `createCsmStaticRefitScheduler`
-exposes the spread schedule the same way. Re-supplying a new
-array with identical caster membership does not invalidate the cache.
+that need the same policy without engine or WebGPU dependencies. The spread scheduler and its
+drift classification are internal cache-orchestration details. Re-supplying a new array with
+identical caster membership does not invalidate the cache.
 
 ### Receiver UBO layout (`_shadowUBO`, 320 bytes / 80 f32)
 

--- a/docs/lite/architecture/17-cascaded-shadow.md
+++ b/docs/lite/architecture/17-cascaded-shadow.md
@@ -43,6 +43,7 @@ function createCsmDirectionalShadowGenerator(engine: EngineContext, light: Direc
 interface CsmStaticCacheOptions {
     refitAngle: number;
     refitMaxIntervalMs?: number;
+    staticCascadesPerFrame?: number; // 0 or omitted: every cascade re-renders in the refit frame
 }
 
 function enableCsmStaticCache(engine: EngineContext, shadowGenerator: ShadowGenerator, options: CsmStaticCacheOptions): Promise<void>;
@@ -68,6 +69,15 @@ interface CsmRefitDecision {
     refit: boolean;
     renderDynamic: boolean;
 }
+
+interface CsmStaticRefitScheduler {
+    arm(spread: boolean): void;
+    pending(): boolean;
+    take(): number[];
+    maxLagFrames(): number;
+}
+
+function createCsmStaticRefitScheduler(cascadeCount: number, cascadesPerFrame: number): CsmStaticRefitScheduler;
 
 interface CsmRefitGate<M extends CsmRefitCaster> {
     syncCasters(casters: readonly M[]): void;
@@ -159,8 +169,18 @@ light is paused so GPU-clock-animated static casters continue refreshing. Genera
 that are not explicitly enabled preserve the original single-task path, allocate no
 cache texture, and do not load the cache implementation.
 
+With `options.staticCascadesPerFrame` above zero, a refit whose only cause is light drift
+(`gate.lastRefitDriftOnly()`) re-renders at most that many static cascades per frame, round-robin,
+so the periodic refresh costs a slice of every frame instead of one long frame; the cascade
+cameras and the receiver UBO are still written for every cascade in the refit frame, so a
+cascade re-rendered later draws with the transform the receivers sample, and its layer lags
+by at most `ceil(cascades / budget) - 1` frames of light drift. A refit caused by the camera,
+the scene content, the caster set, a promotion or a demotion re-renders every cascade in its
+own frame, as without the option.
+
 `createCsmRefitGate` exposes the CPU-only partition/refit state machine for consumers
-that need the same policy without engine or WebGPU dependencies. Re-supplying a new
+that need the same policy without engine or WebGPU dependencies. `createCsmStaticRefitScheduler`
+exposes the spread schedule the same way. Re-supplying a new
 array with identical caster membership does not invalidate the cache.
 
 ### Receiver UBO layout (`_shadowUBO`, 320 bytes / 80 f32)

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -451,7 +451,7 @@ export { createPcfSpotlightShadowGenerator } from "./shadow/pcf-spotlight-shadow
 export { createPcfDirectionalShadowGenerator } from "./shadow/pcf-directional-shadow-generator.js";
 export { createCsmDirectionalShadowGenerator, getCsmReceiverTexture, onCsmReceiverUpdate } from "./shadow/csm-directional-shadow-generator.js";
 export { enableCsmStaticCache } from "./shadow/enable-csm-static-cache.js";
-export { createCsmRefitGate } from "./shadow/csm-refit-gate.js";
+export { createCsmRefitGate, createCsmStaticRefitScheduler } from "./shadow/csm-refit-gate.js";
 export { enableMorphTargetShadows } from "./shadow/enable-morph-target-shadows.js";
 export { enableSkeletonShadows } from "./shadow/enable-skeleton-shadows.js";
 export { setShadowTaskCasterMeshes, setShadowCasterMaxCascade } from "./frame-graph/shadow-inputs.js";
@@ -656,7 +656,7 @@ export type { PcfSpotlightShadowGeneratorConfig } from "./shadow/pcf-spotlight-s
 export type { PcfDirectionalShadowGeneratorConfig } from "./shadow/pcf-directional-shadow-generator.js";
 export type { CsmDirectionalShadowGeneratorConfig } from "./shadow/csm-directional-shadow-generator.js";
 export type { CsmStaticCacheOptions } from "./shadow/enable-csm-static-cache.js";
-export type { CsmRefitCaster, CsmRefitDecision, CsmRefitGate, CsmRefitGateOptions } from "./shadow/csm-refit-gate.js";
+export type { CsmRefitCaster, CsmRefitDecision, CsmRefitGate, CsmRefitGateOptions, CsmStaticRefitScheduler } from "./shadow/csm-refit-gate.js";
 export type { AnimationController } from "./skeleton/skeleton-updater.js";
 export type { AnimationGroup, TargetedAnimation } from "./animation/animation-group.js";
 export type { AnimationManager, AnimationManagerOptions } from "./animation/animation-manager.js";

--- a/packages/babylon-lite/src/index.ts
+++ b/packages/babylon-lite/src/index.ts
@@ -451,7 +451,7 @@ export { createPcfSpotlightShadowGenerator } from "./shadow/pcf-spotlight-shadow
 export { createPcfDirectionalShadowGenerator } from "./shadow/pcf-directional-shadow-generator.js";
 export { createCsmDirectionalShadowGenerator, getCsmReceiverTexture, onCsmReceiverUpdate } from "./shadow/csm-directional-shadow-generator.js";
 export { enableCsmStaticCache } from "./shadow/enable-csm-static-cache.js";
-export { createCsmRefitGate, createCsmStaticRefitScheduler } from "./shadow/csm-refit-gate.js";
+export { createCsmRefitGate } from "./shadow/csm-refit-gate.js";
 export { enableMorphTargetShadows } from "./shadow/enable-morph-target-shadows.js";
 export { enableSkeletonShadows } from "./shadow/enable-skeleton-shadows.js";
 export { setShadowTaskCasterMeshes, setShadowCasterMaxCascade } from "./frame-graph/shadow-inputs.js";

--- a/packages/babylon-lite/src/shadow/csm-refit-gate.ts
+++ b/packages/babylon-lite/src/shadow/csm-refit-gate.ts
@@ -59,9 +59,9 @@ export interface CsmRefitGate<M extends CsmRefitCaster> {
     /** Current classification, for callers that build task membership from a carried gate. */
     isDynamic(caster: M): boolean;
     /** @internal Whether the latest refit was caused by light drift alone. */
-    lastRefitDriftOnly(): boolean;
+    _lastRefitDriftOnly(): boolean;
     /** @internal Whether the dynamic partition changed on the latest update. */
-    lastDynamicChanged(): boolean;
+    _lastDynamicChanged(): boolean;
     /** One walk over the synced casters: computes the static/dynamic version sums, promotes
      *  churning static casters (via `onPromote`, immediately), counts quiet frames, and decides
      *  refit/overlay. Pending demotions are applied (via `onDemote`) only inside a refit; they
@@ -153,10 +153,10 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
         isDynamic(caster: M): boolean {
             return slots.get(caster)?._dynamic ?? true;
         },
-        lastRefitDriftOnly(): boolean {
+        _lastRefitDriftOnly(): boolean {
             return lastDriftOnly;
         },
-        lastDynamicChanged(): boolean {
+        _lastDynamicChanged(): boolean {
             return lastDynamicChanged;
         },
         update(

--- a/packages/babylon-lite/src/shadow/csm-refit-gate.ts
+++ b/packages/babylon-lite/src/shadow/csm-refit-gate.ts
@@ -58,6 +58,13 @@ export interface CsmRefitGate<M extends CsmRefitCaster> {
     markDynamic(caster: M): void;
     /** Current classification, for callers that build task membership from a carried gate. */
     isDynamic(caster: M): boolean;
+    /** Whether the refit returned by the latest `update()` was caused by light drift alone (the angle
+     *  epsilon or the wall-time floor): the camera, the caster set, the static partition and the scene
+     *  content are exactly what the previous refit rendered, so a consumer may spread that refit's static
+     *  re-render over several frames (`createCsmStaticRefitScheduler`) without any cascade drawing a
+     *  stale partition. False after a frame without refit and after a refit with any other cause,
+     *  including a demotion applied inside the refit. */
+    lastRefitDriftOnly(): boolean;
     /** One walk over the synced casters: computes the static/dynamic version sums, promotes
      *  churning static casters (via `onPromote`, immediately), counts quiet frames, and decides
      *  refit/overlay. Pending demotions are applied (via `onDemote`) only inside a refit; they
@@ -109,6 +116,7 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
     let refitDirZ = 0;
     let lastRefitMs = 0;
     let framesSinceRefit = 0;
+    let lastDriftOnly = false;
 
     return {
         syncCasters(next: readonly M[]): void {
@@ -146,6 +154,9 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
         },
         isDynamic(caster: M): boolean {
             return slots.get(caster)?._dynamic ?? true;
+        },
+        lastRefitDriftOnly(): boolean {
+            return lastDriftOnly;
         },
         update(
             lightDirX: number,
@@ -216,7 +227,9 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
             // threshold so an oscillating caster costs at most one extra refit per quiet period.
             const demotionOverdue = pendingDemotions > 0 && framesSinceRefit >= demoteQuietFrames;
 
-            const refit = force || !hasRefit || casterSetChanged || promoted || staticSum !== lastStaticSum || cameraChanged || angleExceeded || intervalElapsed || demotionOverdue;
+            const membershipCause = force || !hasRefit || casterSetChanged || promoted || staticSum !== lastStaticSum || cameraChanged || demotionOverdue;
+            const refit = membershipCause || angleExceeded || intervalElapsed;
+            let demoted = 0;
 
             if (refit) {
                 // Demotions ride refits that happen anyway: moving a caster into the static
@@ -227,6 +240,7 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
                     if (slot._dynamic && slot._quiet >= demoteQuietFrames) {
                         slot._dynamic = false;
                         onDemote(m);
+                        demoted++;
                         // Keep the recorded sums consistent with the new partition, or the
                         // next frame would read the membership change as fresh churn and
                         // refit again.
@@ -244,9 +258,74 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
             }
 
             const renderDynamic = refit || dynamicChanged || dynamicSum !== lastDynamicSum;
+            // A demotion applied inside a drift refit moves a caster between the dynamic and static layers,
+            // which is a membership change for the static render: it disqualifies the spread as well.
+            lastDriftOnly = refit && !membershipCause && demoted === 0;
             lastStaticSum = staticSum;
             lastDynamicSum = dynamicSum;
             return { refit, renderDynamic };
+        },
+    };
+}
+
+/** Which static cascades to re-render this frame when a refit is spread over several frames. */
+export interface CsmStaticRefitScheduler {
+    /** A refit decision landed. `spread` true keeps the per-frame budget (a drift-only refit);
+     *  false re-renders every cascade in the very next `take()` (any other refit cause). */
+    arm(spread: boolean): void;
+    /** Some cascade still waits for its static re-render. */
+    pending(): boolean;
+    /** The cascades to re-render now, in round-robin order so no cascade can starve when refits
+     *  arrive faster than the budget drains; each returned cascade leaves the pending set. */
+    take(): number[];
+    /** The largest number of frames a cascade can lag behind the refit that armed it: 0 when the
+     *  spread is disabled, ceil(cascades / budget) - 1 otherwise. */
+    maxLagFrames(): number;
+}
+
+/** Create the scheduler for `cascadeCount` cascades and a per-frame budget of `cascadesPerFrame`
+ *  static re-renders. A budget of 0 (or one that covers every cascade) disables the spread: every
+ *  refit re-renders all cascades in its own frame, the historical behaviour. */
+export function createCsmStaticRefitScheduler(cascadeCount: number, cascadesPerFrame: number): CsmStaticRefitScheduler {
+    const count = Math.max(0, Math.floor(cascadeCount));
+    const budget = Number.isFinite(cascadesPerFrame) && cascadesPerFrame > 0 && cascadesPerFrame < count ? Math.floor(cascadesPerFrame) : 0;
+    const waiting: boolean[] = new Array<boolean>(count).fill(false);
+    let waitingCount = 0;
+    let immediate = false;
+    let cursor = 0;
+    return {
+        arm(spread: boolean): void {
+            waiting.fill(true);
+            waitingCount = count;
+            immediate = budget === 0 || !spread;
+        },
+        pending(): boolean {
+            return waitingCount > 0;
+        },
+        take(): number[] {
+            const out: number[] = [];
+            if (waitingCount === 0) {
+                return out;
+            }
+            const limit = immediate ? count : budget;
+            for (let step = 0; step < count && out.length < limit; step++) {
+                const cascade = (cursor + step) % count;
+                if (waiting[cascade]) {
+                    waiting[cascade] = false;
+                    waitingCount--;
+                    out.push(cascade);
+                }
+            }
+            if (out.length > 0) {
+                cursor = (out[out.length - 1]! + 1) % count;
+            }
+            if (waitingCount === 0) {
+                immediate = false;
+            }
+            return out;
+        },
+        maxLagFrames(): number {
+            return budget === 0 ? 0 : Math.ceil(count / budget) - 1;
         },
     };
 }

--- a/packages/babylon-lite/src/shadow/csm-refit-gate.ts
+++ b/packages/babylon-lite/src/shadow/csm-refit-gate.ts
@@ -61,9 +61,11 @@ export interface CsmRefitGate<M extends CsmRefitCaster> {
     /** Whether the refit returned by the latest `update()` was caused by light drift alone (the angle
      *  epsilon or the wall-time floor): the camera, the caster set, the static partition and the scene
      *  content are exactly what the previous refit rendered, so a consumer may spread that refit's static
-     *  re-render over several frames (`createCsmStaticRefitScheduler`) without any cascade drawing a
-     *  stale partition. False after a frame without refit and after a refit with any other cause,
-     *  including a demotion applied inside the refit. */
+     *  re-render over several frames (`createCsmStaticRefitScheduler`). Until a cascade's turn comes, its
+     *  layer still shows the previous refit's depth under the new transform: the only inconsistency a
+     *  spread introduces is that light drift, bounded by the spread's lag in frames. False after a frame
+     *  without refit and after a refit with any other cause, including a demotion applied inside the
+     *  refit (the demoted caster would otherwise vanish from the cascades not yet re-rendered). */
     lastRefitDriftOnly(): boolean;
     /** One walk over the synced casters: computes the static/dynamic version sums, promotes
      *  churning static casters (via `onPromote`, immediately), counts quiet frames, and decides

--- a/packages/babylon-lite/src/shadow/csm-refit-gate.ts
+++ b/packages/babylon-lite/src/shadow/csm-refit-gate.ts
@@ -7,7 +7,7 @@
  *
  *  Deliberately free of GPU and engine types so consumers can unit-test the gate with
  *  plain objects. The GPU orchestration (task membership moves, texture copies, camera
- *  updates) lives in `csm-shadow-task-hooks.ts`, which drives this gate through the
+ *  updates) lives in `csm-shadow-cache.ts`, which drives this gate through the
  *  promote/demote callbacks.
  *
  *  Correctness invariant owned by the caller: cascade matrices, the receiver UBO and
@@ -58,15 +58,10 @@ export interface CsmRefitGate<M extends CsmRefitCaster> {
     markDynamic(caster: M): void;
     /** Current classification, for callers that build task membership from a carried gate. */
     isDynamic(caster: M): boolean;
-    /** Whether the refit returned by the latest `update()` was caused by light drift alone (the angle
-     *  epsilon or the wall-time floor): the camera, the caster set, the static partition and the scene
-     *  content are exactly what the previous refit rendered, so a consumer may spread that refit's static
-     *  re-render over several frames (`createCsmStaticRefitScheduler`). Until a cascade's turn comes, its
-     *  layer still shows the previous refit's depth under the new transform: the only inconsistency a
-     *  spread introduces is that light drift, bounded by the spread's lag in frames. False after a frame
-     *  without refit and after a refit with any other cause, including a demotion applied inside the
-     *  refit (the demoted caster would otherwise vanish from the cascades not yet re-rendered). */
+    /** @internal Whether the latest refit was caused by light drift alone. */
     lastRefitDriftOnly(): boolean;
+    /** @internal Whether the dynamic partition changed on the latest update. */
+    lastDynamicChanged(): boolean;
     /** One walk over the synced casters: computes the static/dynamic version sums, promotes
      *  churning static casters (via `onPromote`, immediately), counts quiet frames, and decides
      *  refit/overlay. Pending demotions are applied (via `onDemote`) only inside a refit; they
@@ -119,6 +114,7 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
     let lastRefitMs = 0;
     let framesSinceRefit = 0;
     let lastDriftOnly = false;
+    let lastDynamicChanged = false;
 
     return {
         syncCasters(next: readonly M[]): void {
@@ -159,6 +155,9 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
         },
         lastRefitDriftOnly(): boolean {
             return lastDriftOnly;
+        },
+        lastDynamicChanged(): boolean {
+            return lastDynamicChanged;
         },
         update(
             lightDirX: number,
@@ -259,7 +258,8 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
                 framesSinceRefit = 0;
             }
 
-            const renderDynamic = refit || dynamicChanged || dynamicSum !== lastDynamicSum;
+            lastDynamicChanged = dynamicChanged || dynamicSum !== lastDynamicSum;
+            const renderDynamic = refit || lastDynamicChanged;
             // A demotion applied inside a drift refit moves a caster between the dynamic and static layers,
             // which is a membership change for the static render: it disqualifies the spread as well.
             lastDriftOnly = refit && !membershipCause && demoted === 0;
@@ -270,7 +270,7 @@ export function createCsmRefitGate<M extends CsmRefitCaster>(options: CsmRefitGa
     };
 }
 
-/** Which static cascades to re-render this frame when a refit is spread over several frames. */
+/** @internal Which static cascades to re-render this frame when a refit is spread over several frames. */
 export interface CsmStaticRefitScheduler {
     /** A refit decision landed. `spread` true keeps the per-frame budget (a drift-only refit);
      *  false re-renders every cascade in the very next `take()` (any other refit cause). */
@@ -285,13 +285,14 @@ export interface CsmStaticRefitScheduler {
     maxLagFrames(): number;
 }
 
-/** Create the scheduler for `cascadeCount` cascades and a per-frame budget of `cascadesPerFrame`
+/** @internal Create the scheduler for `cascadeCount` cascades and a per-frame budget of `cascadesPerFrame`
  *  static re-renders. A budget of 0 (or one that covers every cascade) disables the spread: every
  *  refit re-renders all cascades in its own frame, the historical behaviour. */
 export function createCsmStaticRefitScheduler(cascadeCount: number, cascadesPerFrame: number): CsmStaticRefitScheduler {
     const count = Math.max(0, Math.floor(cascadeCount));
     const budget = Number.isFinite(cascadesPerFrame) && cascadesPerFrame > 0 && cascadesPerFrame < count ? Math.floor(cascadesPerFrame) : 0;
     const waiting: boolean[] = new Array<boolean>(count).fill(false);
+    const out: number[] = [];
     let waitingCount = 0;
     let immediate = false;
     let cursor = 0;
@@ -305,7 +306,7 @@ export function createCsmStaticRefitScheduler(cascadeCount: number, cascadesPerF
             return waitingCount > 0;
         },
         take(): number[] {
-            const out: number[] = [];
+            out.length = 0;
             if (waitingCount === 0) {
                 return out;
             }

--- a/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
+++ b/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
@@ -360,7 +360,7 @@ export function renderCsmShadowMapCached(engine: EngineContext, sg: ShadowGenera
         cached._lastCamVersion = camVersion;
         cached._lastCamAspect = camAspect;
         cached._cachedContentVersion = cached._scene._renderableVersion;
-        scheduler.arm(cached._gate.lastRefitDriftOnly() && !scheduler.pending());
+        scheduler.arm(cached._gate._lastRefitDriftOnly() && !scheduler.pending());
     }
     const cascades = scheduler.pending() ? scheduler.take() : null;
     if (cascades) {
@@ -374,7 +374,7 @@ export function renderCsmShadowMapCached(engine: EngineContext, sg: ShadowGenera
     }
     // A dynamic-caster change requires clearing and redrawing every live layer. Otherwise a spread
     // frame touches only the cascades whose static depth and receiver transform were just advanced.
-    if (cached._gate.lastDynamicChanged() || cascades?.length === cfg._numCascades) {
+    if (cached._gate._lastDynamicChanged() || cascades?.length === cfg._numCascades) {
         engine._currentEncoder.copyTextureToTexture(
             { texture: cached._cacheTexture },
             { texture: sg._depthTexture },

--- a/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
+++ b/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
@@ -15,7 +15,7 @@ import { _buildBindings, _resolvePendingMeshes, createRenderTask, removeMeshFrom
 import { retireGpuResources } from "../engine/gpu-resource-retirement.js";
 import { createShadowCamera, updateShadowCameraBase } from "./shadow-base.js";
 import { getNoColorView, shadowCasterMaterialChanged, snapshotShadowCasterMaterial } from "./pcf-shadow-task-hooks.js";
-import { createCsmRefitGate, type CsmRefitGate } from "./csm-refit-gate.js";
+import { createCsmRefitGate, createCsmStaticRefitScheduler, type CsmRefitGate, type CsmStaticRefitScheduler } from "./csm-refit-gate.js";
 import {
     _biasViewProjection,
     _computeCsmCascades,
@@ -32,6 +32,8 @@ interface CsmCachedTaskState extends CsmTaskState {
     _staticTasks: RenderTask[];
     _cacheTexture: GPUTexture;
     _gate: CsmRefitGate<Mesh>;
+    /** Spreads a drift-only refit's static re-render over frames (`staticCascadesPerFrame`). */
+    _staticScheduler: CsmStaticRefitScheduler;
     _onPromote: (mesh: Mesh) => void;
     _onDemote: (mesh: Mesh) => void;
     /** Tasks the last gate decision moved meshes INTO, rebuilt once after the decision. */
@@ -295,6 +297,7 @@ export function ensureCsmShadowCacheState(
         _staticTasks: staticTasks,
         _cacheTexture: cacheTexture,
         _gate: gate,
+        _staticScheduler: createCsmStaticRefitScheduler(cascadeCount, cache._staticCascadesPerFrame ?? 0),
         _onPromote: onPromote,
         _onDemote: onDemote,
         _pendingTransfers: pendingTransferTargets,
@@ -342,7 +345,10 @@ export function renderCsmShadowMapCached(engine: EngineContext, sg: ShadowGenera
         }
         cached._pendingTransfers.clear();
     }
-    if (!decision.renderDynamic) {
+    // A cascade still waiting for its spread static re-render keeps the frame alive even when nothing
+    // dynamic changed: its layer must land, and the copy below then carries it to the sampled map.
+    const scheduler = cached._staticScheduler;
+    if (!decision.renderDynamic && !scheduler.pending()) {
         return 0;
     }
     let draws = 0;
@@ -351,9 +357,14 @@ export function renderCsmShadowMapCached(engine: EngineContext, sg: ShadowGenera
         cached._lastCamVersion = camVersion;
         cached._lastCamAspect = camAspect;
         cached._cachedContentVersion = cached._scene._renderableVersion;
-        for (const task of cached._staticTasks) {
-            draws += task.execute?.() ?? 0;
-        }
+        // The cascade cameras and the receiver UBO are written for every cascade right here, so a
+        // cascade whose static layer is re-rendered a few frames later still draws with the transform
+        // the receivers sample. Only a drift-only refit may be spread: after a camera, content or
+        // membership change every cascade re-renders in this frame, as before.
+        scheduler.arm(cached._gate.lastRefitDriftOnly());
+    }
+    for (const cascade of scheduler.take()) {
+        draws += cached._staticTasks[cascade]!.execute?.() ?? 0;
     }
     engine._currentEncoder.copyTextureToTexture(
         { texture: cached._cacheTexture },

--- a/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
+++ b/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
@@ -23,6 +23,7 @@ import {
     _writeCsmUbo,
     csmCameraAspect,
     csmWorldBiasClipOffset,
+    type CsmCascades,
     type CsmConfig,
     type CsmTaskState,
 } from "./csm-shadow-task-hooks.js";
@@ -34,6 +35,8 @@ interface CsmCachedTaskState extends CsmTaskState {
     _gate: CsmRefitGate<Mesh>;
     /** Spreads a drift-only refit's static re-render over frames (`staticCascadesPerFrame`). */
     _staticScheduler: CsmStaticRefitScheduler;
+    /** Pending cascade generation. Each layer is published only when its matching depth is rendered. */
+    _pendingCascades: CsmCascades | null;
     _onPromote: (mesh: Mesh) => void;
     _onDemote: (mesh: Mesh) => void;
     /** Tasks the last gate decision moved meshes INTO, rebuilt once after the decision. */
@@ -298,6 +301,7 @@ export function ensureCsmShadowCacheState(
         _cacheTexture: cacheTexture,
         _gate: gate,
         _staticScheduler: createCsmStaticRefitScheduler(cascadeCount, cache._staticCascadesPerFrame ?? 0),
+        _pendingCascades: null,
         _onPromote: onPromote,
         _onDemote: onDemote,
         _pendingTransfers: pendingTransferTargets,
@@ -345,49 +349,75 @@ export function renderCsmShadowMapCached(engine: EngineContext, sg: ShadowGenera
         }
         cached._pendingTransfers.clear();
     }
-    // A cascade still waiting for its spread static re-render keeps the frame alive even when nothing
-    // dynamic changed: its layer must land, and the copy below then carries it to the sampled map.
     const scheduler = cached._staticScheduler;
-    if (!decision.renderDynamic && !scheduler.pending()) {
+    const hadPending = scheduler.pending();
+    if (!decision.renderDynamic && !hadPending) {
         return 0;
     }
     let draws = 0;
     if (decision.refit) {
-        applyCsmRefit(engine, sg, cached, cfg, camera);
+        cached._pendingCascades = _computeCsmCascades(cached._scene, camera, sg._light as DirectionalLight, cfg, cached._casterMeshes, cached._cascadeScratch);
         cached._lastCamVersion = camVersion;
         cached._lastCamAspect = camAspect;
         cached._cachedContentVersion = cached._scene._renderableVersion;
-        // The cascade cameras and the receiver UBO are written for every cascade right here. A cascade
-        // whose static layer is re-rendered a few frames later then draws with the transform the receivers
-        // sample; until its turn, the receivers sample its PREVIOUS layer with the NEW transform — an
-        // inconsistency bounded by the light drift accumulated over at most ceil(cascades / budget) - 1
-        // frames (about 0.0006 rad at 35 ms frames and a 360 s day, under the 0.0015 rad epsilon). Two
-        // guards keep that bound: only a drift-only refit may be spread (a camera, content or membership
-        // change re-renders every cascade in this frame, as before), and a drift refit that lands while a
-        // spread is still draining re-renders everything too — otherwise a light turning faster than the
-        // drain (a fast game clock crossing the angle epsilon every frame) would re-arm the spread each
-        // frame and leave the trailing cascades permanently behind the matrices.
         scheduler.arm(cached._gate.lastRefitDriftOnly() && !scheduler.pending());
     }
-    if (scheduler.pending()) {
-        for (const cascade of scheduler.take()) {
+    const cascades = scheduler.pending() ? scheduler.take() : null;
+    if (cascades) {
+        publishCsmCascades(engine, sg, cached, cfg, cached._pendingCascades!, cascades);
+        for (const cascade of cascades) {
             draws += cached._staticTasks[cascade]!.execute?.() ?? 0;
         }
+        if (!scheduler.pending()) {
+            cached._pendingCascades = null;
+        }
     }
-    engine._currentEncoder.copyTextureToTexture(
-        { texture: cached._cacheTexture },
-        { texture: sg._depthTexture },
-        { width: cfg._mapSize, height: cfg._mapSize, depthOrArrayLayers: cfg._numCascades }
-    );
-    for (const task of cached._tasks) {
-        draws += task.execute?.() ?? 0;
+    // A dynamic-caster change requires clearing and redrawing every live layer. Otherwise a spread
+    // frame touches only the cascades whose static depth and receiver transform were just advanced.
+    if (cached._gate.lastDynamicChanged() || cascades?.length === cfg._numCascades) {
+        engine._currentEncoder.copyTextureToTexture(
+            { texture: cached._cacheTexture },
+            { texture: sg._depthTexture },
+            { width: cfg._mapSize, height: cfg._mapSize, depthOrArrayLayers: cfg._numCascades }
+        );
+        for (const task of cached._tasks) {
+            if (task._renderables.length || task._pendingMeshes.length) {
+                draws += task.execute?.() ?? 0;
+            }
+        }
+    } else if (cascades) {
+        for (const cascade of cascades) {
+            engine._currentEncoder.copyTextureToTexture(
+                { texture: cached._cacheTexture, origin: { x: 0, y: 0, z: cascade } },
+                { texture: sg._depthTexture, origin: { x: 0, y: 0, z: cascade } },
+                { width: cfg._mapSize, height: cfg._mapSize, depthOrArrayLayers: 1 }
+            );
+            const task = cached._tasks[cascade]!;
+            if (task._renderables.length || task._pendingMeshes.length) {
+                draws += task.execute?.() ?? 0;
+            }
+        }
     }
     return draws;
 }
 
-function applyCsmRefit(engine: EngineContext, sg: ShadowGenerator, state: CsmTaskState, cfg: CsmConfig, camera: NonNullable<SceneContext["camera"]>): void {
-    const cascades = _computeCsmCascades(state._scene, camera, sg._light as DirectionalLight, cfg, state._casterMeshes, state._cascadeScratch);
-    _writeCsmUbo(state._uboData, cascades, cfg);
+function publishCsmCascades(engine: EngineContext, sg: ShadowGenerator, state: CsmTaskState, cfg: CsmConfig, cascades: CsmCascades, updatedCascades: readonly number[]): void {
+    const fullUpdate = updatedCascades.length === cfg._numCascades;
+    if (fullUpdate) {
+        _writeCsmUbo(state._uboData, cascades, cfg);
+    }
+    state._cameraVersion++;
+    for (const cascade of updatedCascades) {
+        const transform = cascades._transforms[cascade]!;
+        if (!fullUpdate) {
+            state._uboData.set(transform, cascade * 16);
+        }
+        const cascadeCamera = state._cameras[cascade]!;
+        cascadeCamera.fov = 1;
+        const clipBias = cfg._worldSpaceBias === null ? cfg._bias * 0.5 : csmWorldBiasClipOffset(cfg._worldSpaceBias, cascades._near[cascade]!, cascades._far[cascade]!);
+        _biasViewProjection(transform, clipBias);
+        updateShadowCameraBase(cascadeCamera, state._cameraVersion, cascades._near[cascade]!, cascades._far[cascade]!, cascades._views[cascade]!, transform);
+    }
     sg._version++;
     engine._device.queue.writeBuffer(sg._shadowUBO, 0, state._uboData as Float32Array<ArrayBuffer>);
     const receiverCbs = sg._onReceiverData;
@@ -395,14 +425,6 @@ function applyCsmRefit(engine: EngineContext, sg: ShadowGenerator, state: CsmTas
         for (let i = 0; i < receiverCbs.length; i++) {
             receiverCbs[i]!(state._uboData);
         }
-    }
-    state._cameraVersion++;
-    for (let i = 0; i < cascades._transforms.length; i++) {
-        const cascadeCamera = state._cameras[i]!;
-        cascadeCamera.fov = 1;
-        const clipBias = cfg._worldSpaceBias === null ? cfg._bias * 0.5 : csmWorldBiasClipOffset(cfg._worldSpaceBias, cascades._near[i]!, cascades._far[i]!);
-        _biasViewProjection(cascades._transforms[i]!, clipBias);
-        updateShadowCameraBase(cascadeCamera, state._cameraVersion, cascades._near[i]!, cascades._far[i]!, cascades._views[i]!, cascades._transforms[i]!);
     }
 }
 

--- a/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
+++ b/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
@@ -357,11 +357,17 @@ export function renderCsmShadowMapCached(engine: EngineContext, sg: ShadowGenera
         cached._lastCamVersion = camVersion;
         cached._lastCamAspect = camAspect;
         cached._cachedContentVersion = cached._scene._renderableVersion;
-        // The cascade cameras and the receiver UBO are written for every cascade right here, so a
-        // cascade whose static layer is re-rendered a few frames later still draws with the transform
-        // the receivers sample. Only a drift-only refit may be spread: after a camera, content or
-        // membership change every cascade re-renders in this frame, as before.
-        scheduler.arm(cached._gate.lastRefitDriftOnly());
+        // The cascade cameras and the receiver UBO are written for every cascade right here. A cascade
+        // whose static layer is re-rendered a few frames later then draws with the transform the receivers
+        // sample; until its turn, the receivers sample its PREVIOUS layer with the NEW transform — an
+        // inconsistency bounded by the light drift accumulated over at most ceil(cascades / budget) - 1
+        // frames (about 0.0006 rad at 35 ms frames and a 360 s day, under the 0.0015 rad epsilon). Two
+        // guards keep that bound: only a drift-only refit may be spread (a camera, content or membership
+        // change re-renders every cascade in this frame, as before), and a drift refit that lands while a
+        // spread is still draining re-renders everything too — otherwise a light turning faster than the
+        // drain (a fast game clock crossing the angle epsilon every frame) would re-arm the spread each
+        // frame and leave the trailing cascades permanently behind the matrices.
+        scheduler.arm(cached._gate.lastRefitDriftOnly() && !scheduler.pending());
     }
     if (scheduler.pending()) {
         for (const cascade of scheduler.take()) {

--- a/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
+++ b/packages/babylon-lite/src/shadow/csm-shadow-cache.ts
@@ -363,8 +363,10 @@ export function renderCsmShadowMapCached(engine: EngineContext, sg: ShadowGenera
         // membership change every cascade re-renders in this frame, as before.
         scheduler.arm(cached._gate.lastRefitDriftOnly());
     }
-    for (const cascade of scheduler.take()) {
-        draws += cached._staticTasks[cascade]!.execute?.() ?? 0;
+    if (scheduler.pending()) {
+        for (const cascade of scheduler.take()) {
+            draws += cached._staticTasks[cascade]!.execute?.() ?? 0;
+        }
     }
     engine._currentEncoder.copyTextureToTexture(
         { texture: cached._cacheTexture },

--- a/packages/babylon-lite/src/shadow/enable-csm-static-cache.ts
+++ b/packages/babylon-lite/src/shadow/enable-csm-static-cache.ts
@@ -7,6 +7,11 @@ export interface CsmStaticCacheOptions {
     refitAngle: number;
     /** Force a refit after this much wall time, including while the light is paused. Default 0 (no interval floor). */
     refitMaxIntervalMs?: number;
+    /** Spread a drift-only refit's static re-render over frames: at most this many cascades are
+     *  re-rendered per frame, round-robin, so the periodic refresh costs a slice of every frame instead
+     *  of one long frame. Refits caused by the camera, the content or the caster membership still
+     *  re-render every cascade in their own frame. 0 or omitted keeps the single-frame re-render. */
+    staticCascadesPerFrame?: number;
 }
 
 let enabling: WeakMap<ShadowGenerator, Promise<void>> | null = null;
@@ -25,6 +30,10 @@ export function enableCsmStaticCache(engine: EngineContext, sg: ShadowGenerator,
     if (!Number.isFinite(options.refitAngle) || options.refitAngle <= 0) {
         return Promise.reject(new RangeError("enableCsmStaticCache requires a positive finite refitAngle"));
     }
+    const staticCascadesPerFrame = options.staticCascadesPerFrame ?? 0;
+    if (!Number.isInteger(staticCascadesPerFrame) || staticCascadesPerFrame < 0) {
+        return Promise.reject(new RangeError("enableCsmStaticCache requires a non-negative integer staticCascadesPerFrame"));
+    }
     if (sg._shadowTaskState || sg._csmReceiverTexture || engine.surfaces.some((surface) => surface._renderingContexts.length > 0)) {
         return Promise.reject(new Error("enableCsmStaticCache must run before scene registration and receiver texture access"));
     }
@@ -42,7 +51,7 @@ export function enableCsmStaticCache(engine: EngineContext, sg: ShadowGenerator,
         format: "depth32float",
         usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
     });
-    sg._csmCache = { _refitAngle: options.refitAngle, _refitMaxIntervalMs: options.refitMaxIntervalMs ?? 0 };
+    sg._csmCache = { _refitAngle: options.refitAngle, _refitMaxIntervalMs: options.refitMaxIntervalMs ?? 0, _staticCascadesPerFrame: staticCascadesPerFrame };
     oldTexture.destroy();
     const promise = import("./csm-shadow-cache.js").then((module) => {
         sg._csmCache!._loaded = true;

--- a/packages/babylon-lite/src/shadow/shadow-generator.ts
+++ b/packages/babylon-lite/src/shadow/shadow-generator.ts
@@ -57,6 +57,8 @@ export interface ShadowGenerator {
         _refitAngle: number;
         /** @internal */
         _refitMaxIntervalMs: number;
+        /** @internal Static cascades re-rendered per frame after a drift-only refit; 0 = all in one frame. */
+        _staticCascadesPerFrame?: number;
         /** @internal */
         _loaded?: boolean;
     };

--- a/tests/lite/unit/csm-refit-gate.test.ts
+++ b/tests/lite/unit/csm-refit-gate.test.ts
@@ -147,3 +147,56 @@ describe("CSM refit gate", () => {
         ).toBe(true);
     });
 });
+
+describe("CSM refit gate: lastRefitDriftOnly", () => {
+    const step = (gate: ReturnType<typeof createCsmRefitGate<MutableCaster>>, x: number, nowMs: number, camera = false) =>
+        gate.update(
+            x,
+            -1,
+            0,
+            nowMs,
+            camera,
+            false,
+            () => undefined,
+            () => undefined
+        );
+
+    it("is true only for a refit caused by the angle epsilon or the wall-time floor", () => {
+        const caster = { worldMatrixVersion: 1 };
+        const gate = createCsmRefitGate<MutableCaster>({ refitAngle: 0.05, refitMaxIntervalMs: 100, demoteQuietFrames: 100 });
+        gate.syncCasters([caster]);
+        expect(step(gate, 0, 0).refit).toBe(true);
+        expect(gate.lastRefitDriftOnly()).toBe(false); // the very first refit is a full render
+        expect(step(gate, 0, 10).refit).toBe(false);
+        expect(gate.lastRefitDriftOnly()).toBe(false); // no refit, no drift-only claim
+        expect(step(gate, 0.2, 20).refit).toBe(true); // angle epsilon crossed
+        expect(gate.lastRefitDriftOnly()).toBe(true);
+        expect(step(gate, 0.2, 130).refit).toBe(true); // wall-time floor, frozen sun
+        expect(gate.lastRefitDriftOnly()).toBe(true);
+        expect(step(gate, 0.2, 140).refit).toBe(false);
+        expect(gate.lastRefitDriftOnly()).toBe(false);
+    });
+
+    it("is false when the camera, a promotion or a demotion took part in the refit, even with drift", () => {
+        const caster = { worldMatrixVersion: 1 };
+        const gate = createCsmRefitGate<MutableCaster>({ refitAngle: 0.05, refitMaxIntervalMs: 0, demoteQuietFrames: 2 });
+        gate.syncCasters([caster]);
+        step(gate, 0, 0); // first refit; the caster starts dynamic
+        step(gate, 0, 1); // quiet frame 1
+        // Quiet frame 2 with drift: the refit is drift-caused, but it APPLIES the pending demotion, so the
+        // static partition changes inside it and the spread is refused.
+        expect(step(gate, 0.2, 2).refit).toBe(true);
+        expect(gate.isDynamic(caster)).toBe(false);
+        expect(gate.lastRefitDriftOnly()).toBe(false);
+        // Drift alone on the settled partition: spreadable.
+        expect(step(gate, 0.4, 3).refit).toBe(true);
+        expect(gate.lastRefitDriftOnly()).toBe(true);
+        // Drift plus a camera change: full.
+        expect(step(gate, 0.6, 4, true).refit).toBe(true);
+        expect(gate.lastRefitDriftOnly()).toBe(false);
+        // Drift plus a promotion (the static caster moved): full.
+        caster.worldMatrixVersion++;
+        expect(step(gate, 0.8, 5).refit).toBe(true);
+        expect(gate.lastRefitDriftOnly()).toBe(false);
+    });
+});

--- a/tests/lite/unit/csm-refit-gate.test.ts
+++ b/tests/lite/unit/csm-refit-gate.test.ts
@@ -200,3 +200,31 @@ describe("CSM refit gate: lastRefitDriftOnly", () => {
         expect(gate.lastRefitDriftOnly()).toBe(false);
     });
 });
+
+describe("CSM refit gate: demotion applied inside a drift refit", () => {
+    it("refuses the spread when a floor refit applies a demotion, even though demotionOverdue is unreachable", () => {
+        // Production regime: the wall-time floor refits every few frames, so framesSinceRefit never reaches
+        // demoteQuietFrames and demotionOverdue can never fire; a caster that went quiet is demoted INSIDE a
+        // drift refit, and that refit must not be spread (the caster would vanish from the cascades not yet
+        // re-rendered). Frames every 30 ms, floor 100 ms, demoteQuietFrames 5.
+        const caster = { worldMatrixVersion: 1 };
+        const gate = createCsmRefitGate<MutableCaster>({ refitAngle: 1, refitMaxIntervalMs: 100, demoteQuietFrames: 5 });
+        gate.syncCasters([caster]);
+        const onDemote = vi.fn();
+        const step = (nowMs: number) => gate.update(0, -1, 0, nowMs, false, false, () => undefined, onDemote);
+        expect(step(0).refit).toBe(true); // first refit: full
+        let demotedAt = -1;
+        for (let t = 30; t <= 600; t += 30) {
+            const r = step(t);
+            if (onDemote.mock.calls.length === 1 && demotedAt < 0) {
+                demotedAt = t;
+                expect(r.refit).toBe(true); // the demotion is applied by a floor refit...
+                expect(gate.lastRefitDriftOnly()).toBe(false); // ...which therefore must not be spread
+            } else if (r.refit) {
+                expect(gate.lastRefitDriftOnly()).toBe(true); // every other floor refit is drift-only
+            }
+        }
+        expect(demotedAt).toBeGreaterThan(0);
+        expect(gate.isDynamic(caster)).toBe(false);
+    });
+});

--- a/tests/lite/unit/csm-refit-gate.test.ts
+++ b/tests/lite/unit/csm-refit-gate.test.ts
@@ -148,7 +148,7 @@ describe("CSM refit gate", () => {
     });
 });
 
-describe("CSM refit gate: lastRefitDriftOnly", () => {
+describe("CSM refit gate: _lastRefitDriftOnly", () => {
     const step = (gate: ReturnType<typeof createCsmRefitGate<MutableCaster>>, x: number, nowMs: number, camera = false) =>
         gate.update(
             x,
@@ -166,15 +166,15 @@ describe("CSM refit gate: lastRefitDriftOnly", () => {
         const gate = createCsmRefitGate<MutableCaster>({ refitAngle: 0.05, refitMaxIntervalMs: 100, demoteQuietFrames: 100 });
         gate.syncCasters([caster]);
         expect(step(gate, 0, 0).refit).toBe(true);
-        expect(gate.lastRefitDriftOnly()).toBe(false); // the very first refit is a full render
+        expect(gate._lastRefitDriftOnly()).toBe(false); // the very first refit is a full render
         expect(step(gate, 0, 10).refit).toBe(false);
-        expect(gate.lastRefitDriftOnly()).toBe(false); // no refit, no drift-only claim
+        expect(gate._lastRefitDriftOnly()).toBe(false); // no refit, no drift-only claim
         expect(step(gate, 0.2, 20).refit).toBe(true); // angle epsilon crossed
-        expect(gate.lastRefitDriftOnly()).toBe(true);
+        expect(gate._lastRefitDriftOnly()).toBe(true);
         expect(step(gate, 0.2, 130).refit).toBe(true); // wall-time floor, frozen sun
-        expect(gate.lastRefitDriftOnly()).toBe(true);
+        expect(gate._lastRefitDriftOnly()).toBe(true);
         expect(step(gate, 0.2, 140).refit).toBe(false);
-        expect(gate.lastRefitDriftOnly()).toBe(false);
+        expect(gate._lastRefitDriftOnly()).toBe(false);
     });
 
     it("is false when the camera, a promotion or a demotion took part in the refit, even with drift", () => {
@@ -187,17 +187,17 @@ describe("CSM refit gate: lastRefitDriftOnly", () => {
         // static partition changes inside it and the spread is refused.
         expect(step(gate, 0.2, 2).refit).toBe(true);
         expect(gate.isDynamic(caster)).toBe(false);
-        expect(gate.lastRefitDriftOnly()).toBe(false);
+        expect(gate._lastRefitDriftOnly()).toBe(false);
         // Drift alone on the settled partition: spreadable.
         expect(step(gate, 0.4, 3).refit).toBe(true);
-        expect(gate.lastRefitDriftOnly()).toBe(true);
+        expect(gate._lastRefitDriftOnly()).toBe(true);
         // Drift plus a camera change: full.
         expect(step(gate, 0.6, 4, true).refit).toBe(true);
-        expect(gate.lastRefitDriftOnly()).toBe(false);
+        expect(gate._lastRefitDriftOnly()).toBe(false);
         // Drift plus a promotion (the static caster moved): full.
         caster.worldMatrixVersion++;
         expect(step(gate, 0.8, 5).refit).toBe(true);
-        expect(gate.lastRefitDriftOnly()).toBe(false);
+        expect(gate._lastRefitDriftOnly()).toBe(false);
     });
 });
 
@@ -219,9 +219,9 @@ describe("CSM refit gate: demotion applied inside a drift refit", () => {
             if (onDemote.mock.calls.length === 1 && demotedAt < 0) {
                 demotedAt = t;
                 expect(r.refit).toBe(true); // the demotion is applied by a floor refit...
-                expect(gate.lastRefitDriftOnly()).toBe(false); // ...which therefore must not be spread
+                expect(gate._lastRefitDriftOnly()).toBe(false); // ...which therefore must not be spread
             } else if (r.refit) {
-                expect(gate.lastRefitDriftOnly()).toBe(true); // every other floor refit is drift-only
+                expect(gate._lastRefitDriftOnly()).toBe(true); // every other floor refit is drift-only
             }
         }
         expect(demotedAt).toBeGreaterThan(0);

--- a/tests/lite/unit/csm-static-cache-refit.test.ts
+++ b/tests/lite/unit/csm-static-cache-refit.test.ts
@@ -45,7 +45,7 @@ vi.mock("../../../packages/babylon-lite/src/engine/gpu-resource-retirement.js", 
 }));
 
 const { ensureCsmShadowCacheState, renderCsmShadowMapCached } = await import("../../../packages/babylon-lite/src/shadow/csm-shadow-cache");
-const { createCsmRefitGate } = await import("../../../packages/babylon-lite/src/shadow/csm-refit-gate");
+const { createCsmRefitGate, createCsmStaticRefitScheduler } = await import("../../../packages/babylon-lite/src/shadow/csm-refit-gate");
 
 function makeHarness() {
     const staticExecute = vi.fn(() => 1);
@@ -61,6 +61,7 @@ function makeHarness() {
         _staticTasks: [{ execute: staticExecute }],
         _tasks: [{ execute: dynamicExecute }],
         _gate: gate,
+        _staticScheduler: createCsmStaticRefitScheduler(1, 0),
         _onPromote: () => {},
         _onDemote: () => {},
         _pendingTransfers: new Set(),
@@ -142,5 +143,84 @@ describe("renderCsmShadowMapCached static-layer invalidation", () => {
         h.caster.worldMatrixVersion++;
         h.render();
         expect(h.staticExecute).toHaveBeenCalledTimes(before + 1);
+    });
+});
+
+describe("renderCsmShadowMapCached spread static refit (staticCascadesPerFrame)", () => {
+    function makeSpreadHarness(cascadesPerFrame: number) {
+        const staticExecutes = [vi.fn(() => 1), vi.fn(() => 1), vi.fn(() => 1)];
+        const dynamicExecute = vi.fn(() => 1);
+        const scene = { camera: { key: 1 }, _renderableVersion: 7 };
+        const caster = { worldMatrixVersion: 1, thinInstances: null };
+        const gate = createCsmRefitGate<typeof caster>({ refitAngle: 0.05, refitMaxIntervalMs: 0, demoteQuietFrames: 2 });
+        const state = {
+            _scene: scene,
+            _cameras: [{}, {}, {}],
+            _uboData: new Float32Array(80),
+            _casterMeshes: [caster],
+            _staticTasks: staticExecutes.map((execute) => ({ execute })),
+            _tasks: [{ execute: dynamicExecute }, { execute: dynamicExecute }, { execute: dynamicExecute }],
+            _gate: gate,
+            _staticScheduler: createCsmStaticRefitScheduler(3, cascadesPerFrame),
+            _onPromote: () => {},
+            _onDemote: () => {},
+            _pendingTransfers: new Set(),
+            _cachedContentVersion: -1,
+            _lastCamVersion: -1,
+            _lastCamAspect: -1,
+        };
+        const copy = vi.fn();
+        const engine = {
+            _device: { queue: { writeBuffer: vi.fn() } },
+            _currentEncoder: { copyTextureToTexture: copy },
+        };
+        const sg = { _light: { direction: { x: 0, y: -1, z: 0 } }, _shadowUBO: {}, _version: 0, _depthTexture: {} };
+        const cfg = { _numCascades: 3, _mapSize: 4, _bias: 0, _worldSpaceBias: null, _forceRefreshEveryFrame: false };
+        const render = () => renderCsmShadowMapCached(engine as any, sg as any, state as any, cfg as any);
+        const staticCalls = () => staticExecutes.map((fn) => fn.mock.calls.length);
+        // Settle: first (full) refit, quiet frames, then a camera refit applies the demotion so the caster
+        // sits in the static layer and drift alone drives the next refits.
+        render();
+        render();
+        render();
+        scene.camera.key++;
+        render();
+        expect(gate.isDynamic(caster)).toBe(false);
+        return { render, scene, sg, copy, staticCalls, dynamicExecute };
+    }
+
+    it("re-renders one static cascade per frame after a drift refit, none of them later than maxLagFrames", () => {
+        const h = makeSpreadHarness(1);
+        const base = h.staticCalls();
+        const copies = h.copy.mock.calls.length;
+        h.sg._light.direction.x = 0.2; // angle epsilon crossed: a drift-only refit
+        expect(h.render()).toBeGreaterThan(0);
+        expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]!, base[2]!]); // refit frame: cascade 0 only
+        expect(h.render()).toBeGreaterThan(0); // nothing dynamic changed, yet the pending cascade keeps the frame alive
+        expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]! + 1, base[2]!]);
+        h.render();
+        expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]! + 1, base[2]! + 1]); // lag 2 = maxLagFrames(3, 1)
+        expect(h.copy.mock.calls.length).toBe(copies + 3); // the cache is copied to the sampled map on each of the three frames
+        expect(h.render()).toBe(0); // drained and quiet: the frame does nothing again
+        expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]! + 1, base[2]! + 1]);
+    });
+
+    it("re-renders every cascade in the refit frame when the camera moved, even with drift", () => {
+        const h = makeSpreadHarness(1);
+        const base = h.staticCalls();
+        h.sg._light.direction.x = 0.2;
+        h.scene.camera.key++;
+        h.render();
+        expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]! + 1, base[2]! + 1]);
+        expect(h.render()).toBe(0);
+    });
+
+    it("keeps the single-frame re-render when the budget is 0 (historical behaviour)", () => {
+        const h = makeSpreadHarness(0);
+        const base = h.staticCalls();
+        h.sg._light.direction.x = 0.2;
+        h.render();
+        expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]! + 1, base[2]! + 1]);
+        expect(h.render()).toBe(0);
     });
 });

--- a/tests/lite/unit/csm-static-cache-refit.test.ts
+++ b/tests/lite/unit/csm-static-cache-refit.test.ts
@@ -224,3 +224,54 @@ describe("renderCsmShadowMapCached spread static refit (staticCascadesPerFrame)"
         expect(h.render()).toBe(0);
     });
 });
+
+describe("renderCsmShadowMapCached spread static refit: a drift refit during the drain", () => {
+    it("re-renders every cascade when a second drift refit lands before the spread drained (no permanent lag)", () => {
+        // A light turning faster than the drain (a fast game clock) crosses the angle epsilon every frame: each
+        // such refit must fall back to the single-frame re-render instead of re-arming a spread that never ends.
+        const staticExecutes = [vi.fn(() => 1), vi.fn(() => 1), vi.fn(() => 1)];
+        const dynamicExecute = vi.fn(() => 1);
+        const scene = { camera: { key: 1 }, _renderableVersion: 7 };
+        const caster = { worldMatrixVersion: 1, thinInstances: null };
+        const gate = createCsmRefitGate<typeof caster>({ refitAngle: 0.05, refitMaxIntervalMs: 0, demoteQuietFrames: 2 });
+        const state = {
+            _scene: scene,
+            _cameras: [{}, {}, {}],
+            _uboData: new Float32Array(80),
+            _casterMeshes: [caster],
+            _staticTasks: staticExecutes.map((execute) => ({ execute })),
+            _tasks: [{ execute: dynamicExecute }, { execute: dynamicExecute }, { execute: dynamicExecute }],
+            _gate: gate,
+            _staticScheduler: createCsmStaticRefitScheduler(3, 1),
+            _onPromote: () => {},
+            _onDemote: () => {},
+            _pendingTransfers: new Set(),
+            _cachedContentVersion: -1,
+            _lastCamVersion: -1,
+            _lastCamAspect: -1,
+        };
+        const engine = { _device: { queue: { writeBuffer: vi.fn() } }, _currentEncoder: { copyTextureToTexture: vi.fn() } };
+        const sg = { _light: { direction: { x: 0, y: -1, z: 0 } }, _shadowUBO: {}, _version: 0, _depthTexture: {} };
+        const cfg = { _numCascades: 3, _mapSize: 4, _bias: 0, _worldSpaceBias: null, _forceRefreshEveryFrame: false };
+        const render = () => renderCsmShadowMapCached(engine as any, sg as any, state as any, cfg as any);
+        const calls = () => staticExecutes.map((fn) => fn.mock.calls.length);
+        render();
+        render();
+        render();
+        scene.camera.key++;
+        render(); // settled: the caster is static, the next refits are drift-only
+        const base = calls();
+        sg._light.direction.x = 0.2; // drift refit #1: spread, cascade 0 only
+        render();
+        expect(calls()).toEqual([base[0]! + 1, base[1]!, base[2]!]);
+        sg._light.direction.x = 0.4; // drift refit #2 while cascades 1 and 2 still wait: everything, this frame
+        render();
+        expect(calls()).toEqual([base[0]! + 2, base[1]! + 1, base[2]! + 1]);
+        expect(render()).toBe(0); // nothing pending, nothing dynamic: the frame does nothing
+        sg._light.direction.x = 0.6; // and with the drain complete, the next drift refit spreads again: ONE cascade
+        render(); // (the round-robin cursor decides which one — it continues after the last cascade taken)
+        const after = calls();
+        expect(after.reduce((sum, n) => sum + n, 0)).toBe(base[0]! + base[1]! + base[2]! + 5); // +1, +3, then +1
+        expect(after.filter((n, i) => n === [base[0]! + 2, base[1]! + 1, base[2]! + 1][i]! + 1)).toHaveLength(1);
+    });
+});

--- a/tests/lite/unit/csm-static-cache-refit.test.ts
+++ b/tests/lite/unit/csm-static-cache-refit.test.ts
@@ -17,14 +17,35 @@ vi.mock("../../../packages/babylon-lite/src/camera/camera.js", () => ({
 }));
 vi.mock("../../../packages/babylon-lite/src/shadow/shadow-base.js", () => ({
     createShadowCamera: () => ({}),
-    updateShadowCameraBase: () => {},
+    updateShadowCameraBase: (camera: { viewProjection?: Float32Array }, _version: number, _near: number, _far: number, _view: Float32Array, viewProjection: Float32Array) => {
+        camera.viewProjection = viewProjection;
+    },
 }));
 vi.mock("../../../packages/babylon-lite/src/shadow/csm-shadow-task-hooks.js", () => ({
     csmCameraAspect: () => 1,
     csmWorldBiasClipOffset: () => 0,
     _biasViewProjection: () => {},
-    _writeCsmUbo: () => {},
-    _computeCsmCascades: () => ({ _transforms: [new Float32Array(16)], _views: [new Float32Array(16)], _near: [0], _far: [1] }),
+    _writeCsmUbo: (out: Float32Array, cascades: { _transforms: Float32Array[] }) => {
+        out.fill(0);
+        for (let cascade = 0; cascade < cascades._transforms.length; cascade++) {
+            out.set(cascades._transforms[cascade]!, cascade * 16);
+        }
+    },
+    _computeCsmCascades: (_scene: unknown, _camera: unknown, light: { direction: { x: number } }, cfg: { _numCascades: number }) => {
+        const transforms = Array.from({ length: cfg._numCascades }, (_, cascade) => {
+            const transform = new Float32Array(16);
+            transform[0] = cascade + 1 + light.direction.x;
+            return transform;
+        });
+        return {
+            _transforms: transforms,
+            _views: Array.from({ length: cfg._numCascades }, () => new Float32Array(16)),
+            _near: new Array<number>(cfg._numCascades).fill(0),
+            _far: new Array<number>(cfg._numCascades).fill(1),
+            _viewFrustumZ: new Array<number>(cfg._numCascades).fill(1),
+            _frustumLengths: new Array<number>(cfg._numCascades).fill(1),
+        };
+    },
     _createCascadeScratch: () => ({}),
 }));
 vi.mock("../../../packages/babylon-lite/src/frame-graph/render-task.js", () => ({
@@ -59,7 +80,7 @@ function makeHarness() {
         _uboData: new Float32Array(80),
         _casterMeshes: [caster],
         _staticTasks: [{ execute: staticExecute }],
-        _tasks: [{ execute: dynamicExecute }],
+        _tasks: [{ execute: dynamicExecute, _renderables: [{}], _pendingMeshes: [] }],
         _gate: gate,
         _staticScheduler: createCsmStaticRefitScheduler(1, 0),
         _onPromote: () => {},
@@ -149,7 +170,7 @@ describe("renderCsmShadowMapCached static-layer invalidation", () => {
 describe("renderCsmShadowMapCached spread static refit (staticCascadesPerFrame)", () => {
     function makeSpreadHarness(cascadesPerFrame: number) {
         const staticExecutes = [vi.fn(() => 1), vi.fn(() => 1), vi.fn(() => 1)];
-        const dynamicExecute = vi.fn(() => 1);
+        const dynamicExecutes = [vi.fn(() => 1), vi.fn(() => 1), vi.fn(() => 1)];
         const scene = { camera: { key: 1 }, _renderableVersion: 7 };
         const caster = { worldMatrixVersion: 1, thinInstances: null };
         const gate = createCsmRefitGate<typeof caster>({ refitAngle: 0.05, refitMaxIntervalMs: 0, demoteQuietFrames: 2 });
@@ -159,7 +180,7 @@ describe("renderCsmShadowMapCached spread static refit (staticCascadesPerFrame)"
             _uboData: new Float32Array(80),
             _casterMeshes: [caster],
             _staticTasks: staticExecutes.map((execute) => ({ execute })),
-            _tasks: [{ execute: dynamicExecute }, { execute: dynamicExecute }, { execute: dynamicExecute }],
+            _tasks: dynamicExecutes.map((execute) => ({ execute, _renderables: [{}], _pendingMeshes: [] })),
             _gate: gate,
             _staticScheduler: createCsmStaticRefitScheduler(3, cascadesPerFrame),
             _onPromote: () => {},
@@ -186,23 +207,57 @@ describe("renderCsmShadowMapCached spread static refit (staticCascadesPerFrame)"
         scene.camera.key++;
         render();
         expect(gate.isDynamic(caster)).toBe(false);
-        return { render, scene, sg, copy, staticCalls, dynamicExecute };
+        const dynamicCalls = () => dynamicExecutes.map((fn) => fn.mock.calls.length);
+        return { render, scene, sg, state, copy, staticCalls, dynamicCalls };
     }
 
     it("re-renders one static cascade per frame after a drift refit, none of them later than maxLagFrames", () => {
         const h = makeSpreadHarness(1);
         const base = h.staticCalls();
+        const dynamicBase = h.dynamicCalls();
         const copies = h.copy.mock.calls.length;
         h.sg._light.direction.x = 0.2; // angle epsilon crossed: a drift-only refit
         expect(h.render()).toBeGreaterThan(0);
         expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]!, base[2]!]); // refit frame: cascade 0 only
+        expect(h.dynamicCalls()).toEqual([dynamicBase[0]! + 1, dynamicBase[1]!, dynamicBase[2]!]);
+        expect(h.copy.mock.calls[copies]![0].origin.z).toBe(0);
+        expect(h.copy.mock.calls[copies]![2].depthOrArrayLayers).toBe(1);
         expect(h.render()).toBeGreaterThan(0); // nothing dynamic changed, yet the pending cascade keeps the frame alive
         expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]! + 1, base[2]!]);
+        expect(h.dynamicCalls()).toEqual([dynamicBase[0]! + 1, dynamicBase[1]! + 1, dynamicBase[2]!]);
         h.render();
         expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]! + 1, base[2]! + 1]); // lag 2 = maxLagFrames(3, 1)
-        expect(h.copy.mock.calls.length).toBe(copies + 3); // the cache is copied to the sampled map on each of the three frames
+        expect(h.dynamicCalls()).toEqual([dynamicBase[0]! + 1, dynamicBase[1]! + 1, dynamicBase[2]! + 1]);
+        expect(h.copy.mock.calls.length).toBe(copies + 3); // one layer copy on each of the three frames
         expect(h.render()).toBe(0); // drained and quiet: the frame does nothing again
         expect(h.staticCalls()).toEqual([base[0]! + 1, base[1]! + 1, base[2]! + 1]);
+    });
+
+    it("publishes each receiver transform only with the matching refreshed depth layer", () => {
+        const h = makeSpreadHarness(1);
+        expect(h.state._uboData[0]).toBeCloseTo(1);
+        expect(h.state._uboData[16]).toBeCloseTo(2);
+        expect(h.state._uboData[32]).toBeCloseTo(3);
+
+        h.sg._light.direction.x = 0.2;
+        h.render();
+        expect(h.state._uboData[0]).toBeCloseTo(1.2);
+        expect(h.state._uboData[16]).toBeCloseTo(2);
+        expect(h.state._uboData[32]).toBeCloseTo(3);
+
+        h.render();
+        expect(h.state._uboData[0]).toBeCloseTo(1.2);
+        expect(h.state._uboData[16]).toBeCloseTo(2.2);
+        expect(h.state._uboData[32]).toBeCloseTo(3);
+    });
+
+    it("does not begin an empty dynamic-overlay pass while a spread drains", () => {
+        const h = makeSpreadHarness(1);
+        const dynamicBase = h.dynamicCalls();
+        h.state._tasks[0]!._renderables.length = 0;
+        h.sg._light.direction.x = 0.2;
+        h.render();
+        expect(h.dynamicCalls()).toEqual(dynamicBase);
     });
 
     it("re-renders every cascade in the refit frame when the camera moved, even with drift", () => {
@@ -240,7 +295,11 @@ describe("renderCsmShadowMapCached spread static refit: a drift refit during the
             _uboData: new Float32Array(80),
             _casterMeshes: [caster],
             _staticTasks: staticExecutes.map((execute) => ({ execute })),
-            _tasks: [{ execute: dynamicExecute }, { execute: dynamicExecute }, { execute: dynamicExecute }],
+            _tasks: [
+                { execute: dynamicExecute, _renderables: [{}], _pendingMeshes: [] },
+                { execute: dynamicExecute, _renderables: [{}], _pendingMeshes: [] },
+                { execute: dynamicExecute, _renderables: [{}], _pendingMeshes: [] },
+            ],
             _gate: gate,
             _staticScheduler: createCsmStaticRefitScheduler(3, 1),
             _onPromote: () => {},

--- a/tests/lite/unit/csm-static-refit-scheduler.test.ts
+++ b/tests/lite/unit/csm-static-refit-scheduler.test.ts
@@ -11,8 +11,10 @@ describe("CSM static refit scheduler", () => {
 
         scheduler.arm(true);
         expect(scheduler.pending()).toBe(true);
-        expect(scheduler.take()).toEqual([0]); // the refit frame itself renders the first cascade
-        expect(scheduler.take()).toEqual([1]); // lag 1
+        const selection = scheduler.take();
+        expect(selection).toEqual([0]); // the refit frame itself renders the first cascade
+        expect(scheduler.take()).toBe(selection);
+        expect(selection).toEqual([1]); // lag 1; the scheduler reuses its output buffer
         expect(scheduler.take()).toEqual([2]); // lag 2 = maxLagFrames
         expect(scheduler.pending()).toBe(false);
         expect(scheduler.take()).toEqual([]);

--- a/tests/lite/unit/csm-static-refit-scheduler.test.ts
+++ b/tests/lite/unit/csm-static-refit-scheduler.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { createCsmStaticRefitScheduler } from "../../../packages/babylon-lite/src/shadow/csm-refit-gate";
+
+describe("CSM static refit scheduler", () => {
+    it("spreads a drift refit over frames within the per-frame budget and pins the worst lag", () => {
+        const scheduler = createCsmStaticRefitScheduler(3, 1);
+        expect(scheduler.maxLagFrames()).toBe(2);
+        expect(scheduler.pending()).toBe(false);
+        expect(scheduler.take()).toEqual([]);
+
+        scheduler.arm(true);
+        expect(scheduler.pending()).toBe(true);
+        expect(scheduler.take()).toEqual([0]); // the refit frame itself renders the first cascade
+        expect(scheduler.take()).toEqual([1]); // lag 1
+        expect(scheduler.take()).toEqual([2]); // lag 2 = maxLagFrames
+        expect(scheduler.pending()).toBe(false);
+        expect(scheduler.take()).toEqual([]);
+    });
+
+    it("re-renders every cascade in one frame when the refit is not drift-only", () => {
+        const scheduler = createCsmStaticRefitScheduler(3, 1);
+        scheduler.arm(false);
+        expect(scheduler.take()).toEqual([0, 1, 2]);
+        expect(scheduler.pending()).toBe(false);
+    });
+
+    it("keeps the historical single-frame re-render when the budget is 0 or covers every cascade", () => {
+        for (const budget of [0, 3, 4, -1, Number.NaN]) {
+            const scheduler = createCsmStaticRefitScheduler(3, budget);
+            expect(scheduler.maxLagFrames()).toBe(0);
+            scheduler.arm(true);
+            expect(scheduler.take()).toEqual([0, 1, 2]);
+            expect(scheduler.pending()).toBe(false);
+        }
+    });
+
+    it("continues round-robin across refits so no cascade starves when refits arrive faster than the drain", () => {
+        const scheduler = createCsmStaticRefitScheduler(3, 1);
+        scheduler.arm(true);
+        expect(scheduler.take()).toEqual([0]);
+        scheduler.arm(true); // a second drift refit lands before the first drained
+        expect(scheduler.take()).toEqual([1]); // not 0 again
+        expect(scheduler.take()).toEqual([2]);
+        expect(scheduler.take()).toEqual([0]); // the re-armed first cascade gets its turn
+        expect(scheduler.pending()).toBe(false);
+    });
+
+    it("lets a full refit interrupt a spread and returns to the budget afterwards", () => {
+        const scheduler = createCsmStaticRefitScheduler(4, 2);
+        expect(scheduler.maxLagFrames()).toBe(1);
+        scheduler.arm(true);
+        expect(scheduler.take()).toEqual([0, 1]);
+        scheduler.arm(false); // camera moved: everything now
+        expect(scheduler.take()).toEqual([2, 3, 0, 1]);
+        scheduler.arm(true);
+        expect(scheduler.take()).toEqual([2, 3]);
+        expect(scheduler.take()).toEqual([0, 1]);
+        expect(scheduler.pending()).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- add `staticCascadesPerFrame` to spread drift-only CSM static-cache refits across frames
- publish each cascade camera and receiver transform atomically with its refreshed depth layer
- copy and redraw only refreshed layers while draining; redraw all layers only when dynamic casters change or a full refit is required
- keep the scheduler and drift classification internal, with focused orchestration coverage and updated architecture documentation

## Validation
- Not run locally, per request; CI will provide validation.