### PR TITLE
feat(playground): add Babylon Lite Inspector support

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -39,6 +39,10 @@
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" stroke="none" aria-hidden="true"><polygon points="6 4 20 12 6 20 6 4"/></svg>
                         <span class="action-label">Run</span>
                     </button>
+                    <button id="inspectorBtn" class="btn btn-icon" type="button" title="Open Inspector" aria-label="Open Inspector" aria-pressed="false" disabled>
+                        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"/></svg>
+                        <span class="action-label">Inspector</span>
+                    </button>
                     <a id="openFullBtn" class="btn btn-icon" href="#" title="Open this code in the full Lite Playground" aria-label="Open in Lite Playground">
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
                         <span class="action-label">Open in Playground</span>

--- a/playground/public/runner.html
+++ b/playground/public/runner.html
@@ -15,10 +15,16 @@
                 // Default engine path is relative to this runner.html so it resolves
                 // under the app's deploy base (root or a /pr|/v sub-path). The parent
                 // normally passes an explicit, base-resolved URL via `?engine=`.
-                var engine = new URLSearchParams(location.search).get("engine") || "./engine/dev/index.js";
+                var params = new URLSearchParams(location.search);
+                var engine = params.get("engine") || "./engine/dev/index.js";
+                var inspector = params.get("inspector");
                 var map = document.createElement("script");
                 map.type = "importmap";
-                map.textContent = JSON.stringify({ imports: { "@babylonjs/lite": engine } });
+                var imports = { "@babylonjs/lite": engine };
+                if (inspector) {
+                    imports["@babylonjs/inspector/lite"] = inspector;
+                }
+                map.textContent = JSON.stringify({ imports: imports });
                 document.head.appendChild(map);
             })();
         </script>
@@ -78,19 +84,54 @@
                 post({ type: "error", text: format(event.reason) });
             });
 
