### PR TITLE
fix(pbr): preserve specular-glossiness factors

### DIFF
--- a/docs/lite/architecture/06-pbr-material.md
+++ b/docs/lite/architecture/06-pbr-material.md
@@ -52,7 +52,7 @@ pbr-renderable.ts:
 | `PBR_HAS_ALPHA_BLEND`              | `1 << 6`  | Material has alpha blend      | Alpha blend pipeline state                           |
 | `PBR_HAS_SPEC_GLOSS`               | `1 << 7`  | Specular-glossiness workflow  | SpecGloss texture instead of ORM                     |
 | `PBR_HAS_DOUBLE_SIDED`             | `1 << 8`  | Material is double-sided      | `cullMode: 'none'` + front-facing normal flip        |
-| `PBR_HAS_COTANGENT_NORMAL`         | `1 << 9`  | Normal map without tangents   | Cotangent-frame normal perturbation                  |
+| `PBR_HAS_SPEC_GLOSS_FACTORS`       | `1 << 9`  | Internal SG factor tuple      | Reserved by lazy `spec-gloss-fragment.ts`            |
 | `PBR_HAS_METALLIC_REFLECTANCE_MAP` | `1 << 10` | Has metallic reflectance map  | Reflectance texture sampling                         |
 | `PBR_HAS_REFLECTANCE_MAP`          | `1 << 11` | Has reflectance map           | Reflectance map sampling                             |
 | `PBR_HAS_USE_ALPHA_ONLY_MR`        | `1 << 12` | Use alpha-only from MR map    | Alpha-only metallic reflectance                      |
@@ -418,7 +418,7 @@ All fragments live in `src/material/pbr/fragments/` and export factory functions
 
 - **Factory**: `createClearcoatFragment(hasIbl: boolean, hasReflectance?: boolean): ShaderFragment`
 - **ID**: `"clearcoat"`
-- **Dependencies**: `["ibl"]` when `hasIbl`, `["reflectance"]` when `hasReflectance`
+- **Dependencies**: `["ibl"]` when `hasIbl`, `["base-f0"]` when `hasReflectance`
 - **Helper WGSL**: `visibility_Kelemen()`, `getR0RemappedForClearCoat()`
 - **Fragment slots**:
     - `MF` — remaps base F0 using clearcoat IOR/refraction params from `mesh.ccParams` / `mesh.ccRefractionParams`
@@ -442,7 +442,7 @@ All fragments live in `src/material/pbr/fragments/` and export factory functions
 ### `reflectance-fragment.ts` — Metallic Reflectance Extension
 
 - **Factory**: `createReflectanceFragment(hasMetallicReflectanceMap: boolean, hasReflectanceMap: boolean, useAlphaOnlyMR: boolean): ShaderFragment`
-- **ID**: `"reflectance"`
+- **ID**: `"base-f0"`
 - **Bindings**: conditionally `metallicReflectanceMap` + sampler, `reflectanceMap` + sampler
 - **Fragment slots**:
     - `MF` — computes `mrFactors`, dielectric F0, surface reflectivity, `colorF0`/`colorF90`, surface albedo
@@ -726,7 +726,7 @@ metallic  = orm.b
 #### 3. Normal Mapping
 
 - Tangent mode (`PBR_HAS_NORMAL_MAP`): TBN matrix from interpolated tangent/bitangent
-- Cotangent mode (`PBR_HAS_COTANGENT_NORMAL`): cotangent-frame reconstruction from screen-space derivatives
+- Cotangent mode (normal map present, mesh tangents absent; no material feature bit): cotangent-frame reconstruction from screen-space derivatives
 - Neither: `N = normalize(worldNormal)`, with front-face flip if double-sided
 
 #### 4. Emissive

--- a/docs/lite/architecture/specular-glossiness-factors.md
+++ b/docs/lite/architecture/specular-glossiness-factors.md
@@ -1,0 +1,91 @@
+# Specular-glossiness factors
+
+> Package paths: `packages/babylon-lite/src/loader-gltf/` and `packages/babylon-lite/src/material/pbr/`
+
+## Purpose and root cause
+
+Implement the [Khronos KHR_materials_pbrSpecularGlossiness equations](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Archived/KHR_materials_pbrSpecularGlossiness/README.md) for textured and factor-only materials. Factors are linear multipliers; missing textures and factors contribute one.
+
+Previously, the loader did not propagate SG `diffuseFactor`. It reduced `specularFactor` to a scalar maximum in `reflectance` and stored `1 - glossinessFactor` in the MR roughness field. The texture-only SG shader read RGB and alpha directly, ignoring those fields. Without an SG texture, shader selection fell through to MR, losing colored specular reflectance. Core MR diffuse fallback data could also leak into supported SG materials. The correction retains the original factors and selects SG independently of texture presence, without conversion to MR or asset-specific conditions.
+
+## Material representation and loader boundary
+
+The existing public `PbrMaterialProps.specGlossTexture?: Texture2D` remains compatible. No new public API is required. Internal state is:
+
+```typescript
+// On PbrMaterialProps; @internal, removed from published declarations.
+_specularGlossiness?: [number, number, number, number];
+```
+
+The tuple is `[specularFactor.r, specularFactor.g, specularFactor.b, glossinessFactor]`. Its presence selects the SG factor workflow. `baseColorFactor` carries SG diffuse RGBA through its existing floating-point path. Defaults are diffuse `[1, 1, 1, 1]`, specular `[1, 1, 1]`, and glossiness `1`.
+
+The glTF SG extension registers the lazy `base-spec-gloss` PBR extension before returning the tuple. It clears the parsed core `_baseColorFactor` to white and `_baseColorImage` to null before default texture assembly, then supplies SG textures and factors as extension overrides. Absent SG diffuse textures therefore use white even when an MR fallback exists. Material `alpha` is one; diffuse-factor alpha is applied exactly once through `baseColorFactor`.
+
+Both ordinary and variant loaders run material extensions before assembling default textures. SG uses the existing `preParse` hook to remove only `pbrMetallicRoughness.baseColorTexture` on SG materials in the loader-owned working JSON. All `preParse` hooks finish before texture-source `preMesh` hooks and core material assembly. Thus generic loaders never construct the superseded diffuse fallback, and missing SG diffuse reuses the builder's single white texture. Normal, occlusion and emissive references and MR-only materials remain intact. Variants receive the same prepared JSON. Registry merge order also places BasisU before SG; BasisU has no SG knowledge. This correction does not implement compressed SG texture decoding.
+
+Texture uploads request sRGB formats. Hardware sampling decodes RGB and leaves alpha linear. Transform wrappers remain on extension-selected textures; `texCoord: 1` is preserved even without `KHR_texture_transform`. The extended builder derives the diffuse UV mask from the final selected texture. UV transforms are enabled only when present.
+
+## Shader and material UBO
+
+The lazy fragment implements the existing `PbrExt` lifecycle: `detect` selects material bit 9, `frag` contributes one `vec4<f32> specularGlossiness` UBO field, and `writeUbo` writes four scalars at the composed byte offset. Bit 9 was formerly an unused cotangent-normal constant; normal mode continues to derive from normal-map presence and mesh tangents. The shared flag file reserves the bit without exporting a runtime constant.
+
+The fragment contributes assignments at the existing `MF` slot. The core composer has no SG factor hook or registry lookup. Existing BRDF locals (`roughness`, `metallic`, `colorF90`, `surfaceAlbedo`) are mutable with identical initial values. The SG fragment reuses the legacy `specGloss` sample for textured materials and reads the tuple directly otherwise.
+
+Initializer IDs establish the existing composer's deterministic order: `base-f0` (reflectance), then `base-spec-gloss` (SG), then clearcoat, iridescence and material plugins. SG depends on `base-f0` when reflectance is active. Existing clearcoat/iridescence reflectance dependencies target `base-f0`; neither modifier knows SG. The composer lexically sorts ready fragments and reinserts newly ready fragments in that order. Consequently SG runs before modifiers even when it first waits for reflectance, including factor-only or animated-occlusion reflectance. Registration order does not affect this result.
+
+Reflectance uses the same registry and fragment ID, `base-f0`, with and without UV transforms. Both composer and pipeline cache keys already include `features2`, which distinguishes its UV transform bit and layout. Material bindings follow the composed fragment order and match the registry ID, so the canonical identity preserves texture bindings and distinct UV variants. The initializer prefix describes the fragment's role and costs no new core capability or feature check.
+
+The plugin bridge returns its original cached contribution, preserving every dependency and avoiding per-material cloning. At base `d44c413eb217acf93801e9a3f5247149c845dac9`, MR reflectance plus `CUSTOM_FRAGMENT_BEFORE_LIGHTS` composed as `plugin-1|reflectance` (or `plugin-1|reflectance-U`), overwriting the plugin's F0 modification. This pre-existing ordering bug is corrected generically by `base-f0|plugin-1`; SG composes as `base-f0|base-spec-gloss|clearcoat|iridescence|plugin-1` when all are active. Clearcoat, iridescence and the plugin bridge have no SG bit or ID knowledge. Reflectance retains its unchanged occlusion calculation; SG assigns RGB F0, white F90, zero metallic, corrected roughness and surface albedo before modifiers.
+
+The common base-color path computes diffuse and vertex color. With texture samples `d` and `s` already decoded, and absent samples replaced by one:
+
+```text
+diffuse.rgb = d.rgb * diffuseFactor.rgb * vertexColor.rgb
+diffuse.a = d.a * diffuseFactor.a * vertexColor.a
+specular = s.rgb * specularFactor.rgb
+glossiness = s.a * glossinessFactor
+roughness = clamp(1 - glossiness, 0, 1)
+metallic = 0
+F0 = specular
+surfaceAlbedo = diffuse.rgb * (1 - max(specular.r, specular.g, specular.b))
+```
+
+Absent vertex color is one. `max` is used only for diffuse energy conservation, never to replace RGB F0. The ordinary BRDF subsequently squares perceptual roughness and applies its existing numerical floor and optional antialiasing. Factor multiplication does not occur in encoded sRGB space, and alpha is neither decoded nor premultiplied into RGB.
+
+The minimal material UBO grows from 32 to 64 bytes for loader-created SG: 16 bytes for the existing diffuse RGBA slot and 16 bytes for the SG tuple. Other extension fields remain additive and use the normal layout composer. MR materials and directly created legacy texture-only SG materials acquire no SG tuple field.
+
+## Compatibility, lifecycle, and cost
+
+The template retains its legacy texture-only SG equations. Directly created `specGlossTexture` materials therefore work without registering or preloading the glTF factor extension, including runtime material rebuilding. `pbr-renderable.ts` is unchanged. MR keeps its existing data path and equations. Alpha MASK/BLEND, double-sided state, normal mapping, lighting, and IBL continue through the existing pipeline.
+
+Registration, tuple creation, texture wrappers, shader strings, and pipeline construction occur during setup or material rebuilding. The UBO writer updates existing storage with scalar assignments. There are no added steady-frame heap allocations, texture samples, texture resources, samplers, or bind-group entries. The existing material-buffer binding has a larger range for factor SG. The new arithmetic for textured SG is one componentwise RGBA multiply for diffuse and one for specular/glossiness, at most eight scalar multiplications; diffuse uses the existing multiplier. Factor-only SG directly reads its tuple without a texture sample.
+
+The factor-workflow bit distinguishes loader SG from MR and legacy SG in the existing pipeline cache key. Texture presence remains an independent existing distinction. Factor values are uniforms and create no per-value shader permutations. MR feature keys are unchanged.
+
+Fresh scoped builds against `d44c413eb217acf93801e9a3f5247149c845dac9` measure uncompressed, fetched minified runtime JS with the repository bundle harness:
+
+| Scene | Non-SG witness               | Base bytes | Corrected bytes | Delta |
+| ----- | ---------------------------- | ---------: | --------------: | ----: |
+| 1     | glTF / IBL                   |     89,503 |          89,503 |     0 |
+| 6     | PBR / IBL                    |     73,263 |          73,263 |     0 |
+| 27    | Reflectance / variants       |     84,376 |          84,344 |   -32 |
+| 30    | Transmission / UV transforms |    106,237 |         106,234 |    -3 |
+| 19    | Clearcoat                    |     70,652 |          70,648 |    -4 |
+| 177   | Iridescence                  |     70,363 |          70,359 |    -4 |
+| 217   | Material plugins             |     78,193 |          78,193 |     0 |
+
+All seven witnesses meet the no-growth requirement; no ceiling changes. Clearcoat, iridescence and the plugin bridge are retained in their respective scene entry chunks, rather than separate dynamic chunks in these native API scenes. The clearcoat/iridescence dependency ID change saves four bytes in each entry; the plugin bridge has exactly its base implementation and size. Scene 27 saves 29 bytes in its reflectance setter/fragment chunk and three in the generic final-texture UV builder. Scene 30 saves the same three builder bytes. Hashes may change without a size change.
+
+The unfetched SG chunk grows from 459 to 1,735 bytes in scenes 1/27 and to 1,738 bytes in scene 30; scenes 6/19/177/217 build no SG chunk. This is 21 bytes smaller than the previous factor candidate. All SG factor code remains inside the opt-in chunk. Bundle module inventories are captured before the harness removes no-op Vite preload wrappers; the figures above use final served JS payload lengths after that existing pass, not the earlier module inventory's chunk-size field. No compressed transfer metric is used for the gate.
+
+## Validation
+
+Synthetic tests use real glTF material assembly, extension hooks, the composer, the UBO writer, and hardware sRGB sampling. A test-only `PbrExt` contributes a typed storage-texture binding and `BC` slot code. It renders the full production vertex and fragment shaders and observes diffuse, F0/F90, glossiness/roughness, surface albedo and occlusion as four deterministic RGBA texels. `BC` executes late in the shader; the observed locals remain the BRDF input values, unaffected by output lighting and tone mapping. All layouts and UBO offsets come from typed composer metadata. The fixture maps its own storage binding from WGSL access `write` to WebGPU access `write-only`; it neither parses nor replaces emitted WGSL. The occlusion case observes a nonwhite ORM sample mixed with strength. The plugin cases halve initialized F0 at `CUSTOM_FRAGMENT_BEFORE_LIGHTS`, proving both SG and MR reflectance initialization precede plugins. Production code has no probe or emitted-WGSL parsing.
+
+Independent numerical expectations cover defaults, every factor-only/texture-only/product case, combined nonuniform factors, diffuse alpha, MASK discard/survival, BLEND alpha, vertex color, UV transforms/TEXCOORD selection, variant and ordinary MR-fallback isolation, legacy texture-only SG, and an MR control. CPU tests check floating-point packing, default tuples, compressed MR diffuse isolation, legacy operation without SG registration, and identical MR flags/shaders/layout/UBO values across a verified absent-to-present SG registration transition. Focused ordering cases cover MR reflectance factors/textures/transforms plus plugins and SG with absent/factor/textured/transformed reflectance plus clearcoat, iridescence and plugins. A shared-composer test verifies distinct UV layout cache entries. Existing scoped PBR/glTF tests, parity scenes, and bundle ceilings remain regression gates. Fixtures contain only owned synthetic texels; no external scene assets are required.
+
+## File manifest
+
+- Loader: `gltf-ext-spec-gloss.ts`, `gltf-feature-registry.ts`, `gltf-pbr-builder-ext.ts`, `gltf-variants.ts`.
+- Material: `pbr-material.ts`, `pbr-flag-bits.ts`, `pbr-template.ts`, `fragments/spec-gloss-fragment.ts`, `fragments/reflectance-fragment.ts`, `fragments/clearcoat-fragment.ts`, `fragments/iridescence-fragment.ts`, `../plugin/pbr-plugin-bridge.ts`.
+- Tests: `tests/lite/unit/gltf-spec-gloss-factors.test.ts`, `tests/lite/plumbing/spec-gloss-fixture.ts`, `tests/lite/plumbing/spec-gloss-factors.spec.ts`.

