### PR TITLE
fix(compat): remove disposed shadow casters

### DIFF
--- a/packages/babylon-lite-compat/src/shadows/shadow-generator.ts
+++ b/packages/babylon-lite-compat/src/shadows/shadow-generator.ts
@@ -25,13 +25,17 @@ import type { EngineContext, Mesh as LiteMesh } from "babylon-lite";
 
 import { DirectionalLight, type Light } from "../lights/lights.js";
 import type { AbstractMesh } from "../meshes/meshes.js";
+import type { ObserverCallback } from "../misc/observable.js";
+import type { Node } from "../node/node.js";
 
 type LiteShadowGenerator = ReturnType<typeof createEsmDirectionalShadowGenerator>;
+type CasterDisposeSubscription = { caster: AbstractMesh; observer: ObserverCallback<Node> };
 
 export class ShadowGenerator {
     private readonly _mapSize: number;
     private readonly _light: Light;
     private readonly _casters: AbstractMesh[] = [];
+    private readonly _casterDisposeSubscriptions = new Map<LiteMesh, CasterDisposeSubscription>();
     private _casterSyncScheduled = false;
     private _casterSyncDirty = false;
     private readonly _disposeBeforeRenderFlush: (() => void) | undefined = undefined;
@@ -80,8 +84,15 @@ export class ShadowGenerator {
     public addShadowCaster(mesh: AbstractMesh, includeDescendants = true): ShadowGenerator {
         let changed = false;
         for (const caster of this._casterTree(mesh, includeDescendants)) {
-            if (!this._casters.some((existing) => existing._lite === caster._lite)) {
+            const liteCaster = caster._lite as LiteMesh;
+            if (!this._casterDisposeSubscriptions.has(liteCaster)) {
                 this._casters.push(caster);
+                const observer = caster.onDisposeObservable.add(() => {
+                    if (this._removeCaster(liteCaster)) {
+                        this._scheduleCasterSync();
+                    }
+                });
+                this._casterDisposeSubscriptions.set(liteCaster, { caster, observer });
                 changed = true;
             }
         }
@@ -95,11 +106,7 @@ export class ShadowGenerator {
     public removeShadowCaster(mesh: AbstractMesh, includeDescendants = true): ShadowGenerator {
         let changed = false;
         for (const caster of this._casterTree(mesh, includeDescendants)) {
-            const index = this._casters.findIndex((existing) => existing._lite === caster._lite);
-            if (index !== -1) {
-                this._casters.splice(index, 1);
-                changed = true;
-            }
+            changed = this._removeCaster(caster._lite as LiteMesh) || changed;
         }
         if (changed) {
             this._scheduleCasterSync();
@@ -109,6 +116,20 @@ export class ShadowGenerator {
 
     private _casterTree(mesh: AbstractMesh, includeDescendants: boolean): AbstractMesh[] {
         return includeDescendants ? [mesh, ...(mesh.getChildMeshes() as AbstractMesh[])] : [mesh];
+    }
+
+    private _removeCaster(liteCaster: LiteMesh): boolean {
+        const subscription = this._casterDisposeSubscriptions.get(liteCaster);
+        if (!subscription) {
+            return false;
+        }
+        subscription.caster.onDisposeObservable.remove(subscription.observer);
+        this._casterDisposeSubscriptions.delete(liteCaster);
+        const index = this._casters.findIndex((caster) => caster._lite === liteCaster);
+        if (index !== -1) {
+            this._casters.splice(index, 1);
+        }
+        return true;
     }
 
     private _scheduleCasterSync(): void {
@@ -156,6 +177,10 @@ export class ShadowGenerator {
 
     public dispose(): void {
         this._disposeBeforeRenderFlush?.();
+        for (const { caster, observer } of this._casterDisposeSubscriptions.values()) {
+            caster.onDisposeObservable.remove(observer);
+        }
+        this._casterDisposeSubscriptions.clear();
         this._casterSyncScheduled = false;
         this._casterSyncDirty = false;
         this._liteGen = undefined;

--- a/packages/babylon-lite-compat/tests/shadows.test.ts
+++ b/packages/babylon-lite-compat/tests/shadows.test.ts
@@ -95,6 +95,108 @@ describe("ShadowGenerator caster synchronization", () => {
         expect(setShadowTaskCasterMeshes).not.toHaveBeenCalled();
     });
 
+    it("removes disposed pre-build casters from the initial native caster set", () => {
+        const generator = new ShadowGenerator(1024, new DirectionalLight("directional", new Vector3(0, -1, -1)));
+        const caster = createTestMesh("caster");
+        generator.addShadowCaster(caster);
+
+        caster.dispose();
+
+        expect(generator.getShadowMap().renderList).toEqual([]);
+        generator._build({} as EngineContext);
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledOnce();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith(generator._liteGen, []);
+    });
+
+    it("removes disposed runtime casters synchronously and coalesces native resupply", async () => {
+        const generator = new ShadowGenerator(1024, new DirectionalLight("directional", new Vector3(0, -1, -1)));
+        const first = createTestMesh("first");
+        const second = createTestMesh("second");
+        const remaining = createTestMesh("remaining");
+        generator.addShadowCaster(first);
+        generator.addShadowCaster(second);
+        generator.addShadowCaster(remaining);
+        generator._build({} as EngineContext);
+        vi.clearAllMocks();
+
+        first.dispose();
+        second.dispose();
+
+        expect(generator.getShadowMap().renderList).toEqual([remaining]);
+        expect(setShadowTaskCasterMeshes).not.toHaveBeenCalled();
+        await flushCasterSync();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledOnce();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith(generator._liteGen, [remaining._lite]);
+    });
+
+    it("removes recursively disposed descendant casters", async () => {
+        const generator = new ShadowGenerator(1024, new DirectionalLight("directional", new Vector3(0, -1, -1)));
+        const root = createTestMesh("root");
+        const child = createTestMesh("child");
+        const transform = new TransformNode("transform");
+        const nested = createTestMesh("nested");
+        child.parent = root;
+        transform.parent = root;
+        nested.parent = transform;
+        generator.addShadowCaster(root);
+        generator._build({} as EngineContext);
+        vi.clearAllMocks();
+
+        root.dispose();
+
+        expect(generator.getShadowMap().renderList).toEqual([]);
+        await flushCasterSync();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledOnce();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith(generator._liteGen, []);
+    });
+
+    it("removes one disposed caster from every generator independently", async () => {
+        const caster = createTestMesh("caster");
+        const first = new ShadowGenerator(1024, new DirectionalLight("first", new Vector3(0, -1, -1)));
+        const second = new ShadowGenerator(1024, new DirectionalLight("second", new Vector3(0, -1, -1)));
+        first.addShadowCaster(caster);
+        second.addShadowCaster(caster);
+        first._build({} as EngineContext);
+        second._build({} as EngineContext);
+        const firstLiteGenerator = first._liteGen;
+        const secondLiteGenerator = second._liteGen;
+        vi.clearAllMocks();
+
+        caster.dispose();
+
+        expect(first.getShadowMap().renderList).toEqual([]);
+        expect(second.getShadowMap().renderList).toEqual([]);
+        await flushCasterSync();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledTimes(2);
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith(firstLiteGenerator, []);
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith(secondLiteGenerator, []);
+    });
+
+    it("tracks disposal subscriptions by the stored Lite mesh identity", async () => {
+        const generator = new ShadowGenerator(1024, new DirectionalLight("directional", new Vector3(0, -1, -1)));
+        const caster = createTestMesh("caster");
+        const duplicateWrapper = new AbstractMesh("duplicate", caster._lite);
+        generator.addShadowCaster(caster);
+        generator._build({} as EngineContext);
+        vi.clearAllMocks();
+
+        generator.addShadowCaster(duplicateWrapper);
+        duplicateWrapper.dispose();
+        await flushCasterSync();
+
+        expect(generator.getShadowMap().renderList).toEqual([caster]);
+        expect(setShadowTaskCasterMeshes).not.toHaveBeenCalled();
+
+        generator.removeShadowCaster(duplicateWrapper, false);
+        await flushCasterSync();
+        expect(caster.onDisposeObservable.hasObservers()).toBe(false);
+        vi.clearAllMocks();
+
+        caster.dispose();
+        await flushCasterSync();
+        expect(setShadowTaskCasterMeshes).not.toHaveBeenCalled();
+    });
+
     it("includes descendant meshes by default and excludes transform-only nodes", async () => {
         const generator = new ShadowGenerator(1024, new DirectionalLight("directional", new Vector3(0, -1, -1)));
         const root = createTestMesh("root");
@@ -216,6 +318,7 @@ describe("ShadowGenerator caster synchronization", () => {
         generator.dispose();
         await flushCasterSync();
 
+        expect(caster.onDisposeObservable.hasObservers()).toBe(false);
         expect(setShadowTaskCasterMeshes).not.toHaveBeenCalled();
     });
 });
@@ -287,5 +390,21 @@ describe("CascadedShadowGenerator", () => {
         expect(generator._liteGen).toBe(liteGenerator);
         expect(setShadowTaskCasterMeshes).toHaveBeenCalledOnce();
         expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith(liteGenerator, [caster._lite]);
+    });
+
+    it("inherits caster disposal cleanup and native resupply", async () => {
+        const generator = new CascadedShadowGenerator(2048, new DirectionalLight("directional", new Vector3(0, -1, -1)));
+        const caster = createTestMesh("caster");
+        generator.addShadowCaster(caster);
+        generator._build({} as EngineContext);
+        const liteGenerator = generator._liteGen;
+        vi.clearAllMocks();
+
+        caster.dispose();
+
+        expect(generator.getShadowMap().renderList).toEqual([]);
+        await flushCasterSync();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledOnce();
+        expect(setShadowTaskCasterMeshes).toHaveBeenCalledWith(liteGenerator, []);
     });
 });


### PR DESCRIPTION
Closes #703

## Summary
- remove disposed mesh wrappers from each owning shadow generator
- keep `renderList` synchronous while reusing the coalesced native caster sync
- detach caster disposal observers on manual removal and generator disposal
- cover base and cascaded generators, descendants, duplicate wrappers, and multi-generator ownership

## Validation
- `REUSE_BROWSER=1 pnpm exec vitest run --project compat` (643 tests)
- `pnpm --filter @babylonjs/lite-compat build`
- `pnpm exec tsc -p packages/babylon-lite-compat/tsconfig.json --noEmit`
- `pnpm run lint`