-            window.addEventListener("message", async (event) => {
-                const message = event.data;
-                if (!message || message.type !== "run") {
+            let engine = null;
+            let inspectorToken = null;
+            window.addEventListener("babylon-lite-playground-engine-created", (event) => {
+                engine = event.detail;
+                post({ type: "engine-ready" });
+            });
+
+            async function toggleInspector() {
+                if (inspectorToken && !inspectorToken.isDisposed) {
+                    await inspectorToken.dispose();
                     return;
                 }
-                const url = URL.createObjectURL(new Blob([message.code], { type: "text/javascript" }));
-                try {
-                    await import(/* @vite-ignore */ url);
-                    post({ type: "ran" });
-                } catch (err) {
-                    post({ type: "error", text: format(err) });
-                } finally {
-                    URL.revokeObjectURL(url);
+                if (!engine) {
+                    throw new Error("Run a scene before opening Inspector.");
+                }
+                const { ShowInspector } = await import("@babylonjs/inspector/lite");
+                inspectorToken = ShowInspector(engine);
+                inspectorToken.onDisposed.add(() => {
+                    inspectorToken = null;
+                    post({ type: "inspector", open: false });
+                });
+                post({ type: "inspector", open: true });
+            }
+
+            window.addEventListener("message", async (event) => {
+                const message = event.data;
+                if (!message) {
+                    return;
+                }
+                if (message.type === "toggle-inspector") {
+                    try {
+                        await toggleInspector();
+                    } catch (err) {
+                        post({ type: "inspector", open: false });
+                        post({ type: "error", text: format(err) });
+                    }
+                    return;
+                }
+                if (message.type === "run") {
+                    const url = URL.createObjectURL(new Blob([message.code], { type: "text/javascript" }));
+                    try {
+                        await import(/* @vite-ignore */ url);
+                        post({ type: "ran" });
+                    } catch (err) {
+                        post({ type: "error", text: format(err) });
+                    } finally {
+                        URL.revokeObjectURL(url);
+                    }
                 }
             });
 

--- a/playground/src/cdn.ts
+++ b/playground/src/cdn.ts
@@ -18,14 +18,19 @@ export interface Cdn {
     packageUrl(specifier: string): string;
     /** URL for a published `@babylonjs/lite` release (omit `version` for the latest). */
     engineUrl(version?: string): string;
+    /** URL for the Babylon Lite entry point in Inspector v2. */
+    inspectorUrl(): string;
     /** URL for a raw (non-module) file inside a package, e.g. a `.wasm` binary. */
     rawFileUrl(path: string): string;
 }
+
+const INSPECTOR_VERSION = "9.26.0";
 
 const ESM_SH: Cdn = {
     id: "esm.sh",
     packageUrl: (specifier) => `https://esm.sh/${specifier}`,
     engineUrl: (version) => `https://esm.sh/@babylonjs/lite${version ? `@${version}` : ""}`,
+    inspectorUrl: () => `https://esm.sh/@babylonjs/inspector@${INSPECTOR_VERSION}/lite?external=@babylonjs/lite`,
     rawFileUrl: (path) => `https://esm.sh/${path}`,
 };
 
@@ -33,6 +38,7 @@ const JSDELIVR: Cdn = {
     id: "jsdelivr",
     packageUrl: (specifier) => `https://cdn.jsdelivr.net/npm/${specifier}/+esm`,
     engineUrl: (version) => `https://cdn.jsdelivr.net/npm/@babylonjs/lite${version ? `@${version}` : ""}/+esm`,
+    inspectorUrl: () => `https://cdn.jsdelivr.net/npm/@babylonjs/inspector@${INSPECTOR_VERSION}/lite/+esm`,
     rawFileUrl: (path) => `https://cdn.jsdelivr.net/npm/${path}`,
 };
 

--- a/playground/src/engine-entry.ts
+++ b/playground/src/engine-entry.ts
@@ -6,3 +6,16 @@
 // the playground runtime in lockstep with the workspace engine source ("nightly"),
 // while pinned versions are loaded from a CDN instead (see runner import map).
 export * from "babylon-lite";
+
+import { createEngine as createLiteEngine } from "babylon-lite";
+import type { EngineContext, EngineOptions, RenderCanvas } from "babylon-lite";
+
+/**
+ * Playground-only wrapper that lets the runner discover the engine created by a
+ * snippet without requiring snippets or Babylon Lite itself to know about Inspector.
+ */
+export async function createEngine(canvas: RenderCanvas, options?: EngineOptions): Promise<EngineContext> {
+    const engine = await createLiteEngine(canvas, options);
+    window.dispatchEvent(new CustomEvent("babylon-lite-playground-engine-created", { detail: engine }));
+    return engine;
+}

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -19,7 +19,7 @@ import {
     type Project,
 } from "./snippets";
 import { getEmbedMode, decodeCodeHash, openInPlaygroundUrl, EmbedHost } from "./embed";
-import { NIGHTLY, NIGHTLY_ENGINE_URL, fetchDeployedVersions } from "./versions";
+import { NIGHTLY, NIGHTLY_ENGINE_URL, fetchDeployedVersions, supportsInspector } from "./versions";
 import { BASE, stripBase, currentDeployVersion, baseForVersion } from "./base";
 import { getCdn } from "./cdn";
 
@@ -75,6 +75,7 @@ let embedHost: EmbedHost | null = null;
 // snapshot, not by hot-swapping here. Drives the selector's current option and the
 // CDN pin baked into downloaded projects.
 const currentVersion = currentDeployVersion() ?? NIGHTLY;
+const inspectorSupported = supportsInspector(currentVersion);
 
 function appendConsole(level: string, text: string): void {
     const line = document.createElement("div");
@@ -100,9 +101,18 @@ function setInspectorState(available: boolean, open = false): void {
     inspectorBtn.disabled = !available;
     inspectorBtn.classList.toggle("active", open);
     inspectorBtn.setAttribute("aria-pressed", String(open));
-    inspectorBtn.setAttribute("aria-label", open ? "Close Inspector" : "Open Inspector");
-    inspectorBtn.title = open ? "Close Inspector" : "Open Inspector";
+    const label = open
+        ? "Close Inspector"
+        : available
+          ? "Open Inspector"
+          : inspectorSupported
+            ? "Run a scene before opening Inspector"
+            : "Inspector requires Babylon Lite 1.27.0 or newer";
+    inspectorBtn.setAttribute("aria-label", label);
+    inspectorBtn.title = label;
 }
+
+setInspectorState(false);
 
 /** Human-readable byte size, e.g. `48.2 KB`. */
 function formatBytes(bytes: number): string {
@@ -143,41 +153,45 @@ function showToast(text: string, isError = false): void {
     }, 3000);
 }
 
-const runner = new Runner(previewHost, (message: RunnerMessage) => {
-    switch (message.type) {
-        case "console":
-            appendConsole(message.level, message.text);
-            embedHost?.emit({ channel: "babylon-lite-playground", type: "console", level: message.level, text: message.text });
-            break;
-        case "error":
-            setLoading(false);
-            runStartedAt = null;
-            appendConsole("error", message.text);
-            embedHost?.emit({ channel: "babylon-lite-playground", type: "error", text: message.text });
-            break;
-        case "stats":
-            fpsCounter.hidden = false;
-            fpsCounter.textContent = `${Math.round(message.fps)} FPS`;
-            embedHost?.emit({ channel: "babylon-lite-playground", type: "stats", fps: message.fps });
-            break;
-        case "ran":
-            setLoading(false);
-            if (runStartedAt !== null) {
-                appendConsole("system", `Scene ready in ${formatDuration(performance.now() - runStartedAt)}`);
+const runner = new Runner(
+    previewHost,
+    (message: RunnerMessage) => {
+        switch (message.type) {
+            case "console":
+                appendConsole(message.level, message.text);
+                embedHost?.emit({ channel: "babylon-lite-playground", type: "console", level: message.level, text: message.text });
+                break;
+            case "error":
+                setLoading(false);
                 runStartedAt = null;
-            }
-            embedHost?.emit({ channel: "babylon-lite-playground", type: "ran" });
-            break;
-        case "engine-ready":
-            setInspectorState(true);
-            break;
-        case "inspector":
-            setInspectorState(true, message.open);
-            break;
-        default:
-            break;
-    }
-});
+                appendConsole("error", message.text);
+                embedHost?.emit({ channel: "babylon-lite-playground", type: "error", text: message.text });
+                break;
+            case "stats":
+                fpsCounter.hidden = false;
+                fpsCounter.textContent = `${Math.round(message.fps)} FPS`;
+                embedHost?.emit({ channel: "babylon-lite-playground", type: "stats", fps: message.fps });
+                break;
+            case "ran":
+                setLoading(false);
+                if (runStartedAt !== null) {
+                    appendConsole("system", `Scene ready in ${formatDuration(performance.now() - runStartedAt)}`);
+                    runStartedAt = null;
+                }
+                embedHost?.emit({ channel: "babylon-lite-playground", type: "ran" });
+                break;
+            case "engine-ready":
+                setInspectorState(inspectorSupported);
+                break;
+            case "inspector":
+                setInspectorState(inspectorSupported, inspectorSupported && message.open);
+                break;
+            default:
+                break;
+        }
+    },
+    () => setInspectorState(false)
+);
 
 let running = false;
 let rerunPending = false;
@@ -196,7 +210,6 @@ async function run(): Promise<void> {
     runBtn.disabled = true;
     clearConsole();
     setLoading(true, "Compiling…");
-    setInspectorState(false);
     appendConsole("system", "Compiling…");
     try {
         const compileStart = performance.now();
@@ -208,7 +221,7 @@ async function run(): Promise<void> {
         setLoading(true, "Running…");
         appendConsole("system", "Running…");
         runStartedAt = performance.now();
-        const inspectorUrl = (await getCdn()).inspectorUrl();
+        const inspectorUrl = inspectorSupported ? (await getCdn()).inspectorUrl() : undefined;
         await runner.run(code, NIGHTLY_ENGINE_URL, inspectorUrl);
     } catch (err) {
         setLoading(false);

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -21,6 +21,7 @@ import {
 import { getEmbedMode, decodeCodeHash, openInPlaygroundUrl, EmbedHost } from "./embed";
 import { NIGHTLY, NIGHTLY_ENGINE_URL, fetchDeployedVersions } from "./versions";
 import { BASE, stripBase, currentDeployVersion, baseForVersion } from "./base";
+import { getCdn } from "./cdn";
 
 const editorContainer = document.getElementById("editor") as HTMLElement;
 const fileTabsContainer = document.getElementById("fileTabs") as HTMLElement;
@@ -31,6 +32,7 @@ const consoleEl = document.getElementById("console") as HTMLElement;
 const splitEl = document.getElementById("split") as HTMLElement;
 const splitter = document.getElementById("splitter") as HTMLElement;
 const runBtn = document.getElementById("runBtn") as HTMLButtonElement;
+const inspectorBtn = document.getElementById("inspectorBtn") as HTMLButtonElement;
 const newBtn = document.getElementById("newBtn") as HTMLButtonElement;
 const fullscreenBtn = document.getElementById("fullscreenBtn") as HTMLButtonElement;
 const fpsCounter = document.getElementById("fpsCounter") as HTMLElement;
@@ -92,6 +94,14 @@ function setLoading(on: boolean, label?: string): void {
     if (label) {
         previewLoaderText.textContent = label;
     }
+}
+
+function setInspectorState(available: boolean, open = false): void {
+    inspectorBtn.disabled = !available;
+    inspectorBtn.classList.toggle("active", open);
+    inspectorBtn.setAttribute("aria-pressed", String(open));
+    inspectorBtn.setAttribute("aria-label", open ? "Close Inspector" : "Open Inspector");
+    inspectorBtn.title = open ? "Close Inspector" : "Open Inspector";
 }
 
 /** Human-readable byte size, e.g. `48.2 KB`. */
@@ -158,6 +168,12 @@ const runner = new Runner(previewHost, (message: RunnerMessage) => {
             }
             embedHost?.emit({ channel: "babylon-lite-playground", type: "ran" });
             break;
+        case "engine-ready":
+            setInspectorState(true);
+            break;
+        case "inspector":
+            setInspectorState(true, message.open);
+            break;
         default:
             break;
     }
@@ -180,6 +196,7 @@ async function run(): Promise<void> {
     runBtn.disabled = true;
     clearConsole();
     setLoading(true, "Compiling…");
+    setInspectorState(false);
     appendConsole("system", "Compiling…");
     try {
         const compileStart = performance.now();
@@ -191,7 +208,8 @@ async function run(): Promise<void> {
         setLoading(true, "Running…");
         appendConsole("system", "Running…");
         runStartedAt = performance.now();
-        await runner.run(code, NIGHTLY_ENGINE_URL);
+        const inspectorUrl = (await getCdn()).inspectorUrl();
+        await runner.run(code, NIGHTLY_ENGINE_URL, inspectorUrl);
     } catch (err) {
         setLoading(false);
         runStartedAt = null;
@@ -331,6 +349,10 @@ examplesEl.addEventListener("change", () => {
 });
 
 runBtn.addEventListener("click", () => void run());
+inspectorBtn.addEventListener("click", () => {
+    inspectorBtn.disabled = true;
+    runner.toggleInspector();
+});
 
 // --- Mobile chrome: hamburger menu + Code/Scene view toggle ------------------
 // On narrow screens the toolbar actions collapse into a dropdown, and the

--- a/playground/src/runner.ts
+++ b/playground/src/runner.ts
@@ -3,6 +3,8 @@ import { rebaseAssetReferences, withBase } from "./base";
 export type RunnerMessage =
     | { type: "ready" }
     | { type: "ran" }
+    | { type: "engine-ready" }
+    | { type: "inspector"; open: boolean }
     | { type: "console"; level: "log" | "info" | "warn" | "error"; text: string }
     | { type: "error"; text: string }
     | { type: "stats"; fps: number };
@@ -39,11 +41,18 @@ export class Runner {
     };
 
     /** Replace the iframe with a fresh one and run the given transpiled module code. */
-    async run(code: string, engineUrl?: string): Promise<void> {
+    async run(code: string, engineUrl?: string, inspectorUrl?: string): Promise<void> {
         const frame = document.createElement("iframe");
         frame.setAttribute("sandbox", "allow-scripts allow-same-origin");
         const ready = this.waitForReady(frame);
-        frame.src = engineUrl ? withBase(`runner.html?engine=${encodeURIComponent(engineUrl)}`) : withBase("runner.html");
+        const params = new URLSearchParams();
+        if (engineUrl) {
+            params.set("engine", engineUrl);
+        }
+        if (inspectorUrl) {
+            params.set("inspector", inspectorUrl);
+        }
+        frame.src = withBase(`runner.html${params.size > 0 ? `?${params}` : ""}`);
 
         if (this.frame) {
             this.frame.remove();
@@ -56,6 +65,11 @@ export class Runner {
         // page that navigated the frame cross-origin. Rebase root-absolute asset
         // paths so same-origin assets resolve under a /pr or /v sub-path deploy.
         frame.contentWindow?.postMessage({ type: "run", code: rebaseAssetReferences(code) }, window.location.origin);
+    }
+
+    /** Toggle Inspector v2 for the engine created by the current snippet. */
+    toggleInspector(): void {
+        this.frame?.contentWindow?.postMessage({ type: "toggle-inspector" }, window.location.origin);
     }
 
     /** Tear down the current runner iframe, stopping its engine and render loop. */

--- a/playground/src/runner.ts
+++ b/playground/src/runner.ts
@@ -17,11 +17,13 @@ export type RunnerMessage =
 export class Runner {
     private readonly host: HTMLElement;
     private readonly onMessage: (message: RunnerMessage) => void;
+    private readonly onTeardown: () => void;
     private frame: HTMLIFrameElement | null = null;
 
-    constructor(host: HTMLElement, onMessage: (message: RunnerMessage) => void) {
+    constructor(host: HTMLElement, onMessage: (message: RunnerMessage) => void, onTeardown: () => void) {
         this.host = host;
         this.onMessage = onMessage;
+        this.onTeardown = onTeardown;
         window.addEventListener("message", this.handleMessage);
     }
 
@@ -54,9 +56,7 @@ export class Runner {
         }
         frame.src = withBase(`runner.html${params.size > 0 ? `?${params}` : ""}`);
 
-        if (this.frame) {
-            this.frame.remove();
-        }
+        this.dispose();
         this.frame = frame;
         this.host.appendChild(frame);
 
@@ -77,6 +77,7 @@ export class Runner {
         if (this.frame) {
             this.frame.remove();
             this.frame = null;
+            this.onTeardown();
         }
     }
 

--- a/playground/src/styles.css
+++ b/playground/src/styles.css
@@ -172,6 +172,12 @@ body {
     border-color: var(--accent);
 }
 
+.btn.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
 .btn:disabled {
     opacity: 0.5;
     cursor: default;

--- a/playground/src/versions.ts
+++ b/playground/src/versions.ts
@@ -18,8 +18,16 @@ import { withBase } from "./base";
 /** Sentinel value for the self-hosted, source-tracking engine build. */
 export const NIGHTLY = "nightly";
 
+/** First published Babylon Lite version supported by Inspector v2's Lite entry point. */
+const MIN_INSPECTOR_VERSION = "1.27.0";
+
 /** URL of the self-hosted nightly engine bundle (served under the app's deploy base). */
 export const NIGHTLY_ENGINE_URL = withBase("engine/dev/index.js");
+
+/** Whether the selected Babylon Lite snapshot satisfies Inspector v2's peer range. */
+export function supportsInspector(version: string): boolean {
+    return version === NIGHTLY || compareSemver(version, MIN_INSPECTOR_VERSION) >= 0;
+}
 
 /**
  * Location of the deployed-versions manifest, always at the origin root so every


### PR DESCRIPTION
## Summary

- add an Inspector toggle to the Babylon Lite Playground toolbar
- discover the current playground engine through a playground-only `createEngine` wrapper
- lazily load `@babylonjs/inspector@9.26.0/lite` from the configured ESM CDN and call its external `ShowInspector(engine)` API
- keep Inspector out of the Babylon Lite package and normal playground scene bundle

This uses the Babylon Lite support introduced by BabylonJS/Babylon.js#18889.

## Validation

- `pnpm run lint`
- `pnpm run build:playground`
- local browser verification that Inspector opens and closes without page errors