--- a/lab/lite/src/lite/scene256.ts
+++ b/lab/lite/src/lite/scene256.ts
@@ -9,8 +9,8 @@
 // point: it tests an engine's ability to auto-generate a tangent basis at
 // render time (screen-space derivative / cotangent-frame method) rather than
 // relying on precomputed tangents. See docs/lite/architecture/06-pbr-material.md
-// (`_normalMode: "cotangent"` / `PBR_HAS_COTANGENT_NORMAL`) for the cotangent
-// frame math, and scene23 (anisotropy) for another scene whose parity is
+// (`_normalMode: "cotangent"`, derived from PBR_HAS_NORMAL_MAP without
+// MSH_HAS_TANGENTS) for the frame math, and scene23 (anisotropy) whose parity is
 // sensitive to the same dpdx/dpdy cotangent-frame precision.
 import { addToScene, startEngine, createEngine, createSceneContext, createArcRotateCamera, loadEnvironment, loadGltf, attachControl, registerScene } from "babylon-lite";
 

--- a/packages/babylon-lite/src/loader-gltf/gltf-ext-spec-gloss.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-ext-spec-gloss.ts
@@ -7,18 +7,34 @@
  *  Returned values override the core base-material fields via Object.assign
  *  merge order in the loader.
  *
- *  Note: spec-gloss `diffuseFactor` is currently propagated via the core
- *  `GltfMaterialData.baseColorFactor` (which defaults to [1,1,1,1] for assets
- *  that omit pbrMetallicRoughness). Spec-gloss models in our test corpus all
- *  carry a diffuseTexture, so the factor path is exercised through the
- *  texture itself. Add explicit factor handling here only if a regression
- *  appears.
+ *  Factors multiply decoded linear texels, with identity texels when absent.
+ *  The core MR fallback must not contribute to the supported SG workflow.
  */
 import type { GltfFeature } from "./gltf-feature.js";
 import type { PbrMaterialProps } from "../material/pbr/pbr-material.js";
+import { _registerPbrExt } from "../material/pbr/pbr-flags.js";
+import { pbrExt } from "../material/pbr/fragments/spec-gloss-fragment.js";
+import { cloneTexture2D } from "../texture/texture-2d.js";
+import type { Texture2D } from "../texture/texture-2d.js";
+
+// With no KHR_texture_transform feature, the loader's wrapper is an identity.
+// Keep the extension texture's own TEXCOORD selection in that case too.
+function textureCoord(texture: Texture2D, info: { texCoord?: number; extensions?: { KHR_texture_transform?: { texCoord?: number } } }): Texture2D {
+    const coord = info.extensions?.KHR_texture_transform?.texCoord ?? info.texCoord;
+    return coord === 1 && (texture as { _texCoord?: number })._texCoord !== 1 ? cloneTexture2D(texture, { _texCoord: 1 }) : texture;
+}
 
 const ext: GltfFeature = {
     id: "KHR_materials_pbrSpecularGlossiness",
+    async preParse(json) {
+        // SG replaces core diffuse. Remove its fallback reference before generic
+        // texture-source hooks or image decoding, including for variant materials.
+        for (const mat of json.materials ?? []) {
+            if (mat.extensions?.KHR_materials_pbrSpecularGlossiness && mat.pbrMetallicRoughness) {
+                delete mat.pbrMetallicRoughness.baseColorTexture;
+            }
+        }
+    },
     async applyMaterial(mat, ctx) {
         const sg = mat._rawMatDef?.extensions?.KHR_materials_pbrSpecularGlossiness;
         if (!sg) {
@@ -26,12 +42,26 @@ const ext: GltfFeature = {
         }
         const [diffuse, specGloss] = await Promise.all([ctx._texture(sg.diffuseTexture, true), ctx._texture(sg.specularGlossinessTexture, true)]);
         const sf = sg.specularFactor;
-        const out: Partial<PbrMaterialProps> = { metallicFactor: 0, roughnessFactor: 1 - (sg.glossinessFactor ?? 1), reflectance: sf ? Math.max(sf[0], sf[1], sf[2]) : 1 };
+        _registerPbrExt(pbrExt);
+        // Default texture assembly follows this hook. An omitted SG diffuse texture
+        // must use white, never a baked MR fallback factor/image. Keep exact SG factors
+        // in floating-point uniforms, including for factor-only materials.
+        mat._baseColorFactor = [1, 1, 1, 1];
+        mat._baseColorImage = null;
+        const out: Partial<PbrMaterialProps> = {
+            baseColorFactor: sg.diffuseFactor ?? [1, 1, 1, 1],
+            _specularGlossiness: [sf?.[0] ?? 1, sf?.[1] ?? 1, sf?.[2] ?? 1, sg.glossinessFactor ?? 1],
+            alpha: 1,
+        };
         if (diffuse) {
-            out.baseColorTexture = diffuse;
+            out.baseColorTexture = textureCoord(diffuse, sg.diffuseTexture);
         }
         if (specGloss) {
-            out.specGlossTexture = specGloss;
+            out.specGlossTexture = textureCoord(specGloss, sg.specularGlossinessTexture);
+        }
+        if ((diffuse as { _hasTx?: boolean } | undefined)?._hasTx || (specGloss as { _hasTx?: boolean } | undefined)?._hasTx) {
+            const { enableMaterialUvTransform } = await import("../material/pbr/enable-material-uv-transform.js");
+            enableMaterialUvTransform(out);
         }
         return out;
     },

--- a/packages/babylon-lite/src/loader-gltf/gltf-feature-registry.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-feature-registry.ts
@@ -47,13 +47,14 @@ const _features: [Trigger, Loader][] = [
     [M + "anisotropy", () => import("./gltf-ext-anisotropy.js")],
     [M + "diffuse_transmission", () => import("./gltf-ext-diffuse-transmission.js")],
     [M + "unlit", () => import("./gltf-ext-unlit.js")],
-    [M + "pbrSpecularGlossiness", () => import("./gltf-ext-spec-gloss.js")],
     // Dielectric cluster (ior/specular/transmission/volume/dispersion) — any of the five triggers the
     // loader; transmission refraction is wired dynamically by the PBR material path when needed.
     [(j) => ["transmission", "volume", "ior", "specular", "dispersion"].some((e) => j.extensionsUsed?.includes(M + e)), () => import("./gltf-ext-dielectric.js")],
     ["KHR_texture_transform", () => import("./gltf-ext-uv-transform.js")],
     ["KHR_texture_basisu", () => import("./gltf-ext-basisu.js")],
     [needsOrmComposite, () => import("./gltf-ext-orm.js")],
+    // Workflow overrides merge after generic texture-source fallbacks.
+    [M + "pbrSpecularGlossiness", () => import("./gltf-ext-spec-gloss.js")],
     // Per-mesh features (predicates inlined to avoid eager imports)
     [(j) => !!j.skins?.length && anyPrimitive(j, (p) => p.attributes?.JOINTS_0 !== undefined), () => import("./gltf-feature-skeleton.js")],
     [(j) => anyPrimitive(j, (p) => !!p.targets?.length), () => import("./gltf-feature-morph.js")],

--- a/packages/babylon-lite/src/loader-gltf/gltf-pbr-builder-ext.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-pbr-builder-ext.ts
@@ -176,14 +176,6 @@ export function assemblePbrPropsExt(mat: GltfMaterialData, tex: PbrTexturesExt, 
     // normal=4, emissive=8, specGloss=16, occlusion=32). specGloss arrives via extLayers. Occlusion
     // reads `mat._occlusionTexCoord` (set from the glTF material's occlusionTexture.texCoord for
     // every path, including KHR_texture_basisu, since occlusion-on-UV1 always routes through here).
-    const tc1 = (t: unknown): boolean => (t as { _texCoord?: number } | undefined)?._texCoord === 1;
-    const uv2Mask =
-        (tc1(tex.baseColorTexture) ? 1 : 0) |
-        (tc1(tex.ormTexture) ? 2 : 0) |
-        (tc1(tex.normalTexture) ? 4 : 0) |
-        (tc1(tex.emissiveTexture) ? 8 : 0) |
-        (tc1((extLayers as { specGlossTexture?: unknown } | undefined)?.specGlossTexture) ? 16 : 0) |
-        (mat._occlusionTexCoord === 1 ? 32 : 0);
     const props = {
         baseColorTexture: tex.baseColorTexture,
         normalTexture: tex.normalTexture,
@@ -201,10 +193,20 @@ export function assemblePbrPropsExt(mat: GltfMaterialData, tex: PbrTexturesExt, 
         ...(mat._alphaMode === "MASK" ? { alpha: mat._baseColorFactor[3] } : undefined),
         ...(mat._rawMatDef?.name ? { name: mat._rawMatDef.name as string } : undefined),
         ...extLayers,
-        ...(uv2Mask ? { _uv2Mask: uv2Mask } : undefined),
         _buildGroup: getPbrGroupBuilder(),
         _uboVersion: 0,
     } as PbrMaterialProps;
+    const tc1 = (t: unknown): boolean => (t as { _texCoord?: number } | undefined)?._texCoord === 1;
+    const uv2Mask =
+        (tc1(props.baseColorTexture) ? 1 : 0) |
+        (tc1(props.ormTexture) ? 2 : 0) |
+        (tc1(props.normalTexture) ? 4 : 0) |
+        (tc1(props.emissiveTexture) ? 8 : 0) |
+        (tc1(props.specGlossTexture) ? 16 : 0) |
+        (mat._occlusionTexCoord === 1 ? 32 : 0);
+    if (uv2Mask) {
+        props._uv2Mask = uv2Mask;
+    }
     return props;
 }
 

--- a/packages/babylon-lite/src/loader-gltf/gltf-variants.ts
+++ b/packages/babylon-lite/src/loader-gltf/gltf-variants.ts
@@ -69,8 +69,8 @@ export async function loadVariantMaterials(
         let p = pbrCache.get(gltfMat);
         if (!p) {
             p = (async () => {
-                const tex = buildDefaultPbrTexturesExt(engine, gltfMat, sampler, generateMipmaps, getCachedTex, wrapTex);
                 const layers = await runMatExts(gltfMat, exts, extCtx);
+                const tex = buildDefaultPbrTexturesExt(engine, gltfMat, sampler, generateMipmaps, getCachedTex, wrapTex);
                 const props = assemblePbrPropsExt(gltfMat, tex, layers);
                 // UV-transform and emissive are opt-in — see the matching gates in load-gltf.ts.
                 // Order matters: uv-transform registers its ext first, as it did when both lived

--- a/packages/babylon-lite/src/material/pbr/fragments/clearcoat-fragment.ts
+++ b/packages/babylon-lite/src/material/pbr/fragments/clearcoat-fragment.ts
@@ -193,7 +193,7 @@ export function createClearcoatFragment(features: number, features2: number, has
         deps.push("ibl");
     }
     if (hasReflectance) {
-        deps.push("reflectance");
+        deps.push("base-f0");
     }
     // Fragment id varies with texture config so shader-composer's fragmentKey
     // (and downstream pipeline cache) distinguishes variants.

--- a/packages/babylon-lite/src/material/pbr/fragments/iridescence-fragment.ts
+++ b/packages/babylon-lite/src/material/pbr/fragments/iridescence-fragment.ts
@@ -179,7 +179,7 @@ function createIridescenceFragment(features: number, features2: number, meshFeat
     return {
         _id: "iridescence",
         _dependencies:
-            (features & (PBR_HAS_METALLIC_REFLECTANCE_MAP | PBR_HAS_REFLECTANCE_MAP)) !== 0 || (features2 & PBR2_HAS_REFLECTANCE_FACTORS) !== 0 ? ["reflectance"] : undefined,
+            (features & (PBR_HAS_METALLIC_REFLECTANCE_MAP | PBR_HAS_REFLECTANCE_MAP)) !== 0 || (features2 & PBR2_HAS_REFLECTANCE_FACTORS) !== 0 ? ["base-f0"] : undefined,
         _uboFields: uboFields,
         _bindings: bindings,
         _helperFunctions: IRIDESCENCE_HELPERS,

--- a/packages/babylon-lite/src/material/pbr/fragments/reflectance-fragment.ts
+++ b/packages/babylon-lite/src/material/pbr/fragments/reflectance-fragment.ts
@@ -149,8 +149,8 @@ let surfaceReflectivityColor = mrFactors.rgb;
 let dielectricColorF0 = vec3<f32>(dielectricF0) * surfaceReflectivityColor;
 let metallicColorF0 = baseColor;
 var colorF0 = mix(dielectricColorF0, metallicColorF0, metallic);
-let colorF90 = vec3<f32>(mix(specularWeight, 1.0, metallic));
-let surfaceAlbedo = baseColor * (vec3<f32>(1.0) - vec3<f32>(dielectricF0) * surfaceReflectivityColor) * (1.0 - metallic);`;
+var colorF90 = vec3<f32>(mix(specularWeight, 1.0, metallic));
+var surfaceAlbedo = baseColor * (vec3<f32>(1.0) - vec3<f32>(dielectricF0) * surfaceReflectivityColor) * (1.0 - metallic);`;
 
     const uboFields: UboField[] = [
         { _name: "occlusionStrength", _type: "f32" },
@@ -170,7 +170,8 @@ let surfaceAlbedo = baseColor * (vec3<f32>(1.0) - vec3<f32>(dielectricF0) * surf
     }
 
     return {
-        _id: hasUvTx ? "reflectance-U" : "reflectance",
+        // Initializers sort before MF modifiers; features2 distinguishes UV layouts.
+        _id: "base-f0",
 
         _uboFields: uboFields,
 
@@ -185,7 +186,7 @@ let surfaceAlbedo = baseColor * (vec3<f32>(1.0) - vec3<f32>(dielectricF0) * surf
 
 /** Create the reflectance PBR extension (group 1, fragment phase). */
 export const pbrExt: PbrExt = {
-    id: "reflectance",
+    id: "base-f0",
     phase: "fragment",
     detect(mat) {
         const m = mat as PbrMaterialProps;

--- a/packages/babylon-lite/src/material/pbr/fragments/spec-gloss-fragment.ts
+++ b/packages/babylon-lite/src/material/pbr/fragments/spec-gloss-fragment.ts
@@ -1,0 +1,49 @@
+import type { PbrExt } from "../pbr-flags.js";
+import type { PbrMaterialProps } from "../pbr-material.js";
+import { PBR_HAS_SPEC_GLOSS, PBR_HAS_METALLIC_REFLECTANCE_MAP, PBR_HAS_REFLECTANCE_MAP, PBR2_HAS_REFLECTANCE_FACTORS } from "../pbr-flag-bits.js";
+import { wgsl } from "../../../shader/wgsl.js";
+
+// Formerly unused cotangent-normal bit; normal mode is derived from mesh attributes.
+const PBR_HAS_SPEC_GLOSS_FACTORS = 1 << 9;
+
+/** Factor-only and textured SG share one linear RGB/glossiness uniform. */
+export const pbrExt: PbrExt = {
+    id: "base-spec-gloss",
+    phase: "fragment",
+    detect(mat) {
+        return { f: (mat as PbrMaterialProps)._specularGlossiness ? PBR_HAS_SPEC_GLOSS_FACTORS : 0, f2: 0 };
+    },
+    frag(ctx) {
+        if (!(ctx._features & PBR_HAS_SPEC_GLOSS_FACTORS)) {
+            return null;
+        }
+        const hasReflectance = (ctx._features & (PBR_HAS_METALLIC_REFLECTANCE_MAP | PBR_HAS_REFLECTANCE_MAP)) !== 0 || (ctx._features2 & PBR2_HAS_REFLECTANCE_FACTORS) !== 0;
+        return {
+            _id: "base-spec-gloss",
+            // The composer reinserts this initializer before ready MF modifiers.
+            _dependencies: hasReflectance ? ["base-f0"] : undefined,
+            _uboFields: [{ _name: "specularGlossiness", _type: "vec4<f32>" }],
+            _fragmentSlots: {
+                MF: wgsl`
+let sg=${ctx._features & PBR_HAS_SPEC_GLOSS ? wgsl`specGloss*` : ""}material.specularGlossiness;
+roughness=clamp(1.0-sg.a,0.0,1.0);
+metallic=0.0;
+colorF0=sg.rgb;
+colorF90=vec3<f32>(1.0);
+surfaceAlbedo=baseColor*(1.0-max(colorF0.r,max(colorF0.g,colorF0.b)));`,
+            },
+        };
+    },
+    writeUbo(data, mat, offsets) {
+        const offset = offsets.get("specularGlossiness");
+        if (offset === undefined) {
+            return;
+        }
+        const factor = (mat as PbrMaterialProps)._specularGlossiness;
+        const i = offset / 4;
+        data[i] = factor?.[0] ?? 1;
+        data[i + 1] = factor?.[1] ?? 1;
+        data[i + 2] = factor?.[2] ?? 1;
+        data[i + 3] = factor?.[3] ?? 1;
+    },
+};

--- a/packages/babylon-lite/src/material/pbr/pbr-flag-bits.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-flag-bits.ts
@@ -10,7 +10,8 @@ export const PBR_HAS_FOG = 1 << 5;
 export const PBR_HAS_ALPHA_BLEND = 1 << 6;
 export const PBR_HAS_SPEC_GLOSS = 1 << 7;
 export const PBR_HAS_DOUBLE_SIDED = 1 << 8;
-export const PBR_HAS_COTANGENT_NORMAL = 1 << 9;
+// 1<<9 is spec-gloss-factor-local (fragments/spec-gloss-fragment.ts).
+// Cotangent normal mode is derived from normal-map presence and mesh tangents.
 export const PBR_HAS_METALLIC_REFLECTANCE_MAP = 1 << 10;
 export const PBR_HAS_REFLECTANCE_MAP = 1 << 11;
 export const PBR_HAS_USE_ALPHA_ONLY_MR = 1 << 12;

--- a/packages/babylon-lite/src/material/pbr/pbr-material.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-material.ts
@@ -69,6 +69,10 @@ export interface PbrMaterialProps extends Material {
     _emissiveColor?: [number, number, number];
     /** KHR_materials_pbrSpecularGlossiness: RGB=specular, A=glossiness. */
     specGlossTexture?: Texture2D;
+    /** @internal Linear RGB specular factor and glossiness for the SG workflow.
+     *  The glTF SG extension registers its shader/UBO writer before setting this tuple.
+     *  Diffuse RGBA uses baseColorFactor; an absent SG texture means [1,1,1,1]. */
+    _specularGlossiness?: [number, number, number, number];
     /** Whether material is double-sided (disables back-face culling). */
     doubleSided?: boolean;
     /** Overall material alpha (0=fully transparent, 1=opaque). Default 1.0. */

--- a/packages/babylon-lite/src/material/pbr/pbr-template.ts
+++ b/packages/babylon-lite/src/material/pbr/pbr-template.ts
@@ -381,10 +381,10 @@ var alpha=baseColorSample.a${baseColorFactorAlpha};${vertexColorMod}`;
     const specGlossUV = _ext?.uvForSpecGloss ?? "input.uv";
     const roughnessMetallic = _hasSpecGloss
         ? wgsl`let specGloss=textureSample(specGlossTexture,specGlossSampler,${specGlossUV});
-let roughness=clamp(1.0-specGloss.a,0.0,1.0);
-let metallic=0.0;`
-        : wgsl`let roughness=clamp(orm.g*material.roughnessFactor,0.0,1.0);
-let metallic=orm.b*material.metallicFactor;`;
+var roughness=clamp(1.0-specGloss.a,0.0,1.0);
+var metallic=0.0;`
+        : wgsl`var roughness=clamp(orm.g*material.roughnessFactor,0.0,1.0);
+var metallic=orm.b*material.metallicFactor;`;
 
     // Material-view / pass variants can skip extension slots while still compiling the colour path.
     const emissiveUV = _ext?.uvForEmissive ?? "input.uv";
@@ -398,13 +398,13 @@ let metallic=orm.b*material.metallicFactor;`;
         ? ``
         : _hasSpecGloss
           ? wgsl`var colorF0=specGloss.rgb;
-let colorF90=vec3<f32>(1.0);
+var colorF90=vec3<f32>(1.0);
 let maxSpecular=max(colorF0.r,max(colorF0.g,colorF0.b));
-let surfaceAlbedo=baseColor*(1.0-maxSpecular);`
+var surfaceAlbedo=baseColor*(1.0-maxSpecular);`
           : wgsl`let dielectricF0=material.reflectance;
 var colorF0=mix(vec3<f32>(dielectricF0),baseColor,metallic);
-let colorF90=vec3<f32>(1.0);
-let surfaceAlbedo=baseColor*(1.0-dielectricF0)*(1.0-metallic);`;
+var colorF90=vec3<f32>(1.0);
+var surfaceAlbedo=baseColor*(1.0-dielectricF0)*(1.0-metallic);`;
 
     // Specular AA + geometric-curvature roughness factors (BJS getAARoughnessFactors).
     // AA_factor_x is the direct-light roughness floor (matches BJS `computeSheenLighting`

--- a/tests/lite/plumbing/spec-gloss-factors.spec.ts
+++ b/tests/lite/plumbing/spec-gloss-factors.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from "@playwright/test";
+import { resolve } from "node:path";
+import type { SgCase } from "./spec-gloss-fixture";
+
+const cases: SgCase[] = [
+    { name: "defaults" },
+    { name: "diffuse factor", diffuseFactor: [0.052861, 0.138432, 0.052861, 0.8], specularFactor: [0.2, 0.5, 0.8] },
+    { name: "diffuse texture", diffuse: true },
+    { name: "diffuse product", diffuse: true, diffuseFactor: [0.052861, 0.138432, 0.052861, 0.8] },
+    { name: "specular factor", specularFactor: [0.2, 0.5, 0.8] },
+    { name: "specular texture", specular: true },
+    { name: "legacy texture-only SG", specular: true, legacy: true },
+    { name: "specular product", specular: true, specularFactor: [0.2, 0.5, 0.8] },
+    { name: "glossiness factor", glossinessFactor: 0.3 },
+    { name: "glossiness product", specular: true, glossinessFactor: 0.3 },
+    { name: "combined", diffuse: true, specular: true, diffuseFactor: [0.3, 0.6, 0.9, 0.8], specularFactor: [0.2, 0.5, 0.8], glossinessFactor: 0.3 },
+    { name: "fallback ignored", diffuseFactor: [0.3, 0.6, 0.9, 0.8], specularFactor: [0.2, 0.5, 0.8], glossinessFactor: 0.3, fallback: true },
+    { name: "vertex color", diffuse: true, specular: true, diffuseFactor: [0.3, 0.6, 0.9, 0.8], specularFactor: [0.2, 0.5, 0.8], glossinessFactor: 0.3, vertexColor: true },
+    {
+        name: "UV transform and texCoord",
+        diffuse: true,
+        specular: true,
+        diffuseFactor: [0.3, 0.6, 0.9, 0.8],
+        specularFactor: [0.2, 0.5, 0.8],
+        glossinessFactor: 0.3,
+        transformed: true,
+    },
+    { name: "texCoord without transform extension", diffuse: true, specular: true, specularFactor: [0.2, 0.5, 0.8], uv1: true },
+    { name: "MR control", mr: true },
+    { name: "MR reflectance initializer then plugin", mr: true, animatedOcclusion: true, plugin: true },
+    {
+        name: "animated occlusion with SG",
+        diffuse: true,
+        specular: true,
+        diffuseFactor: [0.3, 0.6, 0.9, 0.8],
+        specularFactor: [0.2, 0.5, 0.8],
+        glossinessFactor: 0.3,
+        animatedOcclusion: true,
+    },
+    { name: "SG variant ignores MR fallback", fallback: true, variant: true, diffuseFactor: [0.3, 0.6, 0.9, 0.8], specularFactor: [0.2, 0.5, 0.8], glossinessFactor: 0.3 },
+    { name: "plugin modifies initialized SG F0", specular: true, specularFactor: [0.2, 0.5, 0.8], glossinessFactor: 0.3, plugin: true },
+    { name: "reflectance then SG then plugin", specular: true, specularFactor: [0.2, 0.5, 0.8], glossinessFactor: 0.3, animatedOcclusion: true, plugin: true },
+    {
+        name: "transformed reflectance then SG then plugin",
+        specular: true,
+        specularFactor: [0.2, 0.5, 0.8],
+        glossinessFactor: 0.3,
+        animatedOcclusion: true,
+        plugin: true,
+        reflectanceUv: true,
+    },
+    { name: "MASK discard", diffuse: true, diffuseFactor: [1, 1, 1, 0.4], alphaMode: "MASK" },
+    { name: "MASK survives", diffuse: true, diffuseFactor: [1, 1, 1, 0.8], alphaMode: "MASK" },
+    { name: "BLEND alpha once", diffuse: true, diffuseFactor: [1, 1, 1, 0.8], alphaMode: "BLEND" },
+];
+
+function linear(byte: number) {
+    const x = byte / 255;
+    return x <= 0.04045 ? x / 12.92 : ((x + 0.055) / 1.055) ** 2.4;
+}
+
+for (const c of cases) {
+    test(`SG numerical conformance — ${c.name}`, async ({ page }) => {
+        await page.goto(`http://localhost:${process.env.LAB_TEST_PORT ?? 5179}/`);
+        const result = await page.evaluate(
+            async ({ path, value }) => {
+                const { runSgCase } = await import(/* @vite-ignore */ path);
+                const adapter = await navigator.gpu.requestAdapter();
+                if (!adapter) {
+                    throw new Error("WebGPU required for numerical conformance");
+                }
+                const device = await adapter.requestDevice();
+                const errors: string[] = [];
+                device.addEventListener("uncapturederror", (e) => errors.push(e.error.message));
+                try {
+                    const result = await runSgCase(device, value);
+                    await device.queue.onSubmittedWorkDone();
+                    return { ...result, errors };
+                } finally {
+                    device.destroy();
+                }
+            },
+            { path: `/@fs/${resolve("tests/lite/plumbing/spec-gloss-fixture.ts").replaceAll("\\", "/")}`, value: c }
+        );
+        expect(result.errors).toEqual([]);
+        if (c.mr) {
+            const d = [linear(218), linear(124), linear(170), 153 / 255];
+            // Animated occlusion selects the real reflectance initializer and
+            // uses the fixture's white G/B ORM sample: metallic=1, roughness=1.
+            const expected = c.plugin
+                ? [d, [d[0]! * 0.5, d[1]! * 0.5, d[2]! * 0.5, 0], [0, 0, 0, 1]]
+                : [d, [...d.slice(0, 3).map((x) => 0.04 * 0.6 + x * 0.4), 0.2], [...d.slice(0, 3).map((x) => x * 0.96 * 0.6), 0.8]];
+            expect(result.values[3][0]).toBeCloseTo(c.animatedOcclusion ? 1 + (64 / 255 - 1) * 0.4 : 1, 3);
+            // The existing MR factor-only loader bakes factors into 8-bit sRGB.
+            // Allow one UNORM step for that round trip and hardware sRGB conversion.
+            for (let row = 0; row < 3; row++) {
+                for (let col = 0; col < 4; col++) {
+                    expect(Math.abs(result.values[row][col] - expected[row]![col]!)).toBeLessThan(1 / 255);
+                }
+            }
+            return;
+        }
+        if (c.name === "MASK discard") {
+            expect(result.values).toEqual([
+                [-1, -1, -1, -1],
+                [-1, -1, -1, -1],
+                [-1, -1, -1, -1],
+                [-1, -1, -1, -1],
+            ]);
+            return;
+        }
+        const d = (c.diffuse ? [linear(128), linear(64), linear(192), 128 / 255] : [1, 1, 1, 1]).map(
+            (x, i) => x * (c.diffuseFactor?.[i] ?? 1) * (c.vertexColor ? [0.5, 0.25, 0.75, 0.5][i]! : 1)
+        );
+        const s = (c.specular ? [linear(64), linear(128), linear(192)] : [1, 1, 1]).map((x, i) => x * (c.specularFactor?.[i] ?? 1));
+        const g = (c.specular ? 128 / 255 : 1) * (c.glossinessFactor ?? 1);
+        // The plugin changes F0 after SG initializes surfaceAlbedo.
+        expect(result.values[3][0]).toBeCloseTo(c.animatedOcclusion ? 1 + (64 / 255 - 1) * 0.4 : 1, 3);
+        expect(result.values[3].slice(1)).toEqual([1, 1, 1]);
+        const f0 = c.plugin ? s.map((x) => x * 0.5) : s;
+        const expected = [d, [...f0, g], [...d.slice(0, 3).map((x) => x * (1 - Math.max(...s))), 1 - g]];
+        for (let row = 0; row < 3; row++) {
+            for (let col = 0; col < 4; col++) {
+                expect(result.values[row][col], `${c.name} [${row},${col}]`).toBeCloseTo(expected[row]![col]!, 3);
+            }
+        }
+    });
+}

--- a/tests/lite/plumbing/spec-gloss-fixture.ts
+++ b/tests/lite/plumbing/spec-gloss-fixture.ts
@@ -1,0 +1,274 @@
+import { assembleMaterial } from "../../../packages/babylon-lite/src/loader-gltf/gltf-material";
+import { loadVariantMaterials } from "../../../packages/babylon-lite/src/loader-gltf/gltf-variants";
+import { runGltfMaterialFeatures } from "../../../packages/babylon-lite/src/loader-gltf/gltf-feature-registry";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
+import type { PbrMaterialProps } from "../../../packages/babylon-lite/src/material/pbr/pbr-material";
+import specGloss from "../../../packages/babylon-lite/src/loader-gltf/gltf-ext-spec-gloss";
+import uvTransform from "../../../packages/babylon-lite/src/loader-gltf/gltf-ext-uv-transform";
+import { assemblePbrProps, applyGltfOptInPbrFeatures, buildDefaultPbrTextures } from "../../../packages/babylon-lite/src/loader-gltf/gltf-pbr-builder";
+import { assemblePbrPropsExt, applyGltfUvTransform } from "../../../packages/babylon-lite/src/loader-gltf/gltf-pbr-builder-ext";
+import { createPbrComposer } from "../../../packages/babylon-lite/src/material/pbr/pbr-compose";
+import { createPbrTemplateExt } from "../../../packages/babylon-lite/src/material/pbr/pbr-template-ext";
+import { _computePbrMaterialFeatures } from "../../../packages/babylon-lite/src/material/pbr/pbr-material";
+import { _writeMaterialData } from "../../../packages/babylon-lite/src/material/pbr/pbr-renderable";
+import { MSH_HAS_UV2, MSH_HAS_VERTEX_COLOR } from "../../../packages/babylon-lite/src/material/mesh-features";
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import type { Texture2D } from "../../../packages/babylon-lite/src/texture/texture-2d";
+import { setPbrMetallicReflectance } from "../../../packages/babylon-lite/src/material/pbr/set-metallic-reflectance";
+import { registerPbrPlugins } from "../../../packages/babylon-lite/src/material/plugin/pbr-plugin-bridge";
+import { wgsl } from "../../../packages/babylon-lite/src/shader/wgsl";
+import type { PbrExt } from "../../../packages/babylon-lite/src/material/pbr/pbr-flags";
+import { _registerPbrExt } from "../../../packages/babylon-lite/src/material/pbr/pbr-flags";
+
+// Observe production BRDF locals through a typed fragment and storage binding.
+// BC runs after MF contributions; alpha-test discard has already happened.
+const probeExt: PbrExt = {
+    id: "test-brdf-observer",
+    phase: "fragment",
+    frag: () => ({
+        _id: "test-brdf-observer",
+        _bindings: [{ _name: "brdfProbe", _type: { _kind: "storage-texture", _access: "write", _format: "rgba32float" }, _visibility: 2 }],
+        _fragmentSlots: {
+            BC: wgsl`
+textureStore(brdfProbe,vec2i(0,0),vec4f(baseColor,alpha*material.materialAlpha));
+textureStore(brdfProbe,vec2i(1,0),vec4f(colorF0,1.0-roughness));
+textureStore(brdfProbe,vec2i(2,0),vec4f(surfaceAlbedo,roughness));
+textureStore(brdfProbe,vec2i(3,0),vec4f(occlusion,colorF90));`,
+        },
+    }),
+};
+
+export interface SgCase {
+    name: string;
+    diffuseFactor?: number[];
+    specularFactor?: number[];
+    glossinessFactor?: number;
+    diffuse?: boolean;
+    specular?: boolean;
+    alphaMode?: string;
+    vertexColor?: boolean;
+    transformed?: boolean;
+    uv1?: boolean;
+    fallback?: boolean;
+    mr?: boolean;
+    variant?: boolean;
+    legacy?: boolean;
+    animatedOcclusion?: boolean;
+    plugin?: boolean;
+    reflectanceUv?: boolean;
+}
+
+// Owned synthetic texels, not external assets. RGB uses the hardware sRGB decode;
+// alpha stays linear. Distinct texels make a wrong UV set/transform observable.
+const diffuseBytes = [128, 64, 192, 128];
+const specularBytes = [64, 128, 192, 128];
+
+export async function runSgCase(device: GPUDevice, c: SgCase) {
+    const owned: (GPUTexture | GPUBuffer)[] = [];
+    const engine = { _device: device } as EngineContext;
+    const sampler = device.createSampler({ addressModeU: "repeat" });
+    const makeTexture = (bytes: number[], srgb: boolean): Texture2D => {
+        const t = device.createTexture({ size: [2, 1], format: srgb ? "rgba8unorm-srgb" : "rgba8unorm", usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST });
+        owned.push(t);
+        device.queue.writeTexture({ texture: t }, new Uint8Array([...bytes, 255, 255, 255, 255]), { bytesPerRow: 8 }, [2, 1]);
+        return { texture: t, view: t.createView(), sampler, width: 2, height: 1 };
+    };
+    const buffer = (data: Float32Array, usage = GPUBufferUsage.UNIFORM) => {
+        const b = device.createBuffer({ size: Math.max(16, data.byteLength), usage: usage | GPUBufferUsage.COPY_DST });
+        owned.push(b);
+        device.queue.writeBuffer(b, 0, data as Float32Array<ArrayBuffer>);
+        return b;
+    };
+    try {
+        const info = (index: number) =>
+            c.transformed ? { index, texCoord: 0, extensions: { KHR_texture_transform: { texCoord: 1, offset: [-0.5, 0] } } } : c.uv1 ? { index, texCoord: 1 } : { index };
+        const sg = {
+            diffuseFactor: c.diffuseFactor,
+            specularFactor: c.specularFactor,
+            glossinessFactor: c.glossinessFactor,
+            diffuseTexture: c.diffuse ? info(0) : undefined,
+            specularGlossinessTexture: c.specular ? info(1) : undefined,
+        };
+        const raw = {
+            alphaMode: c.alphaMode ?? "OPAQUE",
+            alphaCutoff: 0.3,
+            doubleSided: true,
+            pbrMetallicRoughness: c.fallback || c.mr ? { baseColorFactor: [0.7, 0.2, 0.4, 0.6], metallicFactor: 0.4, roughnessFactor: 0.8 } : undefined,
+            extensions: c.mr ? undefined : { KHR_materials_pbrSpecularGlossiness: sg },
+        };
+        const mat = await assembleMaterial({ materials: [raw] }, new DataView(new ArrayBuffer(0)), 0, "", []);
+        const ext = await specGloss.applyMaterial!(mat, {
+            _engine: engine,
+            _texture(ti, srgb) {
+                if (!ti) {
+                    return Promise.resolve(undefined);
+                }
+                const t = makeTexture((ti as { index: number }).index === 0 ? diffuseBytes : specularBytes, srgb);
+                return Promise.resolve(c.transformed ? uvTransform.wrapTexture!(t, ti) : t);
+            },
+            _uploadImage() {
+                throw new Error("Unexpected image synthesis");
+            },
+        });
+        const textures = buildDefaultPbrTextures(
+            engine,
+            mat,
+            sampler,
+            () => {},
+            () => {
+                throw new Error("Unexpected fallback image");
+            }
+        );
+        owned.push(textures.baseColorTexture.texture, textures.ormTexture.texture);
+        let props =
+            c.transformed || c.uv1
+                ? assemblePbrPropsExt(mat, { ...textures, occlusionTexture: undefined }, ext ?? undefined)
+                : assemblePbrProps(mat, textures.baseColorTexture, textures.ormTexture, textures.normalTexture, textures.emissiveTexture, ext ?? undefined);
+        if (c.transformed) {
+            await applyGltfUvTransform(props, { ...textures, occlusionTexture: undefined });
+        }
+        await applyGltfOptInPbrFeatures(props, mat);
+        if (c.legacy) {
+            // Public texture-only materials have no glTF factor tuple.
+            delete props._specularGlossiness;
+        }
+        if (c.animatedOcclusion) {
+            setPbrMetallicReflectance(props, {});
+            (props as PbrMaterialProps & { _occlStrengthAnimated: boolean })._occlStrengthAnimated = true;
+            props.occlusionStrength = 0.4;
+            props.ormTexture = makeTexture([64, 255, 255, 255], false);
+        }
+        if (c.reflectanceUv) {
+            const texture = uvTransform.wrapTexture!(makeTexture([90, 140, 200, 255], true), {
+                index: 0,
+                extensions: { KHR_texture_transform: { offset: [0.1, 0] } },
+            });
+            setPbrMetallicReflectance(props, { reflectanceTexture: texture, specularWeight: 0.3 });
+        }
+        if (c.plugin) {
+            registerPbrPlugins(_registerPbrExt);
+            props.plugins = [{ name: "SG F0 modifier", getCustomCode: () => ({ CUSTOM_FRAGMENT_BEFORE_LIGHTS: "colorF0 *= 0.5;" }) }];
+        }
+        if (c.variant) {
+            const json = {
+                materials: [raw],
+                nodes: [{ mesh: 0 }],
+                meshes: [{ primitives: [{ extensions: { KHR_materials_variants: { mappings: [{ material: 0, variants: [0] }] } } }] }],
+            };
+            const variants = await loadVariantMaterials(json, new DataView(new ArrayBuffer(0)), "", ["SG"], [{} as Mesh], engine, [specGloss], runGltfMaterialFeatures);
+            props = variants.variants.SG![0]!.material as PbrMaterialProps;
+            owned.push(props.baseColorTexture!.texture, props.ormTexture!.texture);
+        }
+        _registerPbrExt(probeExt);
+        const flags = _computePbrMaterialFeatures(props);
+        const compose = createPbrComposer({
+            _singleLightWGSL: "",
+            _getSingleLightBlock: null,
+            _multiLightWGSL: "",
+            _multiLightLoop: "",
+            _fogHelper: "",
+            _fogBlock: "",
+            _createPbrTemplateExt: createPbrTemplateExt,
+            _flatNormalWgsl: "",
+            _createPbrShadowFragment: null,
+            _shadowLights: [],
+            _createThinInstanceFragment: null,
+        });
+        const code = compose(
+            flags.features,
+            flags.features2,
+            (c.vertexColor ? MSH_HAS_VERTEX_COLOR : 0) | (c.transformed || c.uv1 ? MSH_HAS_UV2 : 0),
+            0,
+            0,
+            "point",
+            "",
+            undefined,
+            "",
+            props._uv2Mask,
+            props._pi
+        );
+        const sceneLayout = device.createBindGroupLayout({ entries: [{ binding: 0, visibility: 3, buffer: { type: "uniform" } }] });
+        // The composer stores WGSL access names; the test-owned storage binding
+        // supplies the corresponding WebGPU descriptor without reading shader text.
+        const meshLayout = device.createBindGroupLayout({
+            entries: Array.from(code._meshBGLDescriptor.entries, (entry) =>
+                entry.storageTexture ? { ...entry, storageTexture: { ...entry.storageTexture, access: "write-only" } } : entry
+            ),
+        });
+        const pipeline = await device.createRenderPipelineAsync({
+            layout: device.createPipelineLayout({ bindGroupLayouts: [sceneLayout, meshLayout] }),
+            vertex: { module: device.createShaderModule({ code: code._vertexWGSL }), buffers: code._vertexBufferLayouts },
+            fragment: { module: device.createShaderModule({ code: code._fragmentWGSL }), targets: [{ format: "rgba32float" }] },
+            primitive: { topology: "triangle-list" },
+        });
+        const ubo = new Float32Array(code._materialUboSpec!._totalBytes / 4);
+        _writeMaterialData(ubo, props, code._materialUboSpec!);
+        const identity = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        const mesh = new Float32Array(code._meshUboSpec._totalBytes / 4);
+        mesh.set(identity, code._meshUboSpec._offsets.get("world")! / 4);
+        const output = device.createTexture({ size: [4, 1], format: "rgba32float", usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST });
+        owned.push(output);
+        device.queue.writeTexture({ texture: output }, new Float32Array(16).fill(-1), { bytesPerRow: 64 }, [4, 1]);
+        const entries: GPUBindGroupEntry[] = [
+            { binding: 0, resource: { buffer: buffer(mesh) } },
+            { binding: 1, resource: { buffer: buffer(ubo) } },
+        ];
+        // The fixture enables only these base textures, in the documented PBR binding order.
+        const texturesInOrder = [
+            props.baseColorTexture!,
+            props.ormTexture!,
+            ...(props.specGlossTexture ? [props.specGlossTexture] : []),
+            ...(props._reflectanceTexture ? [props._reflectanceTexture] : []),
+        ];
+        let textureIndex = 0;
+        let samplerIndex = 0;
+        for (const layout of code._meshBGLDescriptor.entries) {
+            if (layout.texture) {
+                entries.push({ binding: layout.binding, resource: texturesInOrder[textureIndex++]!.view });
+            } else if (layout.sampler) {
+                entries.push({ binding: layout.binding, resource: texturesInOrder[samplerIndex++]!.sampler });
+            } else if (layout.storageTexture) {
+                entries.push({ binding: layout.binding, resource: output.createView() });
+            }
+        }
+        const scene = new Float32Array(128);
+        scene.set(identity);
+        scene.set(identity, 16);
+        scene[34] = 1;
+        const sceneGroup = device.createBindGroup({ layout: sceneLayout, entries: [{ binding: 0, resource: { buffer: buffer(scene) } }] });
+        const group = device.createBindGroup({ layout: meshLayout, entries });
+        const vertexData = [
+            [-1, -1, 0.5, 3, -1, 0.5, -1, 3, 0.5],
+            [0, 0, 1, 0, 0, 1, 0, 0, 1],
+            Array.from({ length: 3 }, () => [c.uv1 ? 0.75 : 0.25, 0.5]).flat(),
+            ...(c.transformed || c.uv1 ? [Array.from({ length: 3 }, () => [c.transformed ? 0.75 : 0.25, 0.5]).flat()] : []),
+            ...(c.vertexColor ? [Array.from({ length: 3 }, () => [0.5, 0.25, 0.75, 0.5]).flat()] : []),
+        ];
+        const vertexBuffers = vertexData.map((data) => buffer(new Float32Array(data), GPUBufferUsage.VERTEX));
+        const target = device.createTexture({ size: [1, 1], format: "rgba32float", usage: GPUTextureUsage.RENDER_ATTACHMENT });
+        owned.push(target);
+        const readback = device.createBuffer({ size: 256, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+        owned.push(readback);
+        const encoder = device.createCommandEncoder();
+        const pass = encoder.beginRenderPass({
+            colorAttachments: [{ view: target.createView(), loadOp: "clear", storeOp: "store", clearValue: [0, 0, 0, 0] }],
+        });
+        pass.setPipeline(pipeline);
+        pass.setBindGroup(0, sceneGroup);
+        pass.setBindGroup(1, group);
+        vertexBuffers.forEach((value, index) => pass.setVertexBuffer(index, value));
+        pass.draw(3);
+        pass.end();
+        encoder.copyTextureToBuffer({ texture: output }, { buffer: readback, bytesPerRow: 256 }, [4, 1]);
+        device.queue.submit([encoder.finish()]);
+        await readback.mapAsync(GPUMapMode.READ);
+        const data = readback.getMappedRange();
+        const values = [0, 16, 32, 48].map((offset) => Array.from(new Float32Array(data.slice(offset, offset + 16))));
+        readback.unmap();
+        return { values, uboBytes: ubo.byteLength, bindings: entries.length };
+    } finally {
+        for (const item of owned) {
+            item.destroy();
+        }
+    }
+}

--- a/tests/lite/unit/gltf-spec-gloss-factors.test.ts
+++ b/tests/lite/unit/gltf-spec-gloss-factors.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from "vitest";
+import basisu from "../../../packages/babylon-lite/src/loader-gltf/gltf-ext-basisu";
+import * as ktx2 from "../../../packages/babylon-lite/src/texture/ktx2-loader";
+import { loadGltfFeatures, runGltfMaterialFeatures } from "../../../packages/babylon-lite/src/loader-gltf/gltf-feature-registry";
+import specGloss from "../../../packages/babylon-lite/src/loader-gltf/gltf-ext-spec-gloss";
+import { assembleMaterial } from "../../../packages/babylon-lite/src/loader-gltf/gltf-material";
+import { assemblePbrProps } from "../../../packages/babylon-lite/src/loader-gltf/gltf-pbr-builder";
+import { _computePbrMaterialFeatures, createPbrMaterial } from "../../../packages/babylon-lite/src/material/pbr/pbr-material";
+import { _getPbrExts, _registerPbrExt, type PbrExt } from "../../../packages/babylon-lite/src/material/pbr/pbr-flags";
+import { createPbrComposer } from "../../../packages/babylon-lite/src/material/pbr/pbr-compose";
+import { _writeMaterialData, buildPbrRenderables } from "../../../packages/babylon-lite/src/material/pbr/pbr-renderable";
+import { createSceneContext } from "../../../packages/babylon-lite/src/scene/scene";
+import type { Mesh } from "../../../packages/babylon-lite/src/mesh/mesh";
+import type { EngineContext } from "../../../packages/babylon-lite/src/engine/engine";
+import type { Texture2D } from "../../../packages/babylon-lite/src/texture/texture-2d";
+
+import { pbrExt as reflectanceExt } from "../../../packages/babylon-lite/src/material/pbr/fragments/reflectance-fragment";
+import { pbrExt as clearcoatExt } from "../../../packages/babylon-lite/src/material/pbr/fragments/clearcoat-fragment";
+import { pbrExt as iridescenceExt } from "../../../packages/babylon-lite/src/material/pbr/fragments/iridescence-fragment";
+import { registerPbrPlugins } from "../../../packages/babylon-lite/src/material/plugin/pbr-plugin-bridge";
+import { setPbrMetallicReflectance } from "../../../packages/babylon-lite/src/material/pbr/set-metallic-reflectance";
+
+const composer = () =>
+    createPbrComposer({
+        _singleLightWGSL: "",
+        _getSingleLightBlock: null,
+        _multiLightWGSL: "",
+        _multiLightLoop: "",
+        _fogHelper: "",
+        _fogBlock: "",
+        _createPbrTemplateExt: null,
+        _flatNormalWgsl: "",
+        _createPbrShadowFragment: null,
+        _shadowLights: [],
+        _createThinInstanceFragment: null,
+    });
+const texture = {} as Texture2D;
+
+function testEngine(): EngineContext {
+    return {
+        _device: {
+            createTexture: () => ({ createView: () => ({}) }),
+            createSampler: () => ({}),
+            queue: { writeTexture() {} },
+        },
+    } as unknown as EngineContext;
+}
+
+async function load(sg?: Record<string, unknown>) {
+    const mat = await assembleMaterial(
+        {
+            materials: [
+                {
+                    pbrMetallicRoughness: { baseColorFactor: [0.7, 0.2, 0.4, 0.6], roughnessFactor: 0.4, metallicFactor: 0.7 },
+                    extensions: sg ? { KHR_materials_pbrSpecularGlossiness: sg } : undefined,
+                },
+            ],
+        },
+        new DataView(new ArrayBuffer(0)),
+        0,
+        "",
+        []
+    );
+    const ext = await specGloss.applyMaterial!(mat, {
+        _engine: testEngine(),
+        _texture: () => Promise.resolve(undefined),
+        _uploadImage: () => {
+            throw new Error("No image needed");
+        },
+    });
+    return { mat, props: assemblePbrProps(mat, texture, texture, undefined, undefined, ext ?? undefined) };
+}
+
+describe("SG factor state reaches the material UBO", () => {
+    it("keeps directly-created texture-only SG working without registering the glTF factor extension", async () => {
+        // A registry without SG proves that legacy texture-only materials need no new preload.
+        const registry = _getPbrExts() as Map<string, PbrExt>;
+        registry.delete("base-spec-gloss");
+        const createShaderModule = vi.fn((d: GPUShaderModuleDescriptor) => d as unknown as GPUShaderModule);
+        const device = {
+            createBindGroupLayout: vi.fn((d) => d),
+            createPipelineLayout: vi.fn((d) => d),
+            createShaderModule,
+            createRenderPipeline: vi.fn((d) => d),
+            createBindGroup: vi.fn((d) => d),
+            createSampler: vi.fn(() => ({})),
+            createTexture: vi.fn(() => ({ createView: () => ({}), destroy() {} })),
+            createBuffer: vi.fn((d: GPUBufferDescriptor) => ({ destroy() {}, getMappedRange: () => new ArrayBuffer(Number(d.size)), unmap() {} })),
+            queue: { writeBuffer() {}, writeTexture() {} },
+        } as unknown as GPUDevice;
+        const engine = { _device: device, _disposables: [] } as unknown as EngineContext;
+        Object.assign(engine, { engine });
+        const scene = createSceneContext(engine, { defaultRenderTask: false });
+        const material = createPbrMaterial({
+            specGlossTexture: { texture: device.createTexture({} as GPUTextureDescriptor), view: {} as GPUTextureView, sampler: {} as GPUSampler, width: 1, height: 1 },
+        });
+        const mesh = { material, receiveShadows: false, morphTargets: null, worldMatrix: new Float32Array(16), worldMatrixVersion: 1, _gpu: {} } as unknown as Mesh;
+        scene._groups.set(material._buildGroup, [mesh]);
+        const { rebuildSingle } = await buildPbrRenderables(scene, [mesh], undefined);
+        const renderable = rebuildSingle(scene, mesh);
+        renderable.bind(engine, { _colorFormat: "rgba8unorm", _depthStencilFormat: "depth24plus", _sampleCount: 1 });
+        expect(createShaderModule).toHaveBeenCalled();
+        const flags = _computePbrMaterialFeatures(material);
+        const code = composer()(flags.features, flags.features2);
+        expect(code._materialUboSpec!._offsets.has("specularGlossiness")).toBe(false);
+        expect(_getPbrExts().has("base-spec-gloss")).toBe(false);
+    });
+    it("prepares only SG diffuse references and leaves MR and shared channels intact", async () => {
+        const channels = { normalTexture: { index: 2 }, occlusionTexture: { index: 3 }, emissiveTexture: { index: 4 } };
+        const mr = { ...channels, pbrMetallicRoughness: { baseColorTexture: { index: 0 } } };
+        const sg = { ...channels, pbrMetallicRoughness: { baseColorTexture: { index: 1 } }, extensions: { KHR_materials_pbrSpecularGlossiness: {} } };
+        const json = { materials: [mr, sg] };
+        const previous = structuredClone(json);
+        await specGloss.preParse!(json, new DataView(new ArrayBuffer(0)));
+        expect(mr).toEqual(previous.materials[0]);
+        expect(sg).toEqual({ ...channels, pbrMetallicRoughness: {}, extensions: { KHR_materials_pbrSpecularGlossiness: {} } });
+    });
+    it.each([false, true])("prepares SG before BasisU and keeps final diffuse selection (SG diffuse texture: %s)", async (diffuse) => {
+        const json = {
+            extensionsUsed: ["KHR_materials_pbrSpecularGlossiness", "KHR_texture_basisu"],
+            materials: [
+                {
+                    pbrMetallicRoughness: { baseColorTexture: { index: 0 } },
+                    extensions: {
+                        KHR_materials_pbrSpecularGlossiness: {
+                            diffuseFactor: [0.3, 0.6, 0.9, 1],
+                            ...(diffuse ? { diffuseTexture: { index: 1 } } : {}),
+                        },
+                    },
+                },
+            ],
+            textures: [{ extensions: { KHR_texture_basisu: { source: 0 } } }, { source: 1 }],
+            images: [{ uri: "mr-fallback.ktx2" }],
+        };
+        const bin = new DataView(new ArrayBuffer(0));
+        const features = await loadGltfFeatures(json);
+        expect(features.map((f) => f.id)).toEqual(["KHR_texture_basisu", "KHR_materials_pbrSpecularGlossiness"]);
+        for (const feature of features) {
+            await feature.preParse?.(json, bin);
+        }
+        await basisu.preMesh!(json, bin, "https://example.invalid/");
+        const mat = await assembleMaterial(json, bin, 0, "https://example.invalid/", []);
+        const fallback = {} as Texture2D;
+        const selected = {} as Texture2D;
+        const upload = vi.spyOn(ktx2, "uploadKtx2Texture2D").mockResolvedValue(fallback);
+        const fetch = vi.fn(() => Promise.resolve(new Response(new Uint8Array(4))));
+        vi.stubGlobal("fetch", fetch);
+        try {
+            const layers = await runGltfMaterialFeatures(mat, features, {
+                _engine: testEngine(),
+                _texture: (info) => Promise.resolve(info ? selected : undefined),
+                _uploadImage: () => {
+                    throw new Error("Unexpected image upload");
+                },
+            });
+            expect(upload).not.toHaveBeenCalled();
+            expect(fetch).not.toHaveBeenCalled();
+            expect(layers?.baseColorTexture).not.toBe(fallback);
+            if (diffuse) {
+                expect(layers?.baseColorTexture).toBe(selected);
+            } else {
+                expect(layers?.baseColorTexture).toBeUndefined();
+            }
+            expect(layers?.baseColorFactor).toEqual([0.3, 0.6, 0.9, 1]);
+        } finally {
+            upload.mockRestore();
+            vi.unstubAllGlobals();
+        }
+    });
+    it("overrides MR fallback and packs nonuniform RGB plus glossiness without quantization", async () => {
+        const { mat, props } = await load({ diffuseFactor: [0.052861, 0.138432, 0.052861, 0.8], specularFactor: [0.2, 0.5, 0.8], glossinessFactor: 0.3 });
+        expect(mat._baseColorFactor).toEqual([1, 1, 1, 1]);
+        const f = _computePbrMaterialFeatures(props);
+        const shader = composer()(f.features, f.features2);
+        const spec = shader._materialUboSpec!;
+        const data = new Float32Array(spec._totalBytes / 4);
+        _writeMaterialData(data, props, spec);
+        for (const [field, expected] of [
+            ["baseColorFactor", [0.052861, 0.138432, 0.052861, 0.8]],
+            ["specularGlossiness", [0.2, 0.5, 0.8, 0.3]],
+        ] as const) {
+            expect(spec._offsets.has(field)).toBe(true);
+            const offset = spec._offsets.get(field)! / 4;
+            expected.forEach((value, i) => expect(data[offset + i]).toBeCloseTo(value, 7));
+        }
+        expect(data[3]).toBe(1);
+        expect(shader._meshBGLDescriptor.entries).toHaveLength(6);
+    });
+
+    it("defaults the SG factor tuple to one independently of the MR fallback", async () => {
+        const { props } = await load({});
+        const f = _computePbrMaterialFeatures(props);
+        const spec = composer()(f.features, f.features2)._materialUboSpec!;
+        expect(spec._offsets.has("specularGlossiness")).toBe(true);
+        const data = new Float32Array(spec._totalBytes / 4);
+        _writeMaterialData(data, props, spec);
+        const offset = spec._offsets.get("specularGlossiness")! / 4;
+        expect(Array.from(data.slice(offset, offset + 4))).toEqual([1, 1, 1, 1]);
+    });
+
+    it("keeps MR shader, layout and uniform values identical after SG registration", async () => {
+        const registry = _getPbrExts() as Map<string, PbrExt>;
+        const previous = registry.get("base-spec-gloss");
+        registry.delete("base-spec-gloss");
+        try {
+            expect(registry.has("base-spec-gloss")).toBe(false);
+            const { props } = await load();
+            const f = _computePbrMaterialFeatures(props);
+            const before = composer()(f.features, f.features2);
+            const data = new Float32Array(before._materialUboSpec!._totalBytes / 4);
+            _writeMaterialData(data, props, before._materialUboSpec!);
+            await load({ specularFactor: [0.2, 0.5, 0.8] });
+            expect(registry.has("base-spec-gloss")).toBe(true);
+            const nextFlags = _computePbrMaterialFeatures(props);
+            expect(nextFlags).toEqual(f);
+            const after = composer()(nextFlags.features, nextFlags.features2);
+            expect(after).toEqual(before);
+            const next = new Float32Array(data.length);
+            _writeMaterialData(next, props, after._materialUboSpec!);
+            expect(next).toEqual(data);
+        } finally {
+            if (previous) {
+                _registerPbrExt(previous);
+            } else {
+                registry.delete("base-spec-gloss");
+            }
+        }
+    });
+    it("keeps transformed reflectance layouts distinct in one composer cache", () => {
+        const build = composer();
+        const props = createPbrMaterial({});
+        setPbrMetallicReflectance(props, { reflectanceTexture: { _hasTx: false } as unknown as Texture2D });
+        const f = _computePbrMaterialFeatures(props);
+        const plain = build(f.features, f.features2);
+        setPbrMetallicReflectance(props, { reflectanceTexture: { _hasTx: true } as unknown as Texture2D });
+        const transformedFlags = _computePbrMaterialFeatures(props);
+        const transformed = build(transformedFlags.features, transformedFlags.features2);
+        expect(transformed).not.toBe(plain);
+        expect(plain._materialUboSpec!._offsets.has("reflUVm")).toBe(false);
+        expect(transformed._materialUboSpec!._offsets.has("reflUVm")).toBe(true);
+        expect(transformed._materialUboSpec!._totalBytes - plain._materialUboSpec!._totalBytes).toBe(32);
+        expect(build(f.features, f.features2)).toBe(plain);
+        expect(build(transformedFlags.features, transformedFlags.features2)).toBe(transformed);
+    });
+    it.each(["factors", "texture", "uv"])("runs MR BEFORE_LIGHTS plugins after reflectance initialization (%s)", (kind) => {
+        const props = createPbrMaterial({ plugins: [{ name: "MR F0 modifier", getCustomCode: () => ({ CUSTOM_FRAGMENT_BEFORE_LIGHTS: "colorF0 *= 0.5;" }) }] });
+        setPbrMetallicReflectance(props, kind === "factors" ? { color: [0.2, 0.4, 0.6] } : { reflectanceTexture: { _hasTx: kind === "uv" } as unknown as Texture2D });
+        registerPbrPlugins(_registerPbrExt);
+        const f = _computePbrMaterialFeatures(props);
+        const key = composer()(f.features, f.features2, 0, 0, 0, "point", "", undefined, "", 0, props._pi)._fragmentKey.split("|");
+        const initializer = key.findIndex((id) => id.startsWith(reflectanceExt.id));
+        expect(initializer).toBeGreaterThanOrEqual(0);
+        expect(key.indexOf(`plugin-${props._pi}`)).toBeGreaterThan(initializer);
+    });
+    it.each(["none", "factors", "texture", "uv"])("orders SG initializers before modifiers (reflectance: %s)", async (kind) => {
+        const { props } = await load({ specularFactor: [0.2, 0.5, 0.8] });
+        if (kind !== "none") {
+            setPbrMetallicReflectance(props, kind === "factors" ? { color: [0.2, 0.4, 0.6] } : { reflectanceTexture: { _hasTx: kind === "uv" } as unknown as Texture2D });
+        }
+        _registerPbrExt(clearcoatExt);
+        _registerPbrExt(iridescenceExt);
+        props._clearCoat = { isEnabled: true };
+        props._iridescence = { isEnabled: true };
+        registerPbrPlugins(_registerPbrExt);
+        props.plugins = [{ name: "shared modifier", getCustomCode: () => ({ CUSTOM_FRAGMENT_BEFORE_LIGHTS: "colorF0 *= 0.5;" }) }];
+        const f = _computePbrMaterialFeatures(props);
+        const key = composer()(f.features, f.features2, 0, 0, 0, "point", "", undefined, "", 0, props._pi)._fragmentKey.split("|");
+        const sgIndex = key.indexOf("base-spec-gloss");
+        expect(sgIndex).toBeGreaterThanOrEqual(0);
+        if (kind !== "none") {
+            expect(key.indexOf(reflectanceExt.id)).toBeGreaterThanOrEqual(0);
+            expect(key.indexOf(reflectanceExt.id)).toBeLessThan(sgIndex);
+        }
+        for (const modifier of ["clearcoat", "iridescence", "plugin-"]) {
+            expect(key.findIndex((id) => id.startsWith(modifier))).toBeGreaterThan(sgIndex);
+        }
+        // The exact same cached plugin signature must remain usable on MR.
+        const mr = { ...props, _specularGlossiness: undefined, _clearCoat: undefined, _iridescence: undefined };
+        const mrFlags = _computePbrMaterialFeatures(mr);
+        expect(mr._pi).toBe(props._pi);
+        const mrCode = composer()(mrFlags.features, mrFlags.features2, 0, 0, 0, "point", "", undefined, "", 0, mr._pi);
+        expect(mrCode._fragmentKey.split("|")).not.toContain("base-spec-gloss");
+    });
+});


### PR DESCRIPTION
## Summary

Fix `KHR_materials_pbrSpecularGlossiness` factor handling for both
factor-only and textured materials.

The previous path could lose `diffuseFactor`, reduce RGB
`specularFactor` to a scalar, and ignore `glossinessFactor` for textured
specular-glossiness materials.

The corrected equations are:

- diffuse = decoded diffuse texture × diffuseFactor
- specular = decoded spec-gloss RGB × specularFactor
- glossiness = spec-gloss alpha × glossinessFactor
- roughness = 1 - glossiness

RGB specular reflectance remains RGB F0.

## Architecture

- keeps SG factor handling behind the lazy spec-gloss PBR extension
- no new public API
- no additional texture samples or bindings
- no steady-frame allocations
- preserves legacy texture-only SG materials
- keeps metallic-roughness semantics unchanged
- preserves BasisU feature isolation
- fixes generic base-F0 ordering so BEFORE_LIGHTS material plugins execute
  after reflectance initialization

## Validation

- 15 focused CPU SG/order/cache tests
- 25 WebGPU SG/MR numerical tests
- 495 relevant PBR/glTF tests across 52 files
- 7 parity tests
- 17 published-package/generated-WGSL tests
- build PASS
- lint PASS
- six TypeScript projects PASS
- formatting PASS
- diff-check PASS

Fetched uncompressed runtime JS regression witnesses:

| Scene | Delta |
| --- | ---: |
| 1 | 0 B |
| 6 | 0 B |
| 27 | -27 B |
| 30 | -3 B |
| 19 — clearcoat | -4 B |
| 177 — iridescence | -4 B |
| 217 — material plugins | 0 B |

No bundle-size ceiling was changed.

## Notes

`KHR_materials_pbrSpecularGlossiness` is an archived glTF extension but is
still used by existing assets.

The implementation preserves the native specular-glossiness workflow rather
than approximating or converting it to metallic-roughness